### PR TITLE
Define error type for Python UDF

### DIFF
--- a/crates/sail-python-udf/src/cereal/mod.rs
+++ b/crates/sail-python-udf/src/cereal/mod.rs
@@ -1,10 +1,11 @@
-use datafusion_common::Result;
 use pyo3::{Bound, PyAny, Python};
+
+use crate::error::PyUdfResult;
 
 pub mod pyspark_udf;
 pub mod pyspark_udtf;
 
 pub trait PythonFunction: Sized {
-    fn load(v: &[u8]) -> Result<Self>;
-    fn function<'py>(&self, py: Python<'py>) -> Result<Bound<'py, PyAny>>;
+    fn load(v: &[u8]) -> PyUdfResult<Self>;
+    fn function<'py>(&self, py: Python<'py>) -> PyUdfResult<Bound<'py, PyAny>>;
 }

--- a/crates/sail-python-udf/src/cereal/pyspark_udtf.rs
+++ b/crates/sail-python-udf/src/cereal/pyspark_udtf.rs
@@ -2,52 +2,47 @@ use std::hash::{Hash, Hasher};
 
 use arrow::pyarrow::ToPyArrow;
 use datafusion::arrow::datatypes::DataType;
-use datafusion_common::{plan_datafusion_err, plan_err, DataFusionError, Result};
+use datafusion_common::{plan_datafusion_err, plan_err, Result};
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
 use sail_common::config::SparkUdfConfig;
 use sail_common::spec;
 
 use crate::cereal::PythonFunction;
+use crate::error::{PyUdfError, PyUdfResult};
 
 #[derive(Debug, Clone)]
 pub struct PySparkUdtfObject(pub PyObject);
 
 impl PythonFunction for PySparkUdtfObject {
-    fn load(v: &[u8]) -> Result<Self> {
+    fn load(v: &[u8]) -> PyUdfResult<Self> {
         // build_pyspark_udtf_payload adds eval_type to the beginning of the payload
         let (eval_type_bytes, v) = v.split_at(std::mem::size_of::<i32>());
         let eval_type = i32::from_be_bytes(
             eval_type_bytes
                 .try_into()
-                .map_err(|e| plan_datafusion_err!("eval_type from_be_bytes: {e}"))?,
+                .map_err(|e| PyUdfError::invalid(format!("eval_type from_be_bytes: {e}")))?,
         );
         Python::with_gil(|py| {
             let infile: Bound<PyAny> = PyModule::import_bound(py, pyo3::intern!(py, "io"))
                 .and_then(|io| io.getattr(pyo3::intern!(py, "BytesIO")))
-                .and_then(|bytes_io| bytes_io.call1((v,)))
-                .map_err(|e| DataFusionError::External(e.into()))?;
+                .and_then(|bytes_io| bytes_io.call1((v,)))?;
             let pickle_ser: Bound<PyAny> =
                 PyModule::import_bound(py, pyo3::intern!(py, "pyspark.serializers"))
                     .and_then(|serializers| {
                         serializers.getattr(pyo3::intern!(py, "CPickleSerializer"))
                     })
-                    .and_then(|serializer| serializer.call0())
-                    .map_err(|e| DataFusionError::External(e.into()))?;
-            PyModule::import_bound(py, pyo3::intern!(py, "pyspark.worker"))
+                    .and_then(|serializer| serializer.call0())?;
+            let obj = PyModule::import_bound(py, pyo3::intern!(py, "pyspark.worker"))
                 .and_then(|worker| worker.getattr(pyo3::intern!(py, "read_udtf")))
                 .and_then(|read_udtf| read_udtf.call1((pickle_ser, infile, eval_type)))
-                .map(|py_tuple| PySparkUdtfObject(py_tuple.to_object(py)))
-                .map_err(|e| DataFusionError::External(e.into()))
+                .map(|py_tuple| PySparkUdtfObject(py_tuple.to_object(py)))?;
+            Ok(obj)
         })
     }
 
-    fn function<'py>(&self, py: Python<'py>) -> Result<Bound<'py, PyAny>> {
-        self.0
-            .clone_ref(py)
-            .into_bound(py)
-            .get_item(0)
-            .map_err(|err| DataFusionError::External(err.into()))
+    fn function<'py>(&self, py: Python<'py>) -> PyUdfResult<Bound<'py, PyAny>> {
+        Ok(self.0.clone_ref(py).into_bound(py).get_item(0)?)
     }
 }
 
@@ -84,7 +79,7 @@ pub fn deserialize_pyspark_udtf(
     }
     let data: Vec<u8> =
         build_pyspark_udtf_payload(command, eval_type, num_args, return_type, spark_udf_config)?;
