### PR TITLE
Refactor function builder and add more SQL syntax

### DIFF
--- a/crates/sail-common/src/spec/expression.rs
+++ b/crates/sail-common/src/spec/expression.rs
@@ -14,12 +14,7 @@ pub enum Expr {
         name: ObjectName,
         plan_id: Option<i64>,
     },
-    UnresolvedFunction {
-        function_name: String,
-        arguments: Vec<Expr>,
-        is_distinct: bool,
-        is_user_defined_function: bool,
-    },
+    UnresolvedFunction(UnresolvedFunction),
     UnresolvedStar {
         target: Option<ObjectName>,
         wildcard_options: WildcardOptions,
@@ -46,10 +41,7 @@ pub enum Expr {
     },
     Window {
         window_function: Box<Expr>,
-        cluster_spec: Vec<Expr>,
-        partition_spec: Vec<Expr>,
-        order_spec: Vec<SortOrder>,
-        frame_spec: Option<WindowFrame>,
+        window: Window,
     },
     UnresolvedExtractValue {
         child: Box<Expr>,
@@ -116,6 +108,9 @@ pub enum Expr {
         negated: bool,
         escape_char: Option<char>,
         case_insensitive: bool,
+    },
+    Table {
+        expr: Box<Expr>,
     },
 }
 
@@ -220,6 +215,30 @@ pub enum NullOrdering {
     Unspecified,
     NullsFirst,
     NullsLast,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UnresolvedFunction {
+    pub function_name: String,
+    pub arguments: Vec<Expr>,
+    pub is_distinct: bool,
+    pub is_user_defined_function: bool,
+    pub ignore_nulls: Option<bool>,
+    pub filter: Option<Box<Expr>>,
+    pub order_by: Option<Vec<SortOrder>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum Window {
+    Named(Identifier),
+    Unnamed {
+        cluster_by: Vec<Expr>,
+        partition_by: Vec<Expr>,
+        order_by: Vec<SortOrder>,
+        frame: Option<WindowFrame>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/sail-plan/src/function/scalar/array.rs
+++ b/crates/sail-plan/src/function/scalar/array.rs
@@ -8,7 +8,7 @@ use datafusion_expr::{expr, lit, BinaryExpr, Operator};
 use crate::error::{PlanError, PlanResult};
 use crate::extension::function::array_min_max::{ArrayMax, ArrayMin};
 use crate::extension::function::spark_array::SparkArray;
-use crate::function::common::{Function, FunctionContext};
+use crate::function::common::{Function, FunctionInput};
 use crate::utils::ItemTaker;
 
 fn array_repeat(element: expr::Expr, count: expr::Expr) -> expr::Expr {
@@ -44,11 +44,9 @@ fn slice(array: expr::Expr, start: expr::Expr, length: expr::Expr) -> expr::Expr
     expr_fn::array_slice(array, start, end, None)
 }
 
-fn sort_array(
-    args: Vec<expr::Expr>,
-    _function_context: &FunctionContext,
-) -> PlanResult<expr::Expr> {
-    let (array, asc) = args.two()?;
+fn sort_array(input: FunctionInput) -> PlanResult<expr::Expr> {
+    let FunctionInput { arguments, .. } = input;
+    let (array, asc) = arguments.two()?;
     let (sort, nulls) = match asc {
         expr::Expr::Literal(ScalarValue::Boolean(Some(true))) => (
             lit(ScalarValue::Utf8(Some("ASC".to_string()))),

--- a/crates/sail-plan/src/function/scalar/conditional.rs
+++ b/crates/sail-plan/src/function/scalar/conditional.rs
@@ -2,12 +2,13 @@ use datafusion::functions::expr_fn;
 use datafusion_expr::expr;
 
 use crate::error::PlanResult;
-use crate::function::common::{Function, FunctionContext};
+use crate::function::common::{Function, FunctionInput};
 use crate::utils::ItemTaker;
 
-fn case(args: Vec<expr::Expr>, _function_context: &FunctionContext) -> PlanResult<expr::Expr> {
+fn case(input: FunctionInput) -> PlanResult<expr::Expr> {
+    let FunctionInput { arguments, .. } = input;
     let mut when_then_expr = Vec::new();
-    let mut iter = args.into_iter();
+    let mut iter = arguments.into_iter();
     let mut else_expr: Option<Box<expr::Expr>> = None;
     while let Some(condition) = iter.next() {
         if let Some(result) = iter.next() {
@@ -24,8 +25,9 @@ fn case(args: Vec<expr::Expr>, _function_context: &FunctionContext) -> PlanResul
     }))
 }
 
-fn if_expr(args: Vec<expr::Expr>, _function_context: &FunctionContext) -> PlanResult<expr::Expr> {
-    let (when_expr, then_expr, else_expr) = args.three()?;
+fn if_expr(input: FunctionInput) -> PlanResult<expr::Expr> {
+    let FunctionInput { arguments, .. } = input;
+    let (when_expr, then_expr, else_expr) = arguments.three()?;
     Ok(expr::Expr::Case(expr::Case {
         expr: None,
         when_then_expr: vec![(Box::new(when_expr), Box::new(then_expr))],

--- a/crates/sail-plan/src/function/scalar/conversion.rs
+++ b/crates/sail-plan/src/function/scalar/conversion.rs
@@ -5,21 +5,21 @@ use datafusion_common::ScalarValue;
 use datafusion_expr::Expr;
 
 use crate::error::PlanResult;
-use crate::function::common::{Function, FunctionContext};
+use crate::function::common::{Function, FunctionInput};
 use crate::resolver::PlanResolver;
 use crate::utils::ItemTaker;
 
-fn timestamp(args: Vec<Expr>, function_context: &FunctionContext) -> PlanResult<Expr> {
-    if args.len() == 1 {
-        let arg = args.one()?;
+fn timestamp(input: FunctionInput) -> PlanResult<Expr> {
+    if input.arguments.len() == 1 {
+        let arg = input.arguments.one()?;
         match arg {
             Expr::Literal(ScalarValue::Utf8(Some(timestamp_string))) => {
                 let timestamp_micros =
                     string_to_timestamp_nanos(&timestamp_string).map(|x| x / 1_000)?;
                 let timezone = PlanResolver::resolve_timezone(
                     &sail_common::spec::TimeZoneInfo::SQLConfigured,
-                    function_context.plan_config().system_timezone.as_str(),
-                    &function_context.plan_config().timestamp_type,
+                    input.plan_config.system_timezone.as_str(),
+                    &input.plan_config.timestamp_type,
                 )?;
                 Ok(Expr::Literal(ScalarValue::TimestampMicrosecond(
                     Some(timestamp_micros),
@@ -29,7 +29,7 @@ fn timestamp(args: Vec<Expr>, function_context: &FunctionContext) -> PlanResult<
             _ => Ok(expr_fn::to_timestamp_micros(vec![arg])),
         }
     } else {
-        Ok(expr_fn::to_timestamp_micros(args))
+        Ok(expr_fn::to_timestamp_micros(input.arguments))
     }
 }
 

--- a/crates/sail-plan/src/function/scalar/hash.rs
+++ b/crates/sail-plan/src/function/scalar/hash.rs
@@ -8,11 +8,12 @@ use crate::error::PlanResult;
 use crate::extension::function::spark_hex_unhex::SparkHex;
 use crate::extension::function::spark_murmur3_hash::SparkMurmur3Hash;
 use crate::extension::function::spark_xxhash64::SparkXxhash64;
-use crate::function::common::{Function, FunctionContext};
+use crate::function::common::{Function, FunctionInput};
 use crate::utils::ItemTaker;
 
-fn sha2(args: Vec<expr::Expr>, _function_context: &FunctionContext) -> PlanResult<expr::Expr> {
-    let (expr, bit_length) = args.two()?;
+fn sha2(input: FunctionInput) -> PlanResult<expr::Expr> {
+    let FunctionInput { arguments, .. } = input;
+    let (expr, bit_length) = arguments.two()?;
     let result = match bit_length {
         expr::Expr::Literal(ScalarValue::Int32(Some(0)))
         | expr::Expr::Literal(ScalarValue::Int32(Some(256))) => expr_fn::sha256(expr),

--- a/crates/sail-plan/src/function/scalar/json.rs
+++ b/crates/sail-plan/src/function/scalar/json.rs
@@ -3,15 +3,13 @@ use datafusion_expr::{expr, lit};
 use datafusion_functions_json::udfs;
 
 use crate::error::PlanResult;
-use crate::function::common::{Function, FunctionContext};
+use crate::function::common::{Function, FunctionInput};
 use crate::utils::ItemTaker;
 
-fn get_json_object(
-    args: Vec<expr::Expr>,
-    _function_context: &FunctionContext,
-) -> PlanResult<expr::Expr> {
+fn get_json_object(input: FunctionInput) -> PlanResult<expr::Expr> {
     // > 1 path means nested access e.g. json_as_text(json, p1, p2) => json.p1.p2
-    let (expr, paths) = args.at_least_one()?;
+    let FunctionInput { arguments, .. } = input;
+    let (expr, paths) = arguments.at_least_one()?;
     let paths: Vec<expr::Expr> = paths
         .into_iter()
         .map(|path| match &path {

--- a/crates/sail-plan/src/function/scalar/map.rs
+++ b/crates/sail-plan/src/function/scalar/map.rs
@@ -3,14 +3,12 @@ use datafusion_expr::expr;
 
 use crate::error::PlanResult;
 use crate::extension::function::map_function::MapFunction;
-use crate::function::common::{Function, FunctionContext};
+use crate::function::common::{Function, FunctionInput};
 use crate::utils::ItemTaker;
 
-fn map_contains_key(
-    args: Vec<expr::Expr>,
-    _function_context: &FunctionContext,
-) -> PlanResult<expr::Expr> {
-    let (map, key) = args.two()?;
+fn map_contains_key(input: FunctionInput) -> PlanResult<expr::Expr> {
+    let FunctionInput { arguments, .. } = input;
+    let (map, key) = arguments.two()?;
     Ok(expr::Expr::Not(Box::new(expr_fn::array_empty(
         expr_fn::map_extract(map, key),
     ))))

--- a/crates/sail-plan/src/function/scalar/predicate.rs
+++ b/crates/sail-plan/src/function/scalar/predicate.rs
@@ -2,7 +2,7 @@ use datafusion::functions::expr_fn;
 use datafusion_expr::{expr, not, Operator};
 
 use crate::error::PlanResult;
-use crate::function::common::{Function, FunctionContext};
+use crate::function::common::{Function, FunctionInput};
 use crate::utils::ItemTaker;
 
 fn like(expr: expr::Expr, pattern: expr::Expr) -> expr::Expr {
@@ -41,11 +41,9 @@ fn rlike(expr: expr::Expr, pattern: expr::Expr) -> expr::Expr {
     expr_fn::regexp_like(expr, pattern, None)
 }
 
-fn is_in_list(
-    args: Vec<expr::Expr>,
-    _function_context: &FunctionContext,
-) -> PlanResult<expr::Expr> {
-    let (value, list) = args.at_least_one()?;
+fn is_in_list(input: FunctionInput) -> PlanResult<expr::Expr> {
+    let FunctionInput { arguments, .. } = input;
+    let (value, list) = arguments.at_least_one()?;
     Ok(expr::Expr::InList(expr::InList {
         expr: Box::new(value),
         list,

--- a/crates/sail-plan/src/function/scalar/struct.rs
+++ b/crates/sail-plan/src/function/scalar/struct.rs
@@ -5,12 +5,13 @@ use datafusion_expr::{expr, Expr, ScalarUDF};
 
 use crate::error::{PlanError, PlanResult};
 use crate::extension::function::struct_function::StructFunction;
-use crate::function::common::{Function, FunctionContext};
+use crate::function::common::{Function, FunctionInput};
 
-fn r#struct(args: Vec<Expr>, function_context: &FunctionContext) -> PlanResult<Expr> {
-    let field_names: Vec<String> = args
+fn r#struct(input: FunctionInput) -> PlanResult<Expr> {
+    let field_names: Vec<String> = input
+        .arguments
         .iter()
-        .zip(function_context.argument_names())
+        .zip(input.argument_names)
         .enumerate()
         .map(|(i, (expr, name))| -> PlanResult<_> {
             match expr {
@@ -24,7 +25,7 @@ fn r#struct(args: Vec<Expr>, function_context: &FunctionContext) -> PlanResult<E
         .collect::<PlanResult<_>>()?;
     Ok(Expr::ScalarFunction(expr::ScalarFunction {
         func: Arc::new(ScalarUDF::from(StructFunction::new(field_names))),
-        args,
+        args: input.arguments,
     }))
 }
 

--- a/crates/sail-plan/src/resolver/plan.rs
+++ b/crates/sail-plan/src/resolver/plan.rs
@@ -692,12 +692,15 @@ impl PlanResolver<'_> {
         };
         let canonical_function_name = function_name.to_ascii_lowercase();
         if is_built_in_generator_function(&canonical_function_name) {
-            let expr = spec::Expr::UnresolvedFunction {
+            let expr = spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
                 function_name: function_name.to_string(),
                 arguments,
                 is_distinct: false,
                 is_user_defined_function: false,
-            };
+                ignore_nulls: None,
+                filter: None,
+                order_by: None,
+            });
             self.resolve_query_project(None, vec![expr], state).await
         } else {
             let udf = self.ctx.udf(&canonical_function_name).ok();
@@ -2289,12 +2292,15 @@ impl PlanResolver<'_> {
         } else {
             function_name
         };
-        let expression = spec::Expr::UnresolvedFunction {
+        let expression = spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
             function_name,
             arguments,
             is_distinct: false,
             is_user_defined_function: false,
-        };
+            ignore_nulls: None,
+            filter: None,
+            order_by: None,
+        });
         let expression = if let Some(aliases) = column_aliases {
             spec::Expr::Alias {
                 expr: Box::new(expression),

--- a/crates/sail-spark-connect/tests/gold_data/expression/case.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/case.json
@@ -31,7 +31,10 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     },
                     {
@@ -43,7 +46,10 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               },
               {
@@ -55,7 +61,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -93,7 +102,10 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     },
                     {
@@ -105,7 +117,10 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               },
               {
@@ -142,7 +157,10 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     },
                     {
@@ -154,7 +172,10 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               },
               {
@@ -175,7 +196,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -208,7 +232,10 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               },
               {
@@ -240,7 +267,10 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               },
               {
@@ -261,7 +291,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -310,7 +343,10 @@
                                 }
                               ],
                               "isDistinct": false,
-                              "isUserDefinedFunction": false
+                              "isUserDefinedFunction": false,
+                              "ignoreNulls": null,
+                              "filter": null,
+                              "orderBy": null
                             }
                           },
                           {
@@ -331,12 +367,18 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               },
               {
@@ -357,7 +399,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -390,7 +435,10 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               },
               {
@@ -422,7 +470,10 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               },
               {
@@ -443,7 +494,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }

--- a/crates/sail-spark-connect/tests/gold_data/expression/current.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/current.json
@@ -8,7 +8,10 @@
             "functionName": "current_date",
             "arguments": [],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -21,7 +24,10 @@
             "functionName": "current_timestamp",
             "arguments": [],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }

--- a/crates/sail-spark-connect/tests/gold_data/expression/interval.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/interval.json
@@ -16,7 +16,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -40,7 +43,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -64,7 +70,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -85,7 +94,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -110,7 +122,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -131,7 +146,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -155,7 +173,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -179,7 +200,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -203,7 +227,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -227,7 +254,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -252,7 +282,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -277,7 +310,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -301,7 +337,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -325,7 +364,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -349,7 +391,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -373,7 +418,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -394,7 +442,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -415,7 +466,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -439,7 +493,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -463,7 +520,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -487,7 +547,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -511,7 +574,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -532,7 +598,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -553,7 +622,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -578,7 +650,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -602,7 +677,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -626,7 +704,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -650,7 +731,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -674,7 +758,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -698,7 +785,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -722,7 +812,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -746,7 +839,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -770,7 +866,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -794,7 +893,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -818,7 +920,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -839,7 +944,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -860,7 +968,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -884,7 +995,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -908,7 +1022,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -932,7 +1049,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -956,7 +1076,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -977,7 +1100,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -998,7 +1124,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1022,7 +1151,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1046,7 +1178,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1070,7 +1205,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1094,7 +1232,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1119,7 +1260,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1140,7 +1284,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1165,7 +1312,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1189,7 +1339,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1213,7 +1366,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1237,7 +1393,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1261,7 +1420,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1286,7 +1448,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1311,7 +1476,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1335,7 +1503,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1359,7 +1530,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1383,7 +1557,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1407,7 +1584,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1428,7 +1608,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1449,7 +1632,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1473,7 +1659,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1497,7 +1686,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1521,7 +1713,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1545,7 +1740,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1566,7 +1764,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1587,7 +1788,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1612,7 +1816,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1633,7 +1840,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1657,7 +1867,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1681,7 +1894,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1705,7 +1921,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1729,7 +1948,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1754,7 +1976,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1779,7 +2004,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1803,7 +2031,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1827,7 +2058,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1851,7 +2085,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1875,7 +2112,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1896,7 +2136,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1917,7 +2160,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1941,7 +2187,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1965,7 +2214,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1989,7 +2241,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2013,7 +2268,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2034,7 +2292,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2055,7 +2316,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2080,7 +2344,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2101,7 +2368,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2126,7 +2396,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2151,7 +2424,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2176,7 +2452,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2200,7 +2479,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2224,7 +2506,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2248,7 +2533,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2272,7 +2560,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2297,7 +2588,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2322,7 +2616,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2346,7 +2643,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2370,7 +2670,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2394,7 +2697,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2418,7 +2724,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2439,7 +2748,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2460,7 +2772,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2484,7 +2799,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2508,7 +2826,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2532,7 +2853,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2556,7 +2880,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2577,7 +2904,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2598,7 +2928,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2622,7 +2955,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2646,7 +2982,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2670,7 +3009,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2694,7 +3036,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2718,7 +3063,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2742,7 +3090,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2766,7 +3117,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2790,7 +3144,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2814,7 +3171,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2838,7 +3198,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2859,7 +3222,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2880,7 +3246,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2904,7 +3273,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2928,7 +3300,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2952,7 +3327,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2976,7 +3354,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2997,7 +3378,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3018,7 +3402,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3042,7 +3429,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3066,7 +3456,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3090,7 +3483,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3114,7 +3510,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3138,7 +3537,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3163,7 +3565,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3188,7 +3593,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3212,7 +3620,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3236,7 +3647,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3260,7 +3674,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3284,7 +3701,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3305,7 +3725,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3326,7 +3749,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3350,7 +3776,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3374,7 +3803,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3398,7 +3830,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3422,7 +3857,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3443,7 +3881,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3464,7 +3905,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3485,7 +3929,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3510,7 +3957,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3535,7 +3985,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3559,7 +4012,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3583,7 +4039,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3607,7 +4066,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3631,7 +4093,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3656,7 +4121,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3681,7 +4149,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3705,7 +4176,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3729,7 +4203,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3753,7 +4230,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3777,7 +4257,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3798,7 +4281,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3819,7 +4305,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3843,7 +4332,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3867,7 +4359,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3891,7 +4386,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3915,7 +4413,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3936,7 +4437,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3957,7 +4461,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3982,7 +4489,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -4006,7 +4516,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }

--- a/crates/sail-spark-connect/tests/gold_data/expression/like.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/like.json
@@ -35,12 +35,18 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -87,12 +93,18 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -139,12 +151,18 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -180,7 +198,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -216,7 +237,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -259,7 +283,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -306,12 +333,18 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -358,12 +391,18 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -410,12 +449,18 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -466,17 +511,26 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -520,17 +574,26 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -574,17 +637,26 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -617,12 +689,18 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -662,12 +740,18 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -714,12 +798,18 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -770,17 +860,26 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -824,17 +923,26 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -878,17 +986,26 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -921,12 +1038,18 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -955,7 +1078,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -984,7 +1110,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1013,7 +1142,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1042,7 +1174,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1086,17 +1221,26 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1140,17 +1284,26 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1194,17 +1347,26 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1248,17 +1410,26 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1302,17 +1473,26 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1356,17 +1536,26 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }

--- a/crates/sail-spark-connect/tests/gold_data/expression/misc.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/misc.json
@@ -17,7 +17,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -49,7 +52,10 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
             "extraction": {
@@ -105,7 +111,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -195,7 +204,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -227,7 +239,10 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
             "subquery": {
@@ -297,7 +312,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -337,7 +355,10 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
             "subquery": {
@@ -429,7 +450,10 @@
                               }
                             ],
                             "isDistinct": false,
-                            "isUserDefinedFunction": false
+                            "isUserDefinedFunction": false,
+                            "ignoreNulls": null,
+                            "filter": null,
+                            "orderBy": null
                           }
                         }
                       ]
@@ -449,7 +473,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -481,7 +508,10 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
             "arguments": [
@@ -529,22 +559,34 @@
                                 }
                               ],
                               "isDistinct": false,
-                              "isUserDefinedFunction": false
+                              "isUserDefinedFunction": false,
+                              "ignoreNulls": null,
+                              "filter": null,
+                              "orderBy": null
                             }
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -576,7 +618,10 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
             "name": [
@@ -626,17 +671,26 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -806,7 +860,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -863,7 +920,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -893,7 +953,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -923,7 +986,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -953,7 +1019,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -983,7 +1052,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1013,7 +1085,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1047,7 +1122,10 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               },
               {
@@ -1100,7 +1178,10 @@
                                       }
                                     ],
                                     "isDistinct": false,
-                                    "isUserDefinedFunction": false
+                                    "isUserDefinedFunction": false,
+                                    "ignoreNulls": null,
+                                    "filter": null,
+                                    "orderBy": null
                                   }
                                 },
                                 {
@@ -1137,7 +1218,10 @@
                                                         }
                                                       ],
                                                       "isDistinct": false,
-                                                      "isUserDefinedFunction": false
+                                                      "isUserDefinedFunction": false,
+                                                      "ignoreNulls": null,
+                                                      "filter": null,
+                                                      "orderBy": null
                                                     }
                                                   },
                                                   {
@@ -1150,7 +1234,10 @@
                                                   }
                                                 ],
                                                 "isDistinct": false,
-                                                "isUserDefinedFunction": false
+                                                "isUserDefinedFunction": false,
+                                                "ignoreNulls": null,
+                                                "filter": null,
+                                                "orderBy": null
                                               }
                                             },
                                             {
@@ -1163,7 +1250,10 @@
                                             }
                                           ],
                                           "isDistinct": false,
-                                          "isUserDefinedFunction": false
+                                          "isUserDefinedFunction": false,
+                                          "ignoreNulls": null,
+                                          "filter": null,
+                                          "orderBy": null
                                         }
                                       },
                                       {
@@ -1176,27 +1266,42 @@
                                       }
                                     ],
                                     "isDistinct": false,
-                                    "isUserDefinedFunction": false
+                                    "isUserDefinedFunction": false,
+                                    "ignoreNulls": null,
+                                    "filter": null,
+                                    "orderBy": null
                                   }
                                 }
                               ],
                               "isDistinct": false,
-                              "isUserDefinedFunction": false
+                              "isUserDefinedFunction": false,
+                              "ignoreNulls": null,
+                              "filter": null,
+                              "orderBy": null
                             }
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1226,7 +1331,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1256,7 +1364,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1286,7 +1397,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1316,7 +1430,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1346,7 +1463,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1376,7 +1496,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1406,7 +1529,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1461,7 +1587,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1491,7 +1620,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1522,7 +1654,10 @@
                 }
               ],
               "isDistinct": false,
-              "isUserDefinedFunction": false
+              "isUserDefinedFunction": false,
+              "ignoreNulls": null,
+              "filter": null,
+              "orderBy": null
             }
           }
         }
@@ -1554,7 +1689,10 @@
                 }
               ],
               "isDistinct": false,
