### PR TITLE
Clean up Python UDF implementation

### DIFF
--- a/crates/sail-plan/src/extension/function/levenshtein.rs
+++ b/crates/sail-plan/src/extension/function/levenshtein.rs
@@ -147,8 +147,8 @@ mod tests {
     fn to_levenshtein() -> Result<()> {
         let string1_array = Arc::new(StringArray::from(vec!["123", "abc", "xyz", "kitten"]));
         let string2_array = Arc::new(StringArray::from(vec!["321", "def", "zyx", "sitting"]));
-        let res = levenshtein::<i32>(&[string1_array.clone(), string2_array.clone()]).unwrap();
-        let result = as_int32_array(&res).expect("failed to initialized function levenshtein");
+        let res = levenshtein::<i32>(&[string1_array.clone(), string2_array.clone()])?;
+        let result = as_int32_array(&res)?;
         let expected = Int32Array::from(vec![2, 3, 2, 3]);
         assert_eq!(&expected, result);
 
@@ -156,9 +156,8 @@ mod tests {
             string1_array.clone(),
             string2_array.clone(),
             Arc::new(Int64Array::from(vec![2])),
-        ])
-        .unwrap();
-        let result = as_int32_array(&res).expect("failed to initialized function levenshtein");
+        ])?;
+        let result = as_int32_array(&res)?;
         let expected = Int32Array::from(vec![2, -1, 2, -1]);
         assert_eq!(&expected, result);
 
@@ -166,9 +165,8 @@ mod tests {
             string1_array.clone(),
             string2_array.clone(),
             Arc::new(Int64Array::from(vec![3])),
-        ])
-        .unwrap();
-        let result = as_int32_array(&res).expect("failed to initialized function levenshtein");
+        ])?;
+        let result = as_int32_array(&res)?;
         let expected = Int32Array::from(vec![2, 3, 2, 3]);
         assert_eq!(&expected, result);
 
@@ -176,9 +174,8 @@ mod tests {
             string1_array.clone(),
             string2_array.clone(),
             Arc::new(Int64Array::from(vec![4])),
-        ])
-        .unwrap();
-        let result = as_int32_array(&res).expect("failed to initialized function levenshtein");
+        ])?;
+        let result = as_int32_array(&res)?;
         let expected = Int32Array::from(vec![2, 3, 2, 3]);
         assert_eq!(&expected, result);
 

--- a/crates/sail-python-udf/src/cereal/mod.rs
+++ b/crates/sail-python-udf/src/cereal/mod.rs
@@ -1,6 +1,6 @@
 use pyo3::{Bound, PyAny, Python};
 
-use crate::error::PyUdfResult;
+use crate::error::{PyUdfError, PyUdfResult};
 
 pub mod pyspark_udf;
 pub mod pyspark_udtf;
@@ -8,4 +8,17 @@ pub mod pyspark_udtf;
 pub trait PythonFunction: Sized {
     fn load(v: &[u8]) -> PyUdfResult<Self>;
     fn function<'py>(&self, py: Python<'py>) -> PyUdfResult<Bound<'py, PyAny>>;
+}
+
+pub(crate) fn check_python_udf_version(version: &str) -> PyUdfResult<()> {
+    let pyo3_version: String = Python::with_gil(|py| py.version().to_string());
+    if pyo3_version.starts_with(version) {
+        Ok(())
+    } else {
+        Err(PyUdfError::invalid(format!(
+            "Python version used to compile the UDF ({}) does not match the Python version at runtime ({})",
+            version,
+            pyo3_version
+        )))
+    }
 }

--- a/crates/sail-python-udf/src/cereal/pyspark_udf.rs
+++ b/crates/sail-python-udf/src/cereal/pyspark_udf.rs
@@ -1,12 +1,13 @@
 use std::hash::{Hash, Hasher};
 
-use datafusion_common::{plan_datafusion_err, plan_err, Result};
+use datafusion_common::{plan_datafusion_err, Result};
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
 use sail_common::config::SparkUdfConfig;
 use sail_common::spec;
 