-    PySparkUdtfObject::load(&data)
+    Ok(PySparkUdtfObject::load(&data)?)
 }
 
 pub fn build_pyspark_udtf_payload(

--- a/crates/sail-python-udf/src/error.rs
+++ b/crates/sail-python-udf/src/error.rs
@@ -1,0 +1,28 @@
+use datafusion_common::DataFusionError;
+use pyo3::PyErr;
+use thiserror::Error;
+
+pub type PyUdfResult<T> = Result<T, PyUdfError>;
+
+#[derive(Debug, Error)]
+pub enum PyUdfError {
+    #[error("error in Python: {0}")]
+    PythonError(#[from] PyErr),
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
+}
+
+impl PyUdfError {
+    pub fn invalid(message: impl Into<String>) -> Self {
+        PyUdfError::InvalidArgument(message.into())
+    }
+}
+
+impl From<PyUdfError> for DataFusionError {
+    fn from(error: PyUdfError) -> Self {
+        match error {
+            PyUdfError::PythonError(e) => DataFusionError::External(e.into()),
+            PyUdfError::InvalidArgument(message) => DataFusionError::Plan(message),
+        }
+    }
+}

--- a/crates/sail-python-udf/src/lib.rs
+++ b/crates/sail-python-udf/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod cereal;
+pub mod error;
 pub mod udf;

--- a/crates/sail-python-udf/src/udf/mod.rs
+++ b/crates/sail-python-udf/src/udf/mod.rs
@@ -4,10 +4,10 @@ pub mod unresolved_pyspark_udf;
 
 use datafusion::arrow::datatypes::{DataType, SchemaRef};
 use datafusion::arrow::pyarrow::ToPyArrow;
-use datafusion::common::Result;
-use datafusion_common::DataFusionError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+
+use crate::error::PyUdfResult;
 
 /// Generates a unique function name with the memory address of the Python function.
 /// Without this, lambda functions with the name `<lambda>` will be treated as the same function
@@ -17,32 +17,22 @@ pub fn get_udf_name(function_name: &str, function: &PyObject) -> String {
     format!("{}@0x{:x}", function_name, function.as_ptr() as usize)
 }
 
-pub fn get_python_builtins(py: Python) -> Result<Bound<PyModule>> {
-    let builtins: Bound<PyModule> = PyModule::import_bound(py, pyo3::intern!(py, "builtins"))
-        .map_err(|err| DataFusionError::External(err.into()))?;
-    Ok(builtins)
+pub fn get_python_builtins(py: Python) -> PyUdfResult<Bound<PyModule>> {
+    Ok(PyModule::import_bound(py, pyo3::intern!(py, "builtins"))?)
 }
 
-pub fn get_python_builtins_list_function(py: Python) -> Result<Bound<PyAny>> {
-    let builtins_list: Bound<PyAny> = get_python_builtins(py)?
-        .getattr(pyo3::intern!(py, "list"))
-        .map_err(|err| DataFusionError::External(err.into()))?;
-    Ok(builtins_list)
+pub fn get_python_builtins_list_function(py: Python) -> PyUdfResult<Bound<PyAny>> {
+    Ok(get_python_builtins(py)?.getattr(pyo3::intern!(py, "list"))?)
 }
 
-pub fn get_python_builtins_str_function(py: Python) -> Result<Bound<PyAny>> {
-    let builtins_str: Bound<PyAny> = get_python_builtins(py)?
-        .getattr(pyo3::intern!(py, "str"))
-        .map_err(|err| DataFusionError::External(err.into()))?;
-    Ok(builtins_str)
+pub fn get_python_builtins_str_function(py: Python) -> PyUdfResult<Bound<PyAny>> {
+    Ok(get_python_builtins(py)?.getattr(pyo3::intern!(py, "str"))?)
 }
 
-pub fn get_pyarrow_array_function(py: Python) -> Result<Bound<PyAny>> {
+pub fn get_pyarrow_array_function(py: Python) -> PyUdfResult<Bound<PyAny>> {
     let pyarrow_module_array: Bound<PyAny> =
-        PyModule::import_bound(py, pyo3::intern!(py, "pyarrow"))
-            .map_err(|err| DataFusionError::External(err.into()))?
-            .getattr(pyo3::intern!(py, "array"))
-            .map_err(|err| DataFusionError::External(err.into()))?;
+        PyModule::import_bound(py, pyo3::intern!(py, "pyarrow"))?
+            .getattr(pyo3::intern!(py, "array"))?;
     Ok(pyarrow_module_array)
 }
 
@@ -50,15 +40,11 @@ pub fn build_pyarrow_array_kwargs<'py>(
     py: Python<'py>,
     pyarrow_data_type: Bound<'py, PyAny>,
     from_pandas: bool,
-) -> Result<Bound<'py, PyDict>> {
+) -> PyUdfResult<Bound<'py, PyDict>> {
     let array_kwargs: Bound<PyDict> = PyDict::new_bound(py);
-    array_kwargs
-        .set_item("type", pyarrow_data_type)
-        .map_err(|err| DataFusionError::External(err.into()))?;
+    array_kwargs.set_item("type", pyarrow_data_type)?;
     if from_pandas {
-        array_kwargs
-            .set_item("from_pandas", from_pandas)
-            .map_err(|err| DataFusionError::External(err.into()))?;
+        array_kwargs.set_item("from_pandas", from_pandas)?;
     }
     Ok(array_kwargs)
 }
@@ -66,61 +52,45 @@ pub fn build_pyarrow_array_kwargs<'py>(
 pub fn get_pyarrow_output_data_type<'py>(
     output_type: &DataType,
     py: Python<'py>,
-) -> Result<Bound<'py, PyAny>> {
-    let pyarrow_output_data_type: Bound<PyAny> = output_type
-        .to_pyarrow(py)
-        .map_err(|err| DataFusionError::External(err.into()))?
-        .clone_ref(py)
-        .into_bound(py);
-    Ok(pyarrow_output_data_type)
+) -> PyUdfResult<Bound<'py, PyAny>> {
+    Ok(output_type.to_pyarrow(py)?.clone_ref(py).into_bound(py))
 }
 
