### PR TITLE
Refactor Spark Connect operations

### DIFF
--- a/.github/workflows/spark-tests.yml
+++ b/.github/workflows/spark-tests.yml
@@ -57,12 +57,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install jq
-        run: |
-          wget -q -O /usr/local/bin/jq "https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64"
-          chmod +x /usr/local/bin/jq
-          jq --version
-
       - name: Download test logs after the code change
         uses: actions/download-artifact@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,19 +781,6 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
 version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804c8821570c3f8b70230c2ba75ffa5c0f9a4189b9a432b6656c536712acae28"
@@ -822,18 +809,18 @@ dependencies = [
  "bytes",
  "bzip2",
  "chrono",
- "dashmap 6.0.1",
+ "dashmap",
  "datafusion-catalog",
- "datafusion-common 41.0.0",
+ "datafusion-common",
  "datafusion-common-runtime",
- "datafusion-execution 41.0.0",
- "datafusion-expr 41.0.0",
- "datafusion-functions 41.0.0",
- "datafusion-functions-aggregate 41.0.0",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
  "datafusion-functions-nested",
  "datafusion-optimizer",
  "datafusion-physical-expr",
- "datafusion-physical-expr-common 41.0.0",
+ "datafusion-physical-expr-common",
  "datafusion-physical-optimizer",
  "datafusion-physical-plan",
  "datafusion-sql",
@@ -870,30 +857,10 @@ checksum = "e13b3cfbd84c6003594ae1972314e3df303a27ce8ce755fcea3240c90f4c0529"
 dependencies = [
  "arrow-schema",
  "async-trait",
- "datafusion-common 41.0.0",
- "datafusion-execution 41.0.0",
- "datafusion-expr 41.0.0",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
  "datafusion-physical-plan",
-]
-
-[[package]]
-name = "datafusion-common"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def66b642959e7f96f5d2da22e1f43d3bd35598f821e5ce351a0553e0f1b7367"
-dependencies = [
- "ahash",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
- "chrono",
- "half",
- "hashbrown 0.14.5",
- "instant",
- "libc",
- "num_cpus",
- "sqlparser 0.47.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -930,36 +897,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-execution"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ac0fd8b5d80bbca3fc3b6f40da4e9f6907354824ec3b18bbd83fee8cf5c3c3e"
-dependencies = [
- "arrow",
- "chrono",
- "dashmap 5.5.3",
- "datafusion-common 40.0.0",
- "datafusion-expr 40.0.0",
- "futures",
- "hashbrown 0.14.5",
- "log",
- "object_store",
- "parking_lot",
- "rand",
- "tempfile",
- "url",
-]
-
-[[package]]
-name = "datafusion-execution"
 version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799e70968c815b611116951e3dd876aef04bf217da31b72eec01ee6a959336a1"
 dependencies = [
  "arrow",
  "chrono",
- "dashmap 6.0.1",
- "datafusion-common 41.0.0",
- "datafusion-expr 41.0.0",
+ "dashmap",
+ "datafusion-common",
+ "datafusion-expr",
  "futures",
  "hashbrown 0.14.5",
  "log",
@@ -968,25 +914,6 @@ dependencies = [
  "rand",
  "tempfile",
  "url",
-]
-
-[[package]]
-name = "datafusion-expr"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2103d2cc16fb11ef1fa993a6cac57ed5cb028601db4b97566c90e5fa77aa1e68"
-dependencies = [
- "ahash",
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "chrono",
- "datafusion-common 40.0.0",
- "paste",
- "serde_json",
- "sqlparser 0.47.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "strum",
- "strum_macros",
 ]
 
 [[package]]
@@ -1000,34 +927,12 @@ dependencies = [
  "arrow-array",
  "arrow-buffer",
  "chrono",
- "datafusion-common 41.0.0",
+ "datafusion-common",
  "paste",
  "serde_json",
  "sqlparser 0.49.0",
  "strum",
  "strum_macros",
-]
-
-[[package]]
-name = "datafusion-functions"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a369332afd0ef5bd565f6db2139fb9f1dfdd0afa75a7f70f000b74208d76994f"
-dependencies = [
- "arrow",
- "base64 0.22.1",
- "chrono",
- "datafusion-common 40.0.0",
- "datafusion-execution 40.0.0",
- "datafusion-expr 40.0.0",
- "hashbrown 0.14.5",
- "hex",
- "itertools 0.12.1",
- "log",
- "rand",
- "regex",
- "unicode-segmentation",
- "uuid",
 ]
 
 [[package]]
@@ -1042,9 +947,9 @@ dependencies = [
  "blake2",
  "blake3",
  "chrono",
- "datafusion-common 41.0.0",
- "datafusion-execution 41.0.0",
- "datafusion-expr 41.0.0",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
  "hashbrown 0.14.5",
  "hex",
  "itertools 0.12.1",
@@ -1059,24 +964,6 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92718db1aff70c47e5abf9fc975768530097059e5db7c7b78cd64b5e9a11fc77"
-dependencies = [
- "ahash",
- "arrow",
- "arrow-schema",
- "datafusion-common 40.0.0",
- "datafusion-execution 40.0.0",
- "datafusion-expr 40.0.0",
- "datafusion-physical-expr-common 40.0.0",
- "log",
- "paste",
- "sqlparser 0.47.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "datafusion-functions-aggregate"
 version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b4ece19f73c02727e5e8654d79cd5652de371352c1df3c4ac3e419ecd6943fb"
@@ -1084,34 +971,13 @@ dependencies = [
  "ahash",
  "arrow",
  "arrow-schema",
- "datafusion-common 41.0.0",
- "datafusion-execution 41.0.0",
- "datafusion-expr 41.0.0",
- "datafusion-physical-expr-common 41.0.0",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
  "log",
  "paste",
  "sqlparser 0.49.0",
-]
-
-[[package]]
-name = "datafusion-functions-array"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bb80f46ff3dcf4bb4510209c2ba9b8ce1b716ac8b7bf70c6bf7dca6260c831"
-dependencies = [
- "arrow",
- "arrow-array",
- "arrow-buffer",
- "arrow-ord",
- "arrow-schema",
- "datafusion-common 40.0.0",
- "datafusion-execution 40.0.0",
- "datafusion-expr 40.0.0",
- "datafusion-functions 40.0.0",
- "datafusion-functions-aggregate 40.0.0",
- "itertools 0.12.1",
- "log",
- "paste",
 ]
 
 [[package]]
@@ -1125,11 +991,11 @@ dependencies = [
  "arrow-buffer",
  "arrow-ord",
  "arrow-schema",
- "datafusion-common 41.0.0",
- "datafusion-execution 41.0.0",
- "datafusion-expr 41.0.0",
- "datafusion-functions 41.0.0",
- "datafusion-functions-aggregate 41.0.0",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
  "itertools 0.12.1",
  "log",
  "paste",
@@ -1145,8 +1011,8 @@ dependencies = [
  "arrow",
  "async-trait",
  "chrono",
- "datafusion-common 41.0.0",
- "datafusion-expr 41.0.0",
+ "datafusion-common",
+ "datafusion-expr",
  "datafusion-physical-expr",
  "hashbrown 0.14.5",
  "indexmap 2.2.6",
@@ -1171,10 +1037,10 @@ dependencies = [
  "arrow-string",
  "base64 0.22.1",
  "chrono",
- "datafusion-common 41.0.0",
- "datafusion-execution 41.0.0",
- "datafusion-expr 41.0.0",
- "datafusion-physical-expr-common 41.0.0",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
  "half",
  "hashbrown 0.14.5",
  "hex",
@@ -1188,28 +1054,14 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "40.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8a72b0ca908e074aaeca52c14ddf5c28d22361e9cb6bc79bb733cd6661b536"
-dependencies = [
- "ahash",
- "arrow",
- "datafusion-common 40.0.0",
- "datafusion-expr 40.0.0",
- "hashbrown 0.14.5",
- "rand",
-]
-
-[[package]]
-name = "datafusion-physical-expr-common"
 version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db5e7d8532a1601cd916881db87a70b0a599900d23f3db2897d389032da53bc6"
 dependencies = [
  "ahash",
  "arrow",
- "datafusion-common 41.0.0",
- "datafusion-expr 41.0.0",
+ "datafusion-common",
+ "datafusion-expr",
  "hashbrown 0.14.5",
  "rand",
 ]
@@ -1220,8 +1072,8 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb9c78f308e050f5004671039786a925c3fee83b90004e9fcfd328d7febdcc0"
 dependencies = [
- "datafusion-common 41.0.0",
- "datafusion-execution 41.0.0",
+ "datafusion-common",
+ "datafusion-execution",
  "datafusion-physical-expr",
  "datafusion-physical-plan",
 ]
@@ -1240,13 +1092,13 @@ dependencies = [
  "arrow-schema",
  "async-trait",
  "chrono",
- "datafusion-common 41.0.0",
+ "datafusion-common",
  "datafusion-common-runtime",
- "datafusion-execution 41.0.0",
- "datafusion-expr 41.0.0",
- "datafusion-functions-aggregate 41.0.0",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate",
  "datafusion-physical-expr",
- "datafusion-physical-expr-common 41.0.0",
+ "datafusion-physical-expr-common",
  "futures",
  "half",
  "hashbrown 0.14.5",
@@ -1269,8 +1121,8 @@ dependencies = [
  "arrow",
  "arrow-array",
  "arrow-schema",
- "datafusion-common 41.0.0",
- "datafusion-expr 41.0.0",
+ "datafusion-common",
+ "datafusion-expr",
  "log",
  "regex",
  "sqlparser 0.49.0",
@@ -2888,8 +2740,8 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "datafusion",
- "datafusion-common 41.0.0",
- "datafusion-expr 41.0.0",
+ "datafusion-common",
+ "datafusion-expr",
  "glob",
  "lexical-core",
  "pyo3",
@@ -2910,9 +2762,9 @@ dependencies = [
  "chrono",
  "comfy-table",
  "datafusion",
- "datafusion-common 41.0.0",
- "datafusion-expr 41.0.0",
- "datafusion-functions-array",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions-nested",
  "either",
  "futures",
  "html-escape",
@@ -2956,15 +2808,15 @@ dependencies = [
  "arrow-cast",
  "async-trait",
  "datafusion",
- "datafusion-common 41.0.0",
- "datafusion-expr 41.0.0",
- "datafusion-functions-array",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions-nested",
  "pyo3",
  "sail-common",
  "serde",
  "serde_bytes",
  "serde_json",
- "sqlparser 0.47.0 (git+https://github.com/lakehq/sqlparser-rs.git?rev=f631629)",
+ "sqlparser 0.47.0",
  "thiserror",
 ]
 
@@ -2979,9 +2831,9 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "datafusion",
- "datafusion-common 41.0.0",
- "datafusion-expr 41.0.0",
- "datafusion-functions-array",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions-nested",
  "glob",
  "lazy_static",
  "mimalloc",
@@ -3011,7 +2863,7 @@ dependencies = [
  "serde",
  "serde_arrow",
  "serde_json",
- "sqlparser 0.47.0 (git+https://github.com/lakehq/sqlparser-rs.git?rev=f631629)",
+ "sqlparser 0.47.0",
  "syn 2.0.76",
  "thiserror",
  "tokio",
@@ -3040,7 +2892,7 @@ dependencies = [
  "sail-common",
  "serde",
  "serde_json",
- "sqlparser 0.47.0 (git+https://github.com/lakehq/sqlparser-rs.git?rev=f631629)",
+ "sqlparser 0.47.0",
  "thiserror",
 ]
 
@@ -3279,16 +3131,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "sqlparser"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295e9930cd7a97e58ca2a070541a3ca502b17f5d1fa7157376d0fabd85324f25"
-dependencies = [
- "log",
- "sqlparser_derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "sqlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ num-traits = "0.2.19"
 datafusion = { version = "41.0.0", features = ["serde", "pyarrow"] }
 datafusion-common = { version = "41.0.0", features = ["object_store", "pyarrow"] }
 datafusion-expr = "41.0.0"
-datafusion-functions-array = "40.0.0"
+datafusion-functions-nested = "41.0.0"
 # auto-initialize: Changes [`Python::with_gil`] to automatically initialize the Python interpreter if needed.
 # 0.21 breaks when datafusion has pyarrow enabled
 pyo3 = { version = "0.21.2", features = ["auto-initialize", "serde"] }

--- a/crates/sail-common/src/spec/data_type.rs
+++ b/crates/sail-common/src/spec/data_type.rs
@@ -1,10 +1,8 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
 use crate::error::{CommonError, CommonResult};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum DataType {
     Null,
@@ -67,23 +65,23 @@ impl DataType {
                 name: default_field_name.to_string(),
                 data_type: x,
                 nullable,
-                metadata: HashMap::new(),
+                metadata: vec![],
             }]),
         };
         Schema { fields }
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct Field {
     pub name: String,
     pub data_type: DataType,
     pub nullable: bool,
-    pub metadata: HashMap<String, String>,
+    pub metadata: Vec<(String, String)>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct Fields(pub Vec<Field>);
 
 impl Fields {
@@ -108,7 +106,7 @@ impl From<Vec<Field>> for Fields {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub enum DayTimeIntervalField {
     Day = 0,
@@ -134,7 +132,7 @@ impl TryFrom<i32> for DayTimeIntervalField {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "camelCase")]
 pub enum YearMonthIntervalField {
     Year = 0,

--- a/crates/sail-common/src/spec/expression.rs
+++ b/crates/sail-common/src/spec/expression.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
 use crate::spec::data_type::DataType;
@@ -27,7 +25,7 @@ pub enum Expr {
         expr: Box<Expr>,
         /// A single identifier, or multiple identifiers for multi-alias.
         name: Vec<Identifier>,
-        metadata: Option<HashMap<String, String>>,
+        metadata: Option<Vec<(String, String)>>,
     },
     Cast {
         expr: Box<Expr>,
@@ -265,7 +263,7 @@ pub struct CommonInlineUserDefinedTableFunction {
     pub function: TableFunctionDefinition,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum TableFunctionDefinition {
     PythonUdtf {

--- a/crates/sail-plan/Cargo.toml
+++ b/crates/sail-plan/Cargo.toml
@@ -11,7 +11,7 @@ sail-sql = { path = "../sail-sql" }
 datafusion = { workspace = true }
 datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
-datafusion-functions-array = { workspace = true }
+datafusion-functions-nested = { workspace = true }
 thiserror = { workspace = true }
 tokio-stream = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/sail-plan/src/catalog/function.rs
+++ b/crates/sail-plan/src/catalog/function.rs
@@ -1,4 +1,12 @@
+use std::sync::Arc;
+
+use datafusion::datasource::function::TableFunctionImpl;
+use datafusion_common::Result;
+use datafusion_expr::ScalarUDF;
 use serde::{Deserialize, Serialize};
+
+use crate::catalog::CatalogManager;
+use crate::extension::logical::CatalogTableFunction;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct FunctionMetadata {
@@ -8,4 +16,23 @@ pub(crate) struct FunctionMetadata {
     pub(crate) description: Option<String>,
     pub(crate) class_name: String,
     pub(crate) is_temporary: bool,
+}
+
+impl<'a> CatalogManager<'a> {
+    pub(crate) fn register_function(&self, udf: ScalarUDF) -> Result<()> {
+        self.ctx.register_udf(udf);
+        Ok(())
+    }
+
+    pub(crate) fn register_table_function(
+        &self,
+        name: String,
+        udtf: CatalogTableFunction,
+    ) -> Result<()> {
+        let f: Arc<dyn TableFunctionImpl> = match udtf {
+            CatalogTableFunction::PySparkUDTF(x) => Arc::new(x),
+        };
+        self.ctx.register_udtf(name.as_str(), f);
+        Ok(())
+    }
 }

--- a/crates/sail-plan/src/extension/logical/mod.rs
+++ b/crates/sail-plan/src/extension/logical/mod.rs
@@ -3,7 +3,7 @@ mod range;
 mod show_string;
 mod sort;
 
-pub(crate) use catalog::{CatalogCommand, CatalogCommandNode};
+pub(crate) use catalog::{CatalogCommand, CatalogCommandNode, CatalogTableFunction};
 pub(crate) use range::{Range, RangeNode};
 pub(crate) use show_string::{ShowStringFormat, ShowStringNode, ShowStringStyle};
 pub(crate) use sort::SortWithinPartitionsNode;

--- a/crates/sail-plan/src/formatter.rs
+++ b/crates/sail-plan/src/formatter.rs
@@ -398,8 +398,6 @@ impl Display for DecimalDisplay<'_> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use sail_common::spec::Literal;
 
     use super::*;
@@ -540,7 +538,7 @@ mod tests {
                                 contains_null: true,
                             },
                             nullable: false,
-                            metadata: HashMap::new(),
+                            metadata: vec![],
                         },
                         spec::Field {
                             name: "bar".to_string(),
@@ -549,11 +547,11 @@ mod tests {
                                     name: "baz".to_string(),
                                     data_type: spec::DataType::String,
                                     nullable: false,
-                                    metadata: HashMap::new(),
+                                    metadata: vec![],
                                 }]),
                             },
                             nullable: true,
-                            metadata: HashMap::new(),
+                            metadata: vec![],
                         },
                     ]
                     .into()
@@ -569,7 +567,7 @@ mod tests {
                                 name: "baz".to_string(),
                                 data_type: spec::DataType::String,
                                 nullable: false,
-                                metadata: HashMap::new(),
+                                metadata: vec![],
                             }]),
                         },
                         elements: vec![Literal::String("hello".to_string())],

--- a/crates/sail-plan/src/resolver/data_type.rs
+++ b/crates/sail-plan/src/resolver/data_type.rs
@@ -33,7 +33,7 @@ impl PlanResolver<'_> {
                     name: "element".to_string(),
                     data_type: *element_type,
                     nullable: contains_null,
-                    metadata: HashMap::new(),
+                    metadata: vec![],
                 };
                 Ok(adt::DataType::List(Arc::new(self.resolve_field(field)?)))
             }
@@ -74,13 +74,13 @@ impl PlanResolver<'_> {
                         name: "key".to_string(),
                         data_type: *key_type,
                         nullable: false,
-                        metadata: HashMap::new(),
+                        metadata: vec![],
                     },
                     spec::Field {
                         name: "value".to_string(),
                         data_type: *value_type,
                         nullable: value_contains_null,
-                        metadata: HashMap::new(),
+                        metadata: vec![],
                     },
                 ];
                 Ok(adt::DataType::Map(
@@ -258,7 +258,7 @@ impl PlanResolver<'_> {
             name: name.clone(),
             data_type,
             nullable: field.is_nullable(),
-            metadata,
+            metadata: metadata.into_iter().collect(),
         })
     }
 

--- a/crates/sail-plan/src/resolver/expression.rs
+++ b/crates/sail-plan/src/resolver/expression.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
@@ -36,7 +35,7 @@ pub(super) struct NamedExpr {
     /// to be expanded into multiple ones in the projection).
     pub name: Vec<String>,
     pub expr: expr::Expr,
-    pub metadata: HashMap<String, String>,
+    pub metadata: Vec<(String, String)>,
 }
 
 impl NamedExpr {
@@ -44,7 +43,7 @@ impl NamedExpr {
         Self {
             name,
             expr,
-            metadata: HashMap::new(),
+            metadata: vec![],
         }
     }
 
@@ -72,7 +71,7 @@ impl NamedExpr {
         }
     }
 
-    pub fn with_metadata(mut self, metadata: HashMap<String, String>) -> Self {
+    pub fn with_metadata(mut self, metadata: Vec<(String, String)>) -> Self {
         self.metadata = metadata;
         self
     }
@@ -743,7 +742,7 @@ impl PlanResolver<'_> {
         &self,
         expr: spec::Expr,
         name: Vec<spec::Identifier>,
-        metadata: Option<HashMap<String, String>>,
+        metadata: Option<Vec<(String, String)>>,
         schema: &DFSchemaRef,
         state: &mut PlanResolverState,
     ) -> PlanResult<NamedExpr> {

--- a/crates/sail-python-udf/Cargo.toml
+++ b/crates/sail-python-udf/Cargo.toml
@@ -10,7 +10,7 @@ thiserror = { workspace = true }
 datafusion = { workspace = true }
 datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
-datafusion-functions-array = { workspace = true }
+datafusion-functions-nested = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_bytes = { workspace = true }

--- a/crates/sail-python-udf/src/udf/pyspark_udtf.rs
+++ b/crates/sail-python-udf/src/udf/pyspark_udtf.rs
@@ -78,7 +78,7 @@ impl TableProvider for PySparkUserDefinedTable {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct PySparkUDTF {
     return_type: DataType,
     return_schema: SchemaRef,

--- a/crates/sail-spark-connect/Cargo.toml
+++ b/crates/sail-spark-connect/Cargo.toml
@@ -36,7 +36,7 @@ uuid = { workspace = true }
 datafusion = { workspace = true }
 datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
-datafusion-functions-array = { workspace = true }
+datafusion-functions-nested = { workspace = true }
 async-recursion = { workspace = true }
 async-stream = { workspace = true }
 lazy_static = { workspace = true }

--- a/crates/sail-spark-connect/src/proto/data_type.rs
+++ b/crates/sail-spark-connect/src/proto/data_type.rs
@@ -55,7 +55,8 @@ impl TryFrom<sdt::StructField> for spec::Field {
             name,
             data_type,
             nullable,
-            metadata,
+            // TODO: preserve metadata order in serde
+            metadata: metadata.into_iter().collect(),
         })
     }
 }
@@ -223,6 +224,7 @@ impl TryFrom<spec::Field> for sdt::StructField {
             metadata,
         } = field;
         let data_type = data_type.try_into()?;
+        let metadata: HashMap<_, _> = metadata.into_iter().collect();
         let metadata = serde_json::to_string(&metadata)?;
         Ok(sdt::StructField {
             name,

--- a/crates/sail-spark-connect/src/proto/expression.rs
+++ b/crates/sail-spark-connect/src/proto/expression.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use sail_common::spec;
 use sail_sql::data_type::parse_data_type;
 use sail_sql::expression::{
@@ -67,14 +69,14 @@ impl TryFrom<Expression> for spec::Expr {
                     metadata,
                 } = *alias;
                 let expr = expr.required("alias expression")?;
-                let metadata = metadata
+                let metadata: Option<HashMap<String, String>> = metadata
                     .map(|x| serde_json::from_str(&x).map_err(SparkError::from))
                     .transpose()?;
                 let name: Vec<spec::Identifier> = name.into_iter().map(|x| x.into()).collect();
                 Ok(spec::Expr::Alias {
                     expr: Box::new((*expr).try_into()?),
                     name,
-                    metadata,
+                    metadata: metadata.map(|x| x.into_iter().collect()),
                 })
             }
             ExprType::Cast(cast) => {

--- a/crates/sail-spark-connect/src/proto/function.rs
+++ b/crates/sail-spark-connect/src/proto/function.rs
@@ -7,7 +7,6 @@ mod tests {
     use serde::{Deserialize, Serialize};
 
     use crate::error::{SparkError, SparkResult};
-    use crate::executor::execute_query;
     use crate::proto::data_type_json::JsonDataType;
     use crate::session::Session;
 
@@ -50,9 +49,8 @@ mod tests {
         Ok(test_gold_set(
             "tests/gold_data/function/*.json",
             |example: FunctionExample| -> SparkResult<String> {
-                let ctx = session.context();
                 let result =
-                    rt.block_on(async { execute_query(ctx, example.query.as_str()).await });
+                    rt.block_on(async { session.execute_query(example.query.as_str()).await });
                 // TODO: validate the result against the expected output
                 // TODO: handle non-deterministic results and error messages
                 match result {

--- a/crates/sail-spark-connect/src/proto/plan.rs
+++ b/crates/sail-spark-connect/src/proto/plan.rs
@@ -7,7 +7,9 @@ use crate::proto::data_type::{parse_spark_data_type, DEFAULT_FIELD_NAME};
 use crate::spark::connect as sc;
 use crate::spark::connect::catalog::CatType;
 use crate::spark::connect::relation::RelType;
-use crate::spark::connect::{plan, Catalog, Plan, Relation, RelationCommon};
+use crate::spark::connect::{
+    plan, Catalog, Plan, Relation, RelationCommon, WriteOperation, WriteOperationV2,
+};
 
 struct RelationMetadata {
     plan_id: Option<i64>,
@@ -1346,6 +1348,149 @@ impl TryFrom<Catalog> for spec::CommandNode {
                 })
             }
         }
+    }
+}
+
+impl TryFrom<WriteOperation> for spec::Write {
+    type Error = SparkError;
+
+    fn try_from(write: WriteOperation) -> SparkResult<spec::Write> {
+        use crate::spark::connect::write_operation::save_table::TableSaveMethod;
+        use crate::spark::connect::write_operation::{BucketBy, SaveMode, SaveTable, SaveType};
+
+        let WriteOperation {
+            input,
+            source,
+            mode,
+            sort_column_names,
+            partitioning_columns,
+            bucket_by,
+            options,
+            save_type,
+        } = write;
+        let input = input.required("input")?.try_into()?;
+        let mode = match SaveMode::try_from(mode).required("save mode")? {
+            SaveMode::Unspecified => spec::SaveMode::ErrorIfExists,
+            SaveMode::Append => spec::SaveMode::Append,
+            SaveMode::Overwrite => spec::SaveMode::Overwrite,
+            SaveMode::ErrorIfExists => spec::SaveMode::ErrorIfExists,
+            SaveMode::Ignore => spec::SaveMode::Ignore,
+        };
+        let sort_columns = sort_column_names.into_iter().map(|x| x.into()).collect();
+        let partitioning_columns = partitioning_columns.into_iter().map(|x| x.into()).collect();
+        let bucket_by = match bucket_by {
+            Some(x) => {
+                let BucketBy {
+                    bucket_column_names,
+                    num_buckets,
+                } = x;
+                let bucket_column_names =
+                    bucket_column_names.into_iter().map(|x| x.into()).collect();
+                let num_buckets = usize::try_from(num_buckets).required("bucket num buckets")?;
+                Some(spec::SaveBucketBy {
+                    bucket_column_names,
+                    num_buckets,
+                })
+            }
+            None => None,
+        };
+        let options = options.into_iter().collect();
+        let save_type = match save_type.required("save type")? {
+            SaveType::Path(x) => spec::SaveType::Path(x),
+            SaveType::Table(table) => {
+                let SaveTable {
+                    table_name,
+                    save_method,
+                } = table;
+                let table = parse_object_name(table_name.as_str())?;
+                let save_method = TableSaveMethod::try_from(save_method).required("save method")?;
+                let save_method = match save_method {
+                    TableSaveMethod::Unspecified => {
+                        return Err(SparkError::invalid("unspecified save method"))
+                    }
+                    TableSaveMethod::SaveAsTable => spec::TableSaveMethod::SaveAsTable,
+                    TableSaveMethod::InsertInto => spec::TableSaveMethod::InsertInto,
+                };
+                spec::SaveType::Table { table, save_method }
+            }
+        };
+        Ok(spec::Write {
+            input: Box::new(input),
+            source,
+            save_type,
+            mode,
+            sort_columns,
+            partitioning_columns,
+            bucket_by,
+            options,
+            table_properties: vec![],
+            overwrite_condition: None,
+        })
+    }
+}
+
+impl TryFrom<WriteOperationV2> for spec::Write {
+    type Error = SparkError;
+
+    fn try_from(write: WriteOperationV2) -> SparkResult<spec::Write> {
+        use crate::spark::connect::write_operation_v2::Mode;
+
+        let WriteOperationV2 {
+            input,
+            table_name,
+            provider,
+            partitioning_columns,
+            options,
+            table_properties,
+            mode,
+            overwrite_condition,
+        } = write;
+        let input = input.required("input")?.try_into()?;
+        let table = parse_object_name(table_name.as_str())?;
+        let partitioning_columns = partitioning_columns
+            .into_iter()
+            .map(|x| {
+                let expr: spec::Expr = x.try_into()?;
+                match expr {
+                    spec::Expr::UnresolvedAttribute { name, plan_id: _ } => {
+                        let mut name: Vec<String> = name.into();
+                        if name.len() > 1 {
+                            return Err(SparkError::invalid("multiple partitioning column"));
+                        }
+                        let name = name.pop().required("partitioning column")?;
+                        Ok(name.into())
+                    }
+                    _ => Err(SparkError::invalid("partitioning column")),
+                }
+            })
+            .collect::<SparkResult<_>>()?;
+        let options = options.into_iter().collect();
+        let table_properties = table_properties.into_iter().collect();
+        let mode = match Mode::try_from(mode).required("write operation v2 mode")? {
+            Mode::Unspecified => spec::SaveMode::ErrorIfExists,
+            Mode::Create => spec::SaveMode::Create,
+            Mode::Overwrite => spec::SaveMode::Overwrite,
+            Mode::OverwritePartitions => spec::SaveMode::OverwritePartitions,
+            Mode::Append => spec::SaveMode::Append,
+            Mode::Replace => spec::SaveMode::Replace,
+            Mode::CreateOrReplace => spec::SaveMode::CreateOrReplace,
+        };
+        let overwrite_condition = overwrite_condition.map(|x| x.try_into()).transpose()?;
+        Ok(spec::Write {
+            input: Box::new(input),
+            source: provider,
+            save_type: spec::SaveType::Table {
+                table,
+                save_method: spec::TableSaveMethod::SaveAsTable,
+            },
+            mode,
+            sort_columns: vec![],
+            partitioning_columns,
+            bucket_by: None,
+            options,
+            table_properties,
+            overwrite_condition,
+        })
     }
 }
 

--- a/crates/sail-spark-connect/src/server.rs
+++ b/crates/sail-spark-connect/src/server.rs
@@ -92,23 +92,30 @@ impl SparkConnectService for SparkConnectServer {
                             .await?
                     }
                     CommandType::WriteOperationV2(write) => {
-                        service::handle_execute_write_operation_v2(session, write).await?
+                        service::handle_execute_write_operation_v2(session, write, metadata).await?
                     }
                     CommandType::SqlCommand(sql) => {
                         service::handle_execute_sql_command(session, sql, metadata).await?
                     }
                     CommandType::WriteStreamOperationStart(start) => {
-                        service::handle_execute_write_stream_operation_start(session, start).await?
+                        service::handle_execute_write_stream_operation_start(
+                            session, start, metadata,
+                        )
+                        .await?
                     }
                     CommandType::StreamingQueryCommand(stream) => {
-                        service::handle_execute_streaming_query_command(session, stream).await?
+                        service::handle_execute_streaming_query_command(session, stream, metadata)
+                            .await?
                     }
                     CommandType::GetResourcesCommand(resource) => {
-                        service::handle_execute_get_resources_command(session, resource).await?
+                        service::handle_execute_get_resources_command(session, resource, metadata)
+                            .await?
                     }
                     CommandType::StreamingQueryManagerCommand(manager) => {
-                        service::handle_execute_streaming_query_manager_command(session, manager)
-                            .await?
+                        service::handle_execute_streaming_query_manager_command(
+                            session, manager, metadata,
+                        )
+                        .await?
                     }
                     CommandType::RegisterTableFunction(udtf) => {
                         service::handle_execute_register_table_function(session, udtf, metadata)

--- a/crates/sail-spark-connect/src/service/plan_analyzer.rs
+++ b/crates/sail-spark-connect/src/service/plan_analyzer.rs
@@ -7,7 +7,7 @@ use sail_plan::resolver::plan::NamedPlan;
 use sail_plan::resolver::PlanResolver;
 
 use crate::error::{ProtoFieldExt, SparkError, SparkResult};
-use crate::executor::{execute_plan, read_stream};
+use crate::executor::read_stream;
 use crate::proto::data_type::parse_spark_data_type;
 use crate::schema::{to_spark_schema, to_tree_string};
 use crate::session::Session;
@@ -69,10 +69,7 @@ pub(crate) async fn handle_analyze_explain(
         mode: explain_mode.try_into()?,
         input: Box::new(plan.try_into()?),
     }));
-    let ctx = session.context();
-    let resolver = PlanResolver::new(ctx, session.plan_config()?);
-    let explain = resolver.resolve_named_plan(explain).await?;
-    let stream = execute_plan(ctx, explain).await?;
+    let stream = session.execute_plan(explain).await?;
     let batches = read_stream(stream).await?;
     Ok(ExplainResponse {
         // FIXME: The explain output should not be formatted as a table.

--- a/crates/sail-spark-connect/src/service/plan_executor.rs
+++ b/crates/sail-spark-connect/src/service/plan_executor.rs
@@ -3,27 +3,12 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use arrow::compute::concat_batches;
-use datafusion::arrow::datatypes::{
-    DataType as ArrowDataType, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef,
-};
 use datafusion::common::TableReference;
-use datafusion::dataframe::DataFrame;
-use datafusion::datasource::file_format::arrow::ArrowFormatFactory;
-use datafusion::datasource::file_format::avro::AvroFormatFactory;
-use datafusion::datasource::file_format::csv::CsvFormatFactory;
-use datafusion::datasource::file_format::json::JsonFormatFactory;
-use datafusion::datasource::file_format::parquet::ParquetFormatFactory;
-use datafusion::datasource::file_format::{format_as_file_type, FileFormatFactory};
-use datafusion::logical_expr::LogicalPlanBuilder;
-use datafusion_common::config::{ConfigFileType, TableOptions};
-use datafusion_expr::ScalarUDF;
 use sail_common::spec;
 use sail_common::utils::rename_logical_plan;
 use sail_plan::extension::source::temporary_table::TemporaryTableProvider;
 use sail_plan::resolver::plan::NamedPlan;
 use sail_plan::resolver::PlanResolver;
-use sail_python_udf::udf::pyspark_udtf::PySparkUDTF;
-use sail_python_udf::udf::unresolved_pyspark_udf::UnresolvedPySparkUDF;
 use tonic::codegen::tokio_stream::wrappers::ReceiverStream;
 use tonic::codegen::tokio_stream::Stream;
 use tonic::Status;
@@ -31,16 +16,13 @@ use tracing::debug;
 
 use crate::error::{ProtoFieldExt, SparkError, SparkResult};
 use crate::executor::{
-    execute_plan, read_stream, to_arrow_batch, Executor, ExecutorBatch, ExecutorMetadata,
-    ExecutorOutput,
+    read_stream, to_arrow_batch, Executor, ExecutorBatch, ExecutorMetadata, ExecutorOutput,
 };
 use crate::session::Session;
 use crate::spark::connect as sc;
 use crate::spark::connect::execute_plan_response::{
     ResponseType, ResultComplete, SqlCommandResult,
 };
-use crate::spark::connect::write_operation::save_table::TableSaveMethod;
-use crate::spark::connect::write_operation::{SaveMode, SaveType};
 use crate::spark::connect::{
     relation, CommonInlineUserDefinedFunction as SCCommonInlineUserDefinedFunction,
     CommonInlineUserDefinedTableFunction as SCCommonInlineUserDefinedTableFunction,
@@ -114,19 +96,43 @@ impl Stream for ExecutePlanResponseStream {
     }
 }
 
+enum ExecutePlanMode {
+    /// Execute the plan lazily as the client reads the response stream.
+    Lazy,
+    /// Execute the plan eagerly and return an empty response stream.
+    /// This is useful for executing command plans.
+    EagerSilent,
+}
+
 async fn handle_execute_plan(
     session: Arc<Session>,
-    plan: NamedPlan,
+    plan: spec::Plan,
     metadata: ExecutorMetadata,
+    mode: ExecutePlanMode,
 ) -> SparkResult<ExecutePlanResponseStream> {
-    let ctx = session.context();
     let operation_id = metadata.operation_id.clone();
-    let stream = execute_plan(ctx, plan).await?;
-    let executor = Executor::new(metadata, stream);
-    let rx = executor.start()?;
-    session.add_executor(executor)?;
-    let session_id = session.session_id().to_string();
-    Ok(ExecutePlanResponseStream::new(session_id, operation_id, rx))
+    let stream = session.execute_plan(plan).await?;
+    let rx = match mode {
+        ExecutePlanMode::Lazy => {
+            let executor = Executor::new(metadata, stream);
+            let rx = executor.start()?;
+            session.add_executor(executor)?;
+            rx
+        }
+        ExecutePlanMode::EagerSilent => {
+            let _ = read_stream(stream).await?;
+            let (tx, rx) = tokio::sync::mpsc::channel(1);
+            if metadata.reattachable {
+                tx.send(ExecutorOutput::complete()).await?;
+            }
+            ReceiverStream::new(rx)
+        }
+    };
+    Ok(ExecutePlanResponseStream::new(
+        session.session_id().to_string(),
+        operation_id,
+        rx,
+    ))
 }
 
 pub(crate) async fn handle_execute_relation(
@@ -134,10 +140,8 @@ pub(crate) async fn handle_execute_relation(
     relation: Relation,
     metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
-    let ctx = session.context();
-    let resolver = PlanResolver::new(ctx, session.plan_config()?);
-    let plan = resolver.resolve_named_plan(relation.try_into()?).await?;
-    handle_execute_plan(session, plan, metadata).await
+    let plan = relation.try_into()?;
+    handle_execute_plan(session, plan, metadata, ExecutePlanMode::Lazy).await
 }
 
 pub(crate) async fn handle_execute_register_function(
@@ -145,51 +149,10 @@ pub(crate) async fn handle_execute_register_function(
     udf: SCCommonInlineUserDefinedFunction,
     metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
-    // TODO: Call PlanNode::RegisterFunction even though SC implementation registers it directly.
-    let ctx = session.context();
-    let resolver = PlanResolver::new(ctx, session.plan_config()?);
-
-    let udf: spec::CommonInlineUserDefinedFunction = udf.try_into()?;
-    let spec::CommonInlineUserDefinedFunction {
-        function_name,
-        deterministic,
-        arguments: _,
-        function,
-    } = udf;
-    let function_name: &str = function_name.as_str();
-
-    let (output_type, _eval_type, _command, _python_version) = match &function {
-        spec::FunctionDefinition::PythonUdf {
-            output_type,
-            eval_type,
-            command,
-            python_version,
-        } => (output_type, eval_type, command, python_version),
-        _ => {
-            return Err(SparkError::invalid("UDF function type must be Python UDF"));
-        }
-    };
-    let output_type: ArrowDataType = resolver.resolve_data_type(output_type.clone())?;
-
-    let python_udf: UnresolvedPySparkUDF = UnresolvedPySparkUDF::new(
-        function_name.to_owned(),
-        function,
-        output_type,
-        deterministic,
-    );
-
-    let scalar_udf = ScalarUDF::from(python_udf);
-    ctx.register_udf(scalar_udf);
-
-    let (tx, rx) = tokio::sync::mpsc::channel(1);
-    if metadata.reattachable {
-        tx.send(ExecutorOutput::complete()).await?;
-    }
-    Ok(ExecutePlanResponseStream::new(
-        session.session_id().to_string(),
-        metadata.operation_id,
-        ReceiverStream::new(rx),
-    ))
+    let plan = spec::Plan::Command(spec::CommandPlan::new(spec::CommandNode::RegisterFunction(
+        udf.try_into()?,
+    )));
+    handle_execute_plan(session, plan, metadata, ExecutePlanMode::EagerSilent).await
 }
 
 pub(crate) async fn handle_execute_write_operation(
@@ -197,106 +160,10 @@ pub(crate) async fn handle_execute_write_operation(
     write: WriteOperation,
     metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
-    // TODO: Move to resolver
-    let relation = write.input.required("input")?;
-    let ctx = session.context();
-    let save_mode = SaveMode::try_from(write.mode).required("save mode")?;
-    if !write.sort_column_names.is_empty() {
-        return Err(SparkError::unsupported("sort column names"));
-    }
-    if !write.partitioning_columns.is_empty() {
-        return Err(SparkError::unsupported("partitioning columns"));
-    }
-    if write.bucket_by.is_some() {
-        return Err(SparkError::unsupported("bucketing"));
-    }
-
-    let mut table_options = TableOptions::default_from_session_config(ctx.state().config_options());
-    let resolver = PlanResolver::new(ctx, session.plan_config()?);
-    let NamedPlan { plan, fields } = resolver.resolve_named_plan(relation.try_into()?).await?;
-    let plan = if let Some(fields) = fields {
-        rename_logical_plan(plan, &fields)?
-    } else {
-        plan
-    };
-    let plan = match write.save_type.required("save type")? {
-        SaveType::Path(path) => {
-            // always write multi-file output
-            let path = if path.ends_with('/') {
-                path
-            } else {
-                format!("{}/", path)
-            };
-            let source = write.source.required("source")?;
-            // FIXME: option compatibility
-            let format_factory: Arc<dyn FileFormatFactory> = match source.as_str() {
-                "json" => {
-                    table_options.set_config_format(ConfigFileType::JSON);
-                    table_options.alter_with_string_hash_map(&write.options)?;
-                    Arc::new(JsonFormatFactory::new_with_options(table_options.json))
-                }
-                "parquet" => {
-                    table_options.set_config_format(ConfigFileType::PARQUET);
-                    table_options.alter_with_string_hash_map(&write.options)?;
-                    Arc::new(ParquetFormatFactory::new_with_options(
-                        table_options.parquet,
-                    ))
-                }
-                "csv" => {
-                    table_options.set_config_format(ConfigFileType::CSV);
-                    table_options.alter_with_string_hash_map(&write.options)?;
-                    Arc::new(CsvFormatFactory::new_with_options(table_options.csv))
-                }
-                "arrow" => Arc::new(ArrowFormatFactory::new()),
-                "avro" => Arc::new(AvroFormatFactory::new()),
-                _ => {
-                    return Err(SparkError::invalid(format!(
-                        "unsupported source: {}",
-                        source
-                    )))
-                }
-            };
-            LogicalPlanBuilder::copy_to(
-                plan,
-                path,
-                format_as_file_type(format_factory),
-                write.options,
-                write.partitioning_columns,
-            )
-            .map_err(SparkError::from)?
-            .build()
-            .map_err(SparkError::from)?
-        }
-        SaveType::Table(save) => {
-            let table_name = save.table_name.as_str();
-            let table_ref = TableReference::from(table_name.to_string());
-            let save_method =
-                TableSaveMethod::try_from(save.save_method).required("save method")?;
-            let df = DataFrame::new(ctx.state(), plan.clone());
-
-            match save_method {
-                TableSaveMethod::SaveAsTable => {
-                    ctx.register_table(table_ref, df.into_view())?;
-                    plan
-                }
-                TableSaveMethod::InsertInto => {
-                    let arrow_schema = ArrowSchema::from(df.schema());
-                    let overwrite = save_mode == SaveMode::Overwrite;
-                    LogicalPlanBuilder::insert_into(plan, table_ref, &arrow_schema, overwrite)
-                        .map_err(SparkError::from)?
-                        .build()
-                        .map_err(SparkError::from)?
-                }
-                _ => {
-                    return Err(SparkError::invalid(format!(
-                        "WriteOperation:SaveTable:TableSaveMethod not supported: {}",
-                        save_method.as_str_name()
-                    )))
-                }
-            }
-        }
-    };
-    handle_execute_plan(session, NamedPlan { plan, fields: None }, metadata).await
+    let plan = spec::Plan::Command(spec::CommandPlan::new(spec::CommandNode::Write(
+        write.try_into()?,
+    )));
+    handle_execute_plan(session, plan, metadata, ExecutePlanMode::EagerSilent).await
 }
 
 pub(crate) async fn handle_execute_create_dataframe_view(
@@ -331,10 +198,14 @@ pub(crate) async fn handle_execute_create_dataframe_view(
 }
 
 pub(crate) async fn handle_execute_write_operation_v2(
-    _session: Arc<Session>,
-    _write: WriteOperationV2,
+    session: Arc<Session>,
+    write: WriteOperationV2,
+    metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
-    Err(SparkError::todo("write operation v2"))
+    let plan = spec::Plan::Command(spec::CommandPlan::new(spec::CommandNode::Write(
+        write.try_into()?,
+    )));
+    handle_execute_plan(session, plan, metadata, ExecutePlanMode::EagerSilent).await
 }
 
 pub(crate) async fn handle_execute_sql_command(
@@ -354,10 +225,7 @@ pub(crate) async fn handle_execute_sql_command(
     let relation = match plan {
         spec::Plan::Query(_) => relation,
         command @ spec::Plan::Command(_) => {
-            let ctx = session.context();
-            let resolver = PlanResolver::new(ctx, session.plan_config()?);
-            let plan = resolver.resolve_named_plan(command).await?;
-            let stream = execute_plan(ctx, plan).await?;
+            let stream = session.execute_plan(command).await?;
             let schema = stream.schema();
             let data = read_stream(stream).await?;
             let data = concat_batches(&schema, data.iter())?;
@@ -388,6 +256,7 @@ pub(crate) async fn handle_execute_sql_command(
 pub(crate) async fn handle_execute_write_stream_operation_start(
     _session: Arc<Session>,
     _start: WriteStreamOperationStart,
+    _metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
     Err(SparkError::todo("write stream operation start"))
 }
@@ -395,6 +264,7 @@ pub(crate) async fn handle_execute_write_stream_operation_start(
 pub(crate) async fn handle_execute_streaming_query_command(
     _session: Arc<Session>,
     _stream: StreamingQueryCommand,
+    _metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
     Err(SparkError::todo("streaming query command"))
 }
@@ -402,6 +272,7 @@ pub(crate) async fn handle_execute_streaming_query_command(
 pub(crate) async fn handle_execute_get_resources_command(
     _session: Arc<Session>,
     _resource: GetResourcesCommand,
+    _metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
     Err(SparkError::todo("get resources command"))
 }
@@ -409,6 +280,7 @@ pub(crate) async fn handle_execute_get_resources_command(
 pub(crate) async fn handle_execute_streaming_query_manager_command(
     _session: Arc<Session>,
     _manager: StreamingQueryManagerCommand,
+    _metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
     Err(SparkError::todo("streaming query manager command"))
 }
@@ -418,58 +290,10 @@ pub(crate) async fn handle_execute_register_table_function(
     udtf: SCCommonInlineUserDefinedTableFunction,
     metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
-    // TODO: Call PlanNode::RegisterTableFunction even though SC implementation registers it directly.
-    let ctx = session.context();
-    let resolver = PlanResolver::new(ctx, session.plan_config()?);
-
-    let udtf: spec::CommonInlineUserDefinedTableFunction = udtf.try_into()?;
-    let spec::CommonInlineUserDefinedTableFunction {
-        function_name,
-        deterministic,
-        arguments: _,
-        function,
-    } = udtf;
-
-    let (return_type, _eval_type, _command, _python_version) = match &function {
-        spec::TableFunctionDefinition::PythonUdtf {
-            return_type,
-            eval_type,
-            command,
-            python_version,
-        } => (return_type, eval_type, command, python_version),
-    };
-
-    let return_type: ArrowDataType = resolver.resolve_data_type(return_type.clone())?;
-    let return_schema: ArrowSchemaRef = match return_type {
-        ArrowDataType::Struct(ref fields) => {
-            Arc::new(ArrowSchema::new(fields.clone()))
-        },
-        _ => {
-            return Err(SparkError::invalid(format!(
-                "Invalid Python user-defined table function return type. Expect a struct type, but got {}",
-                return_type
-            )))
-        }
-    };
-
-    let python_udtf: PySparkUDTF = PySparkUDTF::new(
-        return_type,
-        return_schema,
-        function,
-        session.plan_config()?.spark_udf_config.clone(),
-        deterministic,
-    );
-    ctx.register_udtf(&function_name, Arc::new(python_udtf));
-
-    let (tx, rx) = tokio::sync::mpsc::channel(1);
-    if metadata.reattachable {
-        tx.send(ExecutorOutput::complete()).await?;
-    }
-    Ok(ExecutePlanResponseStream::new(
-        session.session_id().to_string(),
-        metadata.operation_id,
-        ReceiverStream::new(rx),
-    ))
+    let plan = spec::Plan::Command(spec::CommandPlan::new(
+        spec::CommandNode::RegisterTableFunction(udtf.try_into()?),
+    ));
+    handle_execute_plan(session, plan, metadata, ExecutePlanMode::EagerSilent).await
 }
 
 pub(crate) async fn handle_interrupt_all(session: Arc<Session>) -> SparkResult<Vec<String>> {
@@ -523,8 +347,11 @@ pub(crate) async fn handle_reattach_execute(
     executor.pause_if_running().await?;
     executor.release(response_id)?;
     let rx = executor.start()?;
-    let session_id = session.session_id().to_string();
-    Ok(ExecutePlanResponseStream::new(session_id, operation_id, rx))
+    Ok(ExecutePlanResponseStream::new(
+        session.session_id().to_string(),
+        operation_id,
+        rx,
+    ))
 }
 
 pub(crate) async fn handle_release_execute(

--- a/crates/sail-spark-connect/tests/gold_data/data_type.json
+++ b/crates/sail-spark-connect/tests/gold_data/data_type.json
@@ -20,7 +20,7 @@
                           }
                         },
                         "nullable": true,
-                        "metadata": {}
+                        "metadata": []
                       },
                       {
                         "name": "anotherDecimal",
@@ -31,13 +31,13 @@
                           }
                         },
                         "nullable": true,
-                        "metadata": {}
+                        "metadata": []
                       }
                     ]
                   }
                 },
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               },
               {
                 "name": "MAP",
@@ -53,7 +53,7 @@
                   }
                 },
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               },
               {
                 "name": "arrAy",
@@ -64,7 +64,7 @@
                   }
                 },
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               },
               {
                 "name": "anotherArray",
@@ -79,7 +79,7 @@
                   }
                 },
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               }
             ]
           }
@@ -200,7 +200,7 @@
                     "name": "varchar",
                     "dataType": "string",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   }
                 ]
               }
@@ -237,13 +237,13 @@
                 "name": "TABLE",
                 "dataType": "string",
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               },
               {
                 "name": "DATE",
                 "dataType": "boolean",
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               }
             ]
           }
@@ -260,13 +260,13 @@
                 "name": "int",
                 "dataType": "integer",
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               },
               {
                 "name": "timestamp",
                 "dataType": "timestamp",
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               }
             ]
           }
@@ -283,15 +283,18 @@
                 "name": "x",
                 "dataType": "integer",
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               },
               {
                 "name": "y",
                 "dataType": "string",
                 "nullable": true,
-                "metadata": {
-                  "comment": "test"
-                }
+                "metadata": [
+                  [
+                    "comment",
+                    "test"
+                  ]
+                ]
               }
             ]
           }
