### PR TITLE
Support memory stream replay and improve error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4718,6 +4718,7 @@ name = "sail-server"
 version = "0.2.0"
 dependencies = [
  "log",
+ "sail-common",
  "sail-telemetry",
  "tokio",
  "tonic",

--- a/crates/sail-common/src/config/application.rs
+++ b/crates/sail-common/src/config/application.rs
@@ -75,9 +75,9 @@ pub struct ClusterConfig {
     pub worker_max_idle_time_secs: u64,
     pub worker_launch_timeout_secs: u64,
     pub worker_task_slots: usize,
+    pub worker_stream_buffer: usize,
     pub task_launch_timeout_secs: u64,
     pub job_output_buffer: usize,
-    pub memory_stream_buffer: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/sail-common/src/config/application.rs
+++ b/crates/sail-common/src/config/application.rs
@@ -73,6 +73,8 @@ pub struct ClusterConfig {
     pub worker_initial_count: usize,
     pub worker_max_count: usize,
     pub worker_max_idle_time_secs: u64,
+    pub worker_heartbeat_interval_secs: u64,
+    pub worker_heartbeat_timeout_secs: u64,
     pub worker_launch_timeout_secs: u64,
     pub worker_task_slots: usize,
     pub worker_stream_buffer: usize,

--- a/crates/sail-common/src/config/default.toml
+++ b/crates/sail-common/src/config/default.toml
@@ -14,10 +14,12 @@ worker_external_port = 0
 worker_initial_count = 4
 worker_max_count = 0
 worker_max_idle_time_secs = 300
+worker_heartbeat_interval_secs = 30
+worker_heartbeat_timeout_secs = 120
 worker_launch_timeout_secs = 300
 worker_task_slots = 8
 worker_stream_buffer = 16
-task_launch_timeout_secs = 600
+task_launch_timeout_secs = 300
 job_output_buffer = 16
 
 [execution]

--- a/crates/sail-common/src/config/default.toml
+++ b/crates/sail-common/src/config/default.toml
@@ -16,9 +16,9 @@ worker_max_count = 0
 worker_max_idle_time_secs = 300
 worker_launch_timeout_secs = 300
 worker_task_slots = 8
+worker_stream_buffer = 16
 task_launch_timeout_secs = 600
 job_output_buffer = 16
-memory_stream_buffer = 16
 
 [execution]
 batch_size = 8192

--- a/crates/sail-common/src/config/default.toml
+++ b/crates/sail-common/src/config/default.toml
@@ -21,6 +21,7 @@ worker_task_slots = 8
 worker_stream_buffer = 16
 task_launch_timeout_secs = 300
 job_output_buffer = 16
+rpc_retry_strategy = { "fixed" = { "max_count" = 3, "delay_secs" = 5 } }
 
 [execution]
 batch_size = 8192

--- a/crates/sail-execution/proto/sail/driver/service.proto
+++ b/crates/sail-execution/proto/sail/driver/service.proto
@@ -11,6 +11,13 @@ message RegisterWorkerRequest {
 message RegisterWorkerResponse {
 }
 
+message ReportWorkerHeartbeatRequest {
+  uint64 worker_id = 1;
+}
+
+message ReportWorkerHeartbeatResponse {
+}
+
 message ReportTaskStatusRequest {
   uint64 task_id = 1;
   TaskStatus status = 2;
@@ -31,5 +38,6 @@ message ReportTaskStatusResponse {
 
 service DriverService {
   rpc RegisterWorker(RegisterWorkerRequest) returns (RegisterWorkerResponse) {}
+  rpc ReportWorkerHeartbeat(ReportWorkerHeartbeatRequest) returns (ReportWorkerHeartbeatResponse) {}
   rpc ReportTaskStatus(ReportTaskStatusRequest) returns (ReportTaskStatusResponse) {}
 }

--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -285,7 +285,8 @@ message ShuffleWriteExecNode {
   uint64 stage = 1;
   bytes plan = 2;
   bytes partitioning = 3;
-  repeated TaskWriteLocationList locations = 4;
+  ShuffleConsumption consumption = 4;
+  repeated TaskWriteLocationList locations = 5;
 }
 
 message TaskWriteLocationList {
@@ -306,6 +307,11 @@ message TaskWriteLocationLocal {
 
 message TaskWriteLocationRemote {
   string uri = 1;
+}
+
+enum ShuffleConsumption {
+  SHUFFLE_CONSUMPTION_SINGLE = 0;
+  SHUFFLE_CONSUMPTION_MULTIPLE = 1;
 }
 
 enum TaskStreamPersistence {

--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -302,7 +302,7 @@ message TaskWriteLocation {
 
 message TaskWriteLocationLocal {
   string channel = 1;
-  TaskStreamStorage storage = 2;
+  LocalStreamStorage storage = 2;
 }
 
 message TaskWriteLocationRemote {
@@ -314,10 +314,10 @@ enum ShuffleConsumption {
   SHUFFLE_CONSUMPTION_MULTIPLE = 1;
 }
 
-enum TaskStreamStorage {
-  TASK_STREAM_STORAGE_EPHEMERAL = 0;
-  TASK_STREAM_STORAGE_MEMORY = 1;
-  TASK_STREAM_STORAGE_DISK = 2;
+enum LocalStreamStorage {
+  LOCAL_STREAM_STORAGE_EPHEMERAL = 0;
+  LOCAL_STREAM_STORAGE_MEMORY = 1;
+  LOCAL_STREAM_STORAGE_DISK = 2;
 }
 
 enum CompressionTypeVariant {

--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -302,7 +302,7 @@ message TaskWriteLocation {
 
 message TaskWriteLocationLocal {
   string channel = 1;
-  TaskStreamPersistence persistence = 2;
+  TaskStreamStorage storage = 2;
 }
 
 message TaskWriteLocationRemote {
@@ -314,10 +314,10 @@ enum ShuffleConsumption {
   SHUFFLE_CONSUMPTION_MULTIPLE = 1;
 }
 
-enum TaskStreamPersistence {
-  TASK_STREAM_PERSISTENCE_EPHEMERAL = 0;
-  TASK_STREAM_PERSISTENCE_MEMORY = 1;
-  TASK_STREAM_PERSISTENCE_DISK = 2;
+enum TaskStreamStorage {
+  TASK_STREAM_STORAGE_EPHEMERAL = 0;
+  TASK_STREAM_STORAGE_MEMORY = 1;
+  TASK_STREAM_STORAGE_DISK = 2;
 }
 
 enum CompressionTypeVariant {

--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -294,22 +294,24 @@ message TaskWriteLocationList {
 
 message TaskWriteLocation {
   oneof Location {
-    TaskWriteLocationMemory memory = 1;
-    TaskWriteLocationDisk disk = 2;
-    TaskWriteLocationRemote remote = 3;
+    TaskWriteLocationLocal local = 1;
+    TaskWriteLocationRemote remote = 2;
   }
 }
 
-message TaskWriteLocationMemory {
+message TaskWriteLocationLocal {
   string channel = 1;
-}
-
-message TaskWriteLocationDisk {
-  string channel = 1;
+  TaskStreamPersistence persistence = 2;
 }
 
 message TaskWriteLocationRemote {
   string uri = 1;
+}
+
+enum TaskStreamPersistence {
+  TASK_STREAM_PERSISTENCE_EPHEMERAL = 0;
+  TASK_STREAM_PERSISTENCE_MEMORY = 1;
+  TASK_STREAM_PERSISTENCE_DISK = 2;
 }
 
 enum CompressionTypeVariant {

--- a/crates/sail-execution/proto/sail/worker/service.proto
+++ b/crates/sail-execution/proto/sail/worker/service.proto
@@ -25,6 +25,13 @@ message StopTaskRequest {
 message StopTaskResponse {
 }
 
+message RemoveStreamRequest {
+  string channel_prefix = 1;
+}
+
+message RemoveStreamResponse {
+}
+
 message StopWorkerRequest {
 }
 
@@ -34,5 +41,6 @@ message StopWorkerResponse {
 service WorkerService {
   rpc RunTask(RunTaskRequest) returns (RunTaskResponse) {}
   rpc StopTask(StopTaskRequest) returns (StopTaskResponse) {}
+  rpc RemoveStream(RemoveStreamRequest) returns (RemoveStreamResponse) {}
   rpc StopWorker(StopWorkerRequest) returns (StopWorkerResponse) {}
 }

--- a/crates/sail-execution/src/codec.rs
+++ b/crates/sail-execution/src/codec.rs
@@ -1055,7 +1055,7 @@ impl RemoteExecutionCodec {
 
     fn try_decode_local_stream_storage(&self, storage: i32) -> Result<LocalStreamStorage> {
         let storage = gen::LocalStreamStorage::try_from(storage)
-            .map_err(|e| plan_datafusion_err!("failed to decode task stream storage: {e}"))?;
+            .map_err(|e| plan_datafusion_err!("failed to decode local stream storage: {e}"))?;
         let storage = match storage {
             gen::LocalStreamStorage::Ephemeral => LocalStreamStorage::Ephemeral,
             gen::LocalStreamStorage::Memory => LocalStreamStorage::Memory,

--- a/crates/sail-execution/src/driver/actor/core.rs
+++ b/crates/sail-execution/src/driver/actor/core.rs
@@ -76,11 +76,17 @@ impl Actor for DriverActor {
                 port,
                 result,
             } => self.handle_register_worker(ctx, worker_id, host, port, result),
+            DriverEvent::WorkerHeartbeat { worker_id } => {
+                self.handle_worker_heartbeat(ctx, worker_id)
+            }
             DriverEvent::ProbePendingWorker { worker_id } => {
                 self.handle_probe_pending_worker(ctx, worker_id)
             }
             DriverEvent::ProbeIdleWorker { worker_id } => {
                 self.handle_probe_idle_worker(ctx, worker_id)
+            }
+            DriverEvent::ProbeLostWorker { worker_id } => {
+                self.handle_probe_lost_worker(ctx, worker_id)
             }
             DriverEvent::ExecuteJob { plan, result } => self.handle_execute_job(ctx, plan, result),
             DriverEvent::RemoveJobOutput { job_id } => self.handle_remove_job_output(ctx, job_id),

--- a/crates/sail-execution/src/driver/actor/handler.rs
+++ b/crates/sail-execution/src/driver/actor/handler.rs
@@ -32,7 +32,7 @@ use crate::error::{ExecutionError, ExecutionResult};
 use crate::id::{JobId, TaskId, WorkerId};
 use crate::plan::{ShuffleConsumption, ShuffleReadExec, ShuffleWriteExec};
 use crate::stream::{
-    MergedRecordBatchStream, TaskReadLocation, TaskStreamStorage, TaskWriteLocation,
+    LocalStreamStorage, MergedRecordBatchStream, TaskReadLocation, TaskWriteLocation,
 };
 use crate::worker_manager::WorkerLaunchOptions;
 
@@ -660,8 +660,8 @@ impl DriverActor {
                 Ok(Transformed::yes(Arc::new(shuffle)))
             } else if let Some(shuffle) = node.as_any().downcast_ref::<ShuffleWriteExec>() {
                 let storage = match shuffle.consumption() {
-                    ShuffleConsumption::Single => TaskStreamStorage::Ephemeral,
-                    ShuffleConsumption::Multiple => TaskStreamStorage::Memory,
+                    ShuffleConsumption::Single => LocalStreamStorage::Ephemeral,
+                    ShuffleConsumption::Multiple => LocalStreamStorage::Memory,
                 };
                 let locations = (0..shuffle.locations().len())
                     .map(|partition| {

--- a/crates/sail-execution/src/driver/actor/rpc.rs
+++ b/crates/sail-execution/src/driver/actor/rpc.rs
@@ -12,7 +12,6 @@ use crate::driver::DriverEvent;
 use crate::error::{ExecutionError, ExecutionResult};
 use crate::id::WorkerId;
 use crate::rpc::ClientOptions;
-use crate::worker::WorkerClient;
 
 impl DriverActor {
     pub(super) async fn serve(
@@ -44,7 +43,7 @@ impl DriverActor {
             .map_err(|e| ExecutionError::InternalError(e.to_string()))
     }
 
-    pub(super) fn worker_client(&mut self, id: WorkerId) -> ExecutionResult<&WorkerClient> {
+    pub(super) fn worker_client_options(&mut self, id: WorkerId) -> ExecutionResult<ClientOptions> {
         let worker = self
             .state
             .get_worker(id)
@@ -58,14 +57,10 @@ impl DriverActor {
             }
         };
         let enable_tls = self.options().enable_tls;
-        let client = self.worker_clients.entry(id).or_insert_with(|| {
-            let options = ClientOptions {
-                enable_tls,
-                host,
-                port,
-            };
-            WorkerClient::new(options)
-        });
-        Ok(client)
+        Ok(ClientOptions {
+            enable_tls,
+            host,
+            port,
+        })
     }
 }

--- a/crates/sail-execution/src/driver/client.rs
+++ b/crates/sail-execution/src/driver/client.rs
@@ -34,7 +34,7 @@ impl DriverClient {
             host,
             port: port as u32,
         });
-        let response = self.inner.lock().await?.register_worker(request).await?;
+        let response = self.inner.get().await?.register_worker(request).await?;
         let RegisterWorkerResponse {} = response.into_inner();
         Ok(())
     }
@@ -54,7 +54,7 @@ impl DriverClient {
             message,
             sequence,
         });
-        let response = self.inner.lock().await?.report_task_status(request).await?;
+        let response = self.inner.get().await?.report_task_status(request).await?;
         let ReportTaskStatusResponse {} = response.into_inner();
         Ok(())
     }

--- a/crates/sail-execution/src/driver/client.rs
+++ b/crates/sail-execution/src/driver/client.rs
@@ -39,6 +39,20 @@ impl DriverClient {
         Ok(())
     }
 
+    pub async fn report_worker_heartbeat(&self, worker_id: WorkerId) -> ExecutionResult<()> {
+        let request = tonic::Request::new(gen::ReportWorkerHeartbeatRequest {
+            worker_id: worker_id.into(),
+        });
+        let response = self
+            .inner
+            .get()
+            .await?
+            .report_worker_heartbeat(request)
+            .await?;
+        let gen::ReportWorkerHeartbeatResponse {} = response.into_inner();
+        Ok(())
+    }
+
     pub async fn report_task_status(
         &self,
         task_id: TaskId,

--- a/crates/sail-execution/src/driver/event.rs
+++ b/crates/sail-execution/src/driver/event.rs
@@ -21,10 +21,16 @@ pub enum DriverEvent {
         port: u16,
         result: oneshot::Sender<ExecutionResult<()>>,
     },
+    WorkerHeartbeat {
+        worker_id: WorkerId,
+    },
     ProbePendingWorker {
         worker_id: WorkerId,
     },
     ProbeIdleWorker {
+        worker_id: WorkerId,
+    },
+    ProbeLostWorker {
         worker_id: WorkerId,
     },
     ExecuteJob {

--- a/crates/sail-execution/src/driver/options.rs
+++ b/crates/sail-execution/src/driver/options.rs
@@ -16,6 +16,8 @@ pub struct DriverOptions {
     pub worker_max_count: usize,
     pub worker_task_slots: usize,
     pub worker_max_idle_time: Duration,
+    pub worker_heartbeat_interval: Duration,
+    pub worker_heartbeat_timeout: Duration,
     pub worker_launch_timeout: Duration,
     pub worker_stream_buffer: usize,
     pub task_launch_timeout: Duration,
@@ -59,6 +61,12 @@ impl TryFrom<&AppConfig> for DriverOptions {
             worker_max_count: config.cluster.worker_max_count,
             worker_task_slots: config.cluster.worker_task_slots,
             worker_max_idle_time: Duration::from_secs(config.cluster.worker_max_idle_time_secs),
+            worker_heartbeat_interval: Duration::from_secs(
+                config.cluster.worker_heartbeat_interval_secs,
+            ),
+            worker_heartbeat_timeout: Duration::from_secs(
+                config.cluster.worker_heartbeat_timeout_secs,
+            ),
             worker_launch_timeout: Duration::from_secs(config.cluster.worker_launch_timeout_secs),
             worker_stream_buffer: config.cluster.worker_stream_buffer,
             task_launch_timeout: Duration::from_secs(config.cluster.task_launch_timeout_secs),

--- a/crates/sail-execution/src/driver/options.rs
+++ b/crates/sail-execution/src/driver/options.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use sail_common::config::{AppConfig, ExecutionMode};
+use sail_server::RetryStrategy;
 
 use crate::error::{ExecutionError, ExecutionResult};
 use crate::worker_manager::KubernetesWorkerManagerOptions;
@@ -22,6 +23,7 @@ pub struct DriverOptions {
     pub worker_stream_buffer: usize,
     pub task_launch_timeout: Duration,
     pub job_output_buffer: usize,
+    pub rpc_retry_strategy: RetryStrategy,
     pub worker_manager: WorkerManagerOptions,
 }
 
@@ -68,6 +70,7 @@ impl TryFrom<&AppConfig> for DriverOptions {
                 config.cluster.worker_heartbeat_timeout_secs,
             ),
             worker_launch_timeout: Duration::from_secs(config.cluster.worker_launch_timeout_secs),
+            rpc_retry_strategy: (&config.cluster.rpc_retry_strategy).into(),
             worker_stream_buffer: config.cluster.worker_stream_buffer,
             task_launch_timeout: Duration::from_secs(config.cluster.task_launch_timeout_secs),
             job_output_buffer: config.cluster.job_output_buffer,

--- a/crates/sail-execution/src/driver/options.rs
+++ b/crates/sail-execution/src/driver/options.rs
@@ -17,9 +17,9 @@ pub struct DriverOptions {
     pub worker_task_slots: usize,
     pub worker_max_idle_time: Duration,
     pub worker_launch_timeout: Duration,
+    pub worker_stream_buffer: usize,
     pub task_launch_timeout: Duration,
     pub job_output_buffer: usize,
-    pub memory_stream_buffer: usize,
     pub worker_manager: WorkerManagerOptions,
 }
 
@@ -60,9 +60,9 @@ impl TryFrom<&AppConfig> for DriverOptions {
             worker_task_slots: config.cluster.worker_task_slots,
             worker_max_idle_time: Duration::from_secs(config.cluster.worker_max_idle_time_secs),
             worker_launch_timeout: Duration::from_secs(config.cluster.worker_launch_timeout_secs),
+            worker_stream_buffer: config.cluster.worker_stream_buffer,
             task_launch_timeout: Duration::from_secs(config.cluster.task_launch_timeout_secs),
             job_output_buffer: config.cluster.job_output_buffer,
-            memory_stream_buffer: config.cluster.memory_stream_buffer,
             worker_manager,
         })
     }

--- a/crates/sail-execution/src/driver/server.rs
+++ b/crates/sail-execution/src/driver/server.rs
@@ -7,7 +7,7 @@ use crate::driver::actor::DriverActor;
 use crate::driver::gen::driver_service_server::DriverService;
 use crate::driver::gen::{
     RegisterWorkerRequest, RegisterWorkerResponse, ReportTaskStatusRequest,
-    ReportTaskStatusResponse,
+    ReportTaskStatusResponse, ReportWorkerHeartbeatRequest, ReportWorkerHeartbeatResponse,
 };
 use crate::driver::{gen, DriverEvent};
 use crate::error::ExecutionError;
@@ -52,6 +52,25 @@ impl DriverService for DriverServer {
             .map_err(ExecutionError::from)?;
         rx.await.map_err(ExecutionError::from)??;
         let response = RegisterWorkerResponse {};
+        debug!("{:?}", response);
+        Ok(Response::new(response))
+    }
+
+    async fn report_worker_heartbeat(
+        &self,
+        request: Request<ReportWorkerHeartbeatRequest>,
+    ) -> Result<Response<ReportWorkerHeartbeatResponse>, Status> {
+        let request = request.into_inner();
+        debug!("{:?}", request);
+        let ReportWorkerHeartbeatRequest { worker_id } = request;
+        let event = DriverEvent::WorkerHeartbeat {
+            worker_id: worker_id.into(),
+        };
+        self.handle
+            .send(event)
+            .await
+            .map_err(ExecutionError::from)?;
+        let response = ReportWorkerHeartbeatResponse {};
         debug!("{:?}", response);
         Ok(Response::new(response))
     }

--- a/crates/sail-execution/src/plan/mod.rs
+++ b/crates/sail-execution/src/plan/mod.rs
@@ -11,6 +11,15 @@ pub(crate) mod gen {
     tonic::include_proto!("sail.plan");
 }
 
+/// The way in which a shuffle stream is consumed by downstream tasks.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum ShuffleConsumption {
+    /// Each shuffle stream is consumed by a single downstream tasks.
+    Single,
+    /// Each shuffle stream is consumed by multiple downstream tasks.
+    Multiple,
+}
+
 fn write_list_of_lists<T: Display>(
     f: &mut std::fmt::Formatter,
     data: &[Vec<T>],

--- a/crates/sail-execution/src/plan/shuffle_write.rs
+++ b/crates/sail-execution/src/plan/shuffle_write.rs
@@ -207,7 +207,7 @@ async fn shuffle_write(
         })?;
         for p in 0..partitions.len() {
             if let Some(batch) = partitions[p].take() {
-                partition_writers[p].write(&batch).await?;
+                partition_writers[p].write(batch).await?;
             }
         }
     }

--- a/crates/sail-execution/src/plan/shuffle_write.rs
+++ b/crates/sail-execution/src/plan/shuffle_write.rs
@@ -17,7 +17,7 @@ use datafusion::physical_plan::{
 use futures::future::try_join_all;
 use futures::StreamExt;
 
-use crate::plan::write_list_of_lists;
+use crate::plan::{write_list_of_lists, ShuffleConsumption};
 use crate::stream::{TaskStreamWriter, TaskWriteLocation};
 
 #[derive(Debug, Clone)]
@@ -29,6 +29,7 @@ pub struct ShuffleWriteExec {
     /// The partition count for the shuffle output can be different from the
     /// partition count of the input plan.
     shuffle_partitioning: Partitioning,
+    consumption: ShuffleConsumption,
     /// For each input partition, a list of locations to write to.
     locations: Vec<Vec<TaskWriteLocation>>,
     properties: PlanProperties,
@@ -36,7 +37,12 @@ pub struct ShuffleWriteExec {
 }
 
 impl ShuffleWriteExec {
-    pub fn new(stage: usize, plan: Arc<dyn ExecutionPlan>, partitioning: Partitioning) -> Self {
+    pub fn new(
+        stage: usize,
+        plan: Arc<dyn ExecutionPlan>,
+        partitioning: Partitioning,
+        consumption: ShuffleConsumption,
+    ) -> Self {
         let partitioning = match partitioning {
             Partitioning::Hash(expr, n) if expr.is_empty() => Partitioning::UnknownPartitioning(n),
             Partitioning::Hash(expr, n) => {
@@ -67,6 +73,7 @@ impl ShuffleWriteExec {
             stage,
             plan,
             shuffle_partitioning: partitioning,
+            consumption,
             locations,
             properties,
             writer: None,
@@ -87,6 +94,10 @@ impl ShuffleWriteExec {
 
     pub fn locations(&self) -> &[Vec<TaskWriteLocation>] {
         &self.locations
+    }
+
+    pub fn consumption(&self) -> ShuffleConsumption {
+        self.consumption
     }
 
     pub fn with_locations(self, locations: Vec<Vec<TaskWriteLocation>>) -> Self {

--- a/crates/sail-execution/src/rpc.rs
+++ b/crates/sail-execution/src/rpc.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::sync::Arc;
 
 use arrow_flight::flight_service_client::FlightServiceClient;
-use tokio::sync::{oneshot, Mutex, MutexGuard, OnceCell};
+use tokio::sync::{oneshot, OnceCell};
 use tokio::task::JoinHandle;
 use tonic::transport::Channel;
 
@@ -126,15 +126,15 @@ pub struct ClientHandle<T> {
     /// The client options.
     options: Arc<ClientOptions>,
     /// The shared gRPC client which is lazily initialized.
-    /// Note that this must be `Arc<OnceCell<Mutex<T>>>` instead of `OnceCell<Arc<Mutex<T>>>`.
+    /// Note that this must be `Arc<OnceCell<T>>` instead of `OnceCell<Arc<T>>`.
     /// If we use the latter, when the client is not initialized, an empty `OnceCell` would be
     /// cloned and later initialized independently, resulting in multiple connections.
     /// This could then easily overwhelm the server, and the client would see the
     /// "connection refused" Tonic transport error.
-    inner: Arc<OnceCell<Mutex<T>>>,
+    inner: Arc<OnceCell<T>>,
 }
 
-impl<T: ClientBuilder> ClientHandle<T> {
+impl<T: ClientBuilder + Clone> ClientHandle<T> {
     pub fn new(options: ClientOptions) -> Self {
         Self {
             options: Arc::new(options),
@@ -142,17 +142,18 @@ impl<T: ClientBuilder> ClientHandle<T> {
         }
     }
 
-    async fn init(options: Arc<ClientOptions>) -> ExecutionResult<Mutex<T>> {
-        let client = T::connect(&options).await?;
-        Ok(Mutex::new(client))
-    }
-
-    async fn get(&self) -> ExecutionResult<&Mutex<T>> {
+    /// Returns a clone of the RPC client.
+    /// The client requires `&mut self` when making RPC requests,
+    /// so it is less useful to return `&T` here.
+    /// It is cheap to clone the client and return `T`, since they rely on [Channel] which is
+    /// cheap to clone. The underlying connection is reused among clones of the client.
+    /// Also, since the client can be cheaply cloned, we avoid the overhead of using a mutex
+    /// to protect a shared client instance.
+    pub async fn get(&self) -> ExecutionResult<T> {
         let options = Arc::clone(&self.options);
-        self.inner.get_or_try_init(|| Self::init(options)).await
-    }
-
-    pub async fn lock(&self) -> ExecutionResult<MutexGuard<T>> {
-        Ok(self.get().await?.lock().await)
+        self.inner
+            .get_or_try_init(|| T::connect(&options))
+            .await
+            .cloned()
     }
 }

--- a/crates/sail-execution/src/rpc.rs
+++ b/crates/sail-execution/src/rpc.rs
@@ -119,32 +119,37 @@ impl_client_builder!(DriverServiceClient<Channel>);
 impl_client_builder!(WorkerServiceClient<Channel>);
 impl_client_builder!(FlightServiceClient<Channel>);
 
+/// A handle to a gRPC client to support connection reuse.
+/// The handle can be cheaply cloned and the underlying connection is shared.
 #[derive(Debug, Clone)]
 pub struct ClientHandle<T> {
+    /// The client options.
     options: Arc<ClientOptions>,
-    inner: OnceCell<Arc<Mutex<T>>>,
+    /// The shared gRPC client which is lazily initialized.
+    /// Note that this must be `Arc<OnceCell<Mutex<T>>>` instead of `OnceCell<Arc<Mutex<T>>>`.
+    /// If we use the latter, when the client is not initialized, an empty `OnceCell` would be
+    /// cloned and later initialized independently, resulting in multiple connections.
+    /// This could then easily overwhelm the server, and the client would see the
+    /// "connection refused" Tonic transport error.
+    inner: Arc<OnceCell<Mutex<T>>>,
 }
 
 impl<T: ClientBuilder> ClientHandle<T> {
     pub fn new(options: ClientOptions) -> Self {
         Self {
             options: Arc::new(options),
-            inner: OnceCell::new(),
+            inner: Arc::new(OnceCell::new()),
         }
     }
 
-    async fn init(options: Arc<ClientOptions>) -> ExecutionResult<Arc<Mutex<T>>> {
+    async fn init(options: Arc<ClientOptions>) -> ExecutionResult<Mutex<T>> {
         let client = T::connect(&options).await?;
-        Ok(Arc::new(Mutex::new(client)))
+        Ok(Mutex::new(client))
     }
 
     async fn get(&self) -> ExecutionResult<&Mutex<T>> {
         let options = Arc::clone(&self.options);
-        Ok(self
-            .inner
-            .get_or_try_init(|| Self::init(options))
-            .await?
-            .as_ref())
+        self.inner.get_or_try_init(|| Self::init(options)).await
     }
 
     pub async fn lock(&self) -> ExecutionResult<MutexGuard<T>> {

--- a/crates/sail-execution/src/stream/channel.rs
+++ b/crates/sail-execution/src/stream/channel.rs
@@ -12,6 +12,10 @@ impl ChannelName {
     pub fn new(name: impl Into<String>) -> Self {
         Self(name.into())
     }
+
+    pub fn has_prefix(&self, prefix: &str) -> bool {
+        self.0.starts_with(prefix)
+    }
 }
 
 impl From<String> for ChannelName {

--- a/crates/sail-execution/src/stream/mod.rs
+++ b/crates/sail-execution/src/stream/mod.rs
@@ -7,5 +7,5 @@ pub(crate) use channel::ChannelName;
 pub(crate) use merge::MergedRecordBatchStream;
 pub(crate) use reader::{TaskReadLocation, TaskStreamReader};
 pub(crate) use writer::{
-    RecordBatchStreamWriter, TaskStreamStorage, TaskStreamWriter, TaskWriteLocation,
+    LocalStreamStorage, RecordBatchStreamWriter, TaskStreamWriter, TaskWriteLocation,
 };

--- a/crates/sail-execution/src/stream/mod.rs
+++ b/crates/sail-execution/src/stream/mod.rs
@@ -7,5 +7,5 @@ pub(crate) use channel::ChannelName;
 pub(crate) use merge::MergedRecordBatchStream;
 pub(crate) use reader::{TaskReadLocation, TaskStreamReader};
 pub(crate) use writer::{
-    RecordBatchStreamWriter, TaskStreamPersistence, TaskStreamWriter, TaskWriteLocation,
+    RecordBatchStreamWriter, TaskStreamStorage, TaskStreamWriter, TaskWriteLocation,
 };

--- a/crates/sail-execution/src/stream/mod.rs
+++ b/crates/sail-execution/src/stream/mod.rs
@@ -6,4 +6,6 @@ mod writer;
 pub(crate) use channel::ChannelName;
 pub(crate) use merge::MergedRecordBatchStream;
 pub(crate) use reader::{TaskReadLocation, TaskStreamReader};
-pub(crate) use writer::{RecordBatchStreamWriter, TaskStreamWriter, TaskWriteLocation};
+pub(crate) use writer::{
+    RecordBatchStreamWriter, TaskStreamPersistence, TaskStreamWriter, TaskWriteLocation,
+};

--- a/crates/sail-execution/src/stream/writer.rs
+++ b/crates/sail-execution/src/stream/writer.rs
@@ -20,7 +20,7 @@ pub enum TaskWriteLocation {
     },
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum TaskStreamPersistence {
     Ephemeral,
     Memory,

--- a/crates/sail-execution/src/stream/writer.rs
+++ b/crates/sail-execution/src/stream/writer.rs
@@ -13,7 +13,7 @@ use crate::stream::ChannelName;
 pub enum TaskWriteLocation {
     Local {
         channel: ChannelName,
-        storage: TaskStreamStorage,
+        storage: LocalStreamStorage,
     },
     Remote {
         uri: String,
@@ -21,7 +21,7 @@ pub enum TaskWriteLocation {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum TaskStreamStorage {
+pub enum LocalStreamStorage {
     Ephemeral,
     Memory,
     Disk,
@@ -38,7 +38,7 @@ impl Display for TaskWriteLocation {
     }
 }
 
-impl Display for TaskStreamStorage {
+impl Display for LocalStreamStorage {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Self::Ephemeral => write!(f, "Ephemeral"),

--- a/crates/sail-execution/src/stream/writer.rs
+++ b/crates/sail-execution/src/stream/writer.rs
@@ -13,7 +13,7 @@ use crate::stream::ChannelName;
 pub enum TaskWriteLocation {
     Local {
         channel: ChannelName,
-        persistence: TaskStreamPersistence,
+        storage: TaskStreamStorage,
     },
     Remote {
         uri: String,
@@ -21,7 +21,7 @@ pub enum TaskWriteLocation {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum TaskStreamPersistence {
+pub enum TaskStreamStorage {
     Ephemeral,
     Memory,
     Disk,
@@ -30,16 +30,15 @@ pub enum TaskStreamPersistence {
 impl Display for TaskWriteLocation {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            TaskWriteLocation::Local {
-                channel,
-                persistence,
-            } => write!(f, "Local({}, {})", channel, persistence),
+            TaskWriteLocation::Local { channel, storage } => {
+                write!(f, "Local({}, {})", channel, storage)
+            }
             TaskWriteLocation::Remote { uri } => write!(f, "Remote({})", uri),
         }
     }
 }
 
-impl Display for TaskStreamPersistence {
+impl Display for TaskStreamStorage {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Self::Ephemeral => write!(f, "Ephemeral"),

--- a/crates/sail-execution/src/worker/actor/core.rs
+++ b/crates/sail-execution/src/worker/actor/core.rs
@@ -111,6 +111,9 @@ impl Actor for WorkerActor {
                 schema,
                 result,
             } => self.handle_fetch_remote_stream(ctx, uri, schema, result),
+            WorkerEvent::RemoveLocalStream { channel_prefix } => {
+                self.handle_remove_local_stream(ctx, channel_prefix)
+            }
             WorkerEvent::Shutdown => ActorAction::Stop,
         }
     }

--- a/crates/sail-execution/src/worker/actor/core.rs
+++ b/crates/sail-execution/src/worker/actor/core.rs
@@ -66,6 +66,7 @@ impl Actor for WorkerActor {
             WorkerEvent::ServerReady { port, signal } => {
                 self.handle_server_ready(ctx, port, signal)
             }
+            WorkerEvent::StartHeartbeat => self.handle_start_heartbeat(ctx),
             WorkerEvent::RunTask {
                 task_id,
                 attempt,

--- a/crates/sail-execution/src/worker/actor/core.rs
+++ b/crates/sail-execution/src/worker/actor/core.rs
@@ -84,10 +84,10 @@ impl Actor for WorkerActor {
             } => self.handle_report_task_status(ctx, task_id, attempt, status, message),
             WorkerEvent::CreateLocalStream {
                 channel,
-                persistence,
+                storage,
                 schema,
                 result,
-            } => self.handle_create_local_stream(ctx, channel, persistence, schema, result),
+            } => self.handle_create_local_stream(ctx, channel, storage, schema, result),
             WorkerEvent::CreateRemoteStream {
                 uri,
                 schema,

--- a/crates/sail-execution/src/worker/actor/handler.rs
+++ b/crates/sail-execution/src/worker/actor/handler.rs
@@ -18,7 +18,7 @@ use crate::driver::state::TaskStatus;
 use crate::error::{ExecutionError, ExecutionResult};
 use crate::id::{TaskAttempt, TaskId, WorkerId};
 use crate::plan::{ShuffleReadExec, ShuffleWriteExec};
-use crate::stream::{ChannelName, RecordBatchStreamWriter, TaskStreamPersistence};
+use crate::stream::{ChannelName, RecordBatchStreamWriter, TaskStreamStorage};
 use crate::worker::actor::core::WorkerActor;
 use crate::worker::actor::local_stream::{EphemeralStream, LocalStream, MemoryStream};
 use crate::worker::actor::stream_accessor::WorkerStreamAccessor;
@@ -149,17 +149,17 @@ impl WorkerActor {
         &mut self,
         ctx: &mut ActorContext<Self>,
         channel: ChannelName,
-        persistence: TaskStreamPersistence,
+        storage: TaskStreamStorage,
         schema: SchemaRef,
         result: oneshot::Sender<ExecutionResult<Box<dyn RecordBatchStreamWriter>>>,
     ) -> ActorAction {
-        let mut stream: Box<dyn LocalStream> = match persistence {
-            TaskStreamPersistence::Ephemeral => Box::new(EphemeralStream::new(
+        let mut stream: Box<dyn LocalStream> = match storage {
+            TaskStreamStorage::Ephemeral => Box::new(EphemeralStream::new(
                 self.options().worker_stream_buffer,
                 schema,
             )),
-            TaskStreamPersistence::Memory => Box::new(MemoryStream::new(schema)),
-            TaskStreamPersistence::Disk => {
+            TaskStreamStorage::Memory => Box::new(MemoryStream::new(schema)),
+            TaskStreamStorage::Disk => {
                 return ActorAction::fail("not implemented: create disk stream")
             }
         };

--- a/crates/sail-execution/src/worker/actor/handler.rs
+++ b/crates/sail-execution/src/worker/actor/handler.rs
@@ -243,6 +243,23 @@ impl WorkerActor {
         ActorAction::Continue
     }
 
+    pub(super) fn handle_remove_local_stream(
+        &mut self,
+        _ctx: &mut ActorContext<Self>,
+        channel_prefix: String,
+    ) -> ActorAction {
+        let mut keys = Vec::new();
+        for key in self.local_streams.keys() {
+            if key.has_prefix(&channel_prefix) {
+                keys.push(key.clone());
+            }
+        }
+        for key in keys {
+            self.local_streams.remove(&key);
+        }
+        ActorAction::Continue
+    }
+
     fn session_context(&self) -> Arc<SessionContext> {
         Arc::new(SessionContext::default())
     }

--- a/crates/sail-execution/src/worker/actor/handler.rs
+++ b/crates/sail-execution/src/worker/actor/handler.rs
@@ -18,7 +18,7 @@ use crate::driver::state::TaskStatus;
 use crate::error::{ExecutionError, ExecutionResult};
 use crate::id::{TaskAttempt, TaskId, WorkerId};
 use crate::plan::{ShuffleReadExec, ShuffleWriteExec};
-use crate::stream::{ChannelName, RecordBatchStreamWriter, TaskStreamStorage};
+use crate::stream::{ChannelName, LocalStreamStorage, RecordBatchStreamWriter};
 use crate::worker::actor::core::WorkerActor;
 use crate::worker::actor::local_stream::{EphemeralStream, LocalStream, MemoryStream};
 use crate::worker::actor::stream_accessor::WorkerStreamAccessor;
@@ -149,17 +149,17 @@ impl WorkerActor {
         &mut self,
         ctx: &mut ActorContext<Self>,
         channel: ChannelName,
-        storage: TaskStreamStorage,
+        storage: LocalStreamStorage,
         schema: SchemaRef,
         result: oneshot::Sender<ExecutionResult<Box<dyn RecordBatchStreamWriter>>>,
     ) -> ActorAction {
         let mut stream: Box<dyn LocalStream> = match storage {
-            TaskStreamStorage::Ephemeral => Box::new(EphemeralStream::new(
+            LocalStreamStorage::Ephemeral => Box::new(EphemeralStream::new(
                 self.options().worker_stream_buffer,
                 schema,
             )),
-            TaskStreamStorage::Memory => Box::new(MemoryStream::new(schema)),
-            TaskStreamStorage::Disk => {
+            LocalStreamStorage::Memory => Box::new(MemoryStream::new(schema)),
+            LocalStreamStorage::Disk => {
                 return ActorAction::fail("not implemented: create disk stream")
             }
         };

--- a/crates/sail-execution/src/worker/actor/local_stream.rs
+++ b/crates/sail-execution/src/worker/actor/local_stream.rs
@@ -1,0 +1,50 @@
+use arrow::array::RecordBatch;
+use arrow::datatypes::SchemaRef;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::SendableRecordBatchStream;
+use futures::StreamExt;
+use tokio::sync::mpsc;
+use tonic::codegen::tokio_stream::wrappers::ReceiverStream;
+
+use crate::error::{ExecutionError, ExecutionResult};
+use crate::stream::RecordBatchStreamWriter;
+
+pub(super) trait LocalStream: Send {
+    fn publish(&mut self) -> ExecutionResult<Box<dyn RecordBatchStreamWriter>>;
+    fn subscribe(&mut self) -> ExecutionResult<SendableRecordBatchStream>;
+}
+
+pub(super) struct EphemeralStream {
+    tx: Option<mpsc::Sender<RecordBatch>>,
+    rx: Option<mpsc::Receiver<RecordBatch>>,
+    schema: SchemaRef,
+}
+
+impl EphemeralStream {
+    pub fn new(buffer: usize, schema: SchemaRef) -> Self {
+        let (tx, rx) = mpsc::channel(buffer);
+        Self {
+            tx: Some(tx),
+            rx: Some(rx),
+            schema,
+        }
+    }
+}
+
+impl LocalStream for EphemeralStream {
+    fn publish(&mut self) -> ExecutionResult<Box<dyn RecordBatchStreamWriter>> {
+        let tx = self.tx.take().ok_or_else(|| {
+            ExecutionError::InternalError("ephemeral stream can only be written once".to_string())
+        })?;
+        Ok(Box::new(tx))
+    }
+
+    fn subscribe(&mut self) -> ExecutionResult<SendableRecordBatchStream> {
+        let rx = self.rx.take().ok_or_else(|| {
+            ExecutionError::InternalError("ephemeral stream can only be read once".to_string())
+        })?;
+        let stream =
+            RecordBatchStreamAdapter::new(self.schema.clone(), ReceiverStream::new(rx).map(Ok));
+        Ok(Box::pin(stream))
+    }
+}

--- a/crates/sail-execution/src/worker/actor/local_stream.rs
+++ b/crates/sail-execution/src/worker/actor/local_stream.rs
@@ -1,17 +1,29 @@
+use std::sync::{Arc, RwLock};
+
 use arrow::array::RecordBatch;
 use arrow::datatypes::SchemaRef;
+use datafusion::common::Result;
+use datafusion::error::DataFusionError;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::StreamExt;
-use tokio::sync::mpsc;
+use sail_server::actor::ActorContext;
+use tokio::sync::{mpsc, watch};
 use tonic::codegen::tokio_stream::wrappers::ReceiverStream;
 
 use crate::error::{ExecutionError, ExecutionResult};
 use crate::stream::RecordBatchStreamWriter;
+use crate::worker::WorkerActor;
 
 pub(super) trait LocalStream: Send {
-    fn publish(&mut self) -> ExecutionResult<Box<dyn RecordBatchStreamWriter>>;
-    fn subscribe(&mut self) -> ExecutionResult<SendableRecordBatchStream>;
+    fn publish(
+        &mut self,
+        ctx: &mut ActorContext<WorkerActor>,
+    ) -> ExecutionResult<Box<dyn RecordBatchStreamWriter>>;
+    fn subscribe(
+        &mut self,
+        ctx: &mut ActorContext<WorkerActor>,
+    ) -> ExecutionResult<SendableRecordBatchStream>;
 }
 
 pub(super) struct EphemeralStream {
@@ -32,17 +44,142 @@ impl EphemeralStream {
 }
 
 impl LocalStream for EphemeralStream {
-    fn publish(&mut self) -> ExecutionResult<Box<dyn RecordBatchStreamWriter>> {
+    fn publish(
+        &mut self,
+        _ctx: &mut ActorContext<WorkerActor>,
+    ) -> ExecutionResult<Box<dyn RecordBatchStreamWriter>> {
         let tx = self.tx.take().ok_or_else(|| {
             ExecutionError::InternalError("ephemeral stream can only be written once".to_string())
         })?;
         Ok(Box::new(tx))
     }
 
-    fn subscribe(&mut self) -> ExecutionResult<SendableRecordBatchStream> {
+    fn subscribe(
+        &mut self,
+        _ctx: &mut ActorContext<WorkerActor>,
+    ) -> ExecutionResult<SendableRecordBatchStream> {
         let rx = self.rx.take().ok_or_else(|| {
             ExecutionError::InternalError("ephemeral stream can only be read once".to_string())
         })?;
+        let stream =
+            RecordBatchStreamAdapter::new(self.schema.clone(), ReceiverStream::new(rx).map(Ok));
+        Ok(Box::pin(stream))
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct MemoryStreamState {
+    count: usize,
+    completed: bool,
+}
+
+#[derive(Debug)]
+struct MemoryStreamWriter {
+    tx: watch::Sender<MemoryStreamState>,
+    batches: Arc<RwLock<Vec<RecordBatch>>>,
+}
+
+#[tonic::async_trait]
+impl RecordBatchStreamWriter for MemoryStreamWriter {
+    async fn write(&mut self, batch: RecordBatch) -> Result<()> {
+        let mut batches = self
+            .batches
+            .write()
+            .map_err(|e| DataFusionError::Internal(e.to_string()))?;
+        batches.push(batch);
+        self.tx
+            .send(MemoryStreamState {
+                count: batches.len(),
+                completed: false,
+            })
+            .map_err(|e| DataFusionError::Internal(e.to_string()))
+    }
+
+    fn close(self: Box<Self>) -> Result<()> {
+        let batches = self
+            .batches
+            .read()
+            .map_err(|e| DataFusionError::Internal(e.to_string()))?;
+        self.tx
+            .send(MemoryStreamState {
+                count: batches.len(),
+                completed: true,
+            })
+            .map_err(|e| DataFusionError::Internal(e.to_string()))
+    }
+}
+
+/// A memory stream that can be read multiple times.
+/// It maintains an unbounded list of record batches in memory.
+pub(super) struct MemoryStream {
+    batches: Arc<RwLock<Vec<RecordBatch>>>,
+    schema: SchemaRef,
+    tx: Option<watch::Sender<MemoryStreamState>>,
+    rx: watch::Receiver<MemoryStreamState>,
+}
+
+impl MemoryStream {
+    pub fn new(schema: SchemaRef) -> Self {
+        let (tx, rx) = watch::channel(MemoryStreamState::default());
+        Self {
+            batches: Arc::new(RwLock::new(vec![])),
+            schema,
+            tx: Some(tx),
+            rx,
+        }
+    }
+}
+
+impl LocalStream for MemoryStream {
+    fn publish(
+        &mut self,
+        _ctx: &mut ActorContext<WorkerActor>,
+    ) -> ExecutionResult<Box<dyn RecordBatchStreamWriter>> {
+        let tx = self.tx.take().ok_or_else(|| {
+            ExecutionError::InternalError("memory stream can only be written once".to_string())
+        })?;
+        Ok(Box::new(MemoryStreamWriter {
+            tx,
+            batches: self.batches.clone(),
+        }))
+    }
+
+    fn subscribe(
+        &mut self,
+        ctx: &mut ActorContext<WorkerActor>,
+    ) -> ExecutionResult<SendableRecordBatchStream> {
+        // The channel only needs a capacity of 1 since the stream reader
+        // controls the consumption rate.
+        let (tx, rx) = mpsc::channel(1);
+        let mut watcher = self.rx.clone();
+        let batches = self.batches.clone();
+        ctx.spawn(async move {
+            let mut n = 0;
+            loop {
+                if watcher.changed().await.is_err() {
+                    return;
+                }
+                let MemoryStreamState { count, completed } = watcher.borrow_and_update().clone();
+                // Acquire the read lock inside an inner scope.
+                // The lock is released after collecting all the remaining batches.
+                let remaining = {
+                    let Ok(batches) = batches.read() else {
+                        return;
+                    };
+                    let out = batches[n..count].to_vec();
+                    n = count;
+                    out
+                };
+                for batch in remaining {
+                    if tx.send(batch).await.is_err() {
+                        return;
+                    }
+                }
+                if completed {
+                    return;
+                }
+            }
+        });
         let stream =
             RecordBatchStreamAdapter::new(self.schema.clone(), ReceiverStream::new(rx).map(Ok));
         Ok(Box::pin(stream))

--- a/crates/sail-execution/src/worker/actor/mod.rs
+++ b/crates/sail-execution/src/worker/actor/mod.rs
@@ -1,7 +1,8 @@
 mod core;
 mod handler;
-mod monitor;
+mod local_stream;
 mod rpc;
-mod shuffle;
+mod stream_accessor;
+mod stream_monitor;
 
 pub(crate) use core::WorkerActor;

--- a/crates/sail-execution/src/worker/actor/rpc.rs
+++ b/crates/sail-execution/src/worker/actor/rpc.rs
@@ -6,13 +6,11 @@ use tokio::net::{TcpListener, ToSocketAddrs};
 use tonic::codec::CompressionEncoding;
 
 use crate::error::{ExecutionError, ExecutionResult};
-use crate::id::WorkerId;
-use crate::rpc::ClientOptions;
 use crate::worker::actor::core::WorkerActor;
 use crate::worker::flight_server::WorkerFlightServer;
 use crate::worker::gen::worker_service_server::WorkerServiceServer;
 use crate::worker::server::WorkerServer;
-use crate::worker::{WorkerClient, WorkerEvent};
+use crate::worker::WorkerEvent;
 
 impl WorkerActor {
     pub(super) async fn serve(
@@ -53,23 +51,5 @@ impl WorkerActor {
             })
             .await
             .map_err(|e| ExecutionError::InternalError(e.to_string()))
-    }
-
-    pub(super) fn worker_client(
-        &mut self,
-        id: WorkerId,
-        host: String,
-        port: u16,
-    ) -> ExecutionResult<&WorkerClient> {
-        let enable_tls = self.options().enable_tls;
-        let client = self.worker_clients.entry(id).or_insert_with(|| {
-            let options = ClientOptions {
-                enable_tls,
-                host,
-                port,
-            };
-            WorkerClient::new(options)
-        });
-        Ok(client)
     }
 }

--- a/crates/sail-execution/src/worker/actor/stream_accessor.rs
+++ b/crates/sail-execution/src/worker/actor/stream_accessor.rs
@@ -1,5 +1,5 @@
 use arrow::datatypes::SchemaRef;
-use datafusion::common::{not_impl_err, DataFusionError, Result};
+use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::SendableRecordBatchStream;
 use sail_server::actor::ActorHandle;
 use tokio::sync::oneshot;
@@ -12,19 +12,19 @@ use crate::stream::{
 use crate::worker::{WorkerActor, WorkerEvent};
 
 #[derive(Debug)]
-pub(super) struct WorkerTaskStreamReader {
+pub(super) struct WorkerStreamAccessor {
     worker_id: WorkerId,
     handle: ActorHandle<WorkerActor>,
 }
 
-impl WorkerTaskStreamReader {
+impl WorkerStreamAccessor {
     pub fn new(worker_id: WorkerId, handle: ActorHandle<WorkerActor>) -> Self {
         Self { worker_id, handle }
     }
 }
 
 #[tonic::async_trait]
-impl TaskStreamReader for WorkerTaskStreamReader {
+impl TaskStreamReader for WorkerStreamAccessor {
     async fn open(
         &self,
         location: &TaskReadLocation,
@@ -39,12 +39,12 @@ impl TaskStreamReader for WorkerTaskStreamReader {
                 channel,
             } => {
                 if *worker_id == self.worker_id {
-                    WorkerEvent::FetchThisWorkerTaskStream {
+                    WorkerEvent::FetchThisWorkerStream {
                         channel: channel.clone(),
                         result: tx,
                     }
                 } else {
-                    WorkerEvent::FetchOtherWorkerTaskStream {
+                    WorkerEvent::FetchOtherWorkerStream {
                         worker_id: *worker_id,
                         host: host.clone(),
                         port: *port,
@@ -54,7 +54,11 @@ impl TaskStreamReader for WorkerTaskStreamReader {
                     }
                 }
             }
-            TaskReadLocation::Remote { .. } => return not_impl_err!("remote task read"),
+            TaskReadLocation::Remote { uri } => WorkerEvent::FetchRemoteStream {
+                uri: uri.clone(),
+                schema,
+                result: tx,
+            },
         };
         self.handle
             .send(event)
@@ -66,21 +70,8 @@ impl TaskStreamReader for WorkerTaskStreamReader {
     }
 }
 
-#[derive(Debug)]
-pub(super) struct WorkerTaskStreamWriter {
-    #[allow(dead_code)]
-    worker_id: WorkerId,
-    handle: ActorHandle<WorkerActor>,
-}
-
-impl WorkerTaskStreamWriter {
-    pub fn new(worker_id: WorkerId, handle: ActorHandle<WorkerActor>) -> Self {
-        Self { worker_id, handle }
-    }
-}
-
 #[tonic::async_trait]
-impl TaskStreamWriter for WorkerTaskStreamWriter {
+impl TaskStreamWriter for WorkerStreamAccessor {
     async fn open(
         &self,
         location: &TaskWriteLocation,
@@ -88,26 +79,27 @@ impl TaskStreamWriter for WorkerTaskStreamWriter {
     ) -> Result<Box<dyn RecordBatchStreamWriter>> {
         let (tx, rx) = oneshot::channel();
         let event = match location {
-            TaskWriteLocation::Memory { channel } => WorkerEvent::CreateMemoryTaskStream {
+            TaskWriteLocation::Local {
+                channel,
+                persistence,
+            } => WorkerEvent::CreateLocalStream {
                 channel: channel.clone(),
+                persistence: persistence.clone(),
                 schema,
                 result: tx,
             },
-            TaskWriteLocation::Disk { .. } => {
-                return not_impl_err!("disk task write");
-            }
-            TaskWriteLocation::Remote { .. } => {
-                return not_impl_err!("remote task write");
-            }
+            TaskWriteLocation::Remote { uri } => WorkerEvent::CreateRemoteStream {
+                uri: uri.clone(),
+                schema,
+                result: tx,
+            },
         };
         self.handle
             .send(event)
             .await
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
-        let sender = rx
-            .await
+        rx.await
             .map_err(|e| DataFusionError::External(Box::new(e)))?
-            .map_err(|e| DataFusionError::External(Box::new(e)))?;
-        Ok(Box::new(sender))
+            .map_err(|e| DataFusionError::External(Box::new(e)))
     }
 }

--- a/crates/sail-execution/src/worker/actor/stream_accessor.rs
+++ b/crates/sail-execution/src/worker/actor/stream_accessor.rs
@@ -84,7 +84,7 @@ impl TaskStreamWriter for WorkerStreamAccessor {
                 persistence,
             } => WorkerEvent::CreateLocalStream {
                 channel: channel.clone(),
-                persistence: persistence.clone(),
+                persistence: *persistence,
                 schema,
                 result: tx,
             },

--- a/crates/sail-execution/src/worker/actor/stream_accessor.rs
+++ b/crates/sail-execution/src/worker/actor/stream_accessor.rs
@@ -79,12 +79,9 @@ impl TaskStreamWriter for WorkerStreamAccessor {
     ) -> Result<Box<dyn RecordBatchStreamWriter>> {
         let (tx, rx) = oneshot::channel();
         let event = match location {
-            TaskWriteLocation::Local {
-                channel,
-                persistence,
-            } => WorkerEvent::CreateLocalStream {
+            TaskWriteLocation::Local { channel, storage } => WorkerEvent::CreateLocalStream {
                 channel: channel.clone(),
-                persistence: *persistence,
+                storage: *storage,
                 schema,
                 result: tx,
             },

--- a/crates/sail-execution/src/worker/client.rs
+++ b/crates/sail-execution/src/worker/client.rs
@@ -50,7 +50,7 @@ impl WorkerClient {
             partition: partition as u64,
             channel: channel.map(|x| x.into()),
         };
-        let response = self.client.lock().await?.run_task(request).await?;
+        let response = self.client.get().await?.run_task(request).await?;
         let RunTaskResponse {} = response.into_inner();
         Ok(())
     }
@@ -60,7 +60,7 @@ impl WorkerClient {
             task_id: task_id.into(),
             attempt: attempt as u64,
         };
-        let response = self.client.lock().await?.stop_task(request).await?;
+        let response = self.client.get().await?.stop_task(request).await?;
         let StopTaskResponse {} = response.into_inner();
         Ok(())
     }
@@ -81,7 +81,7 @@ impl WorkerClient {
         let request = arrow_flight::Ticket {
             ticket: ticket.into(),
         };
-        let response = self.flight_client.lock().await?.do_get(request).await?;
+        let response = self.flight_client.get().await?.do_get(request).await?;
         let stream = response.into_inner().map_err(|e| e.into());
         let stream = FlightRecordBatchStream::new_from_flight_data(stream)
             .map_err(|e| exec_datafusion_err!("{e}"));
@@ -90,7 +90,7 @@ impl WorkerClient {
 
     pub async fn stop_worker(&self) -> ExecutionResult<()> {
         let request = StopWorkerRequest {};
-        let response = self.client.lock().await?.stop_worker(request).await?;
+        let response = self.client.get().await?.stop_worker(request).await?;
         let StopWorkerResponse {} = response.into_inner();
         Ok(())
     }

--- a/crates/sail-execution/src/worker/client.rs
+++ b/crates/sail-execution/src/worker/client.rs
@@ -14,8 +14,8 @@ use crate::rpc::{ClientHandle, ClientOptions};
 use crate::stream::ChannelName;
 use crate::worker::gen::worker_service_client::WorkerServiceClient;
 use crate::worker::gen::{
-    RunTaskRequest, RunTaskResponse, StopTaskRequest, StopTaskResponse, StopWorkerRequest,
-    StopWorkerResponse, TaskStreamTicket,
+    RemoveStreamRequest, RemoveStreamResponse, RunTaskRequest, RunTaskResponse, StopTaskRequest,
+    StopTaskResponse, StopWorkerRequest, StopWorkerResponse, TaskStreamTicket,
 };
 
 #[derive(Debug, Clone)]
@@ -86,6 +86,13 @@ impl WorkerClient {
         let stream = FlightRecordBatchStream::new_from_flight_data(stream)
             .map_err(|e| exec_datafusion_err!("{e}"));
         Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+
+    pub async fn remove_stream(&self, channel_prefix: String) -> ExecutionResult<()> {
+        let request = RemoveStreamRequest { channel_prefix };
+        let response = self.client.get().await?.remove_stream(request).await?;
+        let RemoveStreamResponse {} = response.into_inner();
+        Ok(())
     }
 
     pub async fn stop_worker(&self) -> ExecutionResult<()> {

--- a/crates/sail-execution/src/worker/event.rs
+++ b/crates/sail-execution/src/worker/event.rs
@@ -59,5 +59,8 @@ pub enum WorkerEvent {
         schema: SchemaRef,
         result: oneshot::Sender<ExecutionResult<SendableRecordBatchStream>>,
     },
+    RemoveLocalStream {
+        channel_prefix: String,
+    },
     Shutdown,
 }

--- a/crates/sail-execution/src/worker/event.rs
+++ b/crates/sail-execution/src/worker/event.rs
@@ -5,7 +5,7 @@ use tokio::sync::oneshot;
 use crate::driver::state::TaskStatus;
 use crate::error::ExecutionResult;
 use crate::id::{TaskId, WorkerId};
-use crate::stream::{ChannelName, RecordBatchStreamWriter, TaskStreamStorage};
+use crate::stream::{ChannelName, LocalStreamStorage, RecordBatchStreamWriter};
 
 pub enum WorkerEvent {
     ServerReady {
@@ -33,7 +33,7 @@ pub enum WorkerEvent {
     },
     CreateLocalStream {
         channel: ChannelName,
-        storage: TaskStreamStorage,
+        storage: LocalStreamStorage,
         schema: SchemaRef,
         result: oneshot::Sender<ExecutionResult<Box<dyn RecordBatchStreamWriter>>>,
     },

--- a/crates/sail-execution/src/worker/event.rs
+++ b/crates/sail-execution/src/worker/event.rs
@@ -5,7 +5,7 @@ use tokio::sync::oneshot;
 use crate::driver::state::TaskStatus;
 use crate::error::ExecutionResult;
 use crate::id::{TaskId, WorkerId};
-use crate::stream::{ChannelName, RecordBatchStreamWriter, TaskStreamPersistence};
+use crate::stream::{ChannelName, RecordBatchStreamWriter, TaskStreamStorage};
 
 pub enum WorkerEvent {
     ServerReady {
@@ -33,7 +33,7 @@ pub enum WorkerEvent {
     },
     CreateLocalStream {
         channel: ChannelName,
-        persistence: TaskStreamPersistence,
+        storage: TaskStreamStorage,
         schema: SchemaRef,
         result: oneshot::Sender<ExecutionResult<Box<dyn RecordBatchStreamWriter>>>,
     },

--- a/crates/sail-execution/src/worker/event.rs
+++ b/crates/sail-execution/src/worker/event.rs
@@ -14,6 +14,7 @@ pub enum WorkerEvent {
         port: u16,
         signal: oneshot::Sender<()>,
     },
+    StartHeartbeat,
     RunTask {
         task_id: TaskId,
         attempt: usize,

--- a/crates/sail-execution/src/worker/flight_server.rs
+++ b/crates/sail-execution/src/worker/flight_server.rs
@@ -88,7 +88,7 @@ impl FlightService for WorkerFlightServer {
         debug!("{:?}", ticket);
         let TaskStreamTicket { channel } = ticket;
         let (tx, rx) = oneshot::channel();
-        let event = crate::worker::WorkerEvent::FetchThisWorkerTaskStream {
+        let event = crate::worker::WorkerEvent::FetchThisWorkerStream {
             channel: channel.into(),
             result: tx,
         };

--- a/crates/sail-execution/src/worker/options.rs
+++ b/crates/sail-execution/src/worker/options.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use sail_common::config::AppConfig;
+use sail_server::RetryStrategy;
 
 use crate::error::{ExecutionError, ExecutionResult};
 use crate::id::WorkerId;
@@ -17,6 +18,7 @@ pub struct WorkerOptions {
     pub worker_external_port: u16,
     pub worker_heartbeat_interval: Duration,
     pub worker_stream_buffer: usize,
+    pub rpc_retry_strategy: RetryStrategy,
 }
 
 impl TryFrom<&AppConfig> for WorkerOptions {
@@ -40,6 +42,7 @@ impl TryFrom<&AppConfig> for WorkerOptions {
                 config.cluster.worker_heartbeat_interval_secs,
             ),
             worker_stream_buffer: config.cluster.worker_stream_buffer,
+            rpc_retry_strategy: (&config.cluster.rpc_retry_strategy).into(),
         })
     }
 }

--- a/crates/sail-execution/src/worker/options.rs
+++ b/crates/sail-execution/src/worker/options.rs
@@ -13,7 +13,7 @@ pub struct WorkerOptions {
     pub worker_listen_port: u16,
     pub worker_external_host: String,
     pub worker_external_port: u16,
-    pub memory_stream_buffer: usize,
+    pub worker_stream_buffer: usize,
 }
 
 impl TryFrom<&AppConfig> for WorkerOptions {
@@ -33,7 +33,7 @@ impl TryFrom<&AppConfig> for WorkerOptions {
             worker_listen_port: config.cluster.worker_listen_port,
             worker_external_host: config.cluster.worker_external_host.clone(),
             worker_external_port: config.cluster.worker_external_port,
-            memory_stream_buffer: config.cluster.memory_stream_buffer,
+            worker_stream_buffer: config.cluster.worker_stream_buffer,
         })
     }
 }

--- a/crates/sail-execution/src/worker/options.rs
+++ b/crates/sail-execution/src/worker/options.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use sail_common::config::AppConfig;
 
 use crate::error::{ExecutionError, ExecutionResult};
@@ -13,6 +15,7 @@ pub struct WorkerOptions {
     pub worker_listen_port: u16,
     pub worker_external_host: String,
     pub worker_external_port: u16,
+    pub worker_heartbeat_interval: Duration,
     pub worker_stream_buffer: usize,
 }
 
@@ -33,6 +36,9 @@ impl TryFrom<&AppConfig> for WorkerOptions {
             worker_listen_port: config.cluster.worker_listen_port,
             worker_external_host: config.cluster.worker_external_host.clone(),
             worker_external_port: config.cluster.worker_external_port,
+            worker_heartbeat_interval: Duration::from_secs(
+                config.cluster.worker_heartbeat_interval_secs,
+            ),
             worker_stream_buffer: config.cluster.worker_stream_buffer,
         })
     }

--- a/crates/sail-execution/src/worker/server.rs
+++ b/crates/sail-execution/src/worker/server.rs
@@ -6,8 +6,8 @@ use crate::error::ExecutionError;
 use crate::worker::actor::WorkerActor;
 use crate::worker::gen::worker_service_server::WorkerService;
 use crate::worker::gen::{
-    RunTaskRequest, RunTaskResponse, StopTaskRequest, StopTaskResponse, StopWorkerRequest,
-    StopWorkerResponse,
+    RemoveStreamRequest, RemoveStreamResponse, RunTaskRequest, RunTaskResponse, StopTaskRequest,
+    StopTaskResponse, StopWorkerRequest, StopWorkerResponse,
 };
 use crate::worker::WorkerEvent;
 
@@ -68,6 +68,23 @@ impl WorkerService for WorkerServer {
             .await
             .map_err(ExecutionError::from)?;
         let response = StopTaskResponse {};
+        debug!("{:?}", response);
+        Ok(Response::new(response))
+    }
+
+    async fn remove_stream(
+        &self,
+        request: Request<RemoveStreamRequest>,
+    ) -> Result<Response<RemoveStreamResponse>, Status> {
+        let request = request.into_inner();
+        debug!("{:?}", request);
+        let RemoveStreamRequest { channel_prefix } = request;
+        let event = WorkerEvent::RemoveLocalStream { channel_prefix };
+        self.handle
+            .send(event)
+            .await
+            .map_err(ExecutionError::from)?;
+        let response = RemoveStreamResponse {};
         debug!("{:?}", response);
         Ok(Response::new(response))
     }

--- a/crates/sail-execution/src/worker_manager/kubernetes.rs
+++ b/crates/sail-execution/src/worker_manager/kubernetes.rs
@@ -143,11 +143,7 @@ impl KubernetesWorkerManager {
             },
             EnvVar {
                 name: ClusterConfigEnv::ENABLE_TLS.to_string(),
-                value: Some(if enable_tls {
-                    "true".to_string()
-                } else {
-                    "false".to_string()
-                }),
+                value: Some(enable_tls.to_string()),
                 value_from: None,
             },
             EnvVar {

--- a/crates/sail-execution/src/worker_manager/local.rs
+++ b/crates/sail-execution/src/worker_manager/local.rs
@@ -52,6 +52,7 @@ impl WorkerManager for LocalWorkerManager {
             worker_external_port: 0,
             worker_heartbeat_interval: options.worker_heartbeat_interval,
             worker_stream_buffer: options.worker_stream_buffer,
+            rpc_retry_strategy: options.rpc_retry_strategy,
         };
         let mut state = self.state.lock().await;
         let handle = state.system.spawn(options);

--- a/crates/sail-execution/src/worker_manager/local.rs
+++ b/crates/sail-execution/src/worker_manager/local.rs
@@ -50,6 +50,7 @@ impl WorkerManager for LocalWorkerManager {
             worker_listen_port: 0,
             worker_external_host: "127.0.0.1".to_string(),
             worker_external_port: 0,
+            worker_heartbeat_interval: options.worker_heartbeat_interval,
             worker_stream_buffer: options.worker_stream_buffer,
         };
         let mut state = self.state.lock().await;

--- a/crates/sail-execution/src/worker_manager/local.rs
+++ b/crates/sail-execution/src/worker_manager/local.rs
@@ -50,7 +50,7 @@ impl WorkerManager for LocalWorkerManager {
             worker_listen_port: 0,
             worker_external_host: "127.0.0.1".to_string(),
             worker_external_port: 0,
-            memory_stream_buffer: options.memory_stream_buffer,
+            worker_stream_buffer: options.worker_stream_buffer,
         };
         let mut state = self.state.lock().await;
         let handle = state.system.spawn(options);

--- a/crates/sail-execution/src/worker_manager/mod.rs
+++ b/crates/sail-execution/src/worker_manager/mod.rs
@@ -1,6 +1,8 @@
 mod kubernetes;
 mod local;
 
+use std::time::Duration;
+
 use crate::error::ExecutionResult;
 use crate::id::WorkerId;
 
@@ -9,6 +11,7 @@ pub struct WorkerLaunchOptions {
     pub enable_tls: bool,
     pub driver_external_host: String,
     pub driver_external_port: u16,
+    pub worker_heartbeat_interval: Duration,
     pub worker_stream_buffer: usize,
 }
 

--- a/crates/sail-execution/src/worker_manager/mod.rs
+++ b/crates/sail-execution/src/worker_manager/mod.rs
@@ -9,7 +9,7 @@ pub struct WorkerLaunchOptions {
     pub enable_tls: bool,
     pub driver_external_host: String,
     pub driver_external_port: u16,
-    pub memory_stream_buffer: usize,
+    pub worker_stream_buffer: usize,
 }
 
 #[tonic::async_trait]

--- a/crates/sail-execution/src/worker_manager/mod.rs
+++ b/crates/sail-execution/src/worker_manager/mod.rs
@@ -1,19 +1,11 @@
 mod kubernetes;
 mod local;
+mod options;
 
-use std::time::Duration;
+pub(crate) use options::WorkerLaunchOptions;
 
 use crate::error::ExecutionResult;
 use crate::id::WorkerId;
-
-#[derive(Debug)]
-pub struct WorkerLaunchOptions {
-    pub enable_tls: bool,
-    pub driver_external_host: String,
-    pub driver_external_port: u16,
-    pub worker_heartbeat_interval: Duration,
-    pub worker_stream_buffer: usize,
-}
 
 #[tonic::async_trait]
 pub trait WorkerManager: Send + Sync + 'static {

--- a/crates/sail-execution/src/worker_manager/options.rs
+++ b/crates/sail-execution/src/worker_manager/options.rs
@@ -1,0 +1,13 @@
+use std::time::Duration;
+
+use sail_server::RetryStrategy;
+
+#[derive(Debug, Clone)]
+pub struct WorkerLaunchOptions {
+    pub enable_tls: bool,
+    pub driver_external_host: String,
+    pub driver_external_port: u16,
+    pub worker_heartbeat_interval: Duration,
+    pub worker_stream_buffer: usize,
+    pub rpc_retry_strategy: RetryStrategy,
+}

--- a/crates/sail-server/Cargo.toml
+++ b/crates/sail-server/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 
 [dependencies]
 sail-telemetry = { path = "../sail-telemetry" }
+sail-common = { path = "../sail-common" }
 
 tokio = { workspace = true }
 tonic = { workspace = true }

--- a/crates/sail-server/src/lib.rs
+++ b/crates/sail-server/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod actor;
 mod builder;
+mod retry;
 
 pub use builder::{ServerBuilder, ServerBuilderOptions};
+pub use retry::{RetryStrategy, Retryable};

--- a/crates/sail-server/src/lib.rs
+++ b/crates/sail-server/src/lib.rs
@@ -3,4 +3,4 @@ mod builder;
 mod retry;
 
 pub use builder::{ServerBuilder, ServerBuilderOptions};
-pub use retry::{RetryStrategy, Retryable};
+pub use retry::RetryStrategy;

--- a/crates/sail-server/src/retry.rs
+++ b/crates/sail-server/src/retry.rs
@@ -1,0 +1,114 @@
+use std::future::Future;
+use std::time::Duration;
+
+use log::warn;
+use sail_common::config;
+
+#[derive(Debug, Clone)]
+pub enum RetryStrategy {
+    Fixed {
+        max_count: usize,
+        delay: Duration,
+    },
+    ExponentialBackoff {
+        max_count: usize,
+        initial_delay: Duration,
+        max_delay: Duration,
+        factor: u32,
+    },
+}
+
+struct ExponentialBackoffDelay {
+    delay: Duration,
+    max_delay: Duration,
+    factor: u32,
+}
+
+impl Iterator for ExponentialBackoffDelay {
+    type Item = Duration;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let delay = self.delay;
+        self.delay = std::cmp::min(delay * self.factor, self.max_delay);
+        Some(delay)
+    }
+}
+
+impl RetryStrategy {
+    pub fn iter(&self) -> Box<dyn Iterator<Item = Duration> + Send> {
+        match self {
+            Self::ExponentialBackoff {
+                max_count,
+                initial_delay,
+                max_delay,
+                factor,
+            } => Box::new(
+                ExponentialBackoffDelay {
+                    delay: *initial_delay,
+                    max_delay: *max_delay,
+                    factor: *factor,
+                }
+                .take(*max_count),
+            ),
+            Self::Fixed { max_count, delay } => {
+                Box::new(std::iter::repeat(*delay).take(*max_count))
+            }
+        }
+    }
+}
+
+impl From<&config::RetryStrategy> for RetryStrategy {
+    fn from(config: &config::RetryStrategy) -> Self {
+        match config {
+            config::RetryStrategy::Fixed {
+                max_count,
+                delay_secs,
+            } => Self::Fixed {
+                max_count: *max_count,
+                delay: Duration::from_secs(*delay_secs),
+            },
+            config::RetryStrategy::ExponentialBackoff {
+                max_count,
+                initial_delay_secs,
+                max_delay_secs,
+                factor,
+            } => Self::ExponentialBackoff {
+                max_count: *max_count,
+                initial_delay: Duration::from_secs(*initial_delay_secs),
+                max_delay: Duration::from_secs(*max_delay_secs),
+                factor: *factor,
+            },
+        }
+    }
+}
+
+#[tonic::async_trait]
+pub trait Retryable<F, Fut, T, E> {
+    async fn retry(self, strategy: RetryStrategy) -> Result<T, E>;
+}
+
+#[tonic::async_trait]
+impl<F, Fut, T, E> Retryable<F, Fut, T, E> for F
+where
+    F: FnMut() -> Fut + Send,
+    Fut: Future<Output = Result<T, E>> + Send,
+    T: Send,
+    E: std::fmt::Display + Send,
+{
+    async fn retry(mut self, strategy: RetryStrategy) -> Result<T, E> {
+        let mut delay = strategy.iter();
+        loop {
+            match self().await {
+                x @ Ok(_) => return x,
+                Err(e) => {
+                    warn!("retryable operation failed: {e}");
+                    if let Some(delay) = delay.next() {
+                        tokio::time::sleep(delay).await;
+                    } else {
+                        return Err(e);
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
1. Support stream replay for shuffle plans under `CoalescePartitionsExec`.
2. Implement worker heartbeat.
3. Implement retry logic for RPC requests.