-              "isUserDefinedFunction": false
+              "isUserDefinedFunction": false,
+              "ignoreNulls": null,
+              "filter": null,
+              "orderBy": null
             }
           }
         }
@@ -1585,7 +1723,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1615,7 +1756,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1645,7 +1789,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1675,7 +1822,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1705,7 +1855,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1735,7 +1888,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1781,7 +1937,10 @@
                                       }
                                     ],
                                     "isDistinct": false,
-                                    "isUserDefinedFunction": false
+                                    "isUserDefinedFunction": false,
+                                    "ignoreNulls": null,
+                                    "filter": null,
+                                    "orderBy": null
                                   }
                                 },
                                 {
@@ -1794,7 +1953,10 @@
                                 }
                               ],
                               "isDistinct": false,
-                              "isUserDefinedFunction": false
+                              "isUserDefinedFunction": false,
+                              "ignoreNulls": null,
+                              "filter": null,
+                              "orderBy": null
                             }
                           },
                           {
@@ -1807,7 +1969,10 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     },
                     {
@@ -1820,7 +1985,10 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               },
               {
@@ -1833,7 +2001,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -1867,7 +2038,10 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               },
               {
@@ -1892,12 +2066,18 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2261,12 +2441,18 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2296,7 +2482,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2330,7 +2519,10 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               },
               {
@@ -2355,12 +2547,18 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2406,7 +2604,10 @@
                                       }
                                     ],
                                     "isDistinct": false,
