### PR TITLE
Fix issue in Spark build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Currently, Sail features a drop-in replacement for Spark SQL and the Spark DataF
 Sail is available as a Python package on PyPI. You can install it using `pip`.
 
 ```bash
-pip install pysail
+pip install "pysail[spark]"
 ```
 
 Alternatively, you can install Sail from source for better performance for your hardware architecture.
@@ -54,7 +54,7 @@ No changes are needed in your PySpark code!
 ```python
 from pyspark.sql import SparkSession
 
-spark = SparkSession.builder.remote(f"sc://localhost:50051").getOrCreate()
+spark = SparkSession.builder.remote("sc://localhost:50051").getOrCreate()
 spark.sql("SELECT 1 + 1").show()
 ```
 

--- a/docs/development/spark-tests/spark-setup.md
+++ b/docs/development/spark-tests/spark-setup.md
@@ -36,6 +36,12 @@ using the following heuristics.
 
 ::: info
 
+If you have previously checked out the Spark repository and encounter the error `unknown revision or path not in the working tree` when running the `build-pyspark.sh` script, please run `git fetch` in the `opt/spark` directory to update the repository.
+
+:::
+
+::: info
+
 Here are some notes about the `build-pyspark.sh` script.
 
 1. The script will fail with an error if the Spark directory is not clean. The script internally applies a patch

--- a/scripts/spark-gold-data/bootstrap.sh
+++ b/scripts/spark-gold-data/bootstrap.sh
@@ -15,9 +15,9 @@ output_path="${project_path}/crates/sail-spark-connect/tests/gold_data"
 
 source "${project_path}/scripts/shell-tools/git-patch.sh"
 
-cd "${project_path}"/opt/spark
+apply_git_patch "${project_path}"/opt/spark "v3.5.4" "${scripts_path}"/spark-3.5.4.patch
 
-apply_git_patch "v3.5.4" "${scripts_path}"/spark-3.5.4.patch
+cd "${project_path}"/opt/spark
 
 echo "Removing existing test logs..."
 rm -rf "${logs_path}"

--- a/scripts/spark-tests/build-pyspark.sh
+++ b/scripts/spark-tests/build-pyspark.sh
@@ -8,9 +8,9 @@ scripts_path="${project_path}/scripts/spark-tests"
 
 source "${project_path}/scripts/shell-tools/git-patch.sh"
 
-cd "${project_path}"/opt/spark
+apply_git_patch "${project_path}"/opt/spark "v3.5.4" "${scripts_path}"/spark-3.5.4.patch
 
-apply_git_patch "v3.5.4" "${scripts_path}"/spark-3.5.4.patch
+cd "${project_path}"/opt/spark
 
 ./build/mvn \
   --batch-mode \


### PR DESCRIPTION
The `build-pyspark.sh` script can have the following error at the end of the execution.

```text
error: Your local changes to the following files would be overwritten by checkout:
    pom.xml
Please commit your changes or stash them before you switch branches.
```

This issue has been there for a long time. Interestingly, this error only happens locally. The GitHub Actions workflow did not have this issue.

This PR fixes this issue.
