### PR TITLE
Support more SQL syntax

### DIFF
--- a/crates/sail-spark-connect/tests/gold_data/expression/interval.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/interval.json
@@ -4633,21 +4633,21 @@
       "input": "Interval 'interval 1 daysss 2 hoursss'",
       "exception": "\n[INVALID_TYPED_LITERAL] The value of the typed literal \"INTERVAL\" is invalid: 'interval 1 daysss 2 hoursss'.(line 1, pos 0)\n\n== SQL ==\nInterval 'interval 1 daysss 2 hoursss'\n^^^\n",
       "output": {
-        "failure": "invalid argument: found daysss at 11:17 expected '.', '[', '::', 'ESCAPE', 'IS', 'NOT', 'IN', '*', '/', '%', 'DIV', '+', '-', '||', '>>>', '>>', '<<', '&', '^', '|', '!=', '!>', '!<', '==', '=', '>=', '>', '<=>', '<=', '<>', '<', 'BETWEEN', 'LIKE', 'ILIKE', 'RLIKE', 'REGEXP', 'SIMILAR', 'AND', 'OR', 'YEAR', 'YEARS', 'MONTH', 'MONTHS', 'WEEK', 'WEEKS', 'DAY', 'DAYS', 'HOUR', 'HOURS', 'MINUTE', 'MINUTES', 'SECOND', 'SECONDS', 'MILLISECOND', 'MILLISECONDS', 'MICROSECOND', or 'MICROSECONDS'"
+        "failure": "invalid argument: found daysss at 11:17 expected '->', '.', '(', '[', '::', 'ESCAPE', 'IS', 'NOT', 'IN', '*', '/', '%', 'DIV', '+', '-', '||', '>>>', '>>', '<<', '&', '^', '|', '!=', '!>', '!<', '==', '=', '>=', '>', '<=>', '<=', '<>', '<', 'BETWEEN', 'LIKE', 'ILIKE', 'RLIKE', 'REGEXP', 'SIMILAR', 'AND', 'OR', 'YEAR', 'YEARS', 'MONTH', 'MONTHS', 'WEEK', 'WEEKS', 'DAY', 'DAYS', 'HOUR', 'HOURS', 'MINUTE', 'MINUTES', 'SECOND', 'SECONDS', 'MILLISECOND', 'MILLISECONDS', 'MICROSECOND', or 'MICROSECONDS'"
       }
     },
     {
       "input": "Interval 'interval 1 yearsss 2 monthsss'",
       "exception": "\n[INVALID_TYPED_LITERAL] The value of the typed literal \"INTERVAL\" is invalid: 'interval 1 yearsss 2 monthsss'.(line 1, pos 0)\n\n== SQL ==\nInterval 'interval 1 yearsss 2 monthsss'\n^^^\n",
       "output": {
-        "failure": "invalid argument: found yearsss at 11:18 expected '.', '[', '::', 'ESCAPE', 'IS', 'NOT', 'IN', '*', '/', '%', 'DIV', '+', '-', '||', '>>>', '>>', '<<', '&', '^', '|', '!=', '!>', '!<', '==', '=', '>=', '>', '<=>', '<=', '<>', '<', 'BETWEEN', 'LIKE', 'ILIKE', 'RLIKE', 'REGEXP', 'SIMILAR', 'AND', 'OR', 'YEAR', 'YEARS', 'MONTH', 'MONTHS', 'WEEK', 'WEEKS', 'DAY', 'DAYS', 'HOUR', 'HOURS', 'MINUTE', 'MINUTES', 'SECOND', 'SECONDS', 'MILLISECOND', 'MILLISECONDS', 'MICROSECOND', or 'MICROSECONDS'"
+        "failure": "invalid argument: found yearsss at 11:18 expected '->', '.', '(', '[', '::', 'ESCAPE', 'IS', 'NOT', 'IN', '*', '/', '%', 'DIV', '+', '-', '||', '>>>', '>>', '<<', '&', '^', '|', '!=', '!>', '!<', '==', '=', '>=', '>', '<=>', '<=', '<>', '<', 'BETWEEN', 'LIKE', 'ILIKE', 'RLIKE', 'REGEXP', 'SIMILAR', 'AND', 'OR', 'YEAR', 'YEARS', 'MONTH', 'MONTHS', 'WEEK', 'WEEKS', 'DAY', 'DAYS', 'HOUR', 'HOURS', 'MINUTE', 'MINUTES', 'SECOND', 'SECONDS', 'MILLISECOND', 'MILLISECONDS', 'MICROSECOND', or 'MICROSECONDS'"
       }
     },
     {
       "input": "Interval 'interval 3 monthsss 1 hoursss'",
       "exception": "\n[INVALID_TYPED_LITERAL] The value of the typed literal \"INTERVAL\" is invalid: 'interval 3 monthsss 1 hoursss'.(line 1, pos 0)\n\n== SQL ==\nInterval 'interval 3 monthsss 1 hoursss'\n^^^\n",
       "output": {
-        "failure": "invalid argument: found monthsss at 11:19 expected '.', '[', '::', 'ESCAPE', 'IS', 'NOT', 'IN', '*', '/', '%', 'DIV', '+', '-', '||', '>>>', '>>', '<<', '&', '^', '|', '!=', '!>', '!<', '==', '=', '>=', '>', '<=>', '<=', '<>', '<', 'BETWEEN', 'LIKE', 'ILIKE', 'RLIKE', 'REGEXP', 'SIMILAR', 'AND', 'OR', 'YEAR', 'YEARS', 'MONTH', 'MONTHS', 'WEEK', 'WEEKS', 'DAY', 'DAYS', 'HOUR', 'HOURS', 'MINUTE', 'MINUTES', 'SECOND', 'SECONDS', 'MILLISECOND', 'MILLISECONDS', 'MICROSECOND', or 'MICROSECONDS'"
+        "failure": "invalid argument: found monthsss at 11:19 expected '->', '.', '(', '[', '::', 'ESCAPE', 'IS', 'NOT', 'IN', '*', '/', '%', 'DIV', '+', '-', '||', '>>>', '>>', '<<', '&', '^', '|', '!=', '!>', '!<', '==', '=', '>=', '>', '<=>', '<=', '<>', '<', 'BETWEEN', 'LIKE', 'ILIKE', 'RLIKE', 'REGEXP', 'SIMILAR', 'AND', 'OR', 'YEAR', 'YEARS', 'MONTH', 'MONTHS', 'WEEK', 'WEEKS', 'DAY', 'DAYS', 'HOUR', 'HOURS', 'MINUTE', 'MINUTES', 'SECOND', 'SECONDS', 'MILLISECOND', 'MILLISECONDS', 'MICROSECOND', or 'MICROSECONDS'"
       }
     },
     {
@@ -6686,7 +6686,7 @@
       "input": "interval 10 nanoseconds",
       "exception": "\nError parsing ' 10 nanoseconds' to interval, invalid unit 'nanoseconds'.(line 1, pos 9)\n\n== SQL ==\ninterval 10 nanoseconds\n---------^^^\n",
       "output": {
-        "failure": "invalid argument: found 10 at 9:11 expected end of input"
+        "failure": "invalid argument: found nanoseconds at 12:23 expected end of input"
       }
     },
     {

--- a/crates/sail-spark-connect/tests/gold_data/expression/misc.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/misc.json
@@ -706,18 +706,11 @@
       "input": "123_",
       "output": {
         "success": {
-          "alias": {
-            "expr": {
-              "literal": {
-                "int32": {
-                  "value": 123
-                }
-              }
-            },
+          "unresolvedAttribute": {
             "name": [
-              "_"
+              "123_"
             ],
-            "metadata": null
+            "planId": null
           }
         }
       }
@@ -725,7 +718,15 @@
     {
       "input": "1a.123_",
       "output": {
-        "failure": "invalid argument: found .123 at 2:6 expected end of input"
+        "success": {
+          "unresolvedAttribute": {
+            "name": [
+              "1a",
+              "123_"
+            ],
+            "planId": null
+          }
+        }
       }
     },
     {
@@ -2777,25 +2778,57 @@
     {
       "input": "a.123A",
       "output": {
-        "failure": "invalid argument: found .123A at 1:6 expected end of input"
+        "success": {
+          "unresolvedAttribute": {
+            "name": [
+              "a",
+              "123A"
+            ],
+            "planId": null
+          }
+        }
       }
     },
     {
       "input": "a.123BD_column",
       "output": {
-        "failure": "invalid argument: found .123BD at 1:7 expected end of input"
+        "success": {
+          "unresolvedAttribute": {
+            "name": [
+              "a",
+              "123BD_column"
+            ],
+            "planId": null
+          }
+        }
       }
     },
     {
       "input": "a.123D_column",
       "output": {
-        "failure": "invalid argument: found .123D at 1:6 expected end of input"
+        "success": {
+          "unresolvedAttribute": {
+            "name": [
+              "a",
+              "123D_column"
+            ],
+            "planId": null
+          }
+        }
       }
     },
     {
       "input": "a.123E3_column",
       "output": {
-        "failure": "invalid argument: found .123E3 at 1:7 expected end of input"
+        "success": {
+          "unresolvedAttribute": {
+            "name": [
+              "a",
+              "123E3_column"
+            ],
+            "planId": null
+          }
+        }
       }
     },
     {

--- a/crates/sail-spark-connect/tests/gold_data/expression/numeric.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/numeric.json
@@ -336,13 +336,27 @@
     {
       "input": "1SL",
       "output": {
-        "failure": "invalid argument: number postfix: 1SL"
+        "success": {
+          "unresolvedAttribute": {
+            "name": [
+              "1SL"
+            ],
+            "planId": null
+          }
+        }
       }
     },
     {
       "input": "1a",
       "output": {
-        "failure": "invalid argument: number postfix: 1a"
+        "success": {
+          "unresolvedAttribute": {
+            "name": [
+              "1a"
+            ],
+            "planId": null
+          }
+        }
       }
     },
     {

--- a/crates/sail-spark-connect/tests/gold_data/expression/string.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/string.json
@@ -15,7 +15,13 @@
     {
       "input": "\"hello\" 'world'",
       "output": {
-        "failure": "invalid argument: found 'world' at 8:15 expected end of input"
+        "success": {
+          "literal": {
+            "utf8": {
+              "value": "helloworld"
+            }
+          }
+        }
       }
     },
     {
@@ -160,7 +166,13 @@
     {
       "input": "'hello' \" \" 'world'",
       "output": {
-        "failure": "invalid argument: found \" \" at 8:11 expected end of input"
+        "success": {
+          "literal": {
+            "utf8": {
+              "value": "hello world"
+            }
+          }
+        }
       }
     },
     {

--- a/crates/sail-spark-connect/tests/gold_data/plan/ddl_create_table.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/ddl_create_table.json
@@ -217,13 +217,87 @@
     {
       "input": "CREATE TABLE 1m.2g(a INT)",
       "output": {
-        "failure": "invalid argument: found 1m at 13:15 expected 'IF', or identifier"
+        "success": {
+          "command": {
+            "createTable": {
+              "table": [
+                "1m",
+                "2g"
+              ],
+              "schema": {
+                "fields": [
+                  {
+                    "name": "a",
+                    "dataType": "int32",
+                    "nullable": true,
+                    "metadata": []
+                  }
+                ]
+              },
+              "comment": null,
+              "columnDefaults": [],
+              "constraints": [],
+              "location": null,
+              "fileFormat": null,
+              "rowFormat": null,
+              "tablePartitionCols": [],
+              "fileSortOrder": [],
+              "ifNotExists": false,
+              "orReplace": false,
+              "unbounded": false,
+              "options": [],
+              "query": null,
+              "definition": null
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "CREATE TABLE 1m.2g(a INT) USING parquet",
       "output": {
-        "failure": "invalid argument: found 1m at 13:15 expected 'IF', or identifier"
+        "success": {
+          "command": {
+            "createTable": {
+              "table": [
+                "1m",
+                "2g"
+              ],
+              "schema": {
+                "fields": [
+                  {
+                    "name": "a",
+                    "dataType": "int32",
+                    "nullable": true,
+                    "metadata": []
+                  }
+                ]
+              },
+              "comment": null,
+              "columnDefaults": [],
+              "constraints": [],
+              "location": null,
+              "fileFormat": {
+                "general": {
+                  "format": "parquet"
+                }
+              },
+              "rowFormat": null,
+              "tablePartitionCols": [],
+              "fileSortOrder": [],
+              "ifNotExists": false,
+              "orReplace": false,
+              "unbounded": false,
+              "options": [],
+              "query": null,
+              "definition": null
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {

--- a/crates/sail-spark-connect/tests/gold_data/plan/ddl_replace_table.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/ddl_replace_table.json
@@ -138,7 +138,46 @@
     {
       "input": "REPLACE TABLE 1m.2g(a INT) USING parquet",
       "output": {
-        "failure": "invalid argument: found 1m at 14:16 expected identifier"
+        "success": {
+          "command": {
+            "createTable": {
+              "table": [
+                "1m",
+                "2g"
+              ],
+              "schema": {
+                "fields": [
+                  {
+                    "name": "a",
+                    "dataType": "int32",
+                    "nullable": true,
+                    "metadata": []
+                  }
+                ]
+              },
+              "comment": null,
+              "columnDefaults": [],
+              "constraints": [],
+              "location": null,
+              "fileFormat": {
+                "general": {
+                  "format": "parquet"
+                }
+              },
+              "rowFormat": null,
+              "tablePartitionCols": [],
+              "fileSortOrder": [],
+              "ifNotExists": false,
+              "orReplace": true,
+              "unbounded": false,
+              "options": [],
+              "query": null,
+              "definition": null
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {

--- a/crates/sail-spark-connect/tests/gold_data/plan/plan_select.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/plan_select.json
@@ -2203,7 +2203,7 @@
     {
       "input": "select * from t limit cast(9 / 4 as int)",
       "output": {
-        "failure": "invalid argument: literal expression: Atom(Cast(Cast { span: TokenSpan { start: 22, end: 26 } }, LeftParenthesis { span: TokenSpan { start: 26, end: 27 } }, BinaryOperator(Atom(NumberLiteral(NumberLiteral { span: TokenSpan { start: 27, end: 28 }, value: \"9\", suffix: \"\" })), Divide(Slash { span: TokenSpan { start: 29, end: 30 } }), Atom(NumberLiteral(NumberLiteral { span: TokenSpan { start: 31, end: 32 }, value: \"4\", suffix: \"\" }))), As { span: TokenSpan { start: 33, end: 35 } }, Int(None, Int { span: TokenSpan { start: 36, end: 39 } }), RightParenthesis { span: TokenSpan { start: 39, end: 40 } }))"
+        "failure": "invalid argument: literal expression: Atom(Cast(Cast { span: TokenSpan { start: 22, end: 26 } }, LeftParenthesis { span: TokenSpan { start: 26, end: 27 } }, BinaryOperator(Atom(NumberLiteral(NumberLiteral { span: TokenSpan { start: 27, end: 28 }, value: \"9\", suffix: None })), Divide(Slash { span: TokenSpan { start: 29, end: 30 } }), Atom(NumberLiteral(NumberLiteral { span: TokenSpan { start: 31, end: 32 }, value: \"4\", suffix: None }))), As { span: TokenSpan { start: 33, end: 35 } }, Int(None, Int { span: TokenSpan { start: 36, end: 39 } }), RightParenthesis { span: TokenSpan { start: 39, end: 40 } }))"
       }
     },
     {
@@ -2486,7 +2486,38 @@
     {
       "input": "select a from 1k.2m",
       "output": {
-        "failure": "invalid argument: found 1k at 14:16 expected 'LATERAL', 'VALUES', '(', or identifier"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "read": {
+                  "namedTable": {
+                    "name": [
+                      "1k",
+                      "2m"
+                    ],
+                    "options": []
+                  },
+                  "isStreaming": false
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedAttribute": {
+                    "name": [
+                      "a"
+                    ],
+                    "planId": null
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {

--- a/crates/sail-sql-analyzer/src/expression.rs
+++ b/crates/sail-sql-analyzer/src/expression.rs
@@ -856,7 +856,7 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
             target: None,
             wildcard_options: Default::default(),
         }),
-        AtomExpr::StringLiteral(value) => from_ast_string_literal(value),
+        AtomExpr::StringLiteral(head, tail) => from_ast_string_literal(head, tail),
         AtomExpr::NumberLiteral(value) => from_ast_number_literal(value),
         AtomExpr::BooleanLiteral(value) => from_ast_boolean_literal(value),
         AtomExpr::Null(_) => Ok(spec::Expr::Literal(spec::Literal::Null)),

--- a/crates/sail-sql-analyzer/src/statement.rs
+++ b/crates/sail-sql-analyzer/src/statement.rs
@@ -1278,6 +1278,10 @@ fn from_ast_property(property: PropertyKeyValue) -> SqlResult<(String, Option<St
                     Some(Either::Right(Minus { .. })) => "-",
                     None => "",
                 };
+                let suffix = match suffix {
+                    None => "",
+                    Some(x) => x.as_str(),
+                };
                 format!("{sign}{value}{suffix}")
             }
             PropertyValue::Boolean(BooleanLiteral::True(_)) => "true".to_string(),

--- a/crates/sail-sql-parser/src/ast/expression.rs
+++ b/crates/sail-sql-parser/src/ast/expression.rs
@@ -213,7 +213,7 @@ pub enum AtomExpr {
     Date(Date, LeftParenthesis, StringLiteral, RightParenthesis),
     Function(#[parser(function = |(e, _, _), o| boxed(compose(e, o)))] Box<FunctionExpr>),
     Wildcard(operator::Asterisk),
-    StringLiteral(StringLiteral),
+    StringLiteral(StringLiteral, Vec<StringLiteral>),
     NumberLiteral(NumberLiteral),
     BooleanLiteral(BooleanLiteral),
     TimestampLiteral(Timestamp, StringLiteral),

--- a/crates/sail-sql-parser/src/ast/identifier.rs
+++ b/crates/sail-sql-parser/src/ast/identifier.rs
@@ -170,23 +170,12 @@ where
             Some(Token::Punctuation(p @ (Punctuation::Dollar | Punctuation::Colon))),
             Some(Token::Word { keyword: _, raw }),
         ) => {
-            let node = Variable {
+            let variable = Variable {
                 span: input.span_since(marker.offset()).into(),
                 value: format!("{}{}", p.to_char(), raw),
             };
             skip_whitespace(input);
-            Some(node)
-        }
-        (
-            Some(Token::Punctuation(p @ (Punctuation::Dollar | Punctuation::Colon))),
-            Some(Token::Number { value, suffix }),
-        ) => {
-            let node = Variable {
-                span: input.span_since(marker.offset()).into(),
-                value: format!("{}{}{}", p.to_char(), value, suffix),
-            };
-            skip_whitespace(input);
-            Some(node)
+            Some(variable)
         }
         _ => {
             input.rewind(marker);
@@ -205,12 +194,12 @@ where
     let marker = input.save();
     match input.next() {
         Some(Token::Punctuation(p @ Punctuation::QuestionMark)) => {
-            let node = Variable {
+            let variable = Variable {
                 span: input.span_since(marker.offset()).into(),
                 value: format!("{}", p.to_char()),
             };
             skip_whitespace(input);
-            Some(node)
+            Some(variable)
         }
         _ => {
             input.rewind(marker);

--- a/crates/sail-sql-parser/src/ast/literal.rs
+++ b/crates/sail-sql-parser/src/ast/literal.rs
@@ -16,7 +16,147 @@ use crate::utils::{labelled_error, skip_whitespace};
 pub struct NumberLiteral {
     pub span: TokenSpan,
     pub value: String,
-    pub suffix: String,
+    pub suffix: Option<NumberSuffix>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum NumberSuffix {
+    Y,
+    S,
+    L,
+    F,
+    D,
+    Bd,
+}
+
+impl NumberSuffix {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            NumberSuffix::Y => "Y",
+            NumberSuffix::S => "S",
+            NumberSuffix::L => "L",
+            NumberSuffix::F => "F",
+            NumberSuffix::D => "D",
+            NumberSuffix::Bd => "BD",
+        }
+    }
+}
+
+/// The state for number literal parsing.
+/// Formally, the state and state transitions are equivalent to a minimal DFA
+/// derived from the regular grammar for number literals.
+/// We cannot use regular expressions to parse number literals since the literal
+/// may be represented by multiple adjacent non-whitespace tokens.
+#[derive(Debug, Clone)]
+enum NumberState {
+    Start,
+    WholeNumber(String),
+    DecimalPoint(String),
+    DecimalNumber(String),
+    ExponentMarker(String),
+    ExponentSign(String),
+    Exponent(String),
+    SuffixY(String),
+    SuffixS(String),
+    SuffixL(String),
+    SuffixF(String),
+    SuffixD(String),
+    SuffixB(String),
+    SuffixBd(String),
+}
+
+impl NumberState {
+    fn next_slice(mut self, slice: &str) -> Option<NumberState> {
+        let chars = slice.chars();
+        for c in chars {
+            self = self.next(c)?;
+        }
+        Some(self)
+    }
+
+    fn next(self, c: char) -> Option<NumberState> {
+        fn extend(mut s: String, c: char) -> String {
+            s.push(c);
+            s
+        }
+
+        match self {
+            NumberState::Start => match c {
+                '0'..='9' => Some(NumberState::WholeNumber(c.to_string())),
+                '.' => Some(NumberState::DecimalPoint(c.to_string())),
+                _ => None,
+            },
+            NumberState::WholeNumber(x) => match c {
+                '0'..='9' => Some(NumberState::WholeNumber(extend(x, c))),
+                '.' => Some(NumberState::DecimalNumber(extend(x, c))),
+                'e' | 'E' => Some(NumberState::ExponentMarker(extend(x, c))),
+                'y' | 'Y' => Some(NumberState::SuffixY(x)),
+                's' | 'S' => Some(NumberState::SuffixS(x)),
+                'l' | 'L' => Some(NumberState::SuffixL(x)),
+                'f' | 'F' => Some(NumberState::SuffixF(x)),
+                'd' | 'D' => Some(NumberState::SuffixD(x)),
+                'b' | 'B' => Some(NumberState::SuffixB(x)),
+                _ => None,
+            },
+            NumberState::DecimalPoint(x) => match c {
+                '0'..='9' => Some(NumberState::DecimalNumber(extend(x, c))),
+                _ => None,
+            },
+            NumberState::DecimalNumber(x) => match c {
+                '0'..='9' => Some(NumberState::DecimalNumber(extend(x, c))),
+                'e' | 'E' => Some(NumberState::ExponentMarker(extend(x, c))),
+                'f' | 'F' => Some(NumberState::SuffixF(x)),
+                'd' | 'D' => Some(NumberState::SuffixD(x)),
+                'b' | 'B' => Some(NumberState::SuffixB(x)),
+                _ => None,
+            },
+            NumberState::ExponentMarker(x) => match c {
+                '+' | '-' => Some(NumberState::ExponentSign(extend(x, c))),
+                '0'..='9' => Some(NumberState::Exponent(extend(x, c))),
+                _ => None,
+            },
+            NumberState::ExponentSign(x) => match c {
+                '0'..='9' => Some(NumberState::Exponent(extend(x, c))),
+                _ => None,
+            },
+            NumberState::Exponent(x) => match c {
+                '0'..='9' => Some(NumberState::Exponent(extend(x, c))),
+                'f' | 'F' => Some(NumberState::SuffixF(x)),
+                'd' | 'D' => Some(NumberState::SuffixD(x)),
+                'b' | 'B' => Some(NumberState::SuffixB(x)),
+                _ => None,
+            },
+            NumberState::SuffixY(_)
+            | NumberState::SuffixS(_)
+            | NumberState::SuffixL(_)
+            | NumberState::SuffixF(_)
+            | NumberState::SuffixD(_)
+            | NumberState::SuffixBd(_) => None,
+            NumberState::SuffixB(x) => match c {
+                'd' | 'D' => Some(NumberState::SuffixBd(x)),
+                _ => None,
+            },
+        }
+    }
+
+    fn finalize(self) -> Option<(String, Option<NumberSuffix>)> {
+        match self {
+            NumberState::WholeNumber(x)
+            | NumberState::DecimalNumber(x)
+            | NumberState::Exponent(x) => Some((x, None)),
+            NumberState::SuffixY(x) => Some((x, Some(NumberSuffix::Y))),
+            NumberState::SuffixS(x) => Some((x, Some(NumberSuffix::S))),
+            NumberState::SuffixL(x) => Some((x, Some(NumberSuffix::L))),
+            NumberState::SuffixF(x) => Some((x, Some(NumberSuffix::F))),
+            NumberState::SuffixD(x) => Some((x, Some(NumberSuffix::D))),
+            NumberState::SuffixBd(x) => Some((x, Some(NumberSuffix::Bd))),
+            NumberState::Start
+            | NumberState::DecimalPoint(_)
+            | NumberState::ExponentMarker(_)
+            | NumberState::ExponentSign(_)
+            | NumberState::SuffixB(_) => None,
+        }
+    }
 }
 
 impl<'a, I, E> TreeParser<'a, I, E> for NumberLiteral
@@ -28,20 +168,42 @@ where
 {
     fn parser(_args: (), _options: &'a ParserOptions) -> impl Parser<'a, I, Self, E> + Clone {
         custom(|input: &mut InputRef<'a, '_, I, E>| {
-            let before = input.offset();
-            let token = input.next();
-            if let Some(Token::Number { value, suffix }) = token {
-                let node = NumberLiteral {
-                    span: input.span_since(before).into(),
-                    value: value.to_string(),
-                    suffix: suffix.to_string(),
+            let marker = input.save();
+            let mut state = NumberState::Start;
+            let mut candidate = None;
+            let token = loop {
+                let token = input.next();
+                let raw = match &token {
+                    Some(Token::Word { raw, keyword: _ }) => raw,
+                    Some(Token::Punctuation(Punctuation::Period)) => ".",
+                    Some(Token::Punctuation(Punctuation::Plus)) => "+",
+                    Some(Token::Punctuation(Punctuation::Minus)) => "-",
+                    _ => {
+                        break token;
+                    }
                 };
+                if let Some(s) = state.next_slice(raw) {
+                    state = s.clone();
+                    if let Some((value, suffix)) = s.finalize() {
+                        let literal = NumberLiteral {
+                            span: input.span_since(marker.offset()).into(),
+                            value,
+                            suffix,
+                        };
+                        candidate = Some((literal, input.save()));
+                    }
+                } else {
+                    break token;
+                }
+            };
+            if let Some((literal, marker)) = candidate {
+                input.rewind(marker);
                 skip_whitespace(input);
-                return Ok(node);
+                return Ok(literal);
             }
             Err(labelled_error::<I, E>(
                 token,
-                input.span_since(before),
+                input.span_since(marker.offset()),
                 TokenLabel::Number,
             ))
         })
@@ -75,15 +237,15 @@ where
                 }
             };
             let token = input.next();
-            if let Some(Token::Number { value, suffix: "" }) = &token {
-                let value = format!("{}{}", if negative { "-" } else { "" }, value);
+            if let Some(Token::Word { raw, keyword: None }) = &token {
+                let value = format!("{}{}", if negative { "-" } else { "" }, raw);
                 if let Ok(value) = value.parse() {
-                    let node = IntegerLiteral {
+                    let literal = IntegerLiteral {
                         span: input.span_since(marker.offset()).into(),
                         value,
                     };
                     skip_whitespace(input);
-                    return Ok(node);
+                    return Ok(literal);
                 }
             }
             Err(labelled_error::<I, E>(
@@ -161,12 +323,12 @@ where
                         Ok(style) => style.parse(raw, options),
                         Err(e) => StringValue::Invalid { reason: e },
                     };
-                    let node = StringLiteral {
+                    let literal = StringLiteral {
                         span: input.span_since(before).into(),
                         value,
                     };
                     skip_whitespace(input);
-                    return Ok(node);
+                    return Ok(literal);
                 }
                 _ => {}
             }

--- a/crates/sail-sql-parser/src/token.rs
+++ b/crates/sail-sql-parser/src/token.rs
@@ -5,13 +5,12 @@ use std::fmt::{Display, Formatter};
 #[derive(Debug, Clone, PartialEq)]
 pub enum Token<'a> {
     /// A word that is not quoted nor escaped.
+    /// The word may start with a digit, which means it may be part of a numeric literal.
     /// The word may match a SQL keyword.
     Word {
         raw: &'a str,
         keyword: Option<Keyword>,
     },
-    /// A numeric literal with a suffix. The suffix can be empty.
-    Number { value: &'a str, suffix: &'a str },
     /// A string of a specific style.
     /// The raw text includes the delimiters and the prefix (if any).
     /// No escape sequences are processed in the raw text.
@@ -57,9 +56,6 @@ impl Display for Token<'_> {
         match self {
             Token::Word { raw, .. } => {
                 write!(f, "{raw}")
-            }
-            Token::Number { value, suffix } => {
-                write!(f, "{value}{suffix}")
             }
             Token::String { raw, .. } => {
                 write!(f, "{raw}")


### PR DESCRIPTION
1. Support identifiers starting with a digit. The solution is to remove `Token::Number` from the lexer. Whether an unquoted word is parsed as a number literal or an identifier is now decided in the parser, depending on the context. When we used `sqlparser-rs`, this was only partially supported in `CREATE TABLE` statements since we did not have full control over tokenization.
2. Support concatenating multiple string literals into one literal expression.