-                                    "isUserDefinedFunction": false
+                                    "isUserDefinedFunction": false,
+                                    "ignoreNulls": null,
+                                    "filter": null,
+                                    "orderBy": null
                                   }
                                 },
                                 {
@@ -2419,7 +2620,10 @@
                                 }
                               ],
                               "isDistinct": false,
-                              "isUserDefinedFunction": false
+                              "isUserDefinedFunction": false,
+                              "ignoreNulls": null,
+                              "filter": null,
+                              "orderBy": null
                             }
                           },
                           {
@@ -2432,7 +2636,10 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     },
                     {
@@ -2445,7 +2652,10 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               },
               {
@@ -2458,7 +2668,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2487,7 +2700,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2517,7 +2733,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2646,7 +2865,10 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             }
           }
@@ -2712,7 +2934,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2793,7 +3018,10 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   },
@@ -2832,17 +3060,13 @@
                   ],
                   "planId": null
                 }
-              },
-              {
-                "literal": {
-                  "boolean": {
-                    "value": true
-                  }
-                }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": true,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2864,7 +3088,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2877,7 +3104,10 @@
             "functionName": "foo",
             "arguments": [],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2903,7 +3133,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2940,7 +3173,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -2970,7 +3206,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3000,7 +3239,10 @@
               }
             ],
             "isDistinct": true,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3036,7 +3278,10 @@
               }
             ],
             "isDistinct": true,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3055,17 +3300,13 @@
                   ],
                   "planId": null
                 }
