### PR TITLE
Add robots meta tag in docs

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -19,7 +19,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    environment: docs/${{ inputs.stage }}
+    environment: ${{ inputs.stage != 'test' && format('docs/{0}', inputs.stage) || '' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -74,6 +74,16 @@ class Analytics {
   }
 }
 
+class Robots {
+  static head(): HeadConfig[] {
+    if (Site.version() === "main") {
+      return [["meta", { name: "robots", content: "noindex" }]];
+    } else {
+      return [];
+    }
+  }
+}
+
 class TransformPageData {
   static canonicalUrl(pageData: PageData): void {
     const canonicalUrl = `${Site.url()}${pageData.relativePath}`
@@ -113,11 +123,11 @@ class Sidebar {
   private static readonly srcDir = path.join(__dirname, "..");
 
   private static items(
-    trees: TreeNode<PageLink>[],
+    trees: TreeNode<PageLink | null>[],
     base?: string,
   ): DefaultTheme.SidebarItem[] {
     function transform(
-      tree: TreeNode<PageLink>,
+      tree: TreeNode<PageLink | null>,
       level: number,
     ): DefaultTheme.SidebarItem {
       if (tree.data === null) {
@@ -203,6 +213,7 @@ export default async () => {
         { rel: "icon", type: "image/png", href: `${Site.base()}favicon.png` },
       ],
       ...Analytics.head(),
+      ...Robots.head(),
     ],
     transformPageData(pageData) {
       TransformPageData.canonicalUrl(pageData);

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,7 +16,7 @@ export default ts.config(
     ],
   },
   {
-    files: ["**/*.{ts,js,vue}"],
+    files: ["**/*.{ts,mts,js,mjs,vue}"],
     languageOptions: {
       parserOptions: {
         parser: "@typescript-eslint/parser",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
       "@theme/*": ["docs/.vitepress/theme/*"]
     }
   },
-  "include": ["docs/.vitepress/theme/**/*"]
+  "include": ["docs/.vitepress/config.mts", "docs/.vitepress/theme/**/*"]
 }


### PR DESCRIPTION
We would like to prevent search engines from indexing the documentation site for the `main` branch. A `<meta>` tag can be added for this purpose.

According to the [reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name), this is recommended even if we have `robots.txt` to prevent crawling:

> The `robots` `<meta>` tag and `robots.txt` file serve different purposes: `robots.txt` controls the crawling of pages, and does not affect indexing or other behavior controlled by `robots` meta. A page that can't be crawled may still be indexed if it is referenced by another document.