### PR TITLE
Refactor PySpark UDF eval type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,6 +2585,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "object"
 version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,6 +3034,15 @@ checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
  "syn 2.0.77",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -3537,6 +3567,7 @@ dependencies = [
  "datafusion-expr",
  "glob",
  "lexical-core",
+ "num_enum",
  "pyo3",
  "ryu",
  "serde",
@@ -4287,6 +4318,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.22.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+dependencies = [
+ "indexmap 2.4.0",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tonic"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4931,6 +4979,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ lexical-core = { version = "0.8.5", default-features = false, features = ["write
 aws-config = "1.5.5"
 aws-credential-types = "1.2.1"
 clap = { version = "4.5.16", features = ["derive"] }
+num_enum = "0.7.3"
 
 ######
 # The versions of the following dependencies are managed manually.

--- a/crates/sail-common/Cargo.toml
+++ b/crates/sail-common/Cargo.toml
@@ -18,3 +18,4 @@ arrow-schema = { workspace = true }
 glob = { workspace = true }
 pyo3 = { workspace = true }
 lexical-core = { workspace = true }
+num_enum = { workspace = true }

--- a/crates/sail-common/src/spec/data_type.rs
+++ b/crates/sail-common/src/spec/data_type.rs
@@ -1,6 +1,7 @@
+use num_enum::TryFromPrimitive;
 use serde::{Deserialize, Serialize};
 
-use crate::error::{CommonError, CommonResult};
+use crate::error::CommonError;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
@@ -110,8 +111,22 @@ impl From<Vec<Field>> for Fields {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    Hash,
+    TryFromPrimitive,
+)]
 #[serde(rename_all = "camelCase")]
+#[num_enum(error_type(name = CommonError, constructor = DayTimeIntervalField::invalid))]
+#[repr(i32)]
 pub enum DayTimeIntervalField {
     Day = 0,
     Hour = 1,
@@ -119,42 +134,36 @@ pub enum DayTimeIntervalField {
     Second = 3,
 }
 
-impl TryFrom<i32> for DayTimeIntervalField {
-    type Error = CommonError;
-
-    fn try_from(value: i32) -> CommonResult<Self> {
-        match value {
-            0 => Ok(DayTimeIntervalField::Day),
-            1 => Ok(DayTimeIntervalField::Hour),
-            2 => Ok(DayTimeIntervalField::Minute),
-            3 => Ok(DayTimeIntervalField::Second),
-            _ => Err(CommonError::invalid(format!(
-                "day time interval field: {}",
-                value
-            ))),
-        }
+impl DayTimeIntervalField {
+    fn invalid(value: i32) -> CommonError {
+        CommonError::invalid(format!("day time interval field: {}", value))
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize,
+    Hash,
+    TryFromPrimitive,
+)]
 #[serde(rename_all = "camelCase")]
+#[num_enum(error_type(name = CommonError, constructor = YearMonthIntervalField::invalid))]
+#[repr(i32)]
 pub enum YearMonthIntervalField {
     Year = 0,
     Month = 1,
 }
 
-impl TryFrom<i32> for YearMonthIntervalField {
-    type Error = CommonError;
-
-    fn try_from(value: i32) -> CommonResult<Self> {
-        match value {
-            0 => Ok(YearMonthIntervalField::Year),
-            1 => Ok(YearMonthIntervalField::Month),
-            _ => Err(CommonError::invalid(format!(
-                "year month interval field: {}",
-                value
-            ))),
-        }
+impl YearMonthIntervalField {
+    fn invalid(value: i32) -> CommonError {
+        CommonError::invalid(format!("year month interval field: {}", value))
     }
 }
 

--- a/crates/sail-plan/src/resolver/expression.rs
+++ b/crates/sail-plan/src/resolver/expression.rs
@@ -685,8 +685,8 @@ impl PlanResolver<'_> {
                 let python_function: PySparkUdfObject = deserialize_partial_pyspark_udf(
                     python_version,
                     command,
-                    eval_type,
-                    &(arguments.len() as i32),
+                    *eval_type,
+                    arguments.len(),
                     &self.config.spark_udf_config,
                 )
                 .map_err(|e| {
@@ -970,8 +970,8 @@ impl PlanResolver<'_> {
         let python_function: PySparkUdfObject = deserialize_partial_pyspark_udf(
             &python_version,
             &command,
-            &eval_type,
-            &(arguments.len() as i32),
+            eval_type,
+            arguments.len(),
             &self.config.spark_udf_config,
         )
         .map_err(|e| PlanError::invalid(format!("Python UDF deserialization error: {:?}", e)))?;

--- a/crates/sail-python-udf/src/cereal/mod.rs
+++ b/crates/sail-python-udf/src/cereal/mod.rs
@@ -8,35 +8,3 @@ pub trait PythonFunction: Sized {
     fn load(v: &[u8]) -> Result<Self>;
     fn function<'py>(&self, py: Python<'py>) -> Result<Bound<'py, PyAny>>;
 }
-
-pub const PY_SPARK_NON_UDF: i32 = 0;
-pub const PY_SPARK_SQL_BATCHED_UDF: i32 = 100;
-pub const PY_SPARK_SQL_ARROW_BATCHED_UDF: i32 = 101;
-pub const PY_SPARK_SQL_SCALAR_PANDAS_UDF: i32 = 200;
-pub const PY_SPARK_SQL_GROUPED_MAP_PANDAS_UDF: i32 = 201;
-pub const PY_SPARK_SQL_GROUPED_AGG_PANDAS_UDF: i32 = 202;
-pub const PY_SPARK_SQL_WINDOW_AGG_PANDAS_UDF: i32 = 203;
-pub const PY_SPARK_SQL_SCALAR_PANDAS_ITER_UDF: i32 = 204;
-pub const PY_SPARK_SQL_MAP_PANDAS_ITER_UDF: i32 = 205;
-pub const PY_SPARK_SQL_COGROUPED_MAP_PANDAS_UDF: i32 = 206;
-pub const PY_SPARK_SQL_MAP_ARROW_ITER_UDF: i32 = 207;
-pub const PY_SPARK_SQL_GROUPED_MAP_PANDAS_UDF_WITH_STATE: i32 = 208;
-pub const PY_SPARK_SQL_TABLE_UDF: i32 = 300;
-pub const PY_SPARK_SQL_ARROW_TABLE_UDF: i32 = 301;
-
-pub fn is_pyspark_arrow_udf(udf_type: &i32) -> bool {
-    udf_type == &PY_SPARK_SQL_ARROW_BATCHED_UDF
-        || udf_type == &PY_SPARK_SQL_MAP_ARROW_ITER_UDF
-        || udf_type == &PY_SPARK_SQL_ARROW_TABLE_UDF
-}
-
-pub fn is_pyspark_pandas_udf(udf_type: &i32) -> bool {
-    udf_type == &PY_SPARK_SQL_SCALAR_PANDAS_UDF
-        || udf_type == &PY_SPARK_SQL_GROUPED_MAP_PANDAS_UDF
-        || udf_type == &PY_SPARK_SQL_GROUPED_AGG_PANDAS_UDF
-        || udf_type == &PY_SPARK_SQL_WINDOW_AGG_PANDAS_UDF
-        || udf_type == &PY_SPARK_SQL_SCALAR_PANDAS_ITER_UDF
-        || udf_type == &PY_SPARK_SQL_MAP_PANDAS_ITER_UDF
-        || udf_type == &PY_SPARK_SQL_COGROUPED_MAP_PANDAS_UDF
-        || udf_type == &PY_SPARK_SQL_GROUPED_MAP_PANDAS_UDF_WITH_STATE
-}

--- a/crates/sail-python-udf/src/cereal/pyspark_udf.rs
+++ b/crates/sail-python-udf/src/cereal/pyspark_udf.rs
@@ -4,8 +4,9 @@ use datafusion_common::{plan_datafusion_err, plan_err, DataFusionError, Result};
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
 use sail_common::config::SparkUdfConfig;
+use sail_common::spec;
 
-use crate::cereal::{is_pyspark_arrow_udf, is_pyspark_pandas_udf, PythonFunction};
+use crate::cereal::PythonFunction;
 
 #[derive(Debug, Clone)]
 pub struct PySparkUdfObject(pub PyObject);
@@ -70,8 +71,8 @@ impl Eq for PySparkUdfObject {}
 pub fn deserialize_partial_pyspark_udf(
     python_version: &str,
     command: &[u8],
-    eval_type: &i32,
-    num_args: &i32,
+    eval_type: spec::PySparkUdfType,
+    num_args: usize,
     spark_udf_config: &SparkUdfConfig,
 ) -> Result<PySparkUdfObject> {
     let pyo3_python_version: String = Python::with_gil(|py| py.version().to_string());
@@ -88,13 +89,13 @@ pub fn deserialize_partial_pyspark_udf(
 
 pub fn build_pyspark_udf_payload(
     command: &[u8],
-    eval_type: &i32,
-    num_args: &i32,
+    eval_type: spec::PySparkUdfType,
+    num_args: usize,
     spark_udf_config: &SparkUdfConfig,
 ) -> Vec<u8> {
     let mut data: Vec<u8> = Vec::new();
-    data.extend(&eval_type.to_be_bytes()); // Add eval_type for extraction in visit_bytes
-    if is_pyspark_arrow_udf(eval_type) || is_pyspark_pandas_udf(eval_type) {
+    data.extend(&i32::from(eval_type).to_be_bytes()); // Add eval_type for extraction in visit_bytes
+    if eval_type.is_arrow_udf() || eval_type.is_pandas_udf() {
         let configs = [
             &spark_udf_config.timezone,
             &spark_udf_config.pandas_window_bound_types,
@@ -118,7 +119,7 @@ pub fn build_pyspark_udf_payload(
     }
     data.extend(&1i32.to_be_bytes()); // num_udfs
     data.extend(&num_args.to_be_bytes()); // num_args
-    for index in 0..*num_args {
+    for index in 0..num_args {
         data.extend(&index.to_be_bytes()); // arg_offsets
     }
     data.extend(&1i32.to_be_bytes()); // num functions

--- a/crates/sail-python-udf/src/cereal/pyspark_udtf.rs
+++ b/crates/sail-python-udf/src/cereal/pyspark_udtf.rs
@@ -6,8 +6,9 @@ use datafusion_common::{plan_datafusion_err, plan_err, DataFusionError, Result};
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
 use sail_common::config::SparkUdfConfig;
+use sail_common::spec;
 
-use crate::cereal::{is_pyspark_arrow_udf, PythonFunction};
+use crate::cereal::PythonFunction;
 
 #[derive(Debug, Clone)]
 pub struct PySparkUdtfObject(pub PyObject);
@@ -68,8 +69,8 @@ impl Eq for PySparkUdtfObject {}
 pub fn deserialize_pyspark_udtf(
     python_version: &str,
     command: &[u8],
-    eval_type: &i32,
-    num_args: &i32,
+    eval_type: spec::PySparkUdfType,
+    num_args: usize,
     return_type: &DataType,
     spark_udf_config: &SparkUdfConfig,
 ) -> Result<PySparkUdtfObject> {
@@ -88,14 +89,14 @@ pub fn deserialize_pyspark_udtf(
 
 pub fn build_pyspark_udtf_payload(
     command: &[u8],
-    eval_type: &i32,
-    num_args: &i32,
+    eval_type: spec::PySparkUdfType,
+    num_args: usize,
     return_type: &DataType,
     spark_udf_config: &SparkUdfConfig,
 ) -> Vec<u8> {
     let mut data: Vec<u8> = Vec::new();
-    data.extend(&eval_type.to_be_bytes()); // Add eval_type for extraction in visit_bytes
-    if is_pyspark_arrow_udf(eval_type) {
+    data.extend(&i32::from(eval_type).to_be_bytes()); // Add eval_type for extraction in visit_bytes
+    if eval_type.is_arrow_udf() {
         let configs = [
             &spark_udf_config.timezone,
             &spark_udf_config.pandas_convert_to_arrow_array_safely,
@@ -115,7 +116,7 @@ pub fn build_pyspark_udtf_payload(
         data.extend(&temp_data);
     }
     data.extend(&num_args.to_be_bytes()); // num_args
-    for index in 0..*num_args {
+    for index in 0..num_args {
         data.extend(&index.to_be_bytes()); // arg_offsets
     }
     data.extend(&(command.len() as i32).to_be_bytes()); // len of the function

--- a/crates/sail-spark-connect/src/proto/expression.rs
+++ b/crates/sail-spark-connect/src/proto/expression.rs
@@ -329,7 +329,7 @@ impl TryFrom<udf::Function> for spec::FunctionDefinition {
                 let output_type = output_type.required("Python UDF output type")?;
                 Ok(spec::FunctionDefinition::PythonUdf {
                     output_type: output_type.try_into()?,
-                    eval_type,
+                    eval_type: spec::PySparkUdfType::try_from(eval_type)?,
                     command,
                     python_version: python_ver,
                 })
@@ -405,7 +405,7 @@ impl TryFrom<udtf::Function> for spec::TableFunctionDefinition {
                 let return_type = return_type.required("Python UDTF return type")?;
                 Ok(spec::TableFunctionDefinition::PythonUdtf {
                     return_type: return_type.try_into()?,
-                    eval_type,
+                    eval_type: spec::PySparkUdfType::try_from(eval_type)?,
                     command,
                     python_version: python_ver,
                 })


### PR DESCRIPTION
1. Define enum for PySpark UDF eval type.
2. Derive `TryFrom` for a few spec enums with primitive representation.