-              },
-              {
-                "literal": {
-                  "boolean": {
-                    "value": true
-                  }
-                }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": true,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3087,7 +3328,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3109,7 +3353,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3141,12 +3388,18 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3196,12 +3449,18 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -3233,7 +3492,10 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
             "extraction": {
@@ -3286,7 +3548,10 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
             "arguments": [
@@ -3339,7 +3604,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }

--- a/crates/sail-spark-connect/tests/gold_data/expression/numeric.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/numeric.json
@@ -17,7 +17,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -34,13 +37,16 @@
                   "decimal128": {
                     "precision": 11,
                     "scale": 0,
-                    "value": 12300000000
+                    "value": "12300000000"
                   }
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -64,13 +70,16 @@
                   "decimal128": {
                     "precision": 2,
                     "scale": 0,
-                    "value": 90
+                    "value": "90"
                   }
                 }
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -92,7 +101,10 @@
               }
             ],
             "isDistinct": false,
-            "isUserDefinedFunction": false
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
           }
         }
       }
@@ -105,7 +117,7 @@
             "decimal128": {
               "precision": 2,
               "scale": 0,
-              "value": 90
+              "value": "90"
             }
           }
         }
@@ -126,7 +138,7 @@
             "decimal128": {
               "precision": 2,
               "scale": 0,
-              "value": 90
+              "value": "90"
             }
           }
         }
@@ -141,10 +153,7 @@
             "decimal256": {
               "precision": 40,
               "scale": 40,
-              "value": {
-                "low": 120,
-                "high": 0
-              }
+              "value": "120"
             }
           }
         }
@@ -158,7 +167,7 @@
             "decimal128": {
               "precision": 11,
               "scale": 0,
-              "value": 12300000000
+              "value": "12300000000"
             }
           }
         }
@@ -234,7 +243,7 @@
             "decimal128": {
               "precision": 5,
               "scale": 2,
-              "value": 12308
+              "value": "12308"
             }
           }
         }
@@ -248,7 +257,7 @@
             "decimal128": {
               "precision": 4,
               "scale": 1,
-              "value": 1230
+              "value": "1230"
             }
           }
         }
@@ -262,7 +271,7 @@
             "decimal128": {
               "precision": 29,
               "scale": 29,
-              "value": 1230
+              "value": "1230"
             }
           }
         }
@@ -276,7 +285,7 @@
             "decimal128": {
               "precision": 3,
               "scale": 0,
-              "value": 123
+              "value": "123"
             }
           }
         }
@@ -290,7 +299,7 @@
             "decimal128": {
               "precision": 13,
               "scale": 0,
-              "value": 1230000000000
+              "value": "1230000000000"
             }
           }
         }
@@ -304,7 +313,7 @@
             "decimal128": {
               "precision": 10,
               "scale": 10,
-              "value": 123
+              "value": "123"
             }
           }
         }
@@ -318,7 +327,7 @@
             "decimal128": {
               "precision": 13,
               "scale": 0,
-              "value": 1230000000000
+              "value": "1230000000000"
             }
           }
         }
@@ -375,7 +384,7 @@
             "decimal128": {
               "precision": 26,
               "scale": 4,
-              "value": 78732472347982492793712334
+              "value": "78732472347982492793712334"
             }
           }
         }
@@ -389,7 +398,7 @@
             "decimal128": {
               "precision": 26,
               "scale": 0,
-              "value": 78732472347982492793712334
+              "value": "78732472347982492793712334"
             }
           }
         }
@@ -410,7 +419,7 @@
             "decimal128": {
               "precision": 2,
               "scale": 0,
-              "value": 90
+              "value": "90"
             }
           }
         }
@@ -424,7 +433,7 @@
             "decimal128": {
               "precision": 2,
               "scale": 0,
-              "value": 90
+              "value": "90"
             }
           }
         }
@@ -438,7 +447,7 @@
             "decimal128": {
               "precision": 4,
               "scale": 2,
-              "value": 9000
+              "value": "9000"
             }
           }
         }
@@ -452,7 +461,7 @@
             "decimal128": {
               "precision": 3,
               "scale": 1,
-              "value": 900
+              "value": "900"
             }
           }
         }
@@ -466,7 +475,7 @@
             "decimal128": {
               "precision": 38,
               "scale": 0,
-              "value": 90912830918230182310293801923652346786
+              "value": "90912830918230182310293801923652346786"
             }
           }
         }
@@ -480,7 +489,7 @@
             "decimal128": {
               "precision": 1,
               "scale": 1,
-              "value": 9
+              "value": "9"
             }
           }
         }
@@ -494,7 +503,7 @@
             "decimal128": {
               "precision": 2,
               "scale": 0,
-              "value": 90
+              "value": "90"
             }
           }
         }

--- a/crates/sail-spark-connect/tests/gold_data/expression/window.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/window.json
@@ -23,13 +23,20 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [],
-            "orderSpec": [],
-            "frameSpec": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [],
+                "orderBy": [],
+                "frame": null
+              }
+            }
           }
         }
       }
@@ -57,30 +64,37 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              },
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "b"
-                  ],
-                  "planId": null
-                }
+            "window": {
+              "unnamed": {
+                "clusterBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  },
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "b"
+                      ],
+                      "planId": null
+                    }
+                  }
+                ],
+                "partitionBy": [],
+                "orderBy": [],
+                "frame": null
               }
-            ],
-            "partitionSpec": [],
-            "orderSpec": [],
-            "frameSpec": null
+            }
           }
         }
       }
@@ -108,43 +122,50 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              },
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "b"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "c"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  },
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "b"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "c"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": null
               }
-            ],
-            "frameSpec": null
+            }
           }
         }
       }
@@ -172,30 +193,37 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              },
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "b"
-                  ],
-                  "planId": null
-                }
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  },
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "b"
+                      ],
+                      "planId": null
+                    }
+                  }
+                ],
+                "orderBy": [],
+                "frame": null
               }
-            ],
-            "orderSpec": [],
-            "frameSpec": null
+            }
           }
         }
       }
@@ -223,38 +251,45 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "a"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "a"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "descending",
+                    "nullOrdering": "unspecified"
+                  },
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "ascending",
+                    "nullOrdering": "unspecified"
                   }
-                },
-                "direction": "descending",
-                "nullOrdering": "unspecified"
-              },
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "ascending",
-                "nullOrdering": "unspecified"
+                ],
+                "frame": null
               }
-            ],
-            "frameSpec": null
+            }
           }
         }
       }
@@ -282,46 +317,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 0
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 0
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -350,46 +392,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 0
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 0
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -418,46 +467,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 10
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 10
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -486,46 +542,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 10
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 10
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -554,46 +617,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int64": {
-                      "value": 2147483648
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int64": {
+                          "value": 2147483648
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -622,46 +692,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int64": {
-                      "value": 2147483649
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int64": {
+                          "value": 2147483649
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -690,62 +767,72 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": {
-                "value": {
-                  "unresolvedFunction": {
-                    "functionName": "+",
-                    "arguments": [
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 3
-                          }
-                        }
-                      },
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 1
-                          }
-                        }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
                       }
-                    ],
-                    "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
                   }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": {
+                    "value": {
+                      "unresolvedFunction": {
+                        "functionName": "+",
+                        "arguments": [
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 3
+                              }
+                            }
+                          },
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 1
+                              }
+                            }
+                          }
+                        ],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -774,62 +861,72 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": {
-                "value": {
-                  "unresolvedFunction": {
-                    "functionName": "+",
-                    "arguments": [
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 3
-                          }
-                        }
-                      },
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 1
-                          }
-                        }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
                       }
-                    ],
-                    "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
                   }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": {
+                    "value": {
+                      "unresolvedFunction": {
+                        "functionName": "+",
+                        "arguments": [
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 3
+                              }
+                            }
+                          },
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 1
+                              }
+                            }
+                          }
+                        ],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -858,46 +955,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 0
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 0
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -926,46 +1030,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 0
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 0
+                        }
+                      }
+                    }
+                  },
+                  "upper": "unbounded"
                 }
-              },
-              "upper": "unbounded"
+              }
             }
           }
         }
@@ -994,50 +1105,57 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 10
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
-                }
-              },
-              "upper": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 5
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 10
+                        }
+                      }
+                    }
+                  },
+                  "upper": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 5
+                        }
+                      }
                     }
                   }
                 }