-pub fn get_pyarrow_record_batch_from_pandas_function(py: Python) -> Result<Bound<PyAny>> {
+pub fn get_pyarrow_record_batch_from_pandas_function(py: Python) -> PyUdfResult<Bound<PyAny>> {
     let record_batch_from_pandas: Bound<PyAny> =
-        PyModule::import_bound(py, pyo3::intern!(py, "pyarrow"))
-            .map_err(|err| DataFusionError::External(err.into()))?
-            .getattr(pyo3::intern!(py, "RecordBatch"))
-            .map_err(|err| DataFusionError::External(err.into()))?
-            .getattr(pyo3::intern!(py, "from_pandas"))
-            .map_err(|err| DataFusionError::External(err.into()))?;
+        PyModule::import_bound(py, pyo3::intern!(py, "pyarrow"))?
+            .getattr(pyo3::intern!(py, "RecordBatch"))?
+            .getattr(pyo3::intern!(py, "from_pandas"))?;
     Ok(record_batch_from_pandas)
 }
 
-pub fn get_pyarrow_record_batch_from_pylist_function(py: Python) -> Result<Bound<PyAny>> {
+pub fn get_pyarrow_record_batch_from_pylist_function(py: Python) -> PyUdfResult<Bound<PyAny>> {
     let record_batch_from_pylist: Bound<PyAny> =
-        PyModule::import_bound(py, pyo3::intern!(py, "pyarrow"))
-            .map_err(|err| DataFusionError::External(err.into()))?
-            .getattr(pyo3::intern!(py, "RecordBatch"))
-            .map_err(|err| DataFusionError::External(err.into()))?
-            .getattr(pyo3::intern!(py, "from_pylist"))
-            .map_err(|err| DataFusionError::External(err.into()))?;
+        PyModule::import_bound(py, pyo3::intern!(py, "pyarrow"))?
+            .getattr(pyo3::intern!(py, "RecordBatch"))?
+            .getattr(pyo3::intern!(py, "from_pylist"))?;
     Ok(record_batch_from_pylist)
 }
 
 pub fn build_pyarrow_record_batch_kwargs<'py>(
     py: Python<'py>,
     pyarrow_schema: Bound<'py, PyAny>,
-) -> Result<Bound<'py, PyDict>> {
+) -> PyUdfResult<Bound<'py, PyDict>> {
     let record_batch_kwargs: Bound<PyDict> = PyDict::new_bound(py);
-    record_batch_kwargs
-        .set_item("schema", pyarrow_schema)
-        .map_err(|err| DataFusionError::External(err.into()))?;
+    record_batch_kwargs.set_item("schema", pyarrow_schema)?;
     Ok(record_batch_kwargs)
 }
 
-pub fn get_pyarrow_schema<'py>(schema: &SchemaRef, py: Python<'py>) -> Result<Bound<'py, PyAny>> {
-    let pyarrow_schema: Bound<PyAny> = schema
-        .to_pyarrow(py)
-        .map_err(|err| DataFusionError::External(err.into()))?
-        .clone_ref(py)
-        .into_bound(py);
+pub fn get_pyarrow_schema<'py>(
+    schema: &SchemaRef,
+    py: Python<'py>,
+) -> PyUdfResult<Bound<'py, PyAny>> {
+    let pyarrow_schema: Bound<PyAny> = schema.to_pyarrow(py)?.clone_ref(py).into_bound(py);
     Ok(pyarrow_schema)
 }
 
-pub fn get_pyarrow_table_function(py: Python) -> Result<Bound<PyAny>> {
-    let pyarrow_table: Bound<PyAny> = PyModule::import_bound(py, pyo3::intern!(py, "pyarrow"))
-        .map_err(|err| DataFusionError::External(err.into()))?
-        .getattr(pyo3::intern!(py, "table"))
-        .map_err(|err| DataFusionError::External(err.into()))?;
+pub fn get_pyarrow_table_function(py: Python) -> PyUdfResult<Bound<PyAny>> {
+    let pyarrow_table: Bound<PyAny> = PyModule::import_bound(py, pyo3::intern!(py, "pyarrow"))?
+        .getattr(pyo3::intern!(py, "table"))?;
     Ok(pyarrow_table)
 }

--- a/crates/sail-python-udf/src/udf/pyspark_udf.rs
+++ b/crates/sail-python-udf/src/udf/pyspark_udf.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use datafusion::arrow::array::{make_array, Array, ArrayData, ArrayRef};
 use datafusion::arrow::datatypes::DataType;
 use datafusion::arrow::pyarrow::{FromPyArrow, ToPyArrow};
-use datafusion::common::{DataFusionError, Result};
+use datafusion::common::Result;
 use datafusion_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyIterator, PyList, PyTuple, PyType};
@@ -12,6 +12,7 @@ use sail_common::spec;
 
 use crate::cereal::pyspark_udf::PySparkUdfObject;
 use crate::cereal::PythonFunction;
