### PR TITLE
Publish PR comments in a separate workflow

### DIFF
--- a/.github/actions/pull-request-report/action.yml
+++ b/.github/actions/pull-request-report/action.yml
@@ -1,0 +1,46 @@
+name: Pull request report
+description: Add a report as a comment to the pull request
+inputs:
+  workflow_run_id:
+    description: The ID of the workflow run
+    type: string
+    required: true
+  artifact_name:
+    description: The artifact name for the report
+    type: string
+    required: true
+  report_name:
+    description: The name of the report used to distinguish pull request comments
+    type: string
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Download report
+      id: download
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.artifact_name }}
+        run-id: ${{ inputs.workflow_run_id }}
+        path: /tmp/report/${{ inputs.workflow_run_id }}/${{ inputs.artifact_name }}
+
+    - name: Get pull request number
+      id: number
+      env:
+        DOWNLOAD_PATH: ${{ steps.download.outputs.download-path }}
+      run: |
+        file="$DOWNLOAD_PATH/pull-request.txt"
+        if [[ -f "$file" ]]; then
+          echo "value=$(cat "$file")" >> "$GITHUB_OUTPUT"
+        else
+          echo "value=" >> "$GITHUB_OUTPUT"
+        fi
+      shell: bash
+
+    - name: Publish report
+      if: steps.number.outputs.value != ''
+      uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: ${{ inputs.report_name }}
+        number: ${{ steps.number.outputs.value }}
+        path: ${{ steps.download.outputs.download-path }}/report.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,6 @@ jobs:
   spark-tests:
     name: Spark tests
     uses: ./.github/workflows/spark-tests.yml
-    permissions:
-      pull-requests: write
     needs:
       - build
 

--- a/.github/workflows/gold-data.yml
+++ b/.github/workflows/gold-data.yml
@@ -1,12 +1,12 @@
-name: Gold data report
+name: Gold data
 
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
-    paths:
-      - "**/gold_data/**"
+#    paths:
+#      - "**/gold_data/**"
 
 jobs:
   run:
@@ -31,30 +31,18 @@ jobs:
           scripts/common-gold-data/report.sh . tmp/baseline > tmp/report.md
           cat tmp/report.md >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Save pull request number
+        if: github.event_name == 'pull_request'
+        env:
+          NUMBER: ${{ github.event.number }}
+        run: |
+          echo "$NUMBER" > tmp/pull-request.txt
+
       - name: Upload report
         uses: actions/upload-artifact@v4
         with:
           name: gold-data-report
-          path: tmp/report.md
+          path: |
+            tmp/report.md
+            tmp/pull-request.txt
           retention-days: 1
-
-  report:
-    name: Report
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    needs:
-      - run
-    steps:
-      - name: Download report
-        uses: actions/download-artifact@v4
-        with:
-          name: gold-data-report
-          path: tmp
-
-      - name: Publish report
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: gold-data-report
-          path: tmp/report.md

--- a/.github/workflows/gold-data.yml
+++ b/.github/workflows/gold-data.yml
@@ -28,21 +28,20 @@ jobs:
           REPORT_GIT_REF_BEFORE: ${{ steps.baseline.outputs.ref }}
           REPORT_GIT_REF_AFTER: ${{ github.ref }}
         run: |
-          scripts/common-gold-data/report.sh . tmp/baseline > tmp/report.md
-          cat tmp/report.md >> "$GITHUB_STEP_SUMMARY"
+          mkdir -p tmp/report
+          scripts/common-gold-data/report.sh . tmp/baseline > tmp/report/report.md
+          cat tmp/report/report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Save pull request number
         if: github.event_name == 'pull_request'
         env:
           NUMBER: ${{ github.event.number }}
         run: |
-          echo "$NUMBER" > tmp/pull-request.txt
+          echo "$NUMBER" > tmp/report/pull-request.txt
 
       - name: Upload report
         uses: actions/upload-artifact@v4
         with:
           name: gold-data-report
-          path: |
-            tmp/report.md
-            tmp/pull-request.txt
+          path: tmp/report
           retention-days: 1

--- a/.github/workflows/gold-data.yml
+++ b/.github/workflows/gold-data.yml
@@ -5,8 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-#    paths:
-#      - "**/gold_data/**"
+    paths:
+      - "**/gold_data/**"
 
 jobs:
   run:

--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,0 +1,32 @@
+name: Report
+
+on:
+  workflow_run:
+    workflows: ["Build", "Gold data"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+
+jobs:
+  report:
+    name: Report
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/pull-request-report
+        if: github.event.workflow_run.name == 'Build'
+        with:
+          workflow_run_id: ${{ github.event.workflow_run.id }}
+          artifact_name: spark-tests-report
+          report_name: spark-tests
+
+      - uses: ./.github/actions/pull-request-report
+        if: github.event.workflow_run.name == 'Gold data'
+        with:
+          workflow_run_id: ${{ github.event.workflow_run.id }}
+          artifact_name: gold-data-report
+          report_name: gold-data

--- a/.github/workflows/spark-tests.yml
+++ b/.github/workflows/spark-tests.yml
@@ -158,7 +158,8 @@ jobs:
         env:
           BASELINE_WORKFLOW_RUN_ID: ${{ steps.baseline-workflow.outputs.workflow_run_id }}
         run: |
-          report="/tmp/report.md"
+          mkdir -p /tmp/report
+          report="/tmp/report/report.md"
           if [[ -z "$BASELINE_WORKFLOW_RUN_ID" ]]; then
             printf "> [!WARNING]\n> The baseline was not found.\n\n" >> "$report"
           fi
@@ -170,13 +171,11 @@ jobs:
         env:
           NUMBER: ${{ github.event.number }}
         run: |
-          echo "$NUMBER" > /tmp/pull-request.txt
+          echo "$NUMBER" > /tmp/report/pull-request.txt
 
       - name: Upload test report
         uses: actions/upload-artifact@v4
         with:
           name: spark-tests-report
-          path: |
-            /tmp/report.md
-            /tmp/pull-request.txt
+          path: /tmp/report
           retention-days: 1

--- a/.github/workflows/spark-tests.yml
+++ b/.github/workflows/spark-tests.yml
@@ -165,30 +165,18 @@ jobs:
           scripts/spark-tests/generate-test-report.sh /tmp/test-after /tmp/test-before >> "$report"
           cat "$report" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Save pull request number
+        if: github.event_name == 'pull_request'
+        env:
+          NUMBER: ${{ github.event.number }}
+        run: |
+          echo "$NUMBER" > /tmp/pull-request.txt
+
       - name: Upload test report
         uses: actions/upload-artifact@v4
         with:
-          name: test-report
-          path: /tmp/report.md
+          name: spark-tests-report
+          path: |
+            /tmp/report.md
+            /tmp/pull-request.txt
           retention-days: 1
-
-  report:
-    name: Report
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    needs:
-      - analyze
-    steps:
-      - name: Download test report
-        uses: actions/download-artifact@v4
-        with:
-          name: test-report
-          path: /tmp
-
-      - name: Publish test report
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: spark-test-report
-          path: /tmp/report.md


### PR DESCRIPTION
Workflows triggered by fork repo pull requests can only use GitHub read tokens. (A write token for public repo pull requests would result in security vulnerability.) Therefore, publishing reports as PR comments fails due to lack of permissions.

This PR adds a workflow to publish PR comments on `workflow_run` events (rather than `pull_request` events). In this way, the write token can be used to update the PR with comments.