@@ -1070,46 +1188,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 10
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 10
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -1138,46 +1263,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 10
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 10
+                        }
+                      }
+                    }
+                  },
+                  "upper": "unbounded"
                 }
-              },
-              "upper": "unbounded"
+              }
             }
           }
         }
@@ -1206,46 +1338,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int64": {
-                      "value": 2147483648
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int64": {
+                          "value": 2147483648
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -1274,46 +1413,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int64": {
-                      "value": 2147483648
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int64": {
+                          "value": 2147483648
+                        }
+                      }
+                    }
+                  },
+                  "upper": "unbounded"
                 }
-              },
-              "upper": "unbounded"
+              }
             }
           }
         }
@@ -1342,62 +1488,72 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": {
-                "value": {
-                  "unresolvedFunction": {
-                    "functionName": "+",
-                    "arguments": [
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 3
-                          }
-                        }
-                      },
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 1
-                          }
-                        }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
                       }
-                    ],
-                    "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
                   }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": {
+                    "value": {
+                      "unresolvedFunction": {
+                        "functionName": "+",
+                        "arguments": [
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 3
+                              }
+                            }
+                          },
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 1
+                              }
+                            }
+                          }
+                        ],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -1426,62 +1582,72 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": {
-                "value": {
-                  "unresolvedFunction": {
-                    "functionName": "+",
-                    "arguments": [
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 3
-                          }
-                        }
-                      },
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 1
-                          }
-                        }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
                       }
-                    ],
-                    "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
                   }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": {
+                    "value": {
+                      "unresolvedFunction": {
+                        "functionName": "+",
+                        "arguments": [
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 3
+                              }
+                            }
+                          },
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 1
+                              }
+                            }
+                          }
+                        ],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
+                  },
+                  "upper": "unbounded"
                 }
-              },
-              "upper": "unbounded"
+              }
             }
           }
         }
@@ -1510,42 +1676,49 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": "currentRow",
-              "upper": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 0
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": "currentRow",
+                  "upper": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 0
+                        }
+                      }
                     }
                   }
                 }
@@ -1578,42 +1751,49 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": "currentRow",
-              "upper": {
-                "value": {
-                  "literal": {
-                    "int64": {
-                      "value": 2147483649
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": "currentRow",
+                  "upper": {
+                    "value": {
+                      "literal": {
+                        "int64": {
+                          "value": 2147483649
+                        }
+                      }
                     }
                   }
                 }
@@ -1646,59 +1826,69 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": "currentRow",
-              "upper": {
-                "value": {
-                  "unresolvedFunction": {
-                    "functionName": "+",
-                    "arguments": [
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 3
-                          }
-                        }
-                      },
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 1
-                          }
-                        }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
                       }
-                    ],
-                    "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": "currentRow",
+                  "upper": {
+                    "value": {
+                      "unresolvedFunction": {
+                        "functionName": "+",
+                        "arguments": [
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 3
+                              }
+                            }
+                          },
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 1
+                              }
+                            }
+                          }
+                        ],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
                   }
                 }
               }
@@ -1730,42 +1920,49 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": "currentRow",
-              "upper": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 5
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": "currentRow",
+                  "upper": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 5
+                        }
+                      }
                     }
                   }
                 }
@@ -1798,38 +1995,45 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": "currentRow",
+                  "upper": "currentRow"
                 }
               }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": "currentRow",
-              "upper": "currentRow"
             }
           }
         }
@@ -1858,38 +2062,45 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": "currentRow",
+                  "upper": "unbounded"
                 }
               }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": "currentRow",
-              "upper": "unbounded"
             }
           }
         }
@@ -1918,42 +2129,49 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": "unbounded",
-              "upper": {
-                "value": {
-                  "literal": {
-                    "int64": {
-                      "value": 2147483649
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": "unbounded",
+                  "upper": {
+                    "value": {
+                      "literal": {
+                        "int64": {
+                          "value": 2147483649
+                        }
+                      }
                     }
                   }
                 }
@@ -1986,59 +2204,69 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": "unbounded",
-              "upper": {
-                "value": {
-                  "unresolvedFunction": {
-                    "functionName": "+",
-                    "arguments": [
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 3
-                          }
-                        }
-                      },
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 1
-                          }
-                        }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
                       }
-                    ],
-                    "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": "unbounded",
+                  "upper": {
+                    "value": {
+                      "unresolvedFunction": {
+                        "functionName": "+",
+                        "arguments": [
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 3
+                              }
+                            }
+                          },
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 1
+                              }
+                            }
+                          }
+                        ],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
                   }
                 }
               }
@@ -2070,42 +2298,49 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": "unbounded",
-              "upper": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 5
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": "unbounded",
+                  "upper": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 5
+                        }
+                      }
                     }
                   }
                 }
@@ -2138,38 +2373,45 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": "unbounded",
+                  "upper": "currentRow"
                 }
               }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": "unbounded",
-              "upper": "currentRow"
             }
           }
         }
@@ -2198,38 +2440,45 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": "unbounded",
+                  "upper": "unbounded"
                 }
               }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": "unbounded",
-              "upper": "unbounded"
             }
           }
         }
@@ -2258,38 +2507,45 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": "currentRow",
+                  "upper": "currentRow"
                 }
               }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": "currentRow",
-              "upper": "currentRow"
             }
           }
         }
@@ -2318,38 +2574,45 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": "unbounded",
+                  "upper": "currentRow"
                 }
               }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": "unbounded",
-              "upper": "currentRow"
             }
           }
         }
@@ -2378,38 +2641,45 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "range",
+                  "lower": "unbounded",
+                  "upper": "currentRow"
                 }
               }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "range",
-              "lower": "unbounded",
-              "upper": "currentRow"
             }
           }
         }
@@ -2438,46 +2708,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 0
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 0
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -2506,46 +2783,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 0
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 0
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -2574,46 +2858,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 10
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 10
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -2642,46 +2933,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 10
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 10
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -2710,46 +3008,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int64": {
-                      "value": 2147483648
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int64": {
+                          "value": 2147483648
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -2778,46 +3083,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int64": {
-                      "value": 2147483649
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int64": {
+                          "value": 2147483649
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -2846,62 +3158,72 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "unresolvedFunction": {
-                    "functionName": "+",
-                    "arguments": [
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 3
-                          }
-                        }
-                      },
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 1
-                          }
-                        }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
                       }
-                    ],
-                    "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
                   }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "unresolvedFunction": {
+                        "functionName": "+",
+                        "arguments": [
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 3
+                              }
+                            }
+                          },
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 1
+                              }
+                            }
+                          }
+                        ],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -2930,62 +3252,72 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "unresolvedFunction": {
-                    "functionName": "+",
-                    "arguments": [
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 3
-                          }
-                        }
-                      },
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 1
-                          }
-                        }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
                       }
-                    ],
-                    "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
                   }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "unresolvedFunction": {
+                        "functionName": "+",
+                        "arguments": [
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 3
+                              }
+                            }
+                          },
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 1
+                              }
+                            }
+                          }
+                        ],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -3014,46 +3346,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 0
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 0
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -3082,46 +3421,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 0
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 0
+                        }
+                      }
+                    }
+                  },
+                  "upper": "unbounded"
                 }
-              },
-              "upper": "unbounded"
+              }
             }
           }
         }
@@ -3150,50 +3496,57 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 10
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
-                }
-              },
-              "upper": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 5
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 10
+                        }
+                      }
+                    }
+                  },
+                  "upper": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 5
+                        }
+                      }
                     }
                   }
                 }
@@ -3226,46 +3579,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 10
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 10
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -3294,46 +3654,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 10
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 10
+                        }
+                      }
+                    }
+                  },
+                  "upper": "unbounded"
                 }
-              },
-              "upper": "unbounded"
+              }
             }
           }
         }
@@ -3362,46 +3729,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int64": {
-                      "value": 2147483648
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int64": {
+                          "value": 2147483648
+                        }
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -3430,46 +3804,53 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "literal": {
-                    "int64": {
-                      "value": 2147483648
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
                     }
                   }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "literal": {
+                        "int64": {
+                          "value": 2147483648
+                        }
+                      }
+                    }
+                  },
+                  "upper": "unbounded"
                 }
-              },
-              "upper": "unbounded"
+              }
             }
           }
         }
@@ -3498,62 +3879,72 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "unresolvedFunction": {
-                    "functionName": "+",
-                    "arguments": [
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 3
-                          }
-                        }
-                      },
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 1
-                          }
-                        }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
                       }
-                    ],
-                    "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
                   }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "unresolvedFunction": {
+                        "functionName": "+",
+                        "arguments": [
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 3
+                              }
+                            }
+                          },
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 1
+                              }
+                            }
+                          }
+                        ],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -3582,62 +3973,72 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "unresolvedFunction": {
-                    "functionName": "+",
-                    "arguments": [
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 3
-                          }
-                        }
-                      },
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 1
-                          }
-                        }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
                       }
