### PR TITLE
Support removing idle Spark sessions

### DIFF
--- a/crates/sail-common/src/config/application.rs
+++ b/crates/sail-common/src/config/application.rs
@@ -14,6 +14,7 @@ pub struct AppConfig {
     pub execution: ExecutionConfig,
     pub kubernetes: KubernetesConfig,
     pub parquet: ParquetConfig,
+    pub spark: SparkConfig,
     /// Reserved for internal use.
     /// This field ensures that environment variables with prefix `SAIL_INTERNAL_`
     /// can only be used for internal configuration.
@@ -112,12 +113,6 @@ pub struct ExecutionConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ParquetConfig {
-    pub maximum_parallel_row_group_writers: usize,
-    pub maximum_buffered_record_batches_per_stream: usize,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KubernetesConfig {
     pub image: String,
     pub image_pull_policy: String,
@@ -129,6 +124,17 @@ pub struct KubernetesConfig {
     /// The prefix of the name of worker pods.
     /// This should usually end with a hyphen (`-`).
     pub worker_pod_name_prefix: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ParquetConfig {
+    pub maximum_parallel_row_group_writers: usize,
+    pub maximum_buffered_record_batches_per_stream: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SparkConfig {
+    pub session_timeout_secs: u64,
 }
 
 /// Environment variables for application cluster configuration.

--- a/crates/sail-common/src/config/default.toml
+++ b/crates/sail-common/src/config/default.toml
@@ -36,3 +36,6 @@ image_pull_policy = "IfNotPresent"
 namespace = "default"
 driver_pod_name = ""
 worker_pod_name_prefix = "sail-worker-"
+
+[spark]
+session_timeout_secs = 300

--- a/crates/sail-execution/src/driver/actor/handler.rs
+++ b/crates/sail-execution/src/driver/actor/handler.rs
@@ -170,7 +170,7 @@ impl DriverActor {
         if let WorkerState::Running { heartbeat_at, .. } = &worker.state {
             if *heartbeat_at <= instant {
                 warn!("worker {worker_id} heartbeat timeout");
-                let message = "worker heartbeat timeout ".to_string();
+                let message = "worker heartbeat timeout".to_string();
                 self.fail_tasks_for_worker(ctx, worker_id, message.clone());
                 self.stop_worker(ctx, worker_id, Some(message));
             }
@@ -247,7 +247,7 @@ impl DriverActor {
             return ActorAction::Continue;
         };
         if task.attempt == attempt && matches!(&task.state, TaskState::Pending) {
-            let message = "task scheduling timeout ".to_string();
+            let message = "task scheduling timeout".to_string();
             self.update_task(
                 ctx,
                 task_id,

--- a/crates/sail-execution/src/driver/event.rs
+++ b/crates/sail-execution/src/driver/event.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::physical_plan::ExecutionPlan;
 use tokio::sync::oneshot;
+use tokio::time::Instant;
 
 use crate::driver::state::TaskStatus;
 use crate::error::ExecutionResult;
@@ -29,9 +30,11 @@ pub enum DriverEvent {
     },
     ProbeIdleWorker {
         worker_id: WorkerId,
+        instant: Instant,
     },
     ProbeLostWorker {
         worker_id: WorkerId,
+        instant: Instant,
     },
     ExecuteJob {
         plan: Arc<dyn ExecutionPlan>,
@@ -51,6 +54,7 @@ pub enum DriverEvent {
     },
     ProbePendingTask {
         task_id: TaskId,
+        attempt: usize,
     },
     Shutdown,
 }

--- a/crates/sail-execution/src/worker/actor/core.rs
+++ b/crates/sail-execution/src/worker/actor/core.rs
@@ -3,7 +3,7 @@ use std::mem;
 
 use datafusion::prelude::SessionContext;
 use datafusion_proto::physical_plan::PhysicalExtensionCodec;
-use log::debug;
+use log::info;
 use sail_server::actor::{Actor, ActorAction, ActorContext};
 use tokio::sync::oneshot;
 
@@ -122,7 +122,7 @@ impl Actor for WorkerActor {
 
     async fn stop(self, _ctx: &mut ActorContext<Self>) {
         self.server.stop().await;
-        debug!("worker {} server has stopped", self.options.worker_id);
+        info!("worker {} server has stopped", self.options.worker_id);
     }
 }
 

--- a/crates/sail-server/src/actor.rs
+++ b/crates/sail-server/src/actor.rs
@@ -12,7 +12,8 @@ pub trait Actor: Sized + Send + 'static {
     type Options;
 
     fn new(options: Self::Options) -> Self;
-    async fn start(&mut self, ctx: &mut ActorContext<Self>);
+    #[allow(unused_variables)]
+    async fn start(&mut self, ctx: &mut ActorContext<Self>) {}
     /// Process one message and return the next action.
     /// This method should handle errors internally (e.g. by sending itself an error message
     /// for further processing).
@@ -21,7 +22,8 @@ pub trait Actor: Sized + Send + 'static {
     /// If the actor needs to perform async operations, it should spawn tasks via
     /// [ActorContext::spawn].
     fn receive(&mut self, ctx: &mut ActorContext<Self>, message: Self::Message) -> ActorAction;
-    async fn stop(self, ctx: &mut ActorContext<Self>);
+    #[allow(unused_variables)]
+    async fn stop(self, ctx: &mut ActorContext<Self>) {}
 }
 
 pub enum ActorAction {
@@ -228,8 +230,6 @@ mod tests {
             Self
         }
 
-        async fn start(&mut self, _: &mut ActorContext<Self>) {}
-
         fn receive(&mut self, _: &mut ActorContext<Self>, message: Self::Message) -> ActorAction {
             match message {
                 TestMessage::Echo { value, reply } => {
@@ -239,8 +239,6 @@ mod tests {
                 TestMessage::Stop => ActorAction::Stop,
             }
         }
-
-        async fn stop(self, _: &mut ActorContext<Self>) {}
     }
 
     #[tokio::test]

--- a/crates/sail-spark-connect/src/error.rs
+++ b/crates/sail-spark-connect/src/error.rs
@@ -64,10 +64,6 @@ impl SparkError {
         SparkError::InvalidArgument(message.into())
     }
 
-    pub fn send(message: impl Into<String>) -> Self {
-        SparkError::SendError(message.into())
-    }
-
     pub fn internal(message: impl Into<String>) -> Self {
         SparkError::InternalError(message.into())
     }

--- a/crates/sail-spark-connect/src/server.rs
+++ b/crates/sail-spark-connect/src/server.rs
@@ -69,7 +69,8 @@ impl SparkConnectService for SparkConnectServer {
         };
         let ctx = self
             .session_manager
-            .get_or_create_session_context(session_key)?;
+            .get_or_create_session_context(session_key)
+            .await?;
         let Plan { op_type: op } = request.plan.required("plan")?;
         let op = op.required("plan op")?;
         let stream = match op {
@@ -139,7 +140,8 @@ impl SparkConnectService for SparkConnectServer {
         };
         let ctx = self
             .session_manager
-            .get_or_create_session_context(session_key)?;
+            .get_or_create_session_context(session_key)
+            .await?;
         let analyze = request.analyze.required("analyze")?;
         let result = match analyze {
             Analyze::Schema(schema) => {
@@ -215,7 +217,8 @@ impl SparkConnectService for SparkConnectServer {
         };
         let ctx = self
             .session_manager
-            .get_or_create_session_context(session_key)?;
+            .get_or_create_session_context(session_key)
+            .await?;
         let sc::config_request::Operation { op_type: op } =
             request.operation.required("operation")?;
         let op = op.required("operation type")?;
@@ -266,7 +269,8 @@ impl SparkConnectService for SparkConnectServer {
         };
         let ctx = self
             .session_manager
-            .get_or_create_session_context(session_key)?;
+            .get_or_create_session_context(session_key)
+            .await?;
         let payload = first.payload;
         let session_id = first.session_id;
         let stream = async_stream::try_stream! {
@@ -302,7 +306,8 @@ impl SparkConnectService for SparkConnectServer {
         };
         let ctx = self
             .session_manager
-            .get_or_create_session_context(session_key)?;
+            .get_or_create_session_context(session_key)
+            .await?;
         let statuses = service::handle_artifact_statuses(&ctx, request.names).await?;
         let response = ArtifactStatusesResponse { statuses };
         debug!("{:?}", response);
@@ -321,7 +326,8 @@ impl SparkConnectService for SparkConnectServer {
         };
         let ctx = self
             .session_manager
-            .get_or_create_session_context(session_key)?;
+            .get_or_create_session_context(session_key)
+            .await?;
         let ids = match InterruptType::try_from(request.interrupt_type) {
             Ok(InterruptType::All) => Ok(service::handle_interrupt_all(&ctx).await?),
             Ok(InterruptType::Tag) => {
@@ -364,7 +370,8 @@ impl SparkConnectService for SparkConnectServer {
         };
         let ctx = self
             .session_manager
-            .get_or_create_session_context(session_key)?;
+            .get_or_create_session_context(session_key)
+            .await?;
         let stream =
             service::handle_reattach_execute(&ctx, request.operation_id, request.last_response_id)
                 .await?;
@@ -383,7 +390,8 @@ impl SparkConnectService for SparkConnectServer {
         };
         let ctx = self
             .session_manager
-            .get_or_create_session_context(session_key)?;
+            .get_or_create_session_context(session_key)
+            .await?;
         let response_id = match request.release.required("release")? {
             Release::ReleaseAll(ReleaseAll {}) => None,
             Release::ReleaseUntil(ReleaseUntil { response_id }) => Some(response_id),

--- a/crates/sail-spark-connect/src/session_manager.rs
+++ b/crates/sail-spark-connect/src/session_manager.rs
@@ -1,31 +1,46 @@
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use std::fmt::Debug;
+use std::fmt::{Debug, Display};
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use datafusion::execution::runtime_env::{RuntimeConfig, RuntimeEnv};
 use datafusion::execution::SessionStateBuilder;
 use datafusion::prelude::{SessionConfig, SessionContext};
+use log::info;
 use sail_common::config::{AppConfig, ExecutionMode};
 use sail_execution::job::{ClusterJobRunner, JobRunner, LocalJobRunner};
 use sail_plan::function::BUILT_IN_SCALAR_FUNCTIONS;
 use sail_plan::new_query_planner;
 use sail_plan::object_store::DynamicObjectStoreRegistry;
 use sail_plan::temp_view::TemporaryViewManager;
-use sail_server::actor::ActorSystem;
+use sail_server::actor::{Actor, ActorAction, ActorContext, ActorHandle, ActorSystem};
+use tokio::sync::oneshot;
+use tokio::time::Instant;
 
-use crate::error::SparkResult;
+use crate::error::{SparkError, SparkResult};
 use crate::session::{SparkExtension, DEFAULT_SPARK_CATALOG, DEFAULT_SPARK_SCHEMA};
 
 #[derive(Eq, PartialEq, Hash, Clone, Debug)]
-pub(crate) struct SessionKey {
+pub struct SessionKey {
     pub user_id: Option<String>,
     pub session_id: String,
 }
 
+impl Display for SessionKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(user_id) = &self.user_id {
+            write!(f, "{}@{}", user_id, self.session_id)
+        } else {
+            write!(f, "{}", self.session_id)
+        }
+    }
+}
+
 pub struct SessionManager {
-    state: Mutex<SessionManagerState>,
+    system: Arc<Mutex<ActorSystem>>,
+    handle: ActorHandle<SessionManagerActor>,
     config: Arc<AppConfig>,
 }
 
@@ -37,45 +52,48 @@ impl Debug for SessionManager {
 
 impl SessionManager {
     pub fn new(config: Arc<AppConfig>) -> Self {
+        let mut system = ActorSystem::new();
+        let handle = system.spawn::<SessionManagerActor>(config.as_ref().into());
         Self {
-            state: Mutex::new(SessionManagerState::new()),
+            system: Arc::new(Mutex::new(system)),
+            handle,
             config,
         }
     }
 
-    pub(crate) fn get_or_create_session_context(
+    pub async fn get_or_create_session_context(
         &self,
         key: SessionKey,
     ) -> SparkResult<SessionContext> {
-        let mut state = self.state.lock()?;
-        let state = state.deref_mut();
-        let entry = state.sessions.entry(key);
-        match entry {
-            Entry::Occupied(o) => Ok(o.get().clone()),
-            Entry::Vacant(v) => {
-                let key = v.key().clone();
-                let context = self.create_session_context(&mut state.actor_system, key)?;
-                Ok(v.insert(context).clone())
-            }
-        }
+        let (tx, rx) = oneshot::channel();
+        let event = SessionManagerEvent::GetOrCreateSession {
+            key,
+            system: self.system.clone(),
+            config: self.config.clone(),
+            result: tx,
+        };
+        self.handle.send(event).await?;
+        rx.await
+            .map_err(|e| SparkError::internal(format!("failed to get session: {e}")))?
     }
 
-    fn create_session_context(
-        &self,
-        actor_system: &mut ActorSystem,
+    pub fn create_session_context(
+        config: Arc<AppConfig>,
+        system: Arc<Mutex<ActorSystem>>,
         key: SessionKey,
     ) -> SparkResult<SessionContext> {
-        let job_runner: Box<dyn JobRunner> = match self.config.mode {
+        let job_runner: Box<dyn JobRunner> = match config.mode {
             ExecutionMode::Local => Box::new(LocalJobRunner::new()),
             ExecutionMode::LocalCluster | ExecutionMode::KubernetesCluster => {
-                let options = self.config.as_ref().try_into()?;
-                Box::new(ClusterJobRunner::new(actor_system, options))
+                let options = config.as_ref().try_into()?;
+                let mut system = system.lock()?;
+                Box::new(ClusterJobRunner::new(system.deref_mut(), options))
             }
         };
         let spark = SparkExtension::new(key.user_id, key.session_id, job_runner);
         // TODO: support more systematic configuration
         // TODO: return error on invalid environment variables
-        let config = SessionConfig::new()
+        let session_config = SessionConfig::new()
             .with_create_default_catalog_and_schema(true)
             .with_default_catalog_and_schema(DEFAULT_SPARK_CATALOG, DEFAULT_SPARK_SCHEMA)
             .with_information_schema(true)
@@ -83,17 +101,15 @@ impl SessionManager {
             .with_extension(Arc::new(spark))
             .set_usize(
                 "datafusion.execution.batch_size",
-                self.config.execution.batch_size,
+                config.execution.batch_size,
             )
             .set_usize(
                 "datafusion.execution.parquet.maximum_parallel_row_group_writers",
-                self.config.parquet.maximum_parallel_row_group_writers,
+                config.parquet.maximum_parallel_row_group_writers,
             )
             .set_usize(
                 "datafusion.execution.parquet.maximum_buffered_record_batches_per_stream",
-                self.config
-                    .parquet
-                    .maximum_buffered_record_batches_per_stream,
+                config.parquet.maximum_buffered_record_batches_per_stream,
             )
             // Spark defaults to false:
             //  https://spark.apache.org/docs/latest/sql-data-sources-csv.html
@@ -104,7 +120,7 @@ impl SessionManager {
             Arc::new(RuntimeEnv::try_new(config)?)
         };
         let state = SessionStateBuilder::new()
-            .with_config(config)
+            .with_config(session_config)
             .with_runtime_env(runtime)
             .with_default_features()
             .with_query_planner(new_query_planner())
@@ -112,33 +128,128 @@ impl SessionManager {
         let context = SessionContext::new_with_state(state);
 
         // TODO: This is a temp workaround to deregister all built-in functions that we define.
-        //  We should deregister all context.udfs() once we have better coverage of functions.
-        // handler.rs needs to do this
+        //   We should deregister all context.udfs() once we have better coverage of functions.
+        //   handler.rs needs to do this
         for (&name, _function) in BUILT_IN_SCALAR_FUNCTIONS.iter() {
             context.deregister_udf(name);
         }
 
         Ok(context)
     }
+}
 
-    #[allow(dead_code)]
-    pub(crate) fn remove_session(&self, key: &SessionKey) -> SparkResult<()> {
-        let mut state = self.state.lock()?;
-        state.sessions.remove(key);
-        Ok(())
+struct SessionManagerOptions {
+    pub session_timeout: Duration,
+}
+
+impl From<&AppConfig> for SessionManagerOptions {
+    fn from(config: &AppConfig) -> Self {
+        Self {
+            session_timeout: Duration::from_secs(config.spark.session_timeout_secs),
+        }
     }
 }
 
-struct SessionManagerState {
-    sessions: HashMap<SessionKey, SessionContext>,
-    actor_system: ActorSystem,
+enum SessionManagerEvent {
+    GetOrCreateSession {
+        key: SessionKey,
+        system: Arc<Mutex<ActorSystem>>,
+        config: Arc<AppConfig>,
+        result: oneshot::Sender<SparkResult<SessionContext>>,
+    },
+    ProbeIdleSession {
+        key: SessionKey,
+        /// The time when the session was known to be active.
+        instant: Instant,
+    },
 }
 
-impl SessionManagerState {
-    pub fn new() -> Self {
+struct SessionManagerActor {
+    options: SessionManagerOptions,
+    sessions: HashMap<SessionKey, SessionContext>,
+}
+
+#[tonic::async_trait]
+impl Actor for SessionManagerActor {
+    type Message = SessionManagerEvent;
+    type Options = SessionManagerOptions;
+
+    fn new(options: Self::Options) -> Self {
         Self {
+            options,
             sessions: HashMap::new(),
-            actor_system: ActorSystem::new(),
         }
+    }
+
+    fn receive(&mut self, ctx: &mut ActorContext<Self>, message: Self::Message) -> ActorAction {
+        match message {
+            SessionManagerEvent::GetOrCreateSession {
+                key,
+                system,
+                config,
+                result,
+            } => self.handle_get_or_create_session(ctx, key, system, config, result),
+            SessionManagerEvent::ProbeIdleSession { key, instant } => {
+                self.handle_probe_idle_session(ctx, key, instant)
+            }
+        }
+    }
+}
+
+impl SessionManagerActor {
+    fn handle_get_or_create_session(
+        &mut self,
+        ctx: &mut ActorContext<Self>,
+        key: SessionKey,
+        system: Arc<Mutex<ActorSystem>>,
+        config: Arc<AppConfig>,
+        result: oneshot::Sender<SparkResult<SessionContext>>,
+    ) -> ActorAction {
+        let entry = self.sessions.entry(key.clone());
+        let context = match entry {
+            Entry::Occupied(o) => Ok(o.get().clone()),
+            Entry::Vacant(v) => {
+                let key = v.key().clone();
+                info!("creating session {}", key);
+                match SessionManager::create_session_context(config, system, key) {
+                    Ok(context) => Ok(v.insert(context).clone()),
+                    Err(e) => Err(e),
+                }
+            }
+        };
+        if let Ok(context) = &context {
+            if let Ok(active_at) =
+                SparkExtension::get(context).and_then(|spark| spark.track_activity())
+            {
+                ctx.send_with_delay(
+                    SessionManagerEvent::ProbeIdleSession {
+                        key,
+                        instant: active_at,
+                    },
+                    self.options.session_timeout,
+                );
+            }
+        }
+        let _ = result.send(context);
+        ActorAction::Continue
+    }
+
+    fn handle_probe_idle_session(
+        &mut self,
+        ctx: &mut ActorContext<Self>,
+        key: SessionKey,
+        instant: Instant,
+    ) -> ActorAction {
+        let context = self.sessions.get(&key);
+        if let Some(context) = context {
+            if let Ok(spark) = SparkExtension::get(context) {
+                if spark.active_at().is_ok_and(|x| x <= instant) {
+                    info!("removing idle session {}", key);
+                    ctx.spawn(async move { spark.job_runner().stop().await });
+                    self.sessions.remove(&key);
+                }
+            }
+        }
+        ActorAction::Continue
     }
 }


### PR DESCRIPTION
1. Support removing idle Spark sessions.
2. Switch to a more robust approach for timeout event handling in all actors.