@@ -321,7 +324,7 @@
                     "name": "tinYint",
                     "dataType": "byte",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   }
                 ]
               }
@@ -454,13 +457,13 @@
                 "name": "x+y",
                 "dataType": "integer",
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               },
               {
                 "name": "!@#$%^&*()",
                 "dataType": "string",
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               },
               {
                 "name": "1_2.345<>:\"",
@@ -470,7 +473,7 @@
                   }
                 },
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               }
             ]
           }
@@ -487,19 +490,19 @@
                 "name": "end",
                 "dataType": "long",
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               },
               {
                 "name": "select",
                 "dataType": "integer",
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               },
               {
                 "name": "from",
                 "dataType": "string",
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               }
             ]
           }
@@ -516,13 +519,13 @@
                 "name": "intType",
                 "dataType": "integer",
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               },
               {
                 "name": "ts",
                 "dataType": "timestamp",
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               }
             ]
           }
@@ -539,13 +542,13 @@
                 "name": "x",
                 "dataType": "integer",
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               },
               {
                 "name": "y",
                 "dataType": "string",
                 "nullable": true,
-                "metadata": {}
+                "metadata": []
               }
             ]
           }

--- a/crates/sail-spark-connect/tests/gold_data/plan/ddl_create_table.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/ddl_create_table.json
@@ -212,13 +212,13 @@
                     "name": "a",
                     "dataType": "integer",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   },
                   {
                     "name": "b",
                     "dataType": "string",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   }
                 ]
               },