-                    ],
-                    "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
                   }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "unresolvedFunction": {
+                        "functionName": "+",
+                        "arguments": [
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 3
+                              }
+                            }
+                          },
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 1
+                              }
+                            }
+                          }
+                        ],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
+                  },
+                  "upper": "unbounded"
                 }
-              },
-              "upper": "unbounded"
+              }
             }
           }
         }
@@ -3666,42 +4067,49 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": "currentRow",
-              "upper": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 0
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": "currentRow",
+                  "upper": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 0
+                        }
+                      }
                     }
                   }
                 }
@@ -3734,42 +4142,49 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": "currentRow",
-              "upper": {
-                "value": {
-                  "literal": {
-                    "int64": {
-                      "value": 2147483649
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": "currentRow",
+                  "upper": {
+                    "value": {
+                      "literal": {
+                        "int64": {
+                          "value": 2147483649
+                        }
+                      }
                     }
                   }
                 }
@@ -3802,59 +4217,69 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": "currentRow",
-              "upper": {
-                "value": {
-                  "unresolvedFunction": {
-                    "functionName": "+",
-                    "arguments": [
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 3
-                          }
-                        }
-                      },
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 1
-                          }
-                        }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
                       }
-                    ],
-                    "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": "currentRow",
+                  "upper": {
+                    "value": {
+                      "unresolvedFunction": {
+                        "functionName": "+",
+                        "arguments": [
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 3
+                              }
+                            }
+                          },
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 1
+                              }
+                            }
+                          }
+                        ],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
                   }
                 }
               }
@@ -3886,42 +4311,49 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": "currentRow",
-              "upper": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 5
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": "currentRow",
+                  "upper": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 5
+                        }
+                      }
                     }
                   }
                 }
@@ -3954,38 +4386,45 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": "currentRow",
+                  "upper": "currentRow"
                 }
               }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": "currentRow",
-              "upper": "currentRow"
             }
           }
         }
@@ -4014,38 +4453,45 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": "currentRow",
+                  "upper": "unbounded"
                 }
               }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": "currentRow",
-              "upper": "unbounded"
             }
           }
         }
@@ -4074,42 +4520,49 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": "unbounded",
-              "upper": {
-                "value": {
-                  "literal": {
-                    "int64": {
-                      "value": 2147483649
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": "unbounded",
+                  "upper": {
+                    "value": {
+                      "literal": {
+                        "int64": {
+                          "value": 2147483649
+                        }
+                      }
                     }
                   }
                 }
@@ -4142,59 +4595,69 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": "unbounded",
-              "upper": {
-                "value": {
-                  "unresolvedFunction": {
-                    "functionName": "+",
-                    "arguments": [
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 3
-                          }
-                        }
-                      },
-                      {
-                        "literal": {
-                          "int32": {
-                            "value": 1
-                          }
-                        }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
                       }
-                    ],
-                    "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": "unbounded",
+                  "upper": {
+                    "value": {
+                      "unresolvedFunction": {
+                        "functionName": "+",
+                        "arguments": [
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 3
+                              }
+                            }
+                          },
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 1
+                              }
+                            }
+                          }
+                        ],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
                   }
                 }
               }
@@ -4226,42 +4689,49 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": "unbounded",
-              "upper": {
-                "value": {
-                  "literal": {
-                    "int32": {
-                      "value": 5
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": "unbounded",
+                  "upper": {
+                    "value": {
+                      "literal": {
+                        "int32": {
+                          "value": 5
+                        }
+                      }
                     }
                   }
                 }
@@ -4294,38 +4764,45 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": "unbounded",
+                  "upper": "currentRow"
                 }
               }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": "unbounded",
-              "upper": "currentRow"
             }
           }
         }
@@ -4354,38 +4831,45 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": "unbounded",
+                  "upper": "unbounded"
                 }
               }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": "unbounded",
-              "upper": "unbounded"
             }
           }
         }
@@ -4414,38 +4898,45 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": "currentRow",
+                  "upper": "currentRow"
                 }
               }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": "currentRow",
-              "upper": "currentRow"
             }
           }
         }
@@ -4475,56 +4966,66 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": {
-                "value": {
-                  "unresolvedFunction": {
-                    "functionName": "exp",
-                    "arguments": [
-                      {
-                        "unresolvedAttribute": {
-                          "name": [
-                            "b"
-                          ],
-                          "planId": null
-                        }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
                       }
-                    ],
-                    "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
                   }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": {
+                    "value": {
+                      "unresolvedFunction": {
+                        "functionName": "exp",
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "b"
+                              ],
+                              "planId": null
+                            }
+                          }
+                        ],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
+                  },
+                  "upper": "currentRow"
                 }
-              },
-              "upper": "currentRow"
+              }
             }
           }
         }
@@ -4553,38 +5054,45 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": "unbounded",
+                  "upper": "currentRow"
                 }
               }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": "unbounded",
-              "upper": "currentRow"
             }
           }
         }
@@ -4613,38 +5121,45 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  }
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": {
+                  "frameType": "row",
+                  "lower": "unbounded",
+                  "upper": "currentRow"
                 }
               }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
-              }
-            ],
-            "frameSpec": {
-              "frameType": "row",
-              "lower": "unbounded",
-              "upper": "currentRow"
             }
           }
         }
@@ -4673,43 +5188,50 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              },
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "b"
-                  ],
-                  "planId": null
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "c"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  },
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "b"
+                      ],
+                      "planId": null
+                    }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "c"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": null
               }
-            ],
-            "frameSpec": null
+            }
           }
         }
       }
@@ -4737,30 +5259,37 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null
-                }
-              },
-              {
-                "unresolvedAttribute": {
-                  "name": [
-                    "b"
-                  ],
-                  "planId": null
-                }
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "a"
+                      ],
+                      "planId": null
+                    }
+                  },
+                  {
+                    "unresolvedAttribute": {
+                      "name": [
+                        "b"
+                      ],
+                      "planId": null
+                    }
+                  }
+                ],
+                "orderBy": [],
+                "frame": null
               }
-            ],
-            "orderSpec": [],
-            "frameSpec": null
+            }
           }
         }
       }
@@ -4788,38 +5317,45 @@
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [],
-            "orderSpec": [
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "a"
-                    ],
-                    "planId": null
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [],
+                "orderBy": [
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "a"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "descending",
+                    "nullOrdering": "unspecified"
+                  },
+                  {
+                    "child": {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "b"
+                        ],
+                        "planId": null
+                      }
+                    },
+                    "direction": "ascending",
+                    "nullOrdering": "unspecified"
                   }
-                },
-                "direction": "descending",
-                "nullOrdering": "unspecified"
-              },
-              {
-                "child": {
-                  "unresolvedAttribute": {
-                    "name": [
-                      "b"
-                    ],
-                    "planId": null
-                  }
-                },
-                "direction": "ascending",
-                "nullOrdering": "unspecified"
+                ],
+                "frame": null
               }
-            ],
-            "frameSpec": null
+            }
           }
         }
       }
@@ -4827,7 +5363,37 @@
     {
       "input": "foo(*) over w1",
       "output": {
-        "failure": "not implemented: named window function"
+        "success": {
+          "window": {
+            "windowFunction": {
+              "unresolvedFunction": {
+                "functionName": "foo",
+                "arguments": [
+                  {
+                    "unresolvedStar": {
+                      "target": null,
+                      "wildcardOptions": {
+                        "ilikePattern": null,
+                        "excludeColumns": null,
+                        "exceptColumns": null,
+                        "replaceColumns": null,
+                        "renameColumns": null
+                      }
+                    }
+                  }
+                ],
+                "isDistinct": false,
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
+              }
+            },
+            "window": {
+              "named": "w1"
+            }
+          }
+        }
       }
     },
     {
@@ -4860,71 +5426,87 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedFunction": {
-                  "functionName": "+",
-                  "arguments": [
-                    {
-                      "unresolvedFunction": {
-                        "functionName": "/",
-                        "arguments": [
-                          {
-                            "unresolvedAttribute": {
-                              "name": [
-                                "product"
-                              ],
-                              "planId": null
-                            }
-                          },
-                          {
-                            "literal": {
-                              "int32": {
-                                "value": 2
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedFunction": {
+                      "functionName": "+",
+                      "arguments": [
+                        {
+                          "unresolvedFunction": {
+                            "functionName": "/",
+                            "arguments": [
+                              {
+                                "unresolvedAttribute": {
+                                  "name": [
+                                    "product"
+                                  ],
+                                  "planId": null
+                                }
+                              },
+                              {
+                                "literal": {
+                                  "int32": {
+                                    "value": 2
+                                  }
+                                }
                               }
+                            ],
+                            "isDistinct": false,
+                            "isUserDefinedFunction": false,
+                            "ignoreNulls": null,
+                            "filter": null,
+                            "orderBy": null
+                          }
+                        },
+                        {
+                          "literal": {
+                            "int32": {
+                              "value": 1
                             }
                           }
-                        ],
-                        "isDistinct": false,
-                        "isUserDefinedFunction": false
-                      }
-                    },
-                    {
-                      "literal": {
-                        "int32": {
-                          "value": 1
                         }
-                      }
-                    }
-                  ],
-                  "isDistinct": false,
-                  "isUserDefinedFunction": false
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "literal": {
-                    "int32": {
-                      "value": 2
+                      ],
+                      "isDistinct": false,
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "literal": {
+                        "int32": {
+                          "value": 2
+                        }
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": null
               }
-            ],
-            "frameSpec": null
+            }
           }
         }
       }
@@ -4959,55 +5541,68 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   }
                 ],
                 "isDistinct": false,