-use crate::cereal::PythonFunction;
+use crate::cereal::{check_python_udf_version, PythonFunction};
 use crate::error::{PyUdfError, PyUdfResult};
 
 #[derive(Debug, Clone)]
@@ -15,27 +16,23 @@ pub struct PySparkUdfObject(pub PyObject);
 impl PythonFunction for PySparkUdfObject {
     fn load(v: &[u8]) -> PyUdfResult<Self> {
         // build_pyspark_udf_payload adds eval_type to the beginning of the payload
-        let (eval_type_bytes, v) = v.split_at(std::mem::size_of::<i32>());
+        let (eval_type_bytes, v) = v.split_at(size_of::<i32>());
         let eval_type = i32::from_be_bytes(
             eval_type_bytes
                 .try_into()
                 .map_err(|e| PyUdfError::invalid(format!("eval_type from_be_bytes: {e}")))?,
         );
         Python::with_gil(|py| {
-            let infile: Bound<PyAny> = PyModule::import_bound(py, pyo3::intern!(py, "io"))
-                .and_then(|io| io.getattr(pyo3::intern!(py, "BytesIO")))
-                .and_then(|bytes_io| bytes_io.call1((v,)))?;
-            let pickle_ser: Bound<PyAny> =
-                PyModule::import_bound(py, pyo3::intern!(py, "pyspark.serializers"))
-                    .and_then(|serializers| {
-                        serializers.getattr(pyo3::intern!(py, "CPickleSerializer"))
-                    })
-                    .and_then(|serializer| serializer.call0())?;
-            let obj = PyModule::import_bound(py, pyo3::intern!(py, "pyspark.worker"))
-                .and_then(|worker| worker.getattr(pyo3::intern!(py, "read_udfs")))
-                .and_then(|read_udfs| read_udfs.call1((pickle_ser, infile, eval_type)))
-                .map(|py_tuple| PySparkUdfObject(py_tuple.to_object(py)))?;
-            Ok(obj)
+            let infile = PyModule::import_bound(py, intern!(py, "io"))?
+                .getattr(intern!(py, "BytesIO"))?
+                .call1((v,))?;
+            let serializer = PyModule::import_bound(py, intern!(py, "pyspark.serializers"))?
+                .getattr(intern!(py, "CPickleSerializer"))?
+                .call0()?;
+            let tuple = PyModule::import_bound(py, intern!(py, "pyspark.worker"))?
+                .getattr(intern!(py, "read_udfs"))?
+                .call1((serializer, infile, eval_type))?;
+            Ok(PySparkUdfObject(tuple.to_object(py)))
         })
     }
 
@@ -70,15 +67,8 @@ pub fn deserialize_partial_pyspark_udf(
     num_args: usize,
     spark_udf_config: &SparkUdfConfig,
 ) -> Result<PySparkUdfObject> {
-    let pyo3_python_version: String = Python::with_gil(|py| py.version().to_string());
-    if !pyo3_python_version.starts_with(python_version) {
-        return plan_err!(
-            "Python version mismatch. Version used to compile the UDF must match the version used to run the UDF. Version used to compile the UDF: {}. Version used to run the UDF: {}",
-            python_version,
-            pyo3_python_version
-        );
-    }
-    let data: Vec<u8> = build_pyspark_udf_payload(command, eval_type, num_args, spark_udf_config)?;
+    check_python_udf_version(python_version)?;
+    let data = build_pyspark_udf_payload(command, eval_type, num_args, spark_udf_config)?;
     Ok(PySparkUdfObject::load(&data)?)
 }
 
@@ -98,19 +88,19 @@ pub fn build_pyspark_udf_payload(
             &spark_udf_config.pandas_convert_to_arrow_array_safely,
             &spark_udf_config.arrow_max_records_per_batch,
         ];
-        let mut num_conf: i32 = 0;
-        let mut temp_data: Vec<u8> = Vec::new();
+        let mut num_config: i32 = 0;
+        let mut config_data: Vec<u8> = Vec::new();
         for config in configs {
             if let Some(value) = &config.value {
-                temp_data.extend(&(config.key.len() as i32).to_be_bytes()); // len of the key
-                temp_data.extend(config.key.as_bytes());
-                temp_data.extend(&(value.len() as i32).to_be_bytes()); // len of the value
-                temp_data.extend(value.as_bytes());
-                num_conf += 1;
+                config_data.extend(&(config.key.len() as i32).to_be_bytes()); // len of the key
+                config_data.extend(config.key.as_bytes());
+                config_data.extend(&(value.len() as i32).to_be_bytes()); // len of the value
+                config_data.extend(value.as_bytes());
+                num_config += 1;
             }
         }
-        data.extend(&num_conf.to_be_bytes()); // num_conf
-        data.extend(&temp_data);
+        data.extend(&num_config.to_be_bytes()); // num_config
+        data.extend(&config_data);
     }
     data.extend(&1i32.to_be_bytes()); // num_udfs
     let num_args: i32 = num_args