@@ -283,7 +283,7 @@
                     "name": "id",
                     "dataType": "long",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   }
                 ]
               },
@@ -348,7 +348,7 @@
                     "name": "id",
                     "dataType": "long",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   }
                 ]
               },
@@ -396,7 +396,7 @@
                     "name": "id",
                     "dataType": "long",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   }
                 ]
               },
@@ -527,13 +527,13 @@
                     "name": "a",
                     "dataType": "integer",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   },
                   {
                     "name": "b",
                     "dataType": "integer",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   }
                 ]
               },
@@ -579,13 +579,13 @@
                     "name": "a",
                     "dataType": "integer",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   },
                   {
                     "name": "b",
                     "dataType": "integer",
                     "nullable": false,
-                    "metadata": {}
+                    "metadata": []
                   }
                 ]
               },
@@ -632,13 +632,13 @@
                     "name": "a",
                     "dataType": "integer",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   },
                   {
                     "name": "b",
                     "dataType": "string",
                     "nullable": false,
-                    "metadata": {}
+                    "metadata": []
                   }
                 ]
               },
@@ -686,13 +686,13 @@
                     "name": "a",
                     "dataType": "integer",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   },
                   {
                     "name": "b",
                     "dataType": "string",
                     "nullable": false,
-                    "metadata": {}
+                    "metadata": []
                   }
                 ]
               },
