### PR TITLE
Set up application configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2008,6 +2017,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "toml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2762,6 +2785,12 @@ name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "inout"
@@ -3540,6 +3569,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3714,6 +3766,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -4264,6 +4329,7 @@ dependencies = [
  "datafusion",
  "datafusion-common",
  "datafusion-expr",
+ "figment",
  "glob",
  "lexical-core",
  "num_enum",
@@ -4583,6 +4649,15 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
  "serde",
 ]
 
@@ -5037,10 +5112,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -5049,6 +5139,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap 2.6.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]
@@ -5294,6 +5386,15 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicase"
@@ -5798,6 +5899,12 @@ checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,11 +67,12 @@ opentelemetry = "0.26.0"
 opentelemetry_sdk = "0.26.0"
 opentelemetry-otlp = { version = "0.26.0", features = ["tls", "tls-roots"] }
 hdfs-native-object-store = "0.12.1"
-
+figment = { version = "0.10.19", features = ["toml", "env"] }
 
 ######
 # The versions of the following dependencies are managed manually.
 ######
+
 datafusion = { version = "42.2.0", features = ["serde", "pyarrow", "avro"] }
 datafusion-common = { version = "42.2.0", features = ["object_store", "pyarrow", "avro"] }
 datafusion-expr = "42.2.0"
@@ -92,12 +93,11 @@ arrow-flight = { version = "53.1.0" }
 object_store = { version = "0.11.0", features = ["aws", "gcp", "azure", "http"] }
 # We use a patched latest version of sqlparser. The version may be different from the one used in DataFusion.
 sqlparser = { git = "https://github.com/lakehq/sqlparser-rs.git", rev = "0908ddb", features = ["serde", "visitor"] }
+
 ######
 # This is the end of the manually managed dependencies.
 # Do not add more dependencies below.
 ######
-
-
 
 [patch.crates-io]
 # Override dependencies to use our forked versions.

--- a/crates/sail-common/Cargo.toml
+++ b/crates/sail-common/Cargo.toml
@@ -20,3 +20,4 @@ pyo3 = { workspace = true }
 lexical-core = { workspace = true }
 num_enum = { workspace = true }
 sqlparser = { workspace = true }
+figment = { workspace = true }