--- a/crates/sail-python-udf/src/cereal/pyspark_udtf.rs
+++ b/crates/sail-python-udf/src/cereal/pyspark_udtf.rs
@@ -2,13 +2,14 @@ use std::hash::{Hash, Hasher};
 
 use arrow::pyarrow::ToPyArrow;
 use datafusion::arrow::datatypes::DataType;
-use datafusion_common::{plan_datafusion_err, plan_err, Result};
+use datafusion_common::{plan_datafusion_err, Result};
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
 use sail_common::config::SparkUdfConfig;
 use sail_common::spec;
 
-use crate::cereal::PythonFunction;
+use crate::cereal::{check_python_udf_version, PythonFunction};
 use crate::error::{PyUdfError, PyUdfResult};
 
 #[derive(Debug, Clone)]
@@ -17,27 +18,23 @@ pub struct PySparkUdtfObject(pub PyObject);
 impl PythonFunction for PySparkUdtfObject {
     fn load(v: &[u8]) -> PyUdfResult<Self> {
         // build_pyspark_udtf_payload adds eval_type to the beginning of the payload
-        let (eval_type_bytes, v) = v.split_at(std::mem::size_of::<i32>());
+        let (eval_type_bytes, v) = v.split_at(size_of::<i32>());
         let eval_type = i32::from_be_bytes(
             eval_type_bytes
                 .try_into()
                 .map_err(|e| PyUdfError::invalid(format!("eval_type from_be_bytes: {e}")))?,
         );
         Python::with_gil(|py| {
-            let infile: Bound<PyAny> = PyModule::import_bound(py, pyo3::intern!(py, "io"))
-                .and_then(|io| io.getattr(pyo3::intern!(py, "BytesIO")))
-                .and_then(|bytes_io| bytes_io.call1((v,)))?;
-            let pickle_ser: Bound<PyAny> =
-                PyModule::import_bound(py, pyo3::intern!(py, "pyspark.serializers"))
-                    .and_then(|serializers| {
-                        serializers.getattr(pyo3::intern!(py, "CPickleSerializer"))
-                    })
-                    .and_then(|serializer| serializer.call0())?;
-            let obj = PyModule::import_bound(py, pyo3::intern!(py, "pyspark.worker"))
-                .and_then(|worker| worker.getattr(pyo3::intern!(py, "read_udtf")))
-                .and_then(|read_udtf| read_udtf.call1((pickle_ser, infile, eval_type)))
-                .map(|py_tuple| PySparkUdtfObject(py_tuple.to_object(py)))?;
-            Ok(obj)
+            let infile = PyModule::import_bound(py, intern!(py, "io"))?
+                .getattr(intern!(py, "BytesIO"))?
+                .call1((v,))?;
+            let serializer = PyModule::import_bound(py, intern!(py, "pyspark.serializers"))?
+                .getattr(intern!(py, "CPickleSerializer"))?
+                .call0()?;
+            let tuple = PyModule::import_bound(py, intern!(py, "pyspark.worker"))?
+                .getattr(intern!(py, "read_udtf"))?
+                .call1((serializer, infile, eval_type))?;
+            Ok(PySparkUdtfObject(tuple.to_object(py)))
         })
     }
 
@@ -69,15 +66,8 @@ pub fn deserialize_pyspark_udtf(
     return_type: &DataType,
     spark_udf_config: &SparkUdfConfig,
 ) -> Result<PySparkUdtfObject> {
-    let pyo3_python_version: String = Python::with_gil(|py| py.version().to_string());
-    if !pyo3_python_version.starts_with(python_version) {
-        return plan_err!(
-            "Python version mismatch. Version used to compile the UDTF must match the version used to run the UDTF. Version used to compile the UDTF: {}. Version used to run the UDTF: {}",
-            python_version,
-            pyo3_python_version
-        );
-    }
-    let data: Vec<u8> =
+    check_python_udf_version(python_version)?;
+    let data =
         build_pyspark_udtf_payload(command, eval_type, num_args, return_type, spark_udf_config)?;
     Ok(PySparkUdtfObject::load(&data)?)
 }
@@ -96,19 +86,19 @@ pub fn build_pyspark_udtf_payload(
             &spark_udf_config.timezone,
             &spark_udf_config.pandas_convert_to_arrow_array_safely,
         ];
-        let mut num_conf: i32 = 0;
-        let mut temp_data: Vec<u8> = Vec::new();
+        let mut num_config: i32 = 0;
+        let mut config_data: Vec<u8> = Vec::new();
         for config in configs {
             if let Some(value) = &config.value {
-                temp_data.extend(&(config.key.len() as i32).to_be_bytes()); // len of the key
-                temp_data.extend(config.key.as_bytes());
-                temp_data.extend(&(value.len() as i32).to_be_bytes()); // len of the value
-                temp_data.extend(value.as_bytes());
-                num_conf += 1;
+                config_data.extend(&(config.key.len() as i32).to_be_bytes()); // len of the key
+                config_data.extend(config.key.as_bytes());
+                config_data.extend(&(value.len() as i32).to_be_bytes()); // len of the value
+                config_data.extend(value.as_bytes());
+                num_config += 1;
             }
         }
-        data.extend(&num_conf.to_be_bytes()); // num_conf
-        data.extend(&temp_data);
+        data.extend(&num_config.to_be_bytes()); // num_config
+        data.extend(&config_data);
     }
     let num_args: i32 = num_args
         .try_into()