@@ -741,13 +741,13 @@
                     "name": "a",
                     "dataType": "integer",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   },
                   {
                     "name": "b",
                     "dataType": "string",
                     "nullable": false,
-                    "metadata": {}
+                    "metadata": []
                   }
                 ]
               },
@@ -795,13 +795,13 @@
                     "name": "a",
                     "dataType": "integer",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   },
                   {
                     "name": "b",
                     "dataType": "string",
                     "nullable": false,
-                    "metadata": {}
+                    "metadata": []
                   }
                 ]
               },
@@ -918,13 +918,13 @@
                     "name": "a",
                     "dataType": "integer",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   },
                   {
                     "name": "b",
                     "dataType": "string",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   }
                 ]
               },
@@ -963,13 +963,13 @@
                     "name": "a",
                     "dataType": "integer",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   },
                   {
                     "name": "b",
                     "dataType": "string",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   }
                 ]
               },
@@ -1008,13 +1008,13 @@
                     "name": "a",
                     "dataType": "integer",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   },
                   {
                     "name": "b",
                     "dataType": "string",
                     "nullable": true,
-                    "metadata": {}
+                    "metadata": []
                   }
                 ]
               },

--- a/crates/sail-spark-connect/tests/gold_data/table_schema.json
+++ b/crates/sail-spark-connect/tests/gold_data/table_schema.json
@@ -18,7 +18,7 @@
               "name": "A",
               "dataType": "integer",
               "nullable": true,
