### PR TITLE
Avoid hash map in plan specification

### DIFF
--- a/crates/framework-common/src/spec/plan.rs
+++ b/crates/framework-common/src/spec/plan.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
 use crate::spec::data_type::Schema;
@@ -129,7 +127,7 @@ pub enum QueryNode {
     },
     WithColumnsRenamed {
         input: Box<QueryPlan>,
-        rename_columns_map: HashMap<Identifier, Identifier>,
+        rename_columns_map: Vec<(Identifier, Identifier)>,
     },
     Drop {
         input: Box<QueryPlan>,
@@ -248,7 +246,7 @@ pub enum QueryNode {
     WithParameters {
         input: Box<QueryPlan>,
         positional_arguments: Vec<Literal>,
-        named_arguments: HashMap<String, Literal>,
+        named_arguments: Vec<(String, Literal)>,
     },
     Values(Vec<Vec<Expr>>),
     TableAlias {
@@ -397,7 +395,7 @@ pub enum ReadType {
 #[serde(rename_all = "camelCase")]
 pub struct ReadNamedTable {
     pub name: ObjectName,
-    pub options: HashMap<String, String>,
+    pub options: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -405,7 +403,7 @@ pub struct ReadNamedTable {
 pub struct ReadUdtf {
     pub name: ObjectName,
     pub arguments: Vec<Expr>,
-    pub options: HashMap<String, String>,
+    pub options: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -413,7 +411,7 @@ pub struct ReadUdtf {
 pub struct ReadDataSource {
     pub format: Option<String>,
     pub schema: Option<Schema>,
-    pub options: HashMap<String, String>,
+    pub options: Vec<(String, String)>,
     pub paths: Vec<String>,
     pub predicates: Vec<Expr>,
 }
@@ -504,7 +502,7 @@ pub struct Parse {
     pub input: Box<QueryPlan>,
     pub format: ParseFormat,
     pub schema: Option<Schema>,
-    pub options: HashMap<String, String>,
+    pub options: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -575,7 +573,7 @@ pub struct TableDefinition {
     pub if_not_exists: bool,
     pub or_replace: bool,
     pub unbounded: bool,
-    pub options: HashMap<String, String>,
+    pub options: Vec<(String, String)>,
     /// The query for `CREATE TABLE ... AS SELECT ...` (CTAS) statements.
     pub query: Option<Box<QueryPlan>>,
     pub definition: Option<String>,
@@ -587,13 +585,13 @@ pub struct DatabaseDefinition {
     pub if_not_exists: bool,
     pub comment: Option<String>,
     pub location: Option<String>,
-    pub properties: HashMap<String, String>,
+    pub properties: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CatalogDefinition {
-    pub options: HashMap<String, String>,
+    pub options: Vec<(String, String)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -614,8 +612,8 @@ pub struct Write {
     pub sort_columns: Vec<Identifier>,
     pub partitioning_columns: Vec<Identifier>,
     pub bucket_by: Option<SaveBucketBy>,
-    pub options: HashMap<String, String>,
-    pub table_properties: HashMap<String, String>,
+    pub options: Vec<(String, String)>,
+    pub table_properties: Vec<(String, String)>,
     pub overwrite_condition: Option<Expr>,
 }
 

--- a/crates/framework-plan/src/resolver/plan.rs
+++ b/crates/framework-plan/src/resolver/plan.rs
@@ -822,7 +822,7 @@ impl PlanResolver<'_> {
         &self,
         input: spec::QueryPlan,
         positional: Vec<spec::Literal>,
-        named: HashMap<String, spec::Literal>,
+        named: Vec<(String, spec::Literal)>,
         state: &mut PlanResolverState,
     ) -> PlanResult<LogicalPlan> {
         let input = self.resolve_query_plan(input, state).await?;
@@ -1038,7 +1038,7 @@ impl PlanResolver<'_> {
     async fn resolve_query_with_columns_renamed(
         &self,
         input: spec::QueryPlan,
-        rename_columns_map: HashMap<spec::Identifier, spec::Identifier>,
+        rename_columns_map: Vec<(spec::Identifier, spec::Identifier)>,
         state: &mut PlanResolverState,
     ) -> PlanResult<LogicalPlan> {
         let input = self.resolve_query_plan(input, state).await?;

--- a/crates/framework-spark-connect/src/proto/plan.rs
+++ b/crates/framework-spark-connect/src/proto/plan.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use framework_common::spec;
 use framework_sql::expression::{parse_expression, parse_object_name};
 use framework_sql::statement::parse_sql_statement;
@@ -144,7 +142,7 @@ impl TryFrom<RelType> for RelationNode {
                         } = x;
                         spec::ReadType::NamedTable(spec::ReadNamedTable {
                             name: parse_object_name(unparsed_identifier.as_str())?,
-                            options,
+                            options: options.into_iter().collect(),
                         })
                     }
                     ReadType::DataSource(x) => {
@@ -166,7 +164,7 @@ impl TryFrom<RelType> for RelationNode {
                         spec::ReadType::DataSource(spec::ReadDataSource {
                             format,
                             schema,
-                            options,
+                            options: options.into_iter().collect(),
                             paths,
                             predicates,
                         })
@@ -372,7 +370,7 @@ impl TryFrom<RelType> for RelationNode {
                         let named_arguments = args
                             .into_iter()
                             .map(|(k, v)| Ok((k, v.try_into()?)))
-                            .collect::<SparkResult<HashMap<_, _>>>()?;
+                            .collect::<SparkResult<Vec<_>>>()?;
                         Ok(RelationNode::Query(spec::QueryNode::WithParameters {
                             input: Box::new(input),
                             positional_arguments,
@@ -717,7 +715,7 @@ impl TryFrom<RelType> for RelationNode {
                     input: Box::new((*input).try_into()?),
                     format,
                     schema: schema.map(|x| x.into_schema(DEFAULT_FIELD_NAME, true)),
-                    options,
+                    options: options.into_iter().collect(),
                 })))
             }
             RelType::GroupMap(group_map) => {
@@ -1198,7 +1196,7 @@ impl TryFrom<Catalog> for spec::CommandNode {
                         if_not_exists: false,
                         or_replace: false,
                         unbounded: false,
-                        options,
+                        options: options.into_iter().collect(),
                         query: None,
                         definition: None,
                     },
@@ -1230,7 +1228,7 @@ impl TryFrom<Catalog> for spec::CommandNode {
                         if_not_exists: false,
                         or_replace: false,
                         unbounded: false,
-                        options,
+                        options: options.into_iter().collect(),
                         query: None,
                         definition: None,
                     },

--- a/crates/framework-spark-connect/tests/gold_data/plan/ddl_create_table.json
+++ b/crates/framework-spark-connect/tests/gold_data/plan/ddl_create_table.json
@@ -23,10 +23,16 @@
               "ifNotExists": true,
               "orReplace": false,
               "unbounded": false,
-              "options": {
-                "p1": "v1",
-                "p2": "v2"
-              },
+              "options": [
+                [
+                  "p1",
+                  "v1"
+                ],
+                [
+                  "p2",
+                  "v2"
+                ]
+              ],
               "query": {
                 "project": {
                   "input": {
@@ -35,7 +41,7 @@
                         "name": [
                           "src"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -84,10 +90,16 @@
               "ifNotExists": true,
               "orReplace": false,
               "unbounded": false,
-              "options": {
-                "p1": "v1",
-                "p2": "v2"
-              },
+              "options": [
+                [
+                  "p1",
+                  "v1"
+                ],
+                [
+                  "p2",
+                  "v2"
+                ]
+              ],
               "query": {
                 "project": {
                   "input": {
@@ -96,7 +108,7 @@
                         "name": [
                           "src"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -150,11 +162,20 @@
               "ifNotExists": false,
               "orReplace": false,
               "unbounded": false,
-              "options": {
-                "a": "1",
-                "b": "0.1",
-                "c": "'TRUE'"
-              },
+              "options": [
+                [
+                  "a",
+                  "1"
+                ],
+                [
+                  "b",
+                  "0.1"
+                ],
+                [
+                  "c",
+                  "'TRUE'"
+                ]
+              ],
               "query": null,
               "definition": null
             },
@@ -211,7 +232,7 @@
               "ifNotExists": true,
               "orReplace": false,
               "unbounded": false,
-              "options": {},
+              "options": [],
               "query": null,
               "definition": null
             },
@@ -278,7 +299,7 @@
               "ifNotExists": false,
               "orReplace": false,
               "unbounded": false,
-              "options": {},
+              "options": [],
               "query": null,
               "definition": null
             },
@@ -343,7 +364,7 @@
               "ifNotExists": false,
               "orReplace": false,
               "unbounded": false,
-              "options": {},
+              "options": [],
               "query": null,
               "definition": null
             },
@@ -391,7 +412,7 @@
               "ifNotExists": false,
               "orReplace": false,
               "unbounded": false,
-              "options": {},
+              "options": [],
               "query": null,
               "definition": null
             },
@@ -467,7 +488,7 @@
               "ifNotExists": false,
               "orReplace": false,
               "unbounded": false,
-              "options": {},
+              "options": [],
               "query": null,
               "definition": null
             },
@@ -526,7 +547,7 @@
               "ifNotExists": false,
               "orReplace": false,
               "unbounded": false,
-              "options": {},
+              "options": [],
               "query": null,
               "definition": null
             },
@@ -578,7 +599,7 @@
               "ifNotExists": false,
               "orReplace": false,
               "unbounded": false,
-              "options": {},
+              "options": [],
               "query": null,
               "definition": null
             },
@@ -640,7 +661,7 @@
               "ifNotExists": false,
               "orReplace": false,
               "unbounded": false,
-              "options": {},
+              "options": [],
               "query": null,
               "definition": null
             },
@@ -694,7 +715,7 @@
               "ifNotExists": false,
               "orReplace": false,
               "unbounded": false,
-              "options": {},
+              "options": [],
               "query": null,
               "definition": null
             },
@@ -749,7 +770,7 @@
               "ifNotExists": false,
               "orReplace": false,
               "unbounded": false,
-              "options": {},
+              "options": [],
               "query": null,
               "definition": null
             },
@@ -803,7 +824,7 @@
               "ifNotExists": false,
               "orReplace": false,
               "unbounded": false,
-              "options": {},
+              "options": [],
               "query": null,
               "definition": null
             },
@@ -917,7 +938,7 @@
               "ifNotExists": false,
               "orReplace": false,
               "unbounded": false,
-              "options": {},
+              "options": [],
               "query": null,
               "definition": null
             },
@@ -962,7 +983,7 @@
               "ifNotExists": false,
               "orReplace": false,
               "unbounded": false,
-              "options": {},
+              "options": [],
               "query": null,
               "definition": null
             },
@@ -1007,9 +1028,12 @@
               "ifNotExists": false,
               "orReplace": false,
               "unbounded": false,
-              "options": {
-                "test": "test"
-              },
+              "options": [
+                [
+                  "test",
+                  "test"
+                ]
+              ],
               "query": null,
               "definition": null
             },

--- a/crates/framework-spark-connect/tests/gold_data/plan/error_order_by.json
+++ b/crates/framework-spark-connect/tests/gold_data/plan/error_order_by.json
@@ -30,7 +30,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },

--- a/crates/framework-spark-connect/tests/gold_data/plan/plan_group_by.json
+++ b/crates/framework-spark-connect/tests/gold_data/plan/plan_group_by.json
@@ -19,7 +19,7 @@
                     "name": [
                       "d"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },

--- a/crates/framework-spark-connect/tests/gold_data/plan/plan_hint.json
+++ b/crates/framework-spark-connect/tests/gold_data/plan/plan_hint.json
@@ -12,7 +12,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -47,7 +47,7 @@
                       "db",
                       "tab"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -80,7 +80,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -113,7 +113,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -146,7 +146,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -180,7 +180,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -213,7 +213,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -247,7 +247,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -280,7 +280,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -313,7 +313,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -346,7 +346,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -379,7 +379,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -412,7 +412,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -445,7 +445,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -478,7 +478,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -513,7 +513,7 @@
                       "default",
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -546,7 +546,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -579,7 +579,7 @@
                     "name": [
                       "default.t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -616,7 +616,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -692,7 +692,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -725,7 +725,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -758,7 +758,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -791,7 +791,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -824,7 +824,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -857,7 +857,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -890,7 +890,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -923,7 +923,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -956,7 +956,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },

--- a/crates/framework-spark-connect/tests/gold_data/plan/plan_join.json
+++ b/crates/framework-spark-connect/tests/gold_data/plan/plan_join.json
@@ -24,7 +24,7 @@
                                 "name": [
                                   "a"
                                 ],
-                                "options": {}
+                                "options": []
                               },
                               "isStreaming": false
                             },
@@ -37,7 +37,7 @@
                                 "name": [
                                   "b"
                                 ],
-                                "options": {}
+                                "options": []
                               },
                               "isStreaming": false
                             },
@@ -58,7 +58,7 @@
                             "name": [
                               "c"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -79,7 +79,7 @@
                         "name": [
                           "d"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -138,7 +138,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -159,7 +159,7 @@
                             "name": [
                               "u"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -234,7 +234,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -253,7 +253,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -307,7 +307,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -326,7 +326,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -371,7 +371,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -390,7 +390,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -435,7 +435,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -454,7 +454,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -499,7 +499,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -518,7 +518,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -563,7 +563,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -582,7 +582,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -627,7 +627,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -646,7 +646,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -691,7 +691,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -710,7 +710,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -755,7 +755,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -774,7 +774,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -819,7 +819,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -838,7 +838,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -883,7 +883,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -902,7 +902,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -947,7 +947,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -966,7 +966,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1021,7 +1021,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1036,7 +1036,7 @@
                             "name": [
                               "u"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -1109,7 +1109,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1122,7 +1122,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1168,7 +1168,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1183,7 +1183,7 @@
                             "name": [
                               "u"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -1256,7 +1256,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1269,7 +1269,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1321,7 +1321,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1336,7 +1336,7 @@
                             "name": [
                               "u"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -1409,7 +1409,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1422,7 +1422,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1480,7 +1480,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1495,7 +1495,7 @@
                             "name": [
                               "u"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -1568,7 +1568,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1581,7 +1581,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1627,7 +1627,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1642,7 +1642,7 @@
                             "name": [
                               "u"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -1715,7 +1715,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1728,7 +1728,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1780,7 +1780,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1795,7 +1795,7 @@
                             "name": [
                               "u"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -1868,7 +1868,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1881,7 +1881,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1933,7 +1933,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1948,7 +1948,7 @@
                             "name": [
                               "u"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -2021,7 +2021,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -2034,7 +2034,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -2080,7 +2080,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -2095,7 +2095,7 @@
                             "name": [
                               "u"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -2168,7 +2168,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -2181,7 +2181,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -2227,7 +2227,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -2242,7 +2242,7 @@
                             "name": [
                               "u"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -2315,7 +2315,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -2328,7 +2328,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -2374,7 +2374,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -2389,7 +2389,7 @@
                             "name": [
                               "u"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -2462,7 +2462,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -2475,7 +2475,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -2523,7 +2523,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -2544,7 +2544,7 @@
                             "name": [
                               "u"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -2619,7 +2619,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -2638,7 +2638,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -2734,7 +2734,7 @@
                             "name": [
                               "t1"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -2747,7 +2747,7 @@
                             "name": [
                               "t2"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -2770,7 +2770,7 @@
                             "name": [
                               "t3"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -2783,7 +2783,7 @@
                             "name": [
                               "t2"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -2864,7 +2864,7 @@
                                 "name": [
                                   "t1"
                                 ],
-                                "options": {}
+                                "options": []
                               },
                               "isStreaming": false
                             },
@@ -2877,7 +2877,7 @@
                                 "name": [
                                   "t2"
                                 ],
-                                "options": {}
+                                "options": []
                               },
                               "isStreaming": false
                             },
@@ -2898,7 +2898,7 @@
                             "name": [
                               "t3"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -2945,7 +2945,7 @@
                         "name": [
                           "t4"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -3039,7 +3039,7 @@
                         "name": [
                           "t1"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -3054,7 +3054,7 @@
                             "name": [
                               "t3"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -3067,7 +3067,7 @@
                             "name": [
                               "t2"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },

--- a/crates/framework-spark-connect/tests/gold_data/plan/plan_misc.json
+++ b/crates/framework-spark-connect/tests/gold_data/plan/plan_misc.json
@@ -12,7 +12,7 @@
                     "name": [
                       "a"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -45,7 +45,7 @@
                     "name": [
                       "a"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -78,7 +78,7 @@
                     "name": [
                       "a"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -111,7 +111,7 @@
                     "name": [
                       "a"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -199,7 +199,7 @@
                         "name": [
                           "t1"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -225,7 +225,7 @@
                         "name": [
                           "t2"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },

--- a/crates/framework-spark-connect/tests/gold_data/plan/plan_order_by.json
+++ b/crates/framework-spark-connect/tests/gold_data/plan/plan_order_by.json
@@ -77,7 +77,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -145,7 +145,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },

--- a/crates/framework-spark-connect/tests/gold_data/plan/plan_select.json
+++ b/crates/framework-spark-connect/tests/gold_data/plan/plan_select.json
@@ -12,7 +12,7 @@
                     "name": [
                       "a"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -80,7 +80,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -167,7 +167,7 @@
                     "name": [
                       "a"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -362,7 +362,7 @@
                             }
                           }
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -410,7 +410,7 @@
                             }
                           }
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -453,7 +453,7 @@
                         "name": [
                           "testData"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -497,7 +497,7 @@
                       "db",
                       "tab"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -1027,7 +1027,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -1120,7 +1120,7 @@
                     "name": [
                       "a"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -1186,7 +1186,7 @@
                     "name": [
                       "a"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -1240,7 +1240,7 @@
                         }
                       }
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -1335,7 +1335,7 @@
                         }
                       }
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -1378,7 +1378,7 @@
                         }
                       }
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -1411,7 +1411,7 @@
                     "name": [
                       "t"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -1454,7 +1454,7 @@
                             "name": [
                               "t"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -1473,7 +1473,7 @@
                         "name": [
                           "u"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1535,7 +1535,7 @@
                         "name": [
                           "t"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1729,7 +1729,7 @@
                       "db",
                       "c"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -1794,7 +1794,7 @@
                           "db",
                           "c"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1865,7 +1865,7 @@
                       "db",
                       "c"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -1910,7 +1910,7 @@
                       "db",
                       "c"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -1993,7 +1993,7 @@
                       "db",
                       "c"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -2040,7 +2040,7 @@
                           "db",
                           "c"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -2097,7 +2097,7 @@
                     "name": [
                       "t0"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },
@@ -2133,7 +2133,7 @@
                     "name": [
                       "t0"
                     ],
-                    "options": {}
+                    "options": []
                   },
                   "isStreaming": false
                 },

--- a/crates/framework-spark-connect/tests/gold_data/plan/plan_set_operation.json
+++ b/crates/framework-spark-connect/tests/gold_data/plan/plan_set_operation.json
@@ -16,7 +16,7 @@
                             "name": [
                               "a"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -42,7 +42,7 @@
                             "name": [
                               "b"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -78,7 +78,7 @@
                             "name": [
                               "c"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -104,7 +104,7 @@
                             "name": [
                               "d"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -157,7 +157,7 @@
                             "name": [
                               "a"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -183,7 +183,7 @@
                             "name": [
                               "b"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -219,7 +219,7 @@
                             "name": [
                               "c"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -245,7 +245,7 @@
                             "name": [
                               "d"
                             ],
-                            "options": {}
+                            "options": []
                           },
                           "isStreaming": false
                         },
@@ -302,7 +302,7 @@
                                     "name": [
                                       "t0"
                                     ],
-                                    "options": {}
+                                    "options": []
                                   },
                                   "isStreaming": false
                                 },
@@ -331,7 +331,7 @@
                                     "name": [
                                       "t0"
                                     ],
-                                    "options": {}
+                                    "options": []
                                   },
                                   "isStreaming": false
                                 },
@@ -368,7 +368,7 @@
                                 "name": [
                                   "t0"
                                 ],
-                                "options": {}
+                                "options": []
                               },
                               "isStreaming": false
                             },
@@ -438,7 +438,7 @@
                                 "name": [
                                   "t1"
                                 ],
-                                "options": {}
+                                "options": []
                               },
                               "isStreaming": false
                             },
@@ -464,7 +464,7 @@
                                 "name": [
                                   "t2"
                                 ],
-                                "options": {}
+                                "options": []
                               },
                               "isStreaming": false
                             },
@@ -524,7 +524,7 @@
                         "name": [
                           "a"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -550,7 +550,7 @@
                         "name": [
                           "b"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -593,7 +593,7 @@
                         "name": [
                           "a"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -619,7 +619,7 @@
                         "name": [
                           "b"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -662,7 +662,7 @@
                         "name": [
                           "a"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -688,7 +688,7 @@
                         "name": [
                           "b"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -731,7 +731,7 @@
                         "name": [
                           "a"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -757,7 +757,7 @@
                         "name": [
                           "b"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -800,7 +800,7 @@
                         "name": [
                           "a"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -826,7 +826,7 @@
                         "name": [
                           "b"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -869,7 +869,7 @@
                         "name": [
                           "a"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -895,7 +895,7 @@
                         "name": [
                           "b"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -956,7 +956,7 @@
                         "name": [
                           "a"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -982,7 +982,7 @@
                         "name": [
                           "b"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1025,7 +1025,7 @@
                         "name": [
                           "a"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1051,7 +1051,7 @@
                         "name": [
                           "b"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1094,7 +1094,7 @@
                         "name": [
                           "a"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },
@@ -1120,7 +1120,7 @@
                         "name": [
                           "b"
                         ],
-                        "options": {}
+                        "options": []
                       },
                       "isStreaming": false
                     },

--- a/crates/framework-sql/src/parse.rs
+++ b/crates/framework-sql/src/parse.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use sqlparser::ast;
 use sqlparser::parser::Parser;
 use sqlparser::tokenizer::{Token, Word};
@@ -61,13 +59,13 @@ pub fn parse_option_value(parser: &mut Parser) -> SqlResult<String> {
 }
 
 /// [Credit]: <https://github.com/apache/datafusion/blob/13cb65e44136711befb87dd75fb8b41f814af16f/datafusion/sql/src/parser.rs#L849>
-pub fn parse_value_options(parser: &mut Parser) -> SqlResult<HashMap<String, String>> {
-    let mut options = HashMap::new();
+pub fn parse_value_options(parser: &mut Parser) -> SqlResult<Vec<(String, String)>> {
+    let mut options = vec![];
     parser.expect_token(&Token::LParen)?;
     loop {
         let key = parse_option_key(parser)?;
         let value = parse_option_value(parser)?;
-        options.insert(key, value);
+        options.push((key, value));
         let comma = parser.consume_token(&Token::Comma);
         if parser.consume_token(&Token::RParen) {
             // allow a trailing comma, even though it's not in standard

--- a/crates/framework-sql/src/statement.rs
+++ b/crates/framework-sql/src/statement.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use framework_common::spec;
 use sqlparser::ast;
 use sqlparser::keywords::Keyword;
@@ -144,7 +142,7 @@ fn parse_create_statement(parser: &mut Parser) -> SqlResult<Statement> {
 
     let mut file_format: Option<String> = None;
     let mut comment: Option<String> = None;
-    let mut options: HashMap<String, String> = HashMap::new();
+    let mut options: Vec<(String, String)> = vec![];
     let mut table_partition_cols: Vec<spec::Identifier> = vec![];
     let mut location: Option<String> = None;
     let mut table_properties: Vec<ast::SqlOption> = vec![];


### PR DESCRIPTION
We should avoid hash map so that the plan specification is deterministic. This ensures that the gold data stay the same when there is no plan change.