@@ -120,25 +110,20 @@ pub fn build_pyspark_udtf_payload(
     data.extend(&(command.len() as i32).to_be_bytes()); // len of the function
     data.extend_from_slice(command);
 
-    Python::with_gil(|py| {
-        let return_type: Bound<PyAny> = return_type
-            .to_pyarrow(py)
-            .unwrap()
-            .clone_ref(py)
-            .into_bound(py);
-        let result: Bound<PyAny> =
-            PyModule::import_bound(py, pyo3::intern!(py, "pyspark.sql.pandas.types"))
-                .and_then(|types| types.getattr(pyo3::intern!(py, "from_arrow_type")))
-                .and_then(|from_arrow_type| from_arrow_type.call1((return_type,)))
-                .and_then(|result| result.getattr("json"))
-                .and_then(|json_method| json_method.call0())
-                .unwrap();
-        let json_string: String = result.extract().expect("Failed to extract JSON string");
+    Python::with_gil(|py| -> PyUdfResult<_> {
+        let return_type = return_type.to_pyarrow(py)?.clone_ref(py).into_bound(py);
+        let result = PyModule::import_bound(py, intern!(py, "pyspark.sql.pandas.types"))?
+            .getattr(intern!(py, "from_arrow_type"))?
+            .call1((return_type,))?
+            .getattr("json")?
+            .call0()?;
+        let json_string: String = result.extract()?;
         let json_length = json_string.len();
 
         data.extend(&(json_length as u32).to_be_bytes());
         data.extend(json_string.as_bytes());
-    });
+        Ok(())
+    })?;
 
     Ok(data)
 }