-              "metadata": {}
+              "metadata": []
             }
           ]
         }
@@ -33,7 +33,7 @@
               "name": "!@#$%.^&*()",
               "dataType": "string",
               "nullable": true,
-              "metadata": {}
+              "metadata": []
             }
           ]
         }
@@ -55,7 +55,7 @@
               "name": "a",
               "dataType": "integer",
               "nullable": true,
-              "metadata": {}
+              "metadata": []
             }
           ]
         }
@@ -103,19 +103,19 @@
                       "name": "intType",
                       "dataType": "integer",
                       "nullable": true,
-                      "metadata": {}
+                      "metadata": []
                     },
                     {
                       "name": "ts",
                       "dataType": "timestamp",
                       "nullable": true,
-                      "metadata": {}
+                      "metadata": []
                     }
                   ]
                 }
               },
               "nullable": true,
-              "metadata": {}
+              "metadata": []
             }
           ]
         }
@@ -130,9 +130,12 @@
               "name": "a",
               "dataType": "integer",
               "nullable": true,
-              "metadata": {
-                "comment": "test"
-              }
+              "metadata": [
+                [
+                  "comment",
+                  "test"
+                ]
+              ]
             }
           ]
         }
@@ -147,13 +150,13 @@
               "name": "a",
               "dataType": "integer",
               "nullable": true,
