### PR TITLE
Patch Spark connect test setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 name: Build
+
 on:
   push:
     branches:

--- a/.github/workflows/run-spark-tests-internal.yml
+++ b/.github/workflows/run-spark-tests-internal.yml
@@ -24,6 +24,15 @@ on:
         type: string
         default: "3.11"
 
+# All the scripts used in this workflow come from the commit specified by `inputs.ref`,
+# which can be different from the commit that defines the workflow.
+# We assume that the scripts are compatible with the workflow definition between the two commits.
+# Otherwise, we may encounter errors such as "file not found" when the workflow invokes
+# a script that does not exist in the commit being tested.
+# Therefore, when you have both script changes and workflow changes, you should consider
+# separating them into two pull requests. For example, you can add a script in one pull request
+# and update the workflow to invoke the script in a follow-up pull request.
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-spark-tests.yml
+++ b/.github/workflows/run-spark-tests.yml
@@ -1,4 +1,5 @@
 name: Run Spark tests
+
 on:
   workflow_call:
     inputs:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ scripts/spark-tests/build-spark-jars.sh
 scripts/spark-tests/setup-spark-env.sh
 ```
 
+You can use the following commands to update the Spark patch with your local modification.
+
+```bash
+git -C opt/spark add .
+git -C opt/spark diff --staged -p > scripts/spark-tests/spark-3.5.1.patch
+```
+
 ### Python Examples Setup
 
 Run the following commands to set up a virtual environment for the Python examples.

--- a/scripts/spark-tests/spark-3.5.1.patch
+++ b/scripts/spark-tests/spark-3.5.1.patch
@@ -87,10 +87,32 @@ index 7b1aafbefeb..cfdd4ccaec1 100644
              from pyspark.sql.session import SparkSession as PySparkSession
  
 diff --git a/python/pyspark/sql/tests/connect/test_connect_basic.py b/python/pyspark/sql/tests/connect/test_connect_basic.py
-index 2904eb42587..1263b642524 100644
+index 2904eb42587..1226f5021a8 100644
 --- a/python/pyspark/sql/tests/connect/test_connect_basic.py
 +++ b/python/pyspark/sql/tests/connect/test_connect_basic.py
-@@ -3328,6 +3328,7 @@ class SparkConnectSessionTests(ReusedConnectTestCase):
+@@ -110,6 +110,11 @@ class SparkConnectSQLTestCase(ReusedConnectTestCase, SQLTestUtils, PandasOnSpark
+         cls.spark_connect_clean_up_test_data()
+         # Load test data
+         cls.spark_connect_load_test_data()
++        # Load test data for connect
++        _spark = cls.spark
++        cls.spark = cls.connect
++        cls.spark_connect_load_test_data()
++        cls.spark = _spark
+ 
+     @classmethod
+     def tearDownClass(cls):
+@@ -144,8 +149,7 @@ class SparkConnectSQLTestCase(ReusedConnectTestCase, SQLTestUtils, PandasOnSpark
+                 StructField("lastname", StringType(), True),
+             ]
+         )
+-        emptyRDD = cls.spark.sparkContext.emptyRDD()
+-        empty_df = cls.spark.createDataFrame(emptyRDD, empty_table_schema)
++        empty_df = cls.spark.createDataFrame([], empty_table_schema)
+         empty_df.write.saveAsTable(cls.tbl_name_empty)
+ 
+     @classmethod
+@@ -3328,6 +3332,7 @@ class SparkConnectSessionTests(ReusedConnectTestCase):
          )
          spark.stop()
  
@@ -98,7 +120,7 @@ index 2904eb42587..1263b642524 100644
      def test_can_create_multiple_sessions_to_different_remotes(self):
          self.spark.stop()
          self.assertIsNotNone(self.spark._client)
-@@ -3347,6 +3348,7 @@ class SparkConnectSessionTests(ReusedConnectTestCase):
+@@ -3347,6 +3352,7 @@ class SparkConnectSessionTests(ReusedConnectTestCase):
              self.assertIn("Create a new SparkSession is only supported with SparkConnect.", str(e))
  
  


### PR DESCRIPTION
In the original parity test setup, the Spark Connect server and the Spark session are in the same JVM, so table registration only needs to happen once. In our settings, however, the Spark Connect server is standalone, so we need to register the tables with it explicitly.