--- a/crates/sail-python-udf/src/udf/mod.rs
+++ b/crates/sail-python-udf/src/udf/mod.rs
@@ -4,6 +4,7 @@ pub mod unresolved_pyspark_udf;
 
 use datafusion::arrow::datatypes::{DataType, SchemaRef};
 use datafusion::arrow::pyarrow::ToPyArrow;
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
@@ -18,22 +19,19 @@ pub fn get_udf_name(function_name: &str, function: &PyObject) -> String {
 }
 
 pub fn get_python_builtins(py: Python) -> PyUdfResult<Bound<PyModule>> {
-    Ok(PyModule::import_bound(py, pyo3::intern!(py, "builtins"))?)
+    Ok(PyModule::import_bound(py, intern!(py, "builtins"))?)
 }
 
 pub fn get_python_builtins_list_function(py: Python) -> PyUdfResult<Bound<PyAny>> {
-    Ok(get_python_builtins(py)?.getattr(pyo3::intern!(py, "list"))?)
+    Ok(get_python_builtins(py)?.getattr(intern!(py, "list"))?)
 }
 
 pub fn get_python_builtins_str_function(py: Python) -> PyUdfResult<Bound<PyAny>> {
-    Ok(get_python_builtins(py)?.getattr(pyo3::intern!(py, "str"))?)
+    Ok(get_python_builtins(py)?.getattr(intern!(py, "str"))?)
 }
 
 pub fn get_pyarrow_array_function(py: Python) -> PyUdfResult<Bound<PyAny>> {
-    let pyarrow_module_array: Bound<PyAny> =
-        PyModule::import_bound(py, pyo3::intern!(py, "pyarrow"))?
-            .getattr(pyo3::intern!(py, "array"))?;
-    Ok(pyarrow_module_array)
+    Ok(PyModule::import_bound(py, intern!(py, "pyarrow"))?.getattr(intern!(py, "array"))?)
 }
 
 pub fn build_pyarrow_array_kwargs<'py>(
@@ -41,12 +39,12 @@ pub fn build_pyarrow_array_kwargs<'py>(
     pyarrow_data_type: Bound<'py, PyAny>,
     from_pandas: bool,
 ) -> PyUdfResult<Bound<'py, PyDict>> {
-    let array_kwargs: Bound<PyDict> = PyDict::new_bound(py);
-    array_kwargs.set_item("type", pyarrow_data_type)?;
+    let kwargs = PyDict::new_bound(py);
+    kwargs.set_item("type", pyarrow_data_type)?;
     if from_pandas {
-        array_kwargs.set_item("from_pandas", from_pandas)?;
+        kwargs.set_item("from_pandas", from_pandas)?;
     }
-    Ok(array_kwargs)
+    Ok(kwargs)
 }
 
 pub fn get_pyarrow_output_data_type<'py>(