-              "metadata": {}
+              "metadata": []
             },
             {
               "name": "b",
               "dataType": "long",
               "nullable": true,
-              "metadata": {}
+              "metadata": []
             }
           ]
         }
@@ -183,7 +186,7 @@
                                 }
                               },
                               "nullable": true,
-                              "metadata": {}
+                              "metadata": []
                             },
                             {
                               "name": "anotherDecimal",
@@ -194,13 +197,13 @@
                                 }
                               },
                               "nullable": true,
-                              "metadata": {}
+                              "metadata": []
                             }
                           ]
                         }
                       },
                       "nullable": true,
-                      "metadata": {}
+                      "metadata": []
                     },
                     {
                       "name": "MAP",
@@ -216,7 +219,7 @@
                         }
                       },
                       "nullable": true,
-                      "metadata": {}
+                      "metadata": []
                     },
                     {
                       "name": "arrAy",
@@ -227,7 +230,7 @@
                         }
                       },
                       "nullable": true,
-                      "metadata": {}
+                      "metadata": []
                     },
                     {
                       "name": "anotherArray",
@@ -242,13 +245,13 @@
                         }
                       },
                       "nullable": true,
-                      "metadata": {}
+                      "metadata": []
                     }
                   ]
                 }
               },
               "nullable": true,