-                "isUserDefinedFunction": false
+                "isUserDefinedFunction": false,
+                "ignoreNulls": null,
+                "filter": null,
+                "orderBy": null
               }
             },
-            "clusterSpec": [],
-            "partitionSpec": [
-              {
-                "unresolvedFunction": {
-                  "functionName": "+",
-                  "arguments": [
-                    {
-                      "unresolvedAttribute": {
-                        "name": [
-                          "product"
-                        ],
-                        "planId": null
-                      }
-                    },
-                    {
-                      "literal": {
-                        "int32": {
-                          "value": 1
+            "window": {
+              "unnamed": {
+                "clusterBy": [],
+                "partitionBy": [
+                  {
+                    "unresolvedFunction": {
+                      "functionName": "+",
+                      "arguments": [
+                        {
+                          "unresolvedAttribute": {
+                            "name": [
+                              "product"
+                            ],
+                            "planId": null
+                          }
+                        },
+                        {
+                          "literal": {
+                            "int32": {
+                              "value": 1
+                            }
+                          }
                         }
-                      }
-                    }
-                  ],
-                  "isDistinct": false,
-                  "isUserDefinedFunction": false
-                }
-              }
-            ],
-            "orderSpec": [
-              {
-                "child": {
-                  "literal": {
-                    "int32": {
-                      "value": 2
+                      ],
+                      "isDistinct": false,
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   }
-                },
-                "direction": "unspecified",
-                "nullOrdering": "unspecified"
+                ],
+                "orderBy": [
+                  {
+                    "child": {
+                      "literal": {
+                        "int32": {
+                          "value": 2
+                        }
+                      }
+                    },
+                    "direction": "unspecified",
+                    "nullOrdering": "unspecified"
+                  }
+                ],
+                "frame": null
               }
-            ],
-            "frameSpec": null
+            }
           }
         }
       }

--- a/crates/sail-spark-connect/tests/gold_data/plan/error_order_by.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/error_order_by.json
@@ -63,7 +63,10 @@
                                   }
                                 ],
                                 "isDistinct": false,
-                                "isUserDefinedFunction": false
+                                "isUserDefinedFunction": false,
+                                "ignoreNulls": null,
+                                "filter": null,
+                                "orderBy": null
                               }
                             },
                             {
@@ -75,7 +78,10 @@
                             }
                           ],
                           "isDistinct": false,
-                          "isUserDefinedFunction": false
+                          "isUserDefinedFunction": false,
+                          "ignoreNulls": null,
+                          "filter": null,
+                          "orderBy": null
                         }
                       }
                     },
@@ -105,7 +111,10 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     }
                   ],

--- a/crates/sail-spark-connect/tests/gold_data/plan/plan_group_by.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/plan_group_by.json
@@ -77,7 +77,10 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     },
                     "name": [
@@ -176,7 +179,10 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     },
                     "name": [
@@ -269,7 +275,10 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     },
                     "name": [
@@ -362,7 +371,10 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     },
                     "name": [
@@ -455,7 +467,10 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     },
                     "name": [
@@ -561,7 +576,10 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     },
                     "name": [
@@ -654,7 +672,10 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     },
                     "name": [
@@ -747,7 +768,10 @@
                           }
                         ],
                         "isDistinct": false,
-                        "isUserDefinedFunction": false
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
                       }
                     },
                     "name": [
@@ -852,7 +876,10 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               },
               "withGroupingExpressions": false

--- a/crates/sail-spark-connect/tests/gold_data/plan/plan_join.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/plan_join.json
@@ -193,7 +193,10 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   },
                   "joinType": "leftAnti",
@@ -1283,7 +1286,10 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   },
                   "joinType": "fullOuter",
@@ -1444,7 +1450,10 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   },
                   "joinType": "fullOuter",
@@ -1611,7 +1620,10 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   },
                   "joinType": "inner",
@@ -1784,7 +1796,10 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   },
                   "joinType": "inner",
@@ -1945,7 +1960,10 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   },
                   "joinType": "leftAnti",
@@ -2112,7 +2130,10 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   },
                   "joinType": "leftOuter",
@@ -2279,7 +2300,10 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   },
                   "joinType": "leftOuter",
@@ -2440,7 +2464,10 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   },
                   "joinType": "leftSemi",
@@ -2601,7 +2628,10 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   },
                   "joinType": "rightOuter",
@@ -2762,7 +2792,10 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   },
                   "joinType": "rightOuter",
@@ -2923,7 +2956,10 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   },
                   "joinType": "leftSemi",
@@ -3164,7 +3200,10 @@
                             }
                           ],
                           "isDistinct": false,
-                          "isUserDefinedFunction": false
+                          "isUserDefinedFunction": false,
+                          "ignoreNulls": null,
+                          "filter": null,
+                          "orderBy": null
                         }
                       },
                       "joinType": "inner",
@@ -3286,7 +3325,10 @@
                             }
                           ],
                           "isDistinct": false,
-                          "isUserDefinedFunction": false
+                          "isUserDefinedFunction": false,
+                          "ignoreNulls": null,
+                          "filter": null,
+                          "orderBy": null
                         }
                       },
                       "joinType": "inner",
@@ -3333,7 +3375,10 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   },
                   "joinType": "inner",
@@ -3462,7 +3507,10 @@
                             }
                           ],
                           "isDistinct": false,
-                          "isUserDefinedFunction": false
+                          "isUserDefinedFunction": false,
+                          "ignoreNulls": null,
+                          "filter": null,
+                          "orderBy": null
                         }
                       },
                       "joinType": "inner",