+use crate::error::PyUdfResult;
 use crate::udf::{
     build_pyarrow_array_kwargs, get_pyarrow_array_function, get_pyarrow_output_data_type,
     get_python_builtins_list_function, get_python_builtins_str_function, get_udf_name,
@@ -79,7 +80,7 @@ impl ScalarUDFImpl for PySparkUDF {
         let args: Vec<ArrayRef> = ColumnarValue::values_to_arrays(args)?;
 
         if self.eval_type.is_arrow_udf() {
-            let array_data: Result<ArrayData, DataFusionError> = Python::with_gil(|py| {
+            let array_data = Python::with_gil(|py| -> PyUdfResult<_> {
                 let pyarrow_module_array: Bound<PyAny> = get_pyarrow_array_function(py)?;
                 let builtins_list: Bound<PyAny> = get_python_builtins_list_function(py)?;
                 let python_function: Bound<PyAny> = self.python_function.function(py)?;
@@ -93,47 +94,33 @@ impl ScalarUDFImpl for PySparkUDF {
                     .map(|arg| {
                         let arg = arg
                             .into_data()
-                            .to_pyarrow(py)
-                            .map_err(|err| DataFusionError::External(err.into()))?
+                            .to_pyarrow(py)?
                             // FIXME: Should be to_pandas here for performance (Zero-Copy),
                             //  but behavior of results is inconsistent with PySpark's expectations.
-                            .call_method0(py, pyo3::intern!(py, "to_pylist"))
-                            .map_err(|err| DataFusionError::External(err.into()))?
+                            .call_method0(py, pyo3::intern!(py, "to_pylist"))?
                             .clone_ref(py)
                             .into_bound(py);
                         Ok(arg)
                     })
-                    .collect::<Result<Vec<_>, DataFusionError>>()?;
+                    .collect::<PyUdfResult<Vec<_>>>()?;
                 let py_args: Bound<PyTuple> = PyTuple::new_bound(py, &py_args);
 
-                let results: Bound<PyAny> = python_function
-                    .call1((py.None(), (py_args,)))
-                    .map_err(|err| DataFusionError::External(err.into()))?;
-                let results: Bound<PyAny> = builtins_list
-                    .call1((results,))
-                    .map_err(|err| DataFusionError::External(err.into()))?
-                    .get_item(0)
-                    .map_err(|err| DataFusionError::External(err.into()))?;
+                let results: Bound<PyAny> = python_function.call1((py.None(), (py_args,)))?;
+                let results: Bound<PyAny> = builtins_list.call1((results,))?.get_item(0)?;
 
-                let results_data: Bound<PyAny> = results
-                    .get_item(0)
-                    .map_err(|err| DataFusionError::External(err.into()))?;
-                let _results_datatype: Bound<PyAny> = results
-                    .get_item(1)
-                    .map_err(|err| DataFusionError::External(err.into()))?;
-                let results_data: Bound<PyAny> = pyarrow_module_array
-                    .call((results_data,), Some(&pyarrow_array_kwargs))
-                    .map_err(|err| DataFusionError::External(err.into()))?;
+                let results_data: Bound<PyAny> = results.get_item(0)?;
+                let _results_datatype: Bound<PyAny> = results.get_item(1)?;
+                let results_data: Bound<PyAny> =
+                    pyarrow_module_array.call((results_data,), Some(&pyarrow_array_kwargs))?;
 
-                let array_data = ArrayData::from_pyarrow_bound(&results_data)
-                    .map_err(|err| DataFusionError::External(err.into()))?;
+                let array_data = ArrayData::from_pyarrow_bound(&results_data)?;
                 Ok(array_data)
-            });
-            return Ok(ColumnarValue::Array(make_array(array_data?)));
+            })?;
+            return Ok(ColumnarValue::Array(make_array(array_data)));
         }
 
         if self.eval_type.is_pandas_udf() {
-            let array_data: Result<ArrayData, DataFusionError> = Python::with_gil(|py| {
+            let array_data = Python::with_gil(|py| -> PyUdfResult<_> {
                 let pyarrow_module_array: Bound<PyAny> = get_pyarrow_array_function(py)?;
                 let builtins_list: Bound<PyAny> = get_python_builtins_list_function(py)?;
                 let python_function: Bound<PyAny> = self.python_function.function(py)?;
@@ -147,44 +134,30 @@ impl ScalarUDFImpl for PySparkUDF {
                     .map(|arg| {
                         let arg = arg
                             .into_data()
-                            .to_pyarrow(py)
-                            .map_err(|err| DataFusionError::External(err.into()))?
-                            .call_method0(py, pyo3::intern!(py, "to_pandas"))
-                            .map_err(|err| DataFusionError::External(err.into()))?
+                            .to_pyarrow(py)?
+                            .call_method0(py, pyo3::intern!(py, "to_pandas"))?
                             .clone_ref(py)
                             .into_bound(py);
                         Ok(arg)
                     })
-                    .collect::<Result<Vec<_>, DataFusionError>>()?;
+                    .collect::<PyUdfResult<Vec<_>>>()?;
                 let py_args: Bound<PyTuple> = PyTuple::new_bound(py, &py_args);
 
-                let results: Bound<PyAny> = python_function
-                    .call1((py.None(), (py_args,)))
-                    .map_err(|err| DataFusionError::External(err.into()))?;
-                let results: Bound<PyAny> = builtins_list
-                    .call1((results,))
-                    .map_err(|err| DataFusionError::External(err.into()))?
-                    .get_item(0)
-                    .map_err(|err| DataFusionError::External(err.into()))?;
+                let results: Bound<PyAny> = python_function.call1((py.None(), (py_args,)))?;
+                let results: Bound<PyAny> = builtins_list.call1((results,))?.get_item(0)?;
 
-                let results_data: Bound<PyAny> = results
-                    .get_item(0)
-                    .map_err(|err| DataFusionError::External(err.into()))?;
-                let _results_datatype: Bound<PyAny> = results
-                    .get_item(1)
-                    .map_err(|err| DataFusionError::External(err.into()))?;
-                let results_data: Bound<PyAny> = pyarrow_module_array
-                    .call((results_data,), Some(&pyarrow_array_kwargs))
-                    .map_err(|err| DataFusionError::External(err.into()))?;
+                let results_data: Bound<PyAny> = results.get_item(0)?;
+                let _results_datatype: Bound<PyAny> = results.get_item(1)?;
+                let results_data: Bound<PyAny> =
+                    pyarrow_module_array.call((results_data,), Some(&pyarrow_array_kwargs))?;
 
-                let array_data = ArrayData::from_pyarrow_bound(&results_data)
-                    .map_err(|err| DataFusionError::External(err.into()))?;
+                let array_data = ArrayData::from_pyarrow_bound(&results_data)?;
                 Ok(array_data)
-            });
-            return Ok(ColumnarValue::Array(make_array(array_data?)));
+            })?;
+            return Ok(ColumnarValue::Array(make_array(array_data)));
         }
 
-        let array_data: Result<ArrayData, DataFusionError> = Python::with_gil(|py| {
+        let array_data = Python::with_gil(|py| -> PyUdfResult<_> {
             let pyarrow_module_array: Bound<PyAny> = get_pyarrow_array_function(py)?;
             let builtins_list: Bound<PyAny> = get_python_builtins_list_function(py)?;
             let builtins_str: Bound<PyAny> = get_python_builtins_str_function(py)?;
@@ -199,37 +172,25 @@ impl ScalarUDFImpl for PySparkUDF {
                 .map(|arg| {
                     let arg = arg
                         .into_data()
-                        .to_pyarrow(py)
-                        .map_err(|err| DataFusionError::External(err.into()))?
-                        .call_method0(py, pyo3::intern!(py, "to_pylist"))
-                        .map_err(|err| DataFusionError::External(err.into()))?
+                        .to_pyarrow(py)?
+                        .call_method0(py, pyo3::intern!(py, "to_pylist"))?
                         .clone_ref(py)
                         .into_bound(py);
                     Ok(arg)
                 })
-                .collect::<Result<Vec<_>, DataFusionError>>()?;
+                .collect::<PyUdfResult<Vec<_>>>()?;
             let py_args_tuple: Bound<PyTuple> = PyTuple::new_bound(py, &py_args_columns_list);
             // TODO: Do zip in Rust for performance.
-            let py_args_zip: Bound<PyAny> = py
-                .eval_bound("zip", None, None)
-                .map_err(|err| DataFusionError::External(err.into()))?
-                .call1(&py_args_tuple)
-                .map_err(|err| DataFusionError::External(err.into()))?;
-            let py_args: Bound<PyIterator> = PyIterator::from_bound_object(&py_args_zip)
-                .map_err(|err| DataFusionError::External(err.into()))?;
+            let py_args_zip: Bound<PyAny> =
+                py.eval_bound("zip", None, None)?.call1(&py_args_tuple)?;
+            let py_args: Bound<PyIterator> = PyIterator::from_bound_object(&py_args_zip)?;
 
             let mut already_str: bool = false;
             let results: Vec<Bound<PyAny>> = py_args
-                .map(|py_arg| -> Result<Bound<PyAny>, DataFusionError> {
-                    let py_arg = py_arg.map_err(|err| DataFusionError::External(err.into()))?;
-                    let result: Bound<PyAny> = python_function
-                        .call1((py.None(), (py_arg,)))
-                        .map_err(|err| DataFusionError::External(err.into()))?;
-                    let result: Bound<PyAny> = builtins_list
-                        .call1((result,))
-                        .map_err(|err| DataFusionError::External(err.into()))?
-                        .get_item(0)
-                        .map_err(|err| DataFusionError::External(err.into()))?;
+                .map(|py_arg| -> PyUdfResult<Bound<PyAny>> {
+                    let py_arg = py_arg?;
+                    let result: Bound<PyAny> = python_function.call1((py.None(), (py_arg,)))?;
+                    let result: Bound<PyAny> = builtins_list.call1((result,))?.get_item(0)?;
 
                     if matches!(self.eval_type, spec::PySparkUdfType::Batched)
                         && self.deterministic
@@ -239,13 +200,9 @@ impl ScalarUDFImpl for PySparkUDF {
                             return Ok(result);
                         }
                         let result_type: Bound<PyType> = result.get_type();
-                        let result_data_type_name: Cow<str> = result_type
-                            .name()
-                            .map_err(|err| DataFusionError::External(err.into()))?;
+                        let result_data_type_name: Cow<str> = result_type.name()?;
                         if result_data_type_name != "str" {
-                            let result: Bound<PyAny> = builtins_str
-                                .call1((result,))
-                                .map_err(|err| DataFusionError::External(err.into()))?;
+                            let result: Bound<PyAny> = builtins_str.call1((result,))?;
                             return Ok(result);
                         } else {
                             already_str = true;
@@ -253,22 +210,19 @@ impl ScalarUDFImpl for PySparkUDF {
                     }
                     Ok(result)
                 })
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|err| DataFusionError::External(err.into()))?;
+                .collect::<Result<Vec<_>, _>>()?;
 
-            let results: Bound<PyAny> = pyarrow_module_array
-                .call((results,), Some(&pyarrow_array_kwargs))
-                .map_err(|err| DataFusionError::External(err.into()))?;
+            let results: Bound<PyAny> =
+                pyarrow_module_array.call((results,), Some(&pyarrow_array_kwargs))?;
 
-            ArrayData::from_pyarrow_bound(&results)
-                .map_err(|err| DataFusionError::External(err.into()))
-        });
+            Ok(ArrayData::from_pyarrow_bound(&results)?)
+        })?;
 
-        Ok(ColumnarValue::Array(make_array(array_data?)))
+        Ok(ColumnarValue::Array(make_array(array_data)))
     }
 
     fn invoke_no_args(&self, _number_rows: usize) -> Result<ColumnarValue> {
-        let array_data: Result<ArrayData, DataFusionError> = Python::with_gil(|py| {
+        let array_data = Python::with_gil(|py| -> PyUdfResult<_> {
             let pyarrow_module_array: Bound<PyAny> = get_pyarrow_array_function(py)?;
             let builtins_list: Bound<PyAny> = get_python_builtins_list_function(py)?;
             let builtins_str: Bound<PyAny> = get_python_builtins_str_function(py)?;
@@ -278,41 +232,30 @@ impl ScalarUDFImpl for PySparkUDF {
             let pyarrow_array_kwargs: Bound<PyDict> =
                 build_pyarrow_array_kwargs(py, pyarrow_output_data_type, false)?;
 
-            let result: Bound<PyAny> = python_function
-                .call1((py.None(), (PyList::empty_bound(py),)))
-                .map_err(|err| DataFusionError::External(err.into()))?;
+            let result: Bound<PyAny> =
+                python_function.call1((py.None(), (PyList::empty_bound(py),)))?;
 
-            let result: Bound<PyAny> = builtins_list
-                .call1((result,))
-                .map_err(|err| DataFusionError::External(err.into()))?
-                .get_item(0)
-                .map_err(|err| DataFusionError::External(err.into()))?;
+            let result: Bound<PyAny> = builtins_list.call1((result,))?.get_item(0)?;
 
             let result_type: Bound<PyType> = result.get_type();
-            let result_data_type_name: Cow<str> = result_type
-                .name()
-                .map_err(|err| DataFusionError::External(err.into()))?;
+            let result_data_type_name: Cow<str> = result_type.name()?;
 
             let result: Bound<PyAny> = if matches!(self.eval_type, spec::PySparkUdfType::Batched)
                 && self.deterministic
                 && self.output_type == DataType::Utf8
                 && result_data_type_name != "str"
             {
-                builtins_str
-                    .call1((result,))
-                    .map_err(|err| DataFusionError::External(err.into()))?
+                builtins_str.call1((result,))?
             } else {
                 result
             };
 
-            let result: Bound<PyAny> = pyarrow_module_array
-                .call(([result],), Some(&pyarrow_array_kwargs))
-                .map_err(|err| DataFusionError::External(err.into()))?;
+            let result: Bound<PyAny> =
+                pyarrow_module_array.call(([result],), Some(&pyarrow_array_kwargs))?;
 
-            ArrayData::from_pyarrow_bound(&result)
-                .map_err(|err| DataFusionError::External(err.into()))
-        });
+            Ok(ArrayData::from_pyarrow_bound(&result)?)
+        })?;
 
-        Ok(ColumnarValue::Array(make_array(array_data?)))
+        Ok(ColumnarValue::Array(make_array(array_data)))
     }
 }

--- a/crates/sail-python-udf/src/udf/pyspark_udtf.rs
+++ b/crates/sail-python-udf/src/udf/pyspark_udtf.rs
@@ -22,6 +22,7 @@ use sail_common::utils::cast_record_batch;
 
 use crate::cereal::pyspark_udtf::{deserialize_pyspark_udtf, PySparkUdtfObject};
 use crate::cereal::PythonFunction;
+use crate::error::PyUdfResult;
 use crate::udf::{
     build_pyarrow_record_batch_kwargs, get_pyarrow_record_batch_from_pandas_function,
     get_pyarrow_record_batch_from_pylist_function, get_pyarrow_schema,
@@ -109,7 +110,7 @@ impl PySparkUDTF {
         &self,
         args: &[ArrayRef],
         python_function: PySparkUdtfObject,
-    ) -> Result<RecordBatch> {
+    ) -> PyUdfResult<RecordBatch> {
         Python::with_gil(|py| {
             let python_function: Bound<PyAny> = python_function.function(py)?;
             let builtins_list: Bound<PyAny> = get_python_builtins_list_function(py)?;
@@ -121,38 +122,23 @@ impl PySparkUDTF {
                 .map(|arg| {
                     let arg = arg
                         .into_data()
-                        .to_pyarrow(py)
-                        .map_err(|err| DataFusionError::External(err.into()))?
-                        .call_method0(py, pyo3::intern!(py, "to_pandas"))
-                        .map_err(|err| DataFusionError::External(err.into()))?
+                        .to_pyarrow(py)?
+                        .call_method0(py, pyo3::intern!(py, "to_pandas"))?
                         .clone_ref(py)
                         .into_bound(py);
                     Ok(arg)
                 })
-                .collect::<Result<Vec<_>, DataFusionError>>()?;
+                .collect::<PyUdfResult<Vec<_>>>()?;
             let py_args: Bound<PyList> = PyList::new_bound(py, &py_args);
 
-            let results: Bound<PyAny> = python_function
-                .call1((py.None(), (py_args,)))
-                .map_err(|err| DataFusionError::External(err.into()))?;
-            let results: Bound<PyAny> = builtins_list
-                .call1((results,))
-                .map_err(|err| DataFusionError::External(err.into()))?
-                .get_item(0)
-                .map_err(|err| DataFusionError::External(err.into()))?;
+            let results: Bound<PyAny> = python_function.call1((py.None(), (py_args,)))?;
+            let results: Bound<PyAny> = builtins_list.call1((results,))?.get_item(0)?;
 
-            let results_data: Bound<PyAny> = results
-                .get_item(0)
-                .map_err(|err| DataFusionError::External(err.into()))?;
-            let _results_datatype: Bound<PyAny> = results
-                .get_item(1)
-                .map_err(|err| DataFusionError::External(err.into()))?;
+            let results_data: Bound<PyAny> = results.get_item(0)?;
+            let _results_datatype: Bound<PyAny> = results.get_item(1)?;
 
-            let record_batch: Bound<PyAny> = record_batch_from_pandas
-                .call1((results_data,))
-                .map_err(|err| DataFusionError::External(err.into()))?;
-            let record_batch: RecordBatch = RecordBatch::from_pyarrow_bound(&record_batch)
-                .map_err(|err| DataFusionError::External(err.into()))?;
+            let record_batch: Bound<PyAny> = record_batch_from_pandas.call1((results_data,))?;
+            let record_batch: RecordBatch = RecordBatch::from_pyarrow_bound(&record_batch)?;
 
             Ok(record_batch)
         })
@@ -162,7 +148,7 @@ impl PySparkUDTF {
         &self,
         args: &[ArrayRef],
         python_function: PySparkUdtfObject,
-    ) -> Result<RecordBatch> {
+    ) -> PyUdfResult<RecordBatch> {
         Python::with_gil(|py| {
             let python_function: Bound<PyAny> = python_function.function(py)?;
             let builtins_list: Bound<PyAny> = get_python_builtins_list_function(py)?;
@@ -177,51 +163,32 @@ impl PySparkUDTF {
                 .map(|arg| {
                     let arg = arg
                         .into_data()
-                        .to_pyarrow(py)
-                        .map_err(|err| DataFusionError::External(err.into()))?
-                        .call_method0(py, pyo3::intern!(py, "to_pylist"))
-                        .map_err(|err| DataFusionError::External(err.into()))?
+                        .to_pyarrow(py)?
+                        .call_method0(py, pyo3::intern!(py, "to_pylist"))?
                         .clone_ref(py)
                         .into_bound(py);
                     Ok(arg)
                 })
-                .collect::<Result<Vec<_>, DataFusionError>>()?;
+                .collect::<PyUdfResult<Vec<_>>>()?;
             let py_args: Bound<PyTuple> = PyTuple::new_bound(py, &py_args);
-            let py_args: Bound<PyAny> = py
-                .eval_bound("zip", None, None)
-                .map_err(|err| DataFusionError::External(err.into()))?
-                .call1(&py_args)
-                .map_err(|err| DataFusionError::External(err.into()))?;
-            let py_args: Bound<PyIterator> = PyIterator::from_bound_object(&py_args)
-                .map_err(|err| DataFusionError::External(err.into()))?;
+            let py_args: Bound<PyAny> = py.eval_bound("zip", None, None)?.call1(&py_args)?;
+            let py_args: Bound<PyIterator> = PyIterator::from_bound_object(&py_args)?;
 
             let results: Bound<PyList> = PyList::empty_bound(py);
             for py_arg in py_args {
-                let py_arg = py_arg.map_err(|err| DataFusionError::External(err.into()))?;
-                let result: Bound<PyAny> = python_function
-                    .call1((py.None(), (py_arg,)))
-                    .map_err(|err| DataFusionError::External(err.into()))?;
-                let result: Bound<PyAny> = builtins_list
-                    .call1((result,))
-                    .map_err(|err| DataFusionError::External(err.into()))?
-                    .get_item(0)
-                    .map_err(|err| DataFusionError::External(err.into()))?;
-                let result: Bound<PyAny> = builtins_list
-                    .call1((result,))
-                    .map_err(|err| DataFusionError::External(err.into()))?;
+                let py_arg = py_arg?;
+                let result: Bound<PyAny> = python_function.call1((py.None(), (py_arg,)))?;
+                let result: Bound<PyAny> = builtins_list.call1((result,))?.get_item(0)?;
+                let result: Bound<PyAny> = builtins_list.call1((result,))?;
                 let result: Bound<PyList> =
                     list_of_tuples_to_list_of_dicts(py, &result, &self.return_schema)?;
                 for item in result.iter() {
-                    results
-                        .append(item)
-                        .map_err(|err| DataFusionError::External(err.into()))?;
+                    results.append(item)?;
                 }
             }
-            let record_batch: Bound<PyAny> = record_batch_from_pylist
-                .call((results,), Some(&pyarrow_record_batch_kwargs))
-                .map_err(|err| DataFusionError::External(err.into()))?;
-            let record_batch: RecordBatch = RecordBatch::from_pyarrow_bound(&record_batch)
-                .map_err(|err| DataFusionError::External(err.into()))?;
+            let record_batch: Bound<PyAny> =
+                record_batch_from_pylist.call((results,), Some(&pyarrow_record_batch_kwargs))?;
+            let record_batch: RecordBatch = RecordBatch::from_pyarrow_bound(&record_batch)?;
 
             Ok(record_batch)
         })
@@ -230,7 +197,7 @@ impl PySparkUDTF {
     fn apply_pyspark_function_no_args(
         &self,
         python_function: PySparkUdtfObject,
-    ) -> Result<RecordBatch> {
+    ) -> PyUdfResult<RecordBatch> {
         Python::with_gil(|py| {
             let python_function: Bound<PyAny> = python_function.function(py)?;
             let builtins_list: Bound<PyAny> = get_python_builtins_list_function(py)?;
@@ -240,25 +207,16 @@ impl PySparkUDTF {
             let pyarrow_record_batch_kwargs: Bound<PyDict> =
                 build_pyarrow_record_batch_kwargs(py, pyarrow_schema)?;
 
-            let results: Bound<PyAny> = python_function
-                .call1((py.None(), (PyList::empty_bound(py),)))
-                .map_err(|err| DataFusionError::External(err.into()))?;
-            let results: Bound<PyAny> = builtins_list
-                .call1((results,))
-                .map_err(|err| DataFusionError::External(err.into()))?
-                .get_item(0)
-                .map_err(|err| DataFusionError::External(err.into()))?;
-            let results: Bound<PyAny> = builtins_list
-                .call1((results,))
-                .map_err(|err| DataFusionError::External(err.into()))?;
+            let results: Bound<PyAny> =
+                python_function.call1((py.None(), (PyList::empty_bound(py),)))?;
+            let results: Bound<PyAny> = builtins_list.call1((results,))?.get_item(0)?;
+            let results: Bound<PyAny> = builtins_list.call1((results,))?;
             let results: Bound<PyList> =
                 list_of_tuples_to_list_of_dicts(py, &results, &self.return_schema)?;
 
-            let record_batch: Bound<PyAny> = record_batch_from_pylist
-                .call((results,), Some(&pyarrow_record_batch_kwargs))
-                .map_err(|err| DataFusionError::External(err.into()))?;
-            let record_batch: RecordBatch = RecordBatch::from_pyarrow_bound(&record_batch)
-                .map_err(|err| DataFusionError::External(err.into()))?;
+            let record_batch: Bound<PyAny> =
+                record_batch_from_pylist.call((results,), Some(&pyarrow_record_batch_kwargs))?;
+            let record_batch: RecordBatch = RecordBatch::from_pyarrow_bound(&record_batch)?;
 
             Ok(record_batch)
         })
@@ -284,8 +242,7 @@ impl TableFunctionImpl for PySparkUDTF {
             exprs.len(),
             &self.return_type,
             &self.spark_udf_config,
-        )
-        .map_err(|err| DataFusionError::External(err.into()))?;
+        )?;
 
         if exprs.is_empty() {
             let batches: RecordBatch = if eval_type.is_arrow_udf() {
@@ -356,27 +313,20 @@ fn list_of_tuples_to_list_of_dicts<'py>(
     py: Python<'py>,
     results: &Bound<'py, PyAny>,
     schema: &SchemaRef,
-) -> Result<Bound<'py, PyList>, DataFusionError> {
+) -> PyUdfResult<Bound<'py, PyList>> {
     let fields = schema.fields();
     let list_of_dicts: Vec<Bound<PyDict>> = results
-        .iter()
-        .map_err(|err| DataFusionError::External(err.into()))?
-        .map(|result| {
-            result
-                .map_err(|err| DataFusionError::External(err.into()))
-                .and_then(|result| {
-                    let dict: Bound<PyDict> = PyDict::new_bound(py);
-                    for (i, field) in fields.iter().enumerate() {
-                        let field_name = field.name().as_str();
-                        let value = result
-                            .get_item(i)
-                            .map_err(|err| DataFusionError::External(err.into()))?;
-                        dict.set_item(field_name, value)
-                            .map_err(|err| DataFusionError::External(err.into()))?;
-                    }
-                    Ok(dict)
-                })
+        .iter()?
+        .map(|result| -> PyUdfResult<_> {
+            let result = result?;
+            let dict: Bound<PyDict> = PyDict::new_bound(py);
+            for (i, field) in fields.iter().enumerate() {
+                let field_name = field.name().as_str();
+                let value = result.get_item(i)?;
+                dict.set_item(field_name, value)?;
+            }
+            Ok(dict)
         })
-        .collect::<Result<Vec<_>, DataFusionError>>()?;
+        .collect::<PyUdfResult<Vec<_>>>()?;
     Ok(PyList::new_bound(py, list_of_dicts))
 }


### PR DESCRIPTION
This removes the nearly 100 lines of `.map_err(|e| DataFusionError::External(e.into()))` in the Python UDF crate.