### PR TITLE
Improve actor implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4238,6 +4238,7 @@ dependencies = [
 name = "sail-server"
 version = "0.1.6"
 dependencies = [
+ "log",
  "sail-telemetry",
  "tokio",
  "tonic",

--- a/crates/sail-execution/src/driver/actor/rpc.rs
+++ b/crates/sail-execution/src/driver/actor/rpc.rs
@@ -1,5 +1,3 @@
-use std::mem;
-
 use sail_server::actor::ActorHandle;
 use sail_server::ServerBuilder;
 use tokio::net::{TcpListener, ToSocketAddrs};
@@ -15,26 +13,10 @@ use crate::rpc::ClientOptions;
 use crate::worker::WorkerClient;
 
 impl DriverActor {
-    pub(super) fn start_server(&mut self, handle: &ActorHandle<Self>) -> ExecutionResult<()> {
-        if self.server.is_running() {
-            return Ok(());
-        }
-        let addr = (
-            self.options().driver_listen_host.clone(),
-            self.options().driver_listen_port,
-        );
-        tokio::spawn(Self::serve(handle.clone(), addr));
-        Ok(())
-    }
-
-    pub(super) fn stop_server(&mut self) -> ExecutionResult<()> {
-        let server = mem::take(&mut self.server);
-        server.stop();
-        self.server_listen_port = None;
-        Ok(())
-    }
-
-    async fn serve(handle: ActorHandle<Self>, addr: impl ToSocketAddrs) -> ExecutionResult<()> {
+    pub(super) async fn serve(
+        handle: ActorHandle<Self>,
+        addr: impl ToSocketAddrs,
+    ) -> ExecutionResult<()> {
         let listener = TcpListener::bind(addr).await?;
         let port = listener.local_addr()?.port();
         let (tx, rx) = tokio::sync::oneshot::channel();

--- a/crates/sail-execution/src/worker/actor/rpc.rs
+++ b/crates/sail-execution/src/worker/actor/rpc.rs
@@ -1,5 +1,3 @@
-use std::mem;
-
 use arrow_flight::flight_service_server::FlightServiceServer;
 use sail_server::actor::ActorHandle;
 use sail_server::ServerBuilder;
@@ -14,28 +12,7 @@ use crate::worker::server::WorkerServer;
 use crate::worker::WorkerEvent;
 
 impl WorkerActor {
-    pub(super) fn start_server(
-        &mut self,
-        handle: &ActorHandle<WorkerActor>,
-    ) -> ExecutionResult<()> {
-        if self.server.is_running() {
-            return Ok(());
-        }
-        let addr = (
-            self.options().worker_listen_host.clone(),
-            self.options().worker_listen_port,
-        );
-        tokio::spawn(Self::serve(handle.clone(), addr));
-        Ok(())
-    }
-
-    pub(super) fn stop_server(&mut self) -> ExecutionResult<()> {
-        let server = mem::take(&mut self.server);
-        server.stop();
-        Ok(())
-    }
-
-    async fn serve(
+    pub(super) async fn serve(
         handle: ActorHandle<WorkerActor>,
         addr: impl ToSocketAddrs,
     ) -> ExecutionResult<()> {

--- a/crates/sail-server/Cargo.toml
+++ b/crates/sail-server/Cargo.toml
@@ -13,3 +13,4 @@ tonic-health = { workspace = true }
 tonic-types = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
+log = { workspace = true }


### PR DESCRIPTION
1. Implement `ActorContext` to keep track of all Tokio tasks spawned by the actor.
2. Refactor `ServerMonitor` to be an `enum` so that it can manage its state better.