@@ -57,40 +55,33 @@ pub fn get_pyarrow_output_data_type<'py>(
 }
 
 pub fn get_pyarrow_record_batch_from_pandas_function(py: Python) -> PyUdfResult<Bound<PyAny>> {
-    let record_batch_from_pandas: Bound<PyAny> =
-        PyModule::import_bound(py, pyo3::intern!(py, "pyarrow"))?
-            .getattr(pyo3::intern!(py, "RecordBatch"))?
-            .getattr(pyo3::intern!(py, "from_pandas"))?;
-    Ok(record_batch_from_pandas)
+    Ok(PyModule::import_bound(py, intern!(py, "pyarrow"))?
+        .getattr(intern!(py, "RecordBatch"))?
+        .getattr(intern!(py, "from_pandas"))?)
 }
 
 pub fn get_pyarrow_record_batch_from_pylist_function(py: Python) -> PyUdfResult<Bound<PyAny>> {
-    let record_batch_from_pylist: Bound<PyAny> =
-        PyModule::import_bound(py, pyo3::intern!(py, "pyarrow"))?
-            .getattr(pyo3::intern!(py, "RecordBatch"))?
-            .getattr(pyo3::intern!(py, "from_pylist"))?;
-    Ok(record_batch_from_pylist)
+    Ok(PyModule::import_bound(py, intern!(py, "pyarrow"))?
+        .getattr(intern!(py, "RecordBatch"))?
+        .getattr(intern!(py, "from_pylist"))?)
 }
 
 pub fn build_pyarrow_record_batch_kwargs<'py>(
     py: Python<'py>,
     pyarrow_schema: Bound<'py, PyAny>,
 ) -> PyUdfResult<Bound<'py, PyDict>> {
-    let record_batch_kwargs: Bound<PyDict> = PyDict::new_bound(py);
-    record_batch_kwargs.set_item("schema", pyarrow_schema)?;
-    Ok(record_batch_kwargs)
+    let kwargs = PyDict::new_bound(py);
+    kwargs.set_item("schema", pyarrow_schema)?;
+    Ok(kwargs)
 }
 
 pub fn get_pyarrow_schema<'py>(
     schema: &SchemaRef,
     py: Python<'py>,
 ) -> PyUdfResult<Bound<'py, PyAny>> {
-    let pyarrow_schema: Bound<PyAny> = schema.to_pyarrow(py)?.clone_ref(py).into_bound(py);
-    Ok(pyarrow_schema)
+    Ok(schema.to_pyarrow(py)?.clone_ref(py).into_bound(py))
 }
 
 pub fn get_pyarrow_table_function(py: Python) -> PyUdfResult<Bound<PyAny>> {
-    let pyarrow_table: Bound<PyAny> = PyModule::import_bound(py, pyo3::intern!(py, "pyarrow"))?
-        .getattr(pyo3::intern!(py, "table"))?;
-    Ok(pyarrow_table)
+    Ok(PyModule::import_bound(py, intern!(py, "pyarrow"))?.getattr(intern!(py, "table"))?)
 }

--- a/crates/sail-python-udf/src/udf/pyspark_udtf.rs
+++ b/crates/sail-python-udf/src/udf/pyspark_udtf.rs
@@ -14,6 +14,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion_common::DataFusionError;
 use datafusion_expr::expr::Alias;
 use datafusion_expr::{Expr, TableType};
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyIterator, PyList, PyTuple};
 use sail_common::config::SparkUdfConfig;