--- a/crates/sail-spark-connect/tests/gold_data/plan/plan_order_by.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/plan_order_by.json
@@ -3,37 +3,389 @@
     {
       "input": "SELECT PERCENTILE_CONT(0.1) WITHIN GROUP (ORDER BY col DESC)",
       "output": {
-        "failure": "invalid argument: found WITHIN at 28:34 expected statement, or end of input"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "empty": {
+                  "produceOneRow": true
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedFunction": {
+                    "functionName": "PERCENTILE_CONT",
+                    "arguments": [
+                      {
+                        "literal": {
+                          "decimal128": {
+                            "precision": 1,
+                            "scale": 1,
+                            "value": "1"
+                          }
+                        }
+                      }
+                    ],
+                    "isDistinct": false,
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": [
+                      {
+                        "child": {
+                          "unresolvedAttribute": {
+                            "name": [
+                              "col"
+                            ],
+                            "planId": null
+                          }
+                        },
+                        "direction": "descending",
+                        "nullOrdering": "unspecified"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "SELECT PERCENTILE_CONT(0.1) WITHIN GROUP (ORDER BY col)",
       "output": {
-        "failure": "invalid argument: found WITHIN at 28:34 expected statement, or end of input"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "empty": {
+                  "produceOneRow": true
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedFunction": {
+                    "functionName": "PERCENTILE_CONT",
+                    "arguments": [
+                      {
+                        "literal": {
+                          "decimal128": {
+                            "precision": 1,
+                            "scale": 1,
+                            "value": "1"
+                          }
+                        }
+                      }
+                    ],
+                    "isDistinct": false,
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": [
+                      {
+                        "child": {
+                          "unresolvedAttribute": {
+                            "name": [
+                              "col"
+                            ],
+                            "planId": null
+                          }
+                        },
+                        "direction": "unspecified",
+                        "nullOrdering": "unspecified"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "SELECT PERCENTILE_CONT(0.1) WITHIN GROUP (ORDER BY col) FILTER (WHERE id > 10)",
       "output": {
-        "failure": "invalid argument: found WITHIN at 28:34 expected statement, or end of input"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "empty": {
+                  "produceOneRow": true
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedFunction": {
+                    "functionName": "PERCENTILE_CONT",
+                    "arguments": [
+                      {
+                        "literal": {
+                          "decimal128": {
+                            "precision": 1,
+                            "scale": 1,
+                            "value": "1"
+                          }
+                        }
+                      }
+                    ],
+                    "isDistinct": false,
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": {
+                      "unresolvedFunction": {
+                        "functionName": ">",
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "id"
+                              ],
+                              "planId": null
+                            }
+                          },
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 10
+                              }
+                            }
+                          }
+                        ],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    },
+                    "orderBy": [
+                      {
+                        "child": {
+                          "unresolvedAttribute": {
+                            "name": [
+                              "col"
+                            ],
+                            "planId": null
+                          }
+                        },
+                        "direction": "unspecified",
+                        "nullOrdering": "unspecified"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "SELECT PERCENTILE_DISC(0.1) WITHIN GROUP (ORDER BY col DESC)",
       "output": {
-        "failure": "invalid argument: found WITHIN at 28:34 expected statement, or end of input"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "empty": {
+                  "produceOneRow": true
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedFunction": {
+                    "functionName": "PERCENTILE_DISC",
+                    "arguments": [
+                      {
+                        "literal": {
+                          "decimal128": {
+                            "precision": 1,
+                            "scale": 1,
+                            "value": "1"
+                          }
+                        }
+                      }
+                    ],
+                    "isDistinct": false,
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": [
+                      {
+                        "child": {
+                          "unresolvedAttribute": {
+                            "name": [
+                              "col"
+                            ],
+                            "planId": null
+                          }
+                        },
+                        "direction": "descending",
+                        "nullOrdering": "unspecified"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "SELECT PERCENTILE_DISC(0.1) WITHIN GROUP (ORDER BY col)",
       "output": {
-        "failure": "invalid argument: found WITHIN at 28:34 expected statement, or end of input"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "empty": {
+                  "produceOneRow": true
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedFunction": {
+                    "functionName": "PERCENTILE_DISC",
+                    "arguments": [
+                      {
+                        "literal": {
+                          "decimal128": {
+                            "precision": 1,
+                            "scale": 1,
+                            "value": "1"
+                          }
+                        }
+                      }
+                    ],
+                    "isDistinct": false,
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": [
+                      {
+                        "child": {
+                          "unresolvedAttribute": {
+                            "name": [
+                              "col"
+                            ],
+                            "planId": null
+                          }
+                        },
+                        "direction": "unspecified",
+                        "nullOrdering": "unspecified"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "SELECT PERCENTILE_DISC(0.1) WITHIN GROUP (ORDER BY col) FILTER (WHERE id > 10)",
       "output": {
-        "failure": "invalid argument: found WITHIN at 28:34 expected statement, or end of input"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "empty": {
+                  "produceOneRow": true
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedFunction": {
+                    "functionName": "PERCENTILE_DISC",
+                    "arguments": [
+                      {
+                        "literal": {
+                          "decimal128": {
+                            "precision": 1,
+                            "scale": 1,
+                            "value": "1"
+                          }
+                        }
+                      }
+                    ],
+                    "isDistinct": false,
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": {
+                      "unresolvedFunction": {
+                        "functionName": ">",
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "id"
+                              ],
+                              "planId": null
+                            }
+                          },
+                          {
+                            "literal": {
+                              "int32": {
+                                "value": 10
+                              }
+                            }
+                          }
+                        ],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    },
+                    "orderBy": [
+                      {
+                        "child": {
+                          "unresolvedAttribute": {
+                            "name": [
+                              "col"
+                            ],
+                            "planId": null
+                          }
+                        },
+                        "direction": "unspecified",
+                        "nullOrdering": "unspecified"
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {

--- a/crates/sail-spark-connect/tests/gold_data/plan/plan_select.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/plan_select.json
@@ -683,7 +683,10 @@
                       }
                     ],
                     "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": null
                   }
                 }
               ]
@@ -735,7 +738,10 @@
                       }
                     ],
                     "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": null
                   }
                 }
               ]
@@ -787,7 +793,10 @@
                       }
                     ],
                     "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": null
                   }
                 }
               ]
@@ -846,7 +855,10 @@
                       }
                     ],
                     "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": null
                   }
                 }
               ]
@@ -898,7 +910,10 @@
                       }
                     ],
                     "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": null
                   }
                 }
               ]
@@ -943,7 +958,10 @@
                       }
                     ],
                     "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": null
                   }
                 }
               ]
@@ -981,7 +999,10 @@
                       }
                     ],
                     "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": null
                   }
                 }
               ]
@@ -1026,7 +1047,10 @@
                       }
                     ],
                     "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": null
                   }
                 }
               ]
@@ -1064,7 +1088,10 @@
                       }
                     ],
                     "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": null
                   }
                 }
               ]
@@ -1109,7 +1136,10 @@
                       }
                     ],
                     "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": null
                   }
                 }
               ]
@@ -1147,7 +1177,10 @@
                       }
                     ],
                     "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": null
                   }
                 }
               ]
@@ -1181,7 +1214,10 @@
                       }
                     ],
                     "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": null
                   }
                 }
               ]
@@ -1215,7 +1251,10 @@
                       }
                     ],
                     "isDistinct": false,
-                    "isUserDefinedFunction": false
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": null
                   }
                 }
               ]
@@ -1465,7 +1504,10 @@
                                     }
                                   ],
                                   "isDistinct": false,
-                                  "isUserDefinedFunction": false
+                                  "isUserDefinedFunction": false,
+                                  "ignoreNulls": null,
+                                  "filter": null,
+                                  "orderBy": null
                                 }
                               }
                             ]
@@ -1682,55 +1724,45 @@
                     ],
                     "arguments": [
                       {
-                        "unresolvedFunction": {
-                          "functionName": "table",
-                          "arguments": [
-                            {
-                              "unresolvedAttribute": {
-                                "name": [
-                                  "v1"
-                                ],
-                                "planId": null
-                              }
+                        "table": {
+                          "expr": {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "v1"
+                              ],
+                              "planId": null
                             }
-                          ],
-                          "isDistinct": false,
-                          "isUserDefinedFunction": false
+                          }
                         }
                       },
                       {
-                        "unresolvedFunction": {
-                          "functionName": "table",
-                          "arguments": [
-                            {
-                              "scalarSubquery": {
-                                "subquery": {
-                                  "project": {
-                                    "input": {
-                                      "empty": {
-                                        "produceOneRow": true
-                                      },
-                                      "planId": null,
-                                      "sourceInfo": null
+                        "table": {
+                          "expr": {
+                            "scalarSubquery": {
+                              "subquery": {
+                                "project": {
+                                  "input": {
+                                    "empty": {
+                                      "produceOneRow": true
                                     },
-                                    "expressions": [
-                                      {
-                                        "literal": {
-                                          "int32": {
-                                            "value": 1
-                                          }
+                                    "planId": null,
+                                    "sourceInfo": null
+                                  },
+                                  "expressions": [
+                                    {
+                                      "literal": {
+                                        "int32": {
+                                          "value": 1
                                         }
                                       }
-                                    ]
-                                  },
-                                  "planId": null,
-                                  "sourceInfo": null
-                                }
+                                    }
+                                  ]
+                                },
+                                "planId": null,
+                                "sourceInfo": null
                               }
                             }
-                          ],
-                          "isDistinct": false,
-                          "isUserDefinedFunction": false
+                          }
                         }
                       }
                     ],
@@ -2274,7 +2306,10 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   }
                 },
@@ -2597,7 +2632,10 @@
                     }
                   ],
                   "isDistinct": false,
-                  "isUserDefinedFunction": false
+                  "isUserDefinedFunction": false,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
                 }
               },
               "withGroupingExpressions": false
@@ -2651,7 +2689,10 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   }
                 },
@@ -2726,7 +2767,10 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   }
                 },
@@ -2801,7 +2845,10 @@
                         }
                       ],
                       "isDistinct": false,
-                      "isUserDefinedFunction": false
+                      "isUserDefinedFunction": false,
+                      "ignoreNulls": null,
+                      "filter": null,
+                      "orderBy": null
                     }
                   }
                 },

--- a/crates/sail-sql-analyzer/src/literal.rs
+++ b/crates/sail-sql-analyzer/src/literal.rs
@@ -241,7 +241,7 @@ impl TryFrom<LiteralValue<Signed<IntervalExpr>>> for spec::Literal {
         match interval.clone() {
             IntervalExpr::Standard { value, qualifier } => {
                 let kind = from_ast_interval_qualifier(qualifier)?;
-                parse_standard_interval(*value, kind, negated)
+                parse_standard_interval(value, kind, negated)
             }
             IntervalExpr::MultiUnit {
                 head,
@@ -280,10 +280,10 @@ impl TryFrom<LiteralValue<Signed<IntervalExpr>>> for spec::Literal {
                                 negated,
                             )
                         }
-                        _ => parse_multi_unit_interval(vec![*head], negated),
+                        _ => parse_multi_unit_interval(vec![head], negated),
                     }
                 } else {
-                    let values = once(*head).chain(tail).collect();
+                    let values = once(head).chain(tail).collect();
                     parse_multi_unit_interval(values, negated)
                 }
             }


### PR DESCRIPTION
1. Consolidate the function builder "arguments" and "context" into a single "input".
2. Support more SQL syntax for functions (e.g. `IGNORE NULLS`, `WITHIN GROUP`, and `FILTER`).