--- a/crates/sail-common/src/config/application.rs
+++ b/crates/sail-common/src/config/application.rs
@@ -1,0 +1,69 @@
+use figment::providers::{Env, Format, Toml};
+use figment::Figment;
+use serde::{Deserialize, Serialize};
+
+use crate::error::{CommonError, CommonResult};
+
+const DEFAULT_CONFIG: &str = include_str!("default.toml");
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppConfig {
+    pub runner: RunnerKind,
+    pub driver: DriverConfig,
+    pub worker: WorkerConfig,
+    pub network: NetworkConfig,
+    pub execution: ExecutionConfig,
+}
+
+impl AppConfig {
+    pub fn load() -> CommonResult<Self> {
+        Figment::from(Toml::string(DEFAULT_CONFIG))
+            .admerge(Env::prefixed("SAIL__").map(|p| p.as_str().replace("__", ".").into()))
+            .extract()
+            .map_err(|e| CommonError::InvalidArgument(e.to_string()))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RunnerKind {
+    Local,
+    Cluster,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DriverConfig {
+    pub listen_host: String,
+    pub listen_port: u16,
+    pub external_host: String,
+    pub external_port: Option<u16>,
+    pub worker_count_per_job: usize,
+    pub job_output_buffer: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkerConfig {
+    pub id: u64,
+    pub listen_host: String,
+    pub listen_port: u16,
+    pub external_host: String,
+    pub external_port: Option<u16>,
+    pub memory_stream_buffer: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NetworkConfig {
+    pub enable_tls: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExecutionConfig {
+    pub batch_size: usize,
+    pub parquet: ParquetConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParquetConfig {
+    pub maximum_parallel_row_group_writers: usize,
+    pub maximum_buffered_record_batches_per_stream: usize,
+}

--- a/crates/sail-common/src/config/default.toml
+++ b/crates/sail-common/src/config/default.toml
@@ -1,0 +1,27 @@
+runner = "local"
+
+[driver]
+listen_host = "127.0.0.1"
+listen_port = 0
+external_host = "127.0.0.1"
+# external_port = <value>
+worker_count_per_job = 4
+job_output_buffer = 16
+
+[worker]
+id = 1
+listen_host = "127.0.0.1"
+listen_port = 0
+external_host = "127.0.0.1"
+# external_port = <value>
+memory_stream_buffer = 16
+
+[network]
+enable_tls = false
+
+[execution]
+batch_size = 8192
+
+[execution.parquet]
+maximum_parallel_row_group_writers = 2
+maximum_buffered_record_batches_per_stream = 16

--- a/crates/sail-common/src/config/mod.rs
+++ b/crates/sail-common/src/config/mod.rs
@@ -1,0 +1,12 @@
+mod application;
+
+use std::fmt::Debug;
+use std::hash::Hash;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ConfigKeyValue {
+    pub key: String,
+    pub value: Option<String>,
+}
+
+pub use application::*;

--- a/crates/sail-execution/src/driver/options.rs
+++ b/crates/sail-execution/src/driver/options.rs
@@ -1,3 +1,5 @@
+use sail_common::config::AppConfig;
+
 pub struct DriverOptions {
     pub enable_tls: bool,
     pub driver_listen_host: String,
@@ -7,4 +9,18 @@ pub struct DriverOptions {
     // TODO: support dynamic worker allocation
     pub worker_count_per_job: usize,
     pub job_output_buffer: usize,
+}
+
+impl From<&AppConfig> for DriverOptions {
+    fn from(config: &AppConfig) -> Self {
+        Self {
+            enable_tls: config.network.enable_tls,
+            driver_listen_host: config.driver.listen_host.clone(),
+            driver_listen_port: config.driver.listen_port,
+            driver_external_host: config.driver.external_host.clone(),
+            driver_external_port: config.driver.external_port,
+            worker_count_per_job: config.driver.worker_count_per_job,
+            job_output_buffer: config.driver.job_output_buffer,
+        }
+    }
 }

--- a/crates/sail-execution/src/worker/options.rs
+++ b/crates/sail-execution/src/worker/options.rs
@@ -1,3 +1,5 @@
+use sail_common::config::AppConfig;
+
 use crate::id::WorkerId;
 
 pub struct WorkerOptions {
@@ -10,4 +12,20 @@ pub struct WorkerOptions {
     pub worker_external_host: String,
     pub worker_external_port: Option<u16>,
     pub memory_stream_buffer: usize,
+}
+
+impl From<&AppConfig> for WorkerOptions {
+    fn from(config: &AppConfig) -> Self {
+        WorkerOptions {
+            worker_id: config.worker.id.into(),
+            enable_tls: config.network.enable_tls,
+            driver_host: config.driver.listen_host.clone(),
+            driver_port: config.driver.listen_port,
+            worker_listen_host: config.worker.listen_host.clone(),
+            worker_listen_port: config.worker.listen_port,
+            worker_external_host: config.worker.external_host.clone(),
+            worker_external_port: config.worker.external_port,
+            memory_stream_buffer: config.worker.memory_stream_buffer,
+        }
+    }
 }

--- a/crates/sail-execution/src/worker_manager/local.rs
+++ b/crates/sail-execution/src/worker_manager/local.rs
@@ -46,6 +46,7 @@ impl WorkerManager for LocalWorkerManager {
             enable_tls: false,
             driver_host: options.driver_host,
             driver_port: options.driver_port,
+            // TODO: propagate the configuration from the driver
             worker_listen_host: "127.0.0.1".to_string(),
             worker_listen_port: 0,
             worker_external_host: "127.0.0.1".to_string(),

--- a/crates/sail-plan/src/config.rs
+++ b/crates/sail-plan/src/config.rs
@@ -2,7 +2,8 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;
 
-use sail_common::config::{ConfigKeyValue, SparkUdfConfig};
+use sail_common::config::ConfigKeyValue;
+use sail_python_udf::config::SparkUdfConfig;
 
 use crate::formatter::{DefaultPlanFormatter, PlanFormatter};
 

--- a/crates/sail-plan/src/object_store/config.rs
+++ b/crates/sail-plan/src/object_store/config.rs
@@ -1,47 +1,28 @@
 use std::collections::HashMap;
 
 use aws_config::{BehaviorVersion, SdkConfig};
+use tokio::sync::OnceCell;
 
 #[derive(Debug, Clone)]
 pub struct ObjectStoreConfig {
-    aws: Option<SdkConfig>,
-    /// key,value should correspond to a field in {core-site,hdfs-site}.xml hadoop configuration files
-    hdfs: Option<HashMap<String, String>>,
+    pub aws: SdkConfig,
+    /// Key-value pairs corresponding to a field in {core-site,hdfs-site}.xml hadoop configuration files.
+    pub hdfs: HashMap<String, String>,
 }
+
+pub(super) static OBJECT_STORE_CONFIG: OnceCell<ObjectStoreConfig> = OnceCell::const_new();
 
 impl ObjectStoreConfig {
-    pub fn new() -> Self {
-        Self {
-            aws: None,
-            hdfs: None,
-        }
+    /// Initialize the global object store configuration asynchronously.
+    /// This is a no-op if the configuration has already been loaded.
+    pub async fn initialize() {
+        OBJECT_STORE_CONFIG
+            .get_or_init(|| async {
+                Self {
+                    aws: aws_config::defaults(BehaviorVersion::latest()).load().await,
+                    hdfs: HashMap::new(),
+                }
+            })
+            .await;
     }
-
-    pub fn with_aws(mut self, aws: SdkConfig) -> Self {
-        self.aws = Some(aws);
-        self
-    }
-
-    pub fn with_hdfs(mut self, hdfs: HashMap<String, String>) -> Self {
-        self.hdfs = Some(hdfs);
-        self
-    }
-
-    pub fn aws(&self) -> Option<&SdkConfig> {
-        self.aws.as_ref()
-    }
-
-    pub fn hdfs(&self) -> Option<&HashMap<String, String>> {
-        self.hdfs.as_ref()
-    }
-}
-
-impl Default for ObjectStoreConfig {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-pub async fn load_aws_config() -> SdkConfig {
-    aws_config::defaults(BehaviorVersion::latest()).load().await
 }

--- a/crates/sail-plan/src/object_store/mod.rs
+++ b/crates/sail-plan/src/object_store/mod.rs
@@ -2,5 +2,5 @@ mod config;
 mod registry;
 mod s3;
 
-pub use config::{load_aws_config, ObjectStoreConfig};
+pub use config::ObjectStoreConfig;
 pub use registry::DynamicObjectStoreRegistry;

--- a/crates/sail-plan/src/temp_view.rs
+++ b/crates/sail-plan/src/temp_view.rs
@@ -76,7 +76,8 @@ pub(crate) fn manage_temporary_views<T>(
         f(&GLOBAL_TEMPORARY_VIEW_MANAGER)
     } else {
         let views = ctx
-            .state()
+            .state_ref()
+            .read()
             .config()
             .get_extension::<TemporaryViewManager>()
             .ok_or_else(|| internal_datafusion_err!("temporary view manager not found"))?;

--- a/crates/sail-python-udf/src/cereal/pyspark_udf.rs
+++ b/crates/sail-python-udf/src/cereal/pyspark_udf.rs
@@ -4,10 +4,10 @@ use datafusion_common::{plan_datafusion_err, Result};
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
-use sail_common::config::SparkUdfConfig;
 use sail_common::spec;
 
 use crate::cereal::{check_python_udf_version, PythonFunction};
+use crate::config::SparkUdfConfig;
 use crate::error::{PyUdfError, PyUdfResult};
 
 #[derive(Debug)]

--- a/crates/sail-python-udf/src/cereal/pyspark_udtf.rs
+++ b/crates/sail-python-udf/src/cereal/pyspark_udtf.rs
@@ -6,10 +6,10 @@ use datafusion_common::{plan_datafusion_err, Result};
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
-use sail_common::config::SparkUdfConfig;
 use sail_common::spec;
 
 use crate::cereal::{check_python_udf_version, PythonFunction};
+use crate::config::SparkUdfConfig;
 use crate::error::{PyUdfError, PyUdfResult};
 
 #[derive(Debug)]

--- a/crates/sail-python-udf/src/config.rs
+++ b/crates/sail-python-udf/src/config.rs
@@ -1,11 +1,4 @@
-use std::fmt::Debug;
-use std::hash::Hash;
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ConfigKeyValue {
-    pub key: String,
-    pub value: Option<String>,
-}
+use sail_common::config::ConfigKeyValue;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SparkUdfConfig {

--- a/crates/sail-python-udf/src/lib.rs
+++ b/crates/sail-python-udf/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod cereal;
+pub mod config;
 pub mod error;
 pub mod udf;

--- a/crates/sail-python-udf/src/udf/pyspark_udtf.rs
+++ b/crates/sail-python-udf/src/udf/pyspark_udtf.rs
@@ -17,12 +17,12 @@ use datafusion_expr::{Expr, TableType};
 use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyIterator, PyList, PyTuple};
-use sail_common::config::SparkUdfConfig;
 use sail_common::spec::TableFunctionDefinition;
 use sail_common::utils::cast_record_batch;
 
 use crate::cereal::pyspark_udtf::{deserialize_pyspark_udtf, PySparkUdtfObject};
 use crate::cereal::PythonFunction;
+use crate::config::SparkUdfConfig;
 use crate::error::PyUdfResult;
 use crate::udf::{
     build_pyarrow_record_batch_kwargs, build_pyarrow_to_pandas_kwargs,

--- a/crates/sail-spark-connect/src/lib.rs
+++ b/crates/sail-spark-connect/src/lib.rs
@@ -13,6 +13,7 @@ mod schema;
 pub mod server;
 mod service;
 mod session;
+mod session_manager;
 
 const SPARK_VERSION: &str = "3.5.1";
 

--- a/crates/sail-spark-connect/src/proto/function.rs
+++ b/crates/sail-spark-connect/src/proto/function.rs
@@ -1,18 +1,23 @@
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     use arrow::array::RecordBatch;
     use arrow::error::ArrowError;
     use arrow_cast::display::{ArrayFormatter, FormatOptions};
+    use sail_common::config::AppConfig;
     use sail_common::tests::test_gold_set;
-    use sail_execution::job::LocalJobRunner;
-    use sail_plan::object_store::ObjectStoreConfig;
+    use sail_plan::resolve_and_execute_plan;
     use serde::{Deserialize, Serialize};
 
     use crate::error::{SparkError, SparkResult};
+    use crate::executor::read_stream;
     use crate::proto::data_type_json::JsonDataType;
-    use crate::session::Session;
+    use crate::session::SparkSession;
+    use crate::session_manager::{SessionKey, SessionManager};
+    use crate::spark::connect::relation::RelType;
+    use crate::spark::connect::{Relation, Sql};
 
     #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
@@ -49,14 +54,32 @@ mod tests {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;
-        let context = Session::build_context(Arc::new(ObjectStoreConfig::default()))?;
-        let job_runner = Box::new(LocalJobRunner::new(context.clone()));
-        let session = Session::new(None, "test".to_string(), job_runner, context);
+        let config = AppConfig::load()?;
+        let session_manager = SessionManager::new(Arc::new(config));
+        let session_key = SessionKey {
+            user_id: None,
+            session_id: "test".to_string(),
+        };
+        let context = session_manager.get_or_create_session_context(session_key)?;
         Ok(test_gold_set(
             "tests/gold_data/function/*.json",
             |example: FunctionExample| -> SparkResult<String> {
-                let result =
-                    rt.block_on(async { session.execute_query(example.query.as_str()).await });
+                let relation = Relation {
+                    common: None,
+                    rel_type: Some(RelType::Sql(Sql {
+                        query: example.query,
+                        args: HashMap::new(),
+                        pos_args: vec![],
+                    })),
+                };
+                let plan = relation.try_into()?;
+                let result = rt.block_on(async {
+                    let spark = SparkSession::get(&context)?;
+                    let plan =
+                        resolve_and_execute_plan(&context, spark.plan_config()?, plan).await?;
+                    let stream = spark.job_runner().execute(&context, plan).await?;
+                    read_stream(stream).await
+                });
                 // TODO: validate the result against the expected output
                 // TODO: handle non-deterministic results and error messages
                 match result {

--- a/crates/sail-spark-connect/src/service/artifact_manager.rs
+++ b/crates/sail-spark-connect/src/service/artifact_manager.rs
@@ -1,24 +1,23 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 
+use datafusion::prelude::SessionContext;
 use tonic::codegen::tokio_stream::Stream;
 use tonic::Status;
 
 use crate::error::{SparkError, SparkResult};
-use crate::session::Session;
 use crate::spark::connect::add_artifacts_request::Payload;
 use crate::spark::connect::add_artifacts_response::ArtifactSummary;
 use crate::spark::connect::artifact_statuses_response::ArtifactStatus;
 
 pub(crate) async fn handle_add_artifacts(
-    _session: Arc<Session>,
+    _ctx: &SessionContext,
     _stream: impl Stream<Item = Result<Payload, Status>>,
 ) -> SparkResult<Vec<ArtifactSummary>> {
     Err(SparkError::todo("handle add artifacts"))
 }
 
 pub(crate) async fn handle_artifact_statuses(
-    _session: Arc<Session>,
+    _ctx: &SessionContext,
     _names: Vec<String>,
 ) -> SparkResult<HashMap<String, ArtifactStatus>> {
     Err(SparkError::todo("handle artifact statuses"))

--- a/crates/sail-spark-connect/src/service/config_manager.rs
+++ b/crates/sail-spark-connect/src/service/config_manager.rs
@@ -1,102 +1,146 @@
-use std::sync::Arc;
-
+use chrono::{Offset, Utc};
+use chrono_tz::Tz;
+use datafusion::prelude::SessionContext;
 use sail_common::config::ConfigKeyValue;
 
-use crate::config::{ConfigKeyValueList, SparkRuntimeConfig};
-use crate::error::SparkResult;
-use crate::session::Session;
+use crate::config::SparkRuntimeConfig;
+use crate::error::{SparkError, SparkResult};
+use crate::session::SparkSession;
+use crate::spark::config::SPARK_SQL_SESSION_TIME_ZONE;
 use crate::spark::connect::{ConfigResponse, KeyValue};
 
+fn config_set_time_zone(ctx: &SessionContext, value: String) -> SparkResult<()> {
+    let state = ctx.state_ref();
+    let mut state = state.write();
+    let offset_string = if value.starts_with("+") || value.starts_with("-") {
+        value.clone()
+    } else if value.to_lowercase() == "z" {
+        "+00:00".to_string()
+    } else {
+        let tz: Tz = value
+            .parse()
+            .map_err(|e| SparkError::invalid(format!("invalid time zone: {e}")))?;
+        let local_time_offset = Utc::now()
+            .with_timezone(&tz)
+            .offset()
+            .fix()
+            .local_minus_utc();
+        format!(
+            "{:+03}:{:02}",
+            local_time_offset / 3600,
+            (local_time_offset.abs() % 3600) / 60
+        )
+    };
+    state.config_mut().options_mut().execution.time_zone = Some(offset_string);
+    Ok(())
+}
+
 pub(crate) fn handle_config_get(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     keys: Vec<String>,
 ) -> SparkResult<ConfigResponse> {
+    let spark = SparkSession::get(ctx)?;
     let warnings = SparkRuntimeConfig::get_warnings_by_keys(&keys);
-    let pairs = session.get_config(keys)?.into();
+    let pairs = spark.get_config(keys)?;
+    let pairs = pairs.into_iter().map(Into::into).collect();
     Ok(ConfigResponse {
-        session_id: session.session_id().to_string(),
+        session_id: spark.session_id().to_string(),
         pairs,
         warnings,
     })
 }
 
 pub(crate) fn handle_config_set(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     kv: Vec<KeyValue>,
 ) -> SparkResult<ConfigResponse> {
-    let kv: ConfigKeyValueList = kv.into();
+    let spark = SparkSession::get(ctx)?;
+    let kv: Vec<ConfigKeyValue> = kv.into_iter().map(Into::into).collect();
     let warnings = SparkRuntimeConfig::get_warnings(&kv);
-    session.set_config(kv)?;
+    for ConfigKeyValue { key, value } in &kv {
+        if key == SPARK_SQL_SESSION_TIME_ZONE {
+            if let Some(value) = value {
+                config_set_time_zone(ctx, value.clone())?;
+            }
+        }
+    }
+    spark.set_config(kv)?;
     Ok(ConfigResponse {
-        session_id: session.session_id().to_string(),
+        session_id: spark.session_id().to_string(),
         pairs: Vec::new(),
         warnings,
     })
 }
 
 pub(crate) fn handle_config_get_with_default(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     kv: Vec<KeyValue>,
 ) -> SparkResult<ConfigResponse> {
-    let kv: ConfigKeyValueList = kv.into();
+    let spark = SparkSession::get(ctx)?;
+    let kv: Vec<ConfigKeyValue> = kv.into_iter().map(Into::into).collect();
     let warnings = SparkRuntimeConfig::get_warnings(&kv);
-    let pairs = session.get_config_with_default(kv)?.into();
+    let pairs = spark.get_config_with_default(kv)?;
+    let pairs = pairs.into_iter().map(Into::into).collect();
     Ok(ConfigResponse {
-        session_id: session.session_id().to_string(),
+        session_id: spark.session_id().to_string(),
         pairs,
         warnings,
     })
 }
 
 pub(crate) fn handle_config_get_option(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     keys: Vec<String>,
 ) -> SparkResult<ConfigResponse> {
+    let spark = SparkSession::get(ctx)?;
     let warnings = SparkRuntimeConfig::get_warnings_by_keys(&keys);
     let kv = keys
         .into_iter()
         .map(|key| ConfigKeyValue { key, value: None })
-        .collect::<Vec<_>>()
-        .into();
-    let pairs = session.get_config_with_default(kv)?.into();
+        .collect::<Vec<_>>();
+    let pairs = spark.get_config_with_default(kv)?;
+    let pairs = pairs.into_iter().map(Into::into).collect();
     Ok(ConfigResponse {
-        session_id: session.session_id().to_string(),
+        session_id: spark.session_id().to_string(),
         pairs,
         warnings,
     })
 }
 
 pub(crate) fn handle_config_get_all(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     prefix: Option<String>,
 ) -> SparkResult<ConfigResponse> {
-    let kv = session.get_all_config(prefix.as_deref())?;
+    let spark = SparkSession::get(ctx)?;
+    let kv = spark.get_all_config(prefix.as_deref())?;
     let warnings = SparkRuntimeConfig::get_warnings(&kv);
-    let pairs = kv.into();
+    let pairs = kv.into_iter().map(Into::into).collect();
     Ok(ConfigResponse {
-        session_id: session.session_id().to_string(),
+        session_id: spark.session_id().to_string(),
         pairs,
         warnings,
     })
 }
 
 pub(crate) fn handle_config_unset(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     keys: Vec<String>,
 ) -> SparkResult<ConfigResponse> {
+    let spark = SparkSession::get(ctx)?;
     let warnings = SparkRuntimeConfig::get_warnings_by_keys(&keys);
-    session.unset_config(keys)?;
+    spark.unset_config(keys)?;
     Ok(ConfigResponse {
-        session_id: session.session_id().to_string(),
+        session_id: spark.session_id().to_string(),
         pairs: Vec::new(),
         warnings,
     })
 }
 
 pub(crate) fn handle_config_is_modifiable(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     keys: Vec<String>,
 ) -> SparkResult<ConfigResponse> {
+    let spark = SparkSession::get(ctx)?;
     let warnings = SparkRuntimeConfig::get_warnings_by_keys(&keys);
     let pairs = keys
         .into_iter()
@@ -110,7 +154,7 @@ pub(crate) fn handle_config_is_modifiable(
         })
         .collect();
     Ok(ConfigResponse {
-        session_id: session.session_id().to_string(),
+        session_id: spark.session_id().to_string(),
         pairs,
         warnings,
     })

--- a/crates/sail-spark-connect/src/service/plan_analyzer.rs
+++ b/crates/sail-spark-connect/src/service/plan_analyzer.rs
@@ -1,8 +1,8 @@
-use std::sync::Arc;
-
 use datafusion::arrow::util::pretty::pretty_format_batches;
+use datafusion::prelude::SessionContext;
 use sail_common::spec;
 use sail_common::utils::rename_schema;
+use sail_plan::resolve_and_execute_plan;
 use sail_plan::resolver::plan::NamedPlan;
 use sail_plan::resolver::PlanResolver;
 
@@ -10,7 +10,7 @@ use crate::error::{ProtoFieldExt, SparkError, SparkResult};
 use crate::executor::read_stream;
 use crate::proto::data_type::parse_spark_data_type;
 use crate::schema::{to_spark_schema, to_tree_string};
-use crate::session::Session;
+use crate::session::SparkSession;
 use crate::spark::connect as sc;
 use crate::spark::connect::analyze_plan_request::explain::ExplainMode;
 use crate::spark::connect::analyze_plan_request::{
@@ -32,9 +32,9 @@ use crate::spark::connect::analyze_plan_response::{
 use crate::spark::connect::StorageLevel;
 use crate::SPARK_VERSION;
 
-async fn analyze_schema(session: Arc<Session>, plan: sc::Plan) -> SparkResult<sc::DataType> {
-    let ctx = session.context();
-    let resolver = PlanResolver::new(ctx, session.plan_config()?);
+async fn analyze_schema(ctx: &SessionContext, plan: sc::Plan) -> SparkResult<sc::DataType> {
+    let spark = SparkSession::get(ctx)?;
+    let resolver = PlanResolver::new(ctx, spark.plan_config()?);
     let NamedPlan { plan, fields } = resolver
         .resolve_named_plan(spec::Plan::Query(plan.try_into()?))
         .await?;
@@ -47,21 +47,22 @@ async fn analyze_schema(session: Arc<Session>, plan: sc::Plan) -> SparkResult<sc
 }
 
 pub(crate) async fn handle_analyze_schema(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     request: SchemaRequest,
 ) -> SparkResult<SchemaResponse> {
     let SchemaRequest { plan } = request;
     let plan = plan.required("plan")?;
-    let schema = analyze_schema(session, plan).await?;
+    let schema = analyze_schema(ctx, plan).await?;
     Ok(SchemaResponse {
         schema: Some(schema),
     })
 }
 
 pub(crate) async fn handle_analyze_explain(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     request: ExplainRequest,
 ) -> SparkResult<ExplainResponse> {
+    let spark = SparkSession::get(ctx)?;
     let ExplainRequest { plan, explain_mode } = request;
     let plan = plan.required("plan")?;
     let explain_mode = ExplainMode::try_from(explain_mode)?;
@@ -69,7 +70,8 @@ pub(crate) async fn handle_analyze_explain(
         mode: explain_mode.try_into()?,
         input: Box::new(plan.try_into()?),
     }));
-    let stream = session.execute_plan(explain).await?;
+    let plan = resolve_and_execute_plan(ctx, spark.plan_config()?, explain).await?;
+    let stream = spark.job_runner().execute(ctx, plan).await?;
     let batches = read_stream(stream).await?;
     Ok(ExplainResponse {
         // FIXME: The explain output should not be formatted as a table.
@@ -78,26 +80,26 @@ pub(crate) async fn handle_analyze_explain(
 }
 
 pub(crate) async fn handle_analyze_tree_string(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     request: TreeStringRequest,
 ) -> SparkResult<TreeStringResponse> {
     let TreeStringRequest { plan, level } = request;
     let plan = plan.required("plan")?;
-    let schema = analyze_schema(session, plan).await?;
+    let schema = analyze_schema(ctx, plan).await?;
     Ok(TreeStringResponse {
         tree_string: to_tree_string(&schema, level),
     })
 }
 
 pub(crate) async fn handle_analyze_is_local(
-    _session: Arc<Session>,
+    _ctx: &SessionContext,
     _request: IsLocalRequest,
 ) -> SparkResult<IsLocalResponse> {
     Err(SparkError::todo("handle analyze is local"))
 }
 
 pub(crate) async fn handle_analyze_is_streaming(
-    _session: Arc<Session>,
+    _ctx: &SessionContext,
     _request: IsStreamingRequest,
 ) -> SparkResult<IsStreamingResponse> {
     // TODO: support streaming
@@ -107,14 +109,14 @@ pub(crate) async fn handle_analyze_is_streaming(
 }
 
 pub(crate) async fn handle_analyze_input_files(
-    _session: Arc<Session>,
+    _ctx: &SessionContext,
     _request: InputFilesRequest,
 ) -> SparkResult<InputFilesResponse> {
     Err(SparkError::todo("handle analyze input files"))
 }
 
 pub(crate) async fn handle_analyze_spark_version(
-    _session: Arc<Session>,
+    _ctx: &SessionContext,
     _request: SparkVersionRequest,
 ) -> SparkResult<SparkVersionResponse> {
     Ok(SparkVersionResponse {
@@ -123,7 +125,7 @@ pub(crate) async fn handle_analyze_spark_version(
 }
 
 pub(crate) async fn handle_analyze_ddl_parse(
-    _session: Arc<Session>,
+    _ctx: &SessionContext,
     request: DdlParseRequest,
 ) -> SparkResult<DdlParseResponse> {
     let schema = parse_spark_data_type(request.ddl_string.as_str())?;
@@ -133,35 +135,35 @@ pub(crate) async fn handle_analyze_ddl_parse(
 }
 
 pub(crate) async fn handle_analyze_same_semantics(
-    _session: Arc<Session>,
+    _ctx: &SessionContext,
     _request: SameSemanticsRequest,
 ) -> SparkResult<SameSemanticsResponse> {
     Err(SparkError::todo("handle analyze same semantics"))
 }
 
 pub(crate) async fn handle_analyze_semantic_hash(
-    _session: Arc<Session>,
+    _ctx: &SessionContext,
     _request: SemanticHashRequest,
 ) -> SparkResult<SemanticHashResponse> {
     Err(SparkError::todo("handle analyze semantic hash"))
 }
 
 pub(crate) async fn handle_analyze_persist(
-    _session: Arc<Session>,
+    _ctx: &SessionContext,
     _request: PersistRequest,
 ) -> SparkResult<PersistResponse> {
     Ok(PersistResponse {})
 }
 
 pub(crate) async fn handle_analyze_unpersist(
-    _session: Arc<Session>,
+    _ctx: &SessionContext,
     _request: UnpersistRequest,
 ) -> SparkResult<UnpersistResponse> {
     Ok(UnpersistResponse {})
 }
 
 pub(crate) async fn handle_analyze_get_storage_level(
-    _session: Arc<Session>,
+    _ctx: &SessionContext,
     _request: GetStorageLevelRequest,
 ) -> SparkResult<GetStorageLevelResponse> {
     Ok(GetStorageLevelResponse {

--- a/crates/sail-spark-connect/src/service/plan_executor.rs
+++ b/crates/sail-spark-connect/src/service/plan_executor.rs
@@ -1,10 +1,11 @@
 use std::pin::Pin;
-use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use arrow::compute::concat_batches;
+use datafusion::prelude::SessionContext;
 use log::debug;
 use sail_common::spec;
+use sail_plan::resolve_and_execute_plan;
 use tonic::codegen::tokio_stream::wrappers::ReceiverStream;
 use tonic::codegen::tokio_stream::Stream;
 use tonic::Status;
@@ -13,7 +14,7 @@ use crate::error::{SparkError, SparkResult};
 use crate::executor::{
     read_stream, to_arrow_batch, Executor, ExecutorBatch, ExecutorMetadata, ExecutorOutput,
 };
-use crate::session::Session;
+use crate::session::SparkSession;
 use crate::spark::connect as sc;
 use crate::spark::connect::execute_plan_response::{
     ResponseType, ResultComplete, SqlCommandResult,
@@ -99,18 +100,20 @@ enum ExecutePlanMode {
 }
 
 async fn handle_execute_plan(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     plan: spec::Plan,
     metadata: ExecutorMetadata,
     mode: ExecutePlanMode,
 ) -> SparkResult<ExecutePlanResponseStream> {
+    let spark = SparkSession::get(ctx)?;
     let operation_id = metadata.operation_id.clone();
-    let stream = session.execute_plan(plan).await?;
+    let plan = resolve_and_execute_plan(ctx, spark.plan_config()?, plan).await?;
+    let stream = spark.job_runner().execute(ctx, plan).await?;
     let rx = match mode {
         ExecutePlanMode::Lazy => {
             let executor = Executor::new(metadata, stream);
             let rx = executor.start()?;
-            session.add_executor(executor)?;
+            spark.add_executor(executor)?;
             rx
         }
         ExecutePlanMode::EagerSilent => {
@@ -123,68 +126,69 @@ async fn handle_execute_plan(
         }
     };
     Ok(ExecutePlanResponseStream::new(
-        session.session_id().to_string(),
+        spark.session_id().to_string(),
         operation_id,
         rx,
     ))
 }
 
 pub(crate) async fn handle_execute_relation(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     relation: Relation,
     metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
     let plan = relation.try_into()?;
-    handle_execute_plan(session, plan, metadata, ExecutePlanMode::Lazy).await
+    handle_execute_plan(ctx, plan, metadata, ExecutePlanMode::Lazy).await
 }
 
 pub(crate) async fn handle_execute_register_function(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     udf: CommonInlineUserDefinedFunction,
     metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
     let plan = spec::Plan::Command(spec::CommandPlan::new(spec::CommandNode::RegisterFunction(
         udf.try_into()?,
     )));
-    handle_execute_plan(session, plan, metadata, ExecutePlanMode::EagerSilent).await
+    handle_execute_plan(ctx, plan, metadata, ExecutePlanMode::EagerSilent).await
 }
 
 pub(crate) async fn handle_execute_write_operation(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     write: WriteOperation,
     metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
     let plan = spec::Plan::Command(spec::CommandPlan::new(spec::CommandNode::Write(
         write.try_into()?,
     )));
-    handle_execute_plan(session, plan, metadata, ExecutePlanMode::EagerSilent).await
+    handle_execute_plan(ctx, plan, metadata, ExecutePlanMode::EagerSilent).await
 }
 
 pub(crate) async fn handle_execute_create_dataframe_view(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     view: CreateDataFrameViewCommand,
     metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
     let plan = spec::Plan::Command(spec::CommandPlan::new(view.try_into()?));
-    handle_execute_plan(session, plan, metadata, ExecutePlanMode::EagerSilent).await
+    handle_execute_plan(ctx, plan, metadata, ExecutePlanMode::EagerSilent).await
 }
 
 pub(crate) async fn handle_execute_write_operation_v2(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     write: WriteOperationV2,
     metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
     let plan = spec::Plan::Command(spec::CommandPlan::new(spec::CommandNode::Write(
         write.try_into()?,
     )));
-    handle_execute_plan(session, plan, metadata, ExecutePlanMode::EagerSilent).await
+    handle_execute_plan(ctx, plan, metadata, ExecutePlanMode::EagerSilent).await
 }
 
 pub(crate) async fn handle_execute_sql_command(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     sql: SqlCommand,
     metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
+    let spark = SparkSession::get(ctx)?;
     let relation = Relation {
         common: None,
         rel_type: Some(relation::RelType::Sql(sc::Sql {
@@ -197,7 +201,8 @@ pub(crate) async fn handle_execute_sql_command(
     let relation = match plan {
         spec::Plan::Query(_) => relation,
         command @ spec::Plan::Command(_) => {
-            let stream = session.execute_plan(command).await?;
+            let plan = resolve_and_execute_plan(ctx, spark.plan_config()?, command).await?;
+            let stream = spark.job_runner().execute(ctx, plan).await?;
             let schema = stream.schema();
             let data = read_stream(stream).await?;
             let data = concat_batches(&schema, data.iter())?;
@@ -219,14 +224,14 @@ pub(crate) async fn handle_execute_sql_command(
         tx.send(ExecutorOutput::complete()).await?;
     }
     Ok(ExecutePlanResponseStream::new(
-        session.session_id().to_string(),
+        spark.session_id().to_string(),
         metadata.operation_id,
         ReceiverStream::new(rx),
     ))
 }
 
 pub(crate) async fn handle_execute_write_stream_operation_start(
-    _session: Arc<Session>,
+    _ctx: &SessionContext,
     _start: WriteStreamOperationStart,
     _metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
@@ -234,7 +239,7 @@ pub(crate) async fn handle_execute_write_stream_operation_start(
 }
 
 pub(crate) async fn handle_execute_streaming_query_command(
-    _session: Arc<Session>,
+    _ctx: &SessionContext,
     _stream: StreamingQueryCommand,
     _metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
@@ -242,7 +247,7 @@ pub(crate) async fn handle_execute_streaming_query_command(
 }
 
 pub(crate) async fn handle_execute_get_resources_command(
-    _session: Arc<Session>,
+    _ctx: &SessionContext,
     _resource: GetResourcesCommand,
     _metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
@@ -250,7 +255,7 @@ pub(crate) async fn handle_execute_get_resources_command(
 }
 
 pub(crate) async fn handle_execute_streaming_query_manager_command(
-    _session: Arc<Session>,
+    _ctx: &SessionContext,
     _manager: StreamingQueryManagerCommand,
     _metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
@@ -258,19 +263,20 @@ pub(crate) async fn handle_execute_streaming_query_manager_command(
 }
 
 pub(crate) async fn handle_execute_register_table_function(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     udtf: CommonInlineUserDefinedTableFunction,
     metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
     let plan = spec::Plan::Command(spec::CommandPlan::new(
         spec::CommandNode::RegisterTableFunction(udtf.try_into()?),
     ));
-    handle_execute_plan(session, plan, metadata, ExecutePlanMode::EagerSilent).await
+    handle_execute_plan(ctx, plan, metadata, ExecutePlanMode::EagerSilent).await
 }
 
-pub(crate) async fn handle_interrupt_all(session: Arc<Session>) -> SparkResult<Vec<String>> {
+pub(crate) async fn handle_interrupt_all(ctx: &SessionContext) -> SparkResult<Vec<String>> {
+    let spark = SparkSession::get(ctx)?;
     let mut results = vec![];
-    for executor in session.remove_all_executors()? {
+    for executor in spark.remove_all_executors()? {
         executor.pause_if_running().await?;
         results.push(executor.metadata.operation_id.clone());
     }
@@ -278,11 +284,12 @@ pub(crate) async fn handle_interrupt_all(session: Arc<Session>) -> SparkResult<V
 }
 
 pub(crate) async fn handle_interrupt_tag(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     tag: String,
 ) -> SparkResult<Vec<String>> {
+    let spark = SparkSession::get(ctx)?;
     let mut results = vec![];
-    for executor in session.remove_executors_by_tag(tag.as_str())? {
+    for executor in spark.remove_executors_by_tag(tag.as_str())? {
         executor.pause_if_running().await?;
         results.push(executor.metadata.operation_id.clone());
     }
@@ -290,10 +297,11 @@ pub(crate) async fn handle_interrupt_tag(
 }
 
 pub(crate) async fn handle_interrupt_operation_id(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     operation_id: String,
 ) -> SparkResult<Vec<String>> {
-    match session.remove_executor(operation_id.as_str())? {
+    let spark = SparkSession::get(ctx)?;
+    match spark.remove_executor(operation_id.as_str())? {
         Some(executor) => {
             executor.pause_if_running().await?;
             Ok(vec![executor.metadata.operation_id.clone()])
@@ -303,11 +311,12 @@ pub(crate) async fn handle_interrupt_operation_id(
 }
 
 pub(crate) async fn handle_reattach_execute(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     operation_id: String,
     response_id: Option<String>,
 ) -> SparkResult<ExecutePlanResponseStream> {
-    let executor = session
+    let spark = SparkSession::get(ctx)?;
+    let executor = spark
         .get_executor(operation_id.as_str())?
         .ok_or_else(|| SparkError::invalid(format!("operation not found: {}", operation_id)))?;
     if !executor.metadata.reattachable {
@@ -320,20 +329,21 @@ pub(crate) async fn handle_reattach_execute(
     executor.release(response_id)?;
     let rx = executor.start()?;
     Ok(ExecutePlanResponseStream::new(
-        session.session_id().to_string(),
+        spark.session_id().to_string(),
         operation_id,
         rx,
     ))
 }
 
 pub(crate) async fn handle_release_execute(
-    session: Arc<Session>,
+    ctx: &SessionContext,
     operation_id: String,
     response_id: Option<String>,
 ) -> SparkResult<()> {
+    let spark = SparkSession::get(ctx)?;
     // Some operations may not have an executor (e.g. DDL statements),
     // so it is a no-op if the executor is not found.
-    if let Some(executor) = session.get_executor(operation_id.as_str())? {
+    if let Some(executor) = spark.get_executor(operation_id.as_str())? {
         executor.release(response_id)?;
     }
     Ok(())

--- a/crates/sail-spark-connect/src/session.rs
+++ b/crates/sail-spark-connect/src/session.rs
@@ -1,31 +1,16 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::hash::Hash;
 use std::sync::{Arc, Mutex};
 
-#[cfg(test)]
-use arrow::array::RecordBatch;
-use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
-use datafusion::execution::session_state::SessionStateBuilder;
-use datafusion::execution::SendableRecordBatchStream;
-use datafusion::prelude::{SessionConfig, SessionContext};
-use sail_common::config::{ConfigKeyValue, SparkUdfConfig};
-use sail_common::spec;
-use sail_common::utils::rename_physical_plan;
-use sail_execution::job::{JobRunner, LocalJobRunner};
+use datafusion::prelude::SessionContext;
+use sail_common::config::ConfigKeyValue;
+use sail_execution::job::JobRunner;
 use sail_plan::config::{PlanConfig, TimestampType};
 use sail_plan::formatter::DefaultPlanFormatter;
-use sail_plan::function::BUILT_IN_SCALAR_FUNCTIONS;
-use sail_plan::object_store::{DynamicObjectStoreRegistry, ObjectStoreConfig};
-use sail_plan::resolver::plan::NamedPlan;
-use sail_plan::resolver::PlanResolver;
-use sail_plan::temp_view::TemporaryViewManager;
-use sail_plan::{execute_logical_plan, new_query_planner};
+use sail_python_udf::config::SparkUdfConfig;
 
-use crate::config::{ConfigKeyValueList, SparkRuntimeConfig};
+use crate::config::SparkRuntimeConfig;
 use crate::error::{SparkError, SparkResult};
-#[cfg(test)]
-use crate::executor::read_stream;
 use crate::executor::Executor;
 use crate::spark::config::{
     SPARK_SQL_EXECUTION_ARROW_MAX_RECORDS_PER_BATCH,
@@ -34,18 +19,18 @@ use crate::spark::config::{
     SPARK_SQL_SESSION_TIME_ZONE, SPARK_SQL_SOURCES_DEFAULT, SPARK_SQL_WAREHOUSE_DIR,
 };
 
-const DEFAULT_SPARK_SCHEMA: &str = "default";
-const DEFAULT_SPARK_CATALOG: &str = "spark_catalog";
+pub(crate) const DEFAULT_SPARK_SCHEMA: &str = "default";
+pub(crate) const DEFAULT_SPARK_CATALOG: &str = "spark_catalog";
 
-pub(crate) struct Session {
+/// A Spark-specific extension to the DataFusion [SessionContext].
+pub(crate) struct SparkSession {
     user_id: Option<String>,
     session_id: String,
-    context: SessionContext,
     job_runner: Box<dyn JobRunner>,
     state: Mutex<SparkSessionState>,
 }
 
-impl Debug for Session {
+impl Debug for SparkSession {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Session")
             .field("user_id", &self.user_id)
@@ -54,76 +39,28 @@ impl Debug for Session {
     }
 }
 
-impl Session {
+impl SparkSession {
     pub(crate) fn new(
         user_id: Option<String>,
         session_id: String,
         job_runner: Box<dyn JobRunner>,
-        context: SessionContext,
     ) -> Self {
         Self {
             user_id,
             session_id,
-            context,
             job_runner,
             state: Mutex::new(SparkSessionState::new()),
         }
     }
 
-    pub(crate) fn build_context(
-        object_store_config: Arc<ObjectStoreConfig>,
-    ) -> SparkResult<SessionContext> {
-        // TODO: support more systematic configuration
-        // TODO: return error on invalid environment variables
-        let config = SessionConfig::new()
-            .with_create_default_catalog_and_schema(true)
-            .with_default_catalog_and_schema(DEFAULT_SPARK_CATALOG, DEFAULT_SPARK_SCHEMA)
-            .with_information_schema(true)
-            .with_extension(Arc::new(TemporaryViewManager::default()))
-            .set_usize(
-                "datafusion.execution.batch_size",
-                std::env::var("DATAFUSION_BATCH_SIZE")
-                    .ok()
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(8192),
-            )
-            .set_usize(
-                "datafusion.execution.parquet.maximum_parallel_row_group_writers",
-                std::env::var("DATAFUSION_PARQUET_MAX_PARALLEL_ROW_GROUP_WRITERS")
-                    .ok()
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(2),
-            )
-            .set_usize(
-                "datafusion.execution.parquet.maximum_buffered_record_batches_per_stream",
-                std::env::var("DATAFUSION_PARQUET_MAX_BUFFERED_RECORD_BATCHES_PER_STREAM")
-                    .ok()
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(16),
-            )
-            // Spark defaults to false:
-            //  https://spark.apache.org/docs/latest/sql-data-sources-csv.html
-            .set_bool("datafusion.catalog.has_header", false);
-        let runtime = {
-            let registry = DynamicObjectStoreRegistry::new().with_config(object_store_config);
-            let config = RuntimeConfig::default().with_object_store_registry(Arc::new(registry));
-            Arc::new(RuntimeEnv::new(config)?)
-        };
-        let state = SessionStateBuilder::new()
-            .with_config(config)
-            .with_runtime_env(runtime)
-            .with_default_features()
-            .with_query_planner(new_query_planner())
-            .build();
-        let context = SessionContext::new_with_state(state);
-
-        // TODO: This is a temp workaround to deregister all built-in functions that we define.
-        //  We should deregister all context.udfs() once we have better coverage of functions.
-        for (&name, _function) in BUILT_IN_SCALAR_FUNCTIONS.iter() {
-            context.deregister_udf(name);
-        }
-
-        Ok(context)
+    /// Get the Spark session from the DataFusion [SessionContext].
+    pub(crate) fn get(context: &SessionContext) -> SparkResult<Arc<SparkSession>> {
+        context
+            .state_ref()
+            .read()
+            .config()
+            .get_extension::<SparkSession>()
+            .ok_or_else(|| SparkError::invalid("Spark session not found in the session context"))
     }
 
     pub(crate) fn session_id(&self) -> &str {
@@ -133,10 +70,6 @@ impl Session {
     #[allow(dead_code)]
     pub(crate) fn user_id(&self) -> Option<&str> {
         self.user_id.as_deref()
-    }
-
-    pub(crate) fn context(&self) -> &SessionContext {
-        &self.context
     }
 
     pub(crate) fn plan_config(&self) -> SparkResult<Arc<PlanConfig>> {
@@ -212,26 +145,22 @@ impl Session {
         }))
     }
 
-    pub(crate) fn get_config(&self, keys: Vec<String>) -> SparkResult<ConfigKeyValueList> {
+    pub(crate) fn get_config(&self, keys: Vec<String>) -> SparkResult<Vec<ConfigKeyValue>> {
         let state = self.state.lock()?;
-        Ok(keys
-            .into_iter()
+        keys.into_iter()
             .map(|key| {
                 let value = state.config.get(&key)?.map(|v| v.to_string());
                 Ok(ConfigKeyValue { key, value })
             })
-            .collect::<SparkResult<Vec<_>>>()?
-            .into())
+            .collect::<SparkResult<Vec<_>>>()
     }
 
     pub(crate) fn get_config_with_default(
         &self,
-        kv: ConfigKeyValueList,
-    ) -> SparkResult<ConfigKeyValueList> {
+        kv: Vec<ConfigKeyValue>,
+    ) -> SparkResult<Vec<ConfigKeyValue>> {
         let state = self.state.lock()?;
-        let kv: Vec<ConfigKeyValue> = kv.into();
-        Ok(kv
-            .into_iter()
+        kv.into_iter()
             .map(|ConfigKeyValue { key, value }| {
                 let value = state
                     .config
@@ -239,41 +168,13 @@ impl Session {
                     .map(|x| x.to_string());
                 Ok(ConfigKeyValue { key, value })
             })
-            .collect::<SparkResult<Vec<_>>>()?
-            .into())
+            .collect::<SparkResult<Vec<_>>>()
     }
 
-    pub(crate) fn set_config(&self, kv: ConfigKeyValueList) -> SparkResult<()> {
-        use chrono::{Offset, Utc};
-        use chrono_tz::Tz;
+    pub(crate) fn set_config(&self, kv: Vec<ConfigKeyValue>) -> SparkResult<()> {
         let mut state = self.state.lock()?;
-        let kv: Vec<ConfigKeyValue> = kv.into();
         for ConfigKeyValue { key, value } in kv {
             if let Some(value) = value {
-                if key == SPARK_SQL_SESSION_TIME_ZONE {
-                    let state = self.context.state_ref();
-                    let mut state = state.write();
-                    let offset_string = if value.starts_with("+") || value.starts_with("-") {
-                        value.clone()
-                    } else if value.to_lowercase() == "z" {
-                        "+00:00".to_string()
-                    } else {
-                        let tz: Tz = value
-                            .parse()
-                            .map_err(|e| SparkError::invalid(format!("invalid time zone: {e}")))?;
-                        let local_time_offset = Utc::now()
-                            .with_timezone(&tz)
-                            .offset()
-                            .fix()
-                            .local_minus_utc();
-                        format!(
-                            "{:+03}:{:02}",
-                            local_time_offset / 3600,
-                            (local_time_offset.abs() % 3600) / 60
-                        )
-                    };
-                    state.config_mut().options_mut().execution.time_zone = Some(offset_string);
-                }
                 state.config.set(key, value)?;
             } else {
                 return Err(SparkError::invalid(format!(
@@ -292,7 +193,7 @@ impl Session {
         Ok(())
     }
 
-    pub(crate) fn get_all_config(&self, prefix: Option<&str>) -> SparkResult<ConfigKeyValueList> {
+    pub(crate) fn get_all_config(&self, prefix: Option<&str>) -> SparkResult<Vec<ConfigKeyValue>> {
         let state = self.state.lock()?;
         state.config.get_all(prefix)
     }
@@ -344,38 +245,8 @@ impl Session {
         Ok(removed)
     }
 
-    pub(crate) async fn execute_plan(
-        &self,
-        plan: spec::Plan,
-    ) -> SparkResult<SendableRecordBatchStream> {
-        let ctx = self.context();
-        let resolver = PlanResolver::new(ctx, self.plan_config()?);
-        let NamedPlan { plan, fields } = resolver.resolve_named_plan(plan).await?;
-        let df = execute_logical_plan(ctx, plan).await?;
-        let plan = df.create_physical_plan().await?;
-        let plan = if let Some(fields) = fields {
-            rename_physical_plan(plan, fields.as_slice())?
-        } else {
-            plan
-        };
-        Ok(self.job_runner.execute(plan).await?)
-    }
-
-    #[cfg(test)]
-    pub(crate) async fn execute_query(&self, query: &str) -> SparkResult<Vec<RecordBatch>> {
-        use crate::spark::connect::relation::RelType;
-        use crate::spark::connect::{Relation, Sql};
-
-        let relation = Relation {
-            common: None,
-            rel_type: Some(RelType::Sql(Sql {
-                query: query.to_string(),
-                args: HashMap::new(),
-                pos_args: vec![],
-            })),
-        };
-        let stream = self.execute_plan(relation.try_into()?).await?;
-        read_stream(stream).await
+    pub(crate) fn job_runner(&self) -> &dyn JobRunner {
+        self.job_runner.as_ref()
     }
 }
 
@@ -390,68 +261,5 @@ impl SparkSessionState {
             config: SparkRuntimeConfig::new(),
             executors: HashMap::new(),
         }
-    }
-}
-
-#[derive(Eq, PartialEq, Hash, Clone, Debug)]
-pub(crate) struct SessionKey {
-    pub user_id: Option<String>,
-    pub session_id: String,
-}
-
-type SessionStore = HashMap<SessionKey, Arc<Session>>;
-
-#[derive(Debug)]
-pub struct SessionManager {
-    sessions: Mutex<SessionStore>,
-    object_store_config: Arc<ObjectStoreConfig>,
-}
-
-impl Default for SessionManager {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl SessionManager {
-    pub fn new() -> Self {
-        Self {
-            sessions: Mutex::new(SessionStore::new()),
-            object_store_config: Arc::new(ObjectStoreConfig::default()),
-        }
-    }
-
-    pub fn with_object_store_config(mut self, object_store_config: ObjectStoreConfig) -> Self {
-        self.object_store_config = Arc::new(object_store_config);
-        self
-    }
-
-    pub(crate) fn get_session(&self, key: SessionKey) -> SparkResult<Arc<Session>> {
-        use std::collections::hash_map::Entry;
-
-        let mut sessions = self.sessions.lock()?;
-        let entry = sessions.entry(key);
-        match entry {
-            Entry::Occupied(o) => Ok(o.get().clone()),
-            Entry::Vacant(v) => {
-                let context = Session::build_context(Arc::clone(&self.object_store_config))?;
-                // TODO: use cluster job runner based on the configuration
-                // let job_runner = ClusterJobRunner::start()?;
-                let job_runner = LocalJobRunner::new(context.clone());
-                let session = Session::new(
-                    v.key().user_id.clone(),
-                    v.key().session_id.clone(),
-                    Box::new(job_runner),
-                    context,
-                );
-                Ok(v.insert(Arc::new(session)).clone())
-            }
-        }
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn delete_session(&self, key: &SessionKey) -> SparkResult<()> {
-        self.sessions.lock()?.remove(key);
-        Ok(())
     }
 }

--- a/crates/sail-spark-connect/src/session_manager.rs
+++ b/crates/sail-spark-connect/src/session_manager.rs
@@ -1,0 +1,147 @@
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::ops::DerefMut;
+use std::sync::{Arc, Mutex};
+
+use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
+use datafusion::execution::SessionStateBuilder;
+use datafusion::prelude::{SessionConfig, SessionContext};
+use sail_common::config::{AppConfig, RunnerKind};
+use sail_execution::job::{ClusterJobRunner, JobRunner, LocalJobRunner};
+use sail_plan::function::BUILT_IN_SCALAR_FUNCTIONS;
+use sail_plan::new_query_planner;
+use sail_plan::object_store::DynamicObjectStoreRegistry;
+use sail_plan::temp_view::TemporaryViewManager;
+use sail_server::actor::ActorSystem;
+
+use crate::error::SparkResult;
+use crate::session::{SparkSession, DEFAULT_SPARK_CATALOG, DEFAULT_SPARK_SCHEMA};
+
+#[derive(Eq, PartialEq, Hash, Clone, Debug)]
+pub(crate) struct SessionKey {
+    pub user_id: Option<String>,
+    pub session_id: String,
+}
+
+pub struct SessionManager {
+    state: Mutex<SessionManagerState>,
+    config: Arc<AppConfig>,
+}
+
+impl Debug for SessionManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SessionManager").finish()
+    }
+}
+
+impl SessionManager {
+    pub fn new(config: Arc<AppConfig>) -> Self {
+        Self {
+            state: Mutex::new(SessionManagerState::new()),
+            config,
+        }
+    }
+
+    pub(crate) fn get_or_create_session_context(
+        &self,
+        key: SessionKey,
+    ) -> SparkResult<SessionContext> {
+        let mut state = self.state.lock()?;
+        let state = state.deref_mut();
+        let entry = state.sessions.entry(key);
+        match entry {
+            Entry::Occupied(o) => Ok(o.get().clone()),
+            Entry::Vacant(v) => {
+                let key = v.key().clone();
+                let context = self.create_session_context(&mut state.actor_system, key)?;
+                Ok(v.insert(context).clone())
+            }
+        }
+    }
+
+    fn create_session_context(
+        &self,
+        actor_system: &mut ActorSystem,
+        key: SessionKey,
+    ) -> SparkResult<SessionContext> {
+        let job_runner: Box<dyn JobRunner> = match self.config.runner {
+            RunnerKind::Local => Box::new(LocalJobRunner::new()),
+            RunnerKind::Cluster => Box::new(ClusterJobRunner::try_new(
+                actor_system,
+                self.config.as_ref().into(),
+            )?),
+        };
+        let spark = SparkSession::new(key.user_id, key.session_id, job_runner);
+        // TODO: support more systematic configuration
+        // TODO: return error on invalid environment variables
+        let config = SessionConfig::new()
+            .with_create_default_catalog_and_schema(true)
+            .with_default_catalog_and_schema(DEFAULT_SPARK_CATALOG, DEFAULT_SPARK_SCHEMA)
+            .with_information_schema(true)
+            .with_extension(Arc::new(TemporaryViewManager::default()))
+            .with_extension(Arc::new(spark))
+            .set_usize(
+                "datafusion.execution.batch_size",
+                self.config.execution.batch_size,
+            )
+            .set_usize(
+                "datafusion.execution.parquet.maximum_parallel_row_group_writers",
+                self.config
+                    .execution
+                    .parquet
+                    .maximum_parallel_row_group_writers,
+            )
+            .set_usize(
+                "datafusion.execution.parquet.maximum_buffered_record_batches_per_stream",
+                self.config
+                    .execution
+                    .parquet
+                    .maximum_buffered_record_batches_per_stream,
+            )
+            // Spark defaults to false:
+            //  https://spark.apache.org/docs/latest/sql-data-sources-csv.html
+            .set_bool("datafusion.catalog.has_header", false);
+        let runtime = {
+            let registry = DynamicObjectStoreRegistry::new();
+            let config = RuntimeConfig::default().with_object_store_registry(Arc::new(registry));
+            Arc::new(RuntimeEnv::new(config)?)
+        };
+        let state = SessionStateBuilder::new()
+            .with_config(config)
+            .with_runtime_env(runtime)
+            .with_default_features()
+            .with_query_planner(new_query_planner())
+            .build();
+        let context = SessionContext::new_with_state(state);
+
+        // TODO: This is a temp workaround to deregister all built-in functions that we define.
+        //  We should deregister all context.udfs() once we have better coverage of functions.
+        for (&name, _function) in BUILT_IN_SCALAR_FUNCTIONS.iter() {
+            context.deregister_udf(name);
+        }
+
+        Ok(context)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn remove_session(&self, key: &SessionKey) -> SparkResult<()> {
+        let mut state = self.state.lock()?;
+        state.sessions.remove(key);
+        Ok(())
+    }
+}
+
+struct SessionManagerState {
+    sessions: HashMap<SessionKey, SessionContext>,
+    actor_system: ActorSystem,
+}
+
+impl SessionManagerState {
+    pub fn new() -> Self {
+        Self {
+            sessions: HashMap::new(),
+            actor_system: ActorSystem::new(),
+        }
+    }
+}


### PR DESCRIPTION
1. Set up configuration at the application level using [Figment](https://github.com/sergiobenitez/figment).
2. Remove `ConfigKeyValueList` in favor of using `Vec<ConfigKeyValue>` directly.
3. Move `SparkUdfConfig` to the `sail-python-udf` crate.
4. Refactor `DynamicObjectStoreRegistry` to use global object store configuration.
5. Refactor Spark session. We now have `SparkSession` as an extension in the DataFusion `SessionContext`. Previously, we have the `Session` struct that wraps DataFusion `SessionContext`.