@@ -112,33 +113,32 @@ impl PySparkUDTF {
         python_function: PySparkUdtfObject,
     ) -> PyUdfResult<RecordBatch> {
         Python::with_gil(|py| {
-            let python_function: Bound<PyAny> = python_function.function(py)?;
-            let builtins_list: Bound<PyAny> = get_python_builtins_list_function(py)?;
-            let record_batch_from_pandas: Bound<PyAny> =
-                get_pyarrow_record_batch_from_pandas_function(py)?;
+            let python_function = python_function.function(py)?;
+            let builtins_list = get_python_builtins_list_function(py)?;
+            let record_batch_from_pandas = get_pyarrow_record_batch_from_pandas_function(py)?;
 
-            let py_args: Vec<Bound<PyAny>> = args
+            let py_args = args
                 .iter()
                 .map(|arg| {
                     let arg = arg
                         .into_data()
                         .to_pyarrow(py)?
-                        .call_method0(py, pyo3::intern!(py, "to_pandas"))?
+                        .call_method0(py, intern!(py, "to_pandas"))?
                         .clone_ref(py)
                         .into_bound(py);
                     Ok(arg)
                 })
                 .collect::<PyUdfResult<Vec<_>>>()?;
-            let py_args: Bound<PyList> = PyList::new_bound(py, &py_args);
+            let py_args = PyList::new_bound(py, &py_args);
 
-            let results: Bound<PyAny> = python_function.call1((py.None(), (py_args,)))?;
-            let results: Bound<PyAny> = builtins_list.call1((results,))?.get_item(0)?;
+            let results = python_function.call1((py.None(), (py_args,)))?;
+            let results = builtins_list.call1((results,))?.get_item(0)?;
 
-            let results_data: Bound<PyAny> = results.get_item(0)?;
-            let _results_datatype: Bound<PyAny> = results.get_item(1)?;
+            let results_data = results.get_item(0)?;
+            let _results_datatype = results.get_item(1)?;
 
-            let record_batch: Bound<PyAny> = record_batch_from_pandas.call1((results_data,))?;
-            let record_batch: RecordBatch = RecordBatch::from_pyarrow_bound(&record_batch)?;
+            let record_batch = record_batch_from_pandas.call1((results_data,))?;
+            let record_batch = RecordBatch::from_pyarrow_bound(&record_batch)?;
 
             Ok(record_batch)
         })
@@ -150,45 +150,43 @@ impl PySparkUDTF {
         python_function: PySparkUdtfObject,
     ) -> PyUdfResult<RecordBatch> {
         Python::with_gil(|py| {
-            let python_function: Bound<PyAny> = python_function.function(py)?;
-            let builtins_list: Bound<PyAny> = get_python_builtins_list_function(py)?;
-            let record_batch_from_pylist: Bound<PyAny> =
-                get_pyarrow_record_batch_from_pylist_function(py)?;
-            let pyarrow_schema: Bound<PyAny> = get_pyarrow_schema(&self.return_schema, py)?;
-            let pyarrow_record_batch_kwargs: Bound<PyDict> =
+            let python_function = python_function.function(py)?;
+            let builtins_list = get_python_builtins_list_function(py)?;
+            let record_batch_from_pylist = get_pyarrow_record_batch_from_pylist_function(py)?;
+            let pyarrow_schema = get_pyarrow_schema(&self.return_schema, py)?;
+            let pyarrow_record_batch_kwargs =
                 build_pyarrow_record_batch_kwargs(py, pyarrow_schema)?;
 
-            let py_args: Vec<Bound<PyAny>> = args
+            let py_args = args
                 .iter()
                 .map(|arg| {
                     let arg = arg
                         .into_data()
                         .to_pyarrow(py)?
-                        .call_method0(py, pyo3::intern!(py, "to_pylist"))?
+                        .call_method0(py, intern!(py, "to_pylist"))?
                         .clone_ref(py)
                         .into_bound(py);
                     Ok(arg)
                 })
                 .collect::<PyUdfResult<Vec<_>>>()?;
-            let py_args: Bound<PyTuple> = PyTuple::new_bound(py, &py_args);
-            let py_args: Bound<PyAny> = py.eval_bound("zip", None, None)?.call1(&py_args)?;
-            let py_args: Bound<PyIterator> = PyIterator::from_bound_object(&py_args)?;
+            let py_args = PyTuple::new_bound(py, &py_args);
+            let py_args = py.eval_bound("zip", None, None)?.call1(&py_args)?;
+            let py_args = PyIterator::from_bound_object(&py_args)?;
 
-            let results: Bound<PyList> = PyList::empty_bound(py);
+            let results = PyList::empty_bound(py);
             for py_arg in py_args {
                 let py_arg = py_arg?;
-                let result: Bound<PyAny> = python_function.call1((py.None(), (py_arg,)))?;
-                let result: Bound<PyAny> = builtins_list.call1((result,))?.get_item(0)?;
-                let result: Bound<PyAny> = builtins_list.call1((result,))?;
-                let result: Bound<PyList> =
-                    list_of_tuples_to_list_of_dicts(py, &result, &self.return_schema)?;
+                let result = python_function.call1((py.None(), (py_arg,)))?;
+                let result = builtins_list.call1((result,))?.get_item(0)?;
+                let result = builtins_list.call1((result,))?;
+                let result = list_of_tuples_to_list_of_dicts(py, &result, &self.return_schema)?;
                 for item in result.iter() {
                     results.append(item)?;
                 }
             }
-            let record_batch: Bound<PyAny> =
+            let record_batch =
                 record_batch_from_pylist.call((results,), Some(&pyarrow_record_batch_kwargs))?;
-            let record_batch: RecordBatch = RecordBatch::from_pyarrow_bound(&record_batch)?;
+            let record_batch = RecordBatch::from_pyarrow_bound(&record_batch)?;
 
             Ok(record_batch)
         })
@@ -199,24 +197,21 @@ impl PySparkUDTF {
         python_function: PySparkUdtfObject,
     ) -> PyUdfResult<RecordBatch> {
         Python::with_gil(|py| {
-            let python_function: Bound<PyAny> = python_function.function(py)?;
-            let builtins_list: Bound<PyAny> = get_python_builtins_list_function(py)?;
-            let record_batch_from_pylist: Bound<PyAny> =
-                get_pyarrow_record_batch_from_pylist_function(py)?;
-            let pyarrow_schema: Bound<PyAny> = get_pyarrow_schema(&self.return_schema, py)?;
-            let pyarrow_record_batch_kwargs: Bound<PyDict> =
+            let python_function = python_function.function(py)?;
+            let builtins_list = get_python_builtins_list_function(py)?;
+            let record_batch_from_pylist = get_pyarrow_record_batch_from_pylist_function(py)?;
+            let pyarrow_schema = get_pyarrow_schema(&self.return_schema, py)?;
+            let pyarrow_record_batch_kwargs =
                 build_pyarrow_record_batch_kwargs(py, pyarrow_schema)?;
 
-            let results: Bound<PyAny> =
-                python_function.call1((py.None(), (PyList::empty_bound(py),)))?;
-            let results: Bound<PyAny> = builtins_list.call1((results,))?.get_item(0)?;
-            let results: Bound<PyAny> = builtins_list.call1((results,))?;
-            let results: Bound<PyList> =
-                list_of_tuples_to_list_of_dicts(py, &results, &self.return_schema)?;
+            let results = python_function.call1((py.None(), (PyList::empty_bound(py),)))?;
+            let results = builtins_list.call1((results,))?.get_item(0)?;
+            let results = builtins_list.call1((results,))?;
+            let results = list_of_tuples_to_list_of_dicts(py, &results, &self.return_schema)?;
 
-            let record_batch: Bound<PyAny> =
+            let record_batch =
                 record_batch_from_pylist.call((results,), Some(&pyarrow_record_batch_kwargs))?;
-            let record_batch: RecordBatch = RecordBatch::from_pyarrow_bound(&record_batch)?;
+            let record_batch = RecordBatch::from_pyarrow_bound(&record_batch)?;
 
             Ok(record_batch)
         })
@@ -315,11 +310,11 @@ fn list_of_tuples_to_list_of_dicts<'py>(
     schema: &SchemaRef,
 ) -> PyUdfResult<Bound<'py, PyList>> {
     let fields = schema.fields();
-    let list_of_dicts: Vec<Bound<PyDict>> = results
+    let list_of_dicts = results
         .iter()?
         .map(|result| -> PyUdfResult<_> {
             let result = result?;
-            let dict: Bound<PyDict> = PyDict::new_bound(py);
+            let dict = PyDict::new_bound(py);
             for (i, field) in fields.iter().enumerate() {
                 let field_name = field.name().as_str();
                 let value = result.get_item(i)?;


### PR DESCRIPTION
1. Remove `.and_then()` in a few places since now we support error conversion after #185.
2. Remove a few obvious type annotations to make the code more readable.
3. Remove some unnecessary use of local variables.