-              "metadata": {}
+              "metadata": []
             }
           ]
         }

--- a/crates/sail-sql/src/data_type.rs
+++ b/crates/sail-sql/src/data_type.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use sail_common::spec;
 use sqlparser::ast;
 use sqlparser::ast::DateTimeField;
@@ -200,9 +198,9 @@ pub fn from_ast_data_type(sql_type: &ast::DataType) -> SqlResult<spec::DataType>
                         None => return Err(SqlError::invalid("missing field name")),
                     };
                     let data_type = from_ast_data_type(&f.field_type)?;
-                    let mut metadata = HashMap::new();
+                    let mut metadata = vec![];
                     if let Some(comment) = &f.comment {
-                        metadata.insert("comment".to_string(), comment.clone());
+                        metadata.push(("comment".to_string(), comment.clone()));
                     };
                     Ok(spec::Field {
                         name,

--- a/crates/sail-sql/src/utils.rs
+++ b/crates/sail-sql/src/utils.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use sail_common::spec;
 use sqlparser::ast;
 
@@ -51,7 +49,7 @@ pub fn build_schema_from_columns(columns: Vec<ast::ColumnDef>) -> SqlResult<spec
             name: normalize_ident(column.name),
             data_type: from_ast_data_type(&column.data_type)?,
             nullable: !not_nullable,
-            metadata: HashMap::new(),
+            metadata: vec![],
         };
         fields.push(field);
     }


### PR DESCRIPTION
1. Move the logic of a few Spark Connect operations to the plan resolver.
2. Fix the `datafusion-functions-nested` dependency.
3. Update the type of `metadata` in the plan specification.