### PR TITLE
Support more SQL syntax

### DIFF
--- a/crates/sail-common/src/spec/plan.rs
+++ b/crates/sail-common/src/spec/plan.rs
@@ -261,6 +261,7 @@ pub enum QueryNode {
         input: Option<Box<QueryPlan>>,
         function: ObjectName,
         arguments: Vec<Expr>,
+        named_arguments: Vec<(Identifier, Expr)>,
         table_alias: Option<ObjectName>,
         column_aliases: Option<Vec<Identifier>>,
         outer: bool,
@@ -399,7 +400,7 @@ pub enum CommandNode {
         input: Box<QueryPlan>,
         table: ObjectName,
         columns: Vec<Identifier>,
-        partition_spec: Vec<(String, Option<Expr>)>,
+        partition_spec: Vec<(Identifier, Option<Expr>)>,
         replace: Option<Expr>,
         if_not_exists: bool,
         overwrite: bool,
@@ -447,11 +448,11 @@ pub enum CommandNode {
         location: String,
         table: ObjectName,
         overwrite: bool,
-        partition: Vec<(String, Option<Expr>)>,
+        partition: Vec<(Identifier, Option<Expr>)>,
     },
     AnalyzeTable {
         table: ObjectName,
-        partition: Vec<(String, Option<Expr>)>,
+        partition: Vec<(Identifier, Option<Expr>)>,
         columns: Vec<ObjectName>,
         no_scan: bool,
     },
@@ -477,7 +478,7 @@ pub enum CommandNode {
     DescribeTable {
         table: ObjectName,
         extended: bool,
-        partition: Vec<(String, Option<Expr>)>,
+        partition: Vec<(Identifier, Option<Expr>)>,
         column: Option<ObjectName>,
     },
     CommentOnCatalog {
@@ -549,6 +550,7 @@ pub enum TableSampleMethod {
 pub struct ReadUdtf {
     pub name: ObjectName,
     pub arguments: Vec<Expr>,
+    pub named_arguments: Vec<(Identifier, Expr)>,
     pub options: Vec<(String, String)>,
 }
 
@@ -567,9 +569,8 @@ pub struct ReadDataSource {
 pub struct Join {
     pub left: Box<QueryPlan>,
     pub right: Box<QueryPlan>,
-    pub join_condition: Option<Expr>,
     pub join_type: JoinType,
-    pub using_columns: Vec<Identifier>,
+    pub join_criteria: Option<JoinCriteria>,
     pub join_data_type: Option<JoinDataType>,
 }
 
@@ -740,7 +741,7 @@ pub struct HtmlString {
 pub struct TableDefinition {
     pub schema: Schema,
     pub comment: Option<String>,
-    pub column_defaults: Vec<(String, Expr)>,
+    pub column_defaults: Vec<(Identifier, Expr)>,
     pub constraints: Vec<TableConstraint>,
     pub location: Option<String>,
     pub file_format: Option<TableFileFormat>,
@@ -859,6 +860,14 @@ pub enum JoinType {
     LeftAnti,
     RightAnti,
     Cross,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", rename_all_fields = "camelCase")]
+pub enum JoinCriteria {
+    Natural,
+    On(Expr),
+    Using(Vec<Identifier>),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/sail-plan/src/resolver/expression.rs
+++ b/crates/sail-plan/src/resolver/expression.rs
@@ -615,8 +615,7 @@ impl PlanResolver<'_> {
         schema: &DFSchemaRef,
         state: &mut PlanResolverState,
     ) -> PlanResult<Option<(String, expr::Expr)>> {
-        let name: Vec<&str> = name.into();
-        let candidates = Self::generate_qualified_nested_field_candidates(&name);
+        let candidates = Self::generate_qualified_nested_field_candidates(name.parts());
         let mut candidates = schema
             .iter()
             .flat_map(|(qualifier, field)| {
@@ -626,13 +625,15 @@ impl PlanResolver<'_> {
                 candidates
                     .iter()
                     .filter_map(|(q, name, inner)| {
-                        if qualifier_matches(q.as_ref(), qualifier) && info.matches(name, plan_id) {
+                        if qualifier_matches(q.as_ref(), qualifier)
+                            && info.matches(name.as_ref(), plan_id)
+                        {
                             let expr = Self::resolve_nested_field(
                                 col((qualifier, field)),
                                 field.data_type(),
                                 inner,
                             )?;
-                            let name = inner.last().unwrap_or(name).to_string();
+                            let name = inner.last().unwrap_or(name).as_ref().to_string();
                             Some((name, expr))
                         } else {
                             None
@@ -655,8 +656,7 @@ impl PlanResolver<'_> {
         schema: &DFSchemaRef,
         state: &mut PlanResolverState,
     ) -> PlanResult<Option<(String, expr::Expr)>> {
-        let name: Vec<&str> = name.into();
-        let candidates = Self::generate_qualified_field_candidates(&name);
+        let candidates = Self::generate_qualified_field_candidates(name.parts());
         let mut candidates = schema
             .iter()
             .flat_map(|(qualifier, field)| {
@@ -666,11 +666,12 @@ impl PlanResolver<'_> {
                 candidates
                     .iter()
                     .filter(|(q, name)| {
-                        qualifier_matches(q.as_ref(), qualifier) && info.matches(name, None)
+                        qualifier_matches(q.as_ref(), qualifier)
+                            && info.matches(name.as_ref(), None)
                     })
                     .map(|(_, name)| {
                         (
-                            name.to_string(),
+                            name.as_ref().to_string(),
                             expr::Expr::OuterReferenceColumn(
                                 field.data_type().clone(),
                                 Column::new(qualifier.cloned(), field.name()),
@@ -688,17 +689,17 @@ impl PlanResolver<'_> {
         Ok(candidates.pop())
     }
 
-    fn resolve_nested_field(
+    fn resolve_nested_field<T: AsRef<str>>(
         expr: expr::Expr,
         data_type: &DataType,
-        inner: &[&str],
+        inner: &[T],
     ) -> Option<expr::Expr> {
         match inner {
             [] => Some(expr),
             [name, remaining @ ..] => match data_type {
                 DataType::Struct(fields) => fields
                     .iter()
-                    .find(|x| x.name().eq_ignore_ascii_case(name))
+                    .find(|x| x.name().eq_ignore_ascii_case(name.as_ref()))
                     .and_then(|field| {
                         let args = vec![expr, lit(field.name().to_string())];
                         let expr =
@@ -753,12 +754,20 @@ impl PlanResolver<'_> {
         let spec::UnresolvedFunction {
             function_name,
             arguments,
+            named_arguments,
             is_distinct,
             is_user_defined_function: _,
             ignore_nulls,
             filter,
             order_by,
         } = function;
+
+        let Ok(function_name) = <Vec<String>>::from(function_name).one() else {
+            return Err(PlanError::unsupported("qualified function name"));
+        };
+        if !named_arguments.is_empty() {
+            return Err(PlanError::todo("named function arguments"));
+        }
         let canonical_function_name = function_name.to_ascii_lowercase();
         if let Ok(udf) = self.ctx.udf(&canonical_function_name) {
             if udf.inner().as_any().is::<PySparkUnresolvedUDF>() {
@@ -935,12 +944,19 @@ impl PlanResolver<'_> {
                 spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
                     function_name,
                     arguments,
+                    named_arguments,
                     is_user_defined_function: false,
                     is_distinct,
                     ignore_nulls: None,
                     filter: None,
                     order_by: None,
                 }) => {
+                    let Ok(function_name) = <Vec<String>>::from(function_name).one() else {
+                        return Err(PlanError::unsupported("qualified window function name"));
+                    };
+                    if !named_arguments.is_empty() {
+                        return Err(PlanError::todo("named window function arguments"));
+                    }
                     let canonical_function_name = function_name.to_ascii_lowercase();
                     let (argument_names, arguments) = self
                         .resolve_expressions_and_names(arguments, schema, state)
@@ -964,6 +980,7 @@ impl PlanResolver<'_> {
                         arguments,
                         function,
                     } = function;
+                    let function_name: String = function_name.into();
                     let (argument_names, arguments) = self
                         .resolve_expressions_and_names(arguments, schema, state)
                         .await?;
@@ -1076,8 +1093,7 @@ impl PlanResolver<'_> {
         schema: &DFSchemaRef,
         state: &mut PlanResolverState,
     ) -> PlanResult<NamedExpr> {
-        let name: Vec<&str> = name.into();
-        let candidates = Self::generate_qualified_wildcard_candidates(&name)
+        let candidates = Self::generate_qualified_wildcard_candidates(name.parts())
             .into_iter()
             .flat_map(|(q, name)| match name {
                 [] => {
@@ -1102,7 +1118,9 @@ impl PlanResolver<'_> {
                         let Ok(info) = state.get_field_info(field.name()) else {
                             return None;
                         };
-                        if qualifier_matches(q.as_ref(), qualifier) && info.matches(column, None) {
+                        if qualifier_matches(q.as_ref(), qualifier)
+                            && info.matches(column.as_ref(), None)
+                        {
                             Self::resolve_nested_field_wildcard(
                                 col((q.as_ref(), field)),
                                 field.data_type(),
@@ -1125,10 +1143,10 @@ impl PlanResolver<'_> {
             .map_err(|_| PlanError::AnalysisError(format!("cannot resolve wildcard: {name:?}")))
     }
 
-    fn resolve_nested_field_wildcard(
+    fn resolve_nested_field_wildcard<T: AsRef<str>>(
         expr: expr::Expr,
         data_type: &DataType,
-        inner: &[&str],
+        inner: &[T],
     ) -> Option<NamedExpr> {
         let DataType::Struct(fields) = data_type else {
             return None;
@@ -1153,7 +1171,7 @@ impl PlanResolver<'_> {
             }
             [name, remaining @ ..] => fields
                 .iter()
-                .find(|x| x.name().eq_ignore_ascii_case(name))
+                .find(|x| x.name().eq_ignore_ascii_case(name.as_ref()))
                 .and_then(|field| {
                     let args = vec![expr, lit(field.name().to_string())];
                     let expr =
@@ -1357,6 +1375,7 @@ impl PlanResolver<'_> {
             arguments,
             function,
         } = function;
+        let function_name: String = function_name.into();
         let (argument_names, arguments) = self
             .resolve_expressions_and_names(arguments, schema, state)
             .await?;
@@ -1426,13 +1445,10 @@ impl PlanResolver<'_> {
         schema: &DFSchemaRef,
         state: &mut PlanResolverState,
     ) -> PlanResult<NamedExpr> {
-        let function_name: Vec<String> = function_name.into();
-        let Ok(function_name) = function_name.one() else {
-            return Err(PlanError::todo("qualified function name"));
-        };
         let function = spec::UnresolvedFunction {
             function_name,
             arguments,
+            named_arguments: vec![],
             is_distinct: false,
             is_user_defined_function: false,
             ignore_nulls: None,
@@ -1792,49 +1808,63 @@ impl PlanResolver<'_> {
         ))
     }
 
-    fn generate_qualified_field_candidates<'a>(
-        name: &'a [&'a str],
-    ) -> Vec<(Option<TableReference>, &'a str)> {
+    fn generate_qualified_field_candidates<T: AsRef<str>>(
+        name: &[T],
+    ) -> Vec<(Option<TableReference>, &T)> {
         match name {
-            [n1] => vec![(None, *n1)],
-            [n1, n2] => vec![(Some(TableReference::bare(*n1)), *n2)],
-            [n1, n2, n3] => vec![(Some(TableReference::partial(*n1, *n2)), *n3)],
-            [n1, n2, n3, n4] => vec![(Some(TableReference::full(*n1, *n2, *n3)), *n4)],
+            [n1] => vec![(None, n1)],
+            [n1, n2] => vec![(Some(TableReference::bare(n1.as_ref())), n2)],
+            [n1, n2, n3] => vec![(Some(TableReference::partial(n1.as_ref(), n2.as_ref())), n3)],
+            [n1, n2, n3, n4] => vec![(
+                Some(TableReference::full(n1.as_ref(), n2.as_ref(), n3.as_ref())),
+                n4,
+            )],
             _ => vec![],
         }
     }
 
-    fn generate_qualified_nested_field_candidates<'a>(
-        name: &'a [&'a str],
-    ) -> Vec<(Option<TableReference>, &'a str, &'a [&'a str])> {
+    fn generate_qualified_nested_field_candidates<T: AsRef<str>>(
+        name: &[T],
+    ) -> Vec<(Option<TableReference>, &T, &[T])> {
         let mut out = vec![];
         if let [n1, x @ ..] = name {
-            out.push((None, *n1, x));
+            out.push((None, n1, x));
         }
         if let [n1, n2, x @ ..] = name {
-            out.push((Some(TableReference::bare(*n1)), *n2, x));
+            out.push((Some(TableReference::bare(n1.as_ref())), n2, x));
         }
         if let [n1, n2, n3, x @ ..] = name {
-            out.push((Some(TableReference::partial(*n1, *n2)), *n3, x));
+            out.push((
+                Some(TableReference::partial(n1.as_ref(), n2.as_ref())),
+                n3,
+                x,
+            ));
         }
         if let [n1, n2, n3, n4, x @ ..] = name {
-            out.push((Some(TableReference::full(*n1, *n2, *n3)), *n4, x));
+            out.push((
+                Some(TableReference::full(n1.as_ref(), n2.as_ref(), n3.as_ref())),
+                n4,
+                x,
+            ));
         }
         out
     }
 
-    fn generate_qualified_wildcard_candidates<'a>(
-        name: &'a [&'a str],
-    ) -> Vec<(Option<TableReference>, &'a [&'a str])> {
+    fn generate_qualified_wildcard_candidates<T: AsRef<str>>(
+        name: &[T],
+    ) -> Vec<(Option<TableReference>, &[T])> {
         let mut out = vec![(None, name)];
         if let [n1, x @ ..] = name {
-            out.push((Some(TableReference::bare(*n1)), x));
+            out.push((Some(TableReference::bare(n1.as_ref())), x));
         }
         if let [n1, n2, x @ ..] = name {
-            out.push((Some(TableReference::partial(*n1, *n2)), x));
+            out.push((Some(TableReference::partial(n1.as_ref(), n2.as_ref())), x));
         }
         if let [n1, n2, n3, x @ ..] = name {
-            out.push((Some(TableReference::full(*n1, *n2, *n3)), x));
+            out.push((
+                Some(TableReference::full(n1.as_ref(), n2.as_ref(), n3.as_ref())),
+                x,
+            ));
         }
         out
     }
@@ -2001,10 +2031,11 @@ mod tests {
             resolve(
                 &resolver,
                 spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                    function_name: "not".to_string(),
+                    function_name: spec::ObjectName::bare("not"),
                     arguments: vec![spec::Expr::Literal(spec::Literal::Boolean {
                         value: Some(true)
                     })],
+                    named_arguments: vec![],
                     is_distinct: false,
                     is_user_defined_function: false,
                     ignore_nulls: None,
@@ -2029,7 +2060,7 @@ mod tests {
                         // The resolver assigns a name (a human-readable string) for the function,
                         // and is then overridden by the explicitly specified outer name.
                         expr: Box::new(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                            function_name: "+".to_string(),
+                            function_name: spec::ObjectName::bare("+"),
                             arguments: vec![
                                 spec::Expr::Alias {
                                     // The resolver assigns a name "1" for the literal,
@@ -2043,6 +2074,7 @@ mod tests {
                                 // The resolver assigns a name "2" for the literal.
                                 spec::Expr::Literal(spec::Literal::Int32 { value: Some(2) }),
                             ],
+                            named_arguments: vec![],
                             is_distinct: false,
                             is_user_defined_function: false,
                             ignore_nulls: None,

--- a/crates/sail-plan/src/resolver/plan.rs
+++ b/crates/sail-plan/src/resolver/plan.rs
@@ -2249,6 +2249,7 @@ impl PlanResolver<'_> {
         self.resolve_query_plan(input, state).await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn resolve_query_lateral_view(
         &self,
         input: Option<spec::QueryPlan>,

--- a/crates/sail-plan/src/resolver/plan.rs
+++ b/crates/sail-plan/src/resolver/plan.rs
@@ -363,6 +363,7 @@ impl PlanResolver<'_> {
                 input,
                 function,
                 arguments,
+                named_arguments,
                 table_alias,
                 column_aliases,
                 outer,
@@ -371,6 +372,7 @@ impl PlanResolver<'_> {
                     input.map(|x| *x),
                     function,
                     arguments,
+                    named_arguments,
                     table_alias,
                     column_aliases,
                     outer,
@@ -711,25 +713,21 @@ impl PlanResolver<'_> {
         let spec::ReadUdtf {
             name,
             arguments,
+            named_arguments,
             options,
         } = udtf;
         if !options.is_empty() {
             return Err(PlanError::todo("ReadType::UDTF options"));
         }
-        let table_reference = self.resolve_table_reference(&name)?;
-        let function_name = match &table_reference {
-            TableReference::Bare { table } => table.as_ref(),
-            _ => {
-                return Err(PlanError::unsupported(format!(
-                    "qualified table function name: {table_reference}"
-                )))
-            }
+        let Ok(function_name) = <Vec<String>>::from(name).one() else {
+            return Err(PlanError::unsupported("qualified table function name"));
         };
         let canonical_function_name = function_name.to_ascii_lowercase();
         if is_built_in_generator_function(&canonical_function_name) {
             let expr = spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: function_name.to_string(),
+                function_name: spec::ObjectName::bare(function_name),
                 arguments,
+                named_arguments,
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -756,7 +754,7 @@ impl PlanResolver<'_> {
                         .await?;
                     self.resolve_python_udtf_plan(
                         udtf,
-                        function_name,
+                        &function_name,
                         input,
                         arguments,
                         None,
@@ -903,105 +901,96 @@ impl PlanResolver<'_> {
         let spec::Join {
             left,
             right,
-            join_condition,
             join_type,
-            using_columns,
+            join_criteria,
             join_data_type,
         } = join;
         let left = self.resolve_query_plan(*left, state).await?;
         let right = self.resolve_query_plan(*right, state).await?;
-        let (join_type, is_cross_join) = match join_type {
-            JoinType::Inner => (plan::JoinType::Inner, false),
-            JoinType::LeftOuter => (plan::JoinType::Left, false),
-            JoinType::RightOuter => (plan::JoinType::Right, false),
-            JoinType::FullOuter => (plan::JoinType::Full, false),
-            JoinType::LeftSemi => (plan::JoinType::LeftSemi, false),
-            JoinType::RightSemi => (plan::JoinType::RightSemi, false),
-            JoinType::LeftAnti => (plan::JoinType::LeftAnti, false),
-            JoinType::RightAnti => (plan::JoinType::RightAnti, false),
-            // use inner join type to build the schema for cross join
-            JoinType::Cross => (plan::JoinType::Inner, true),
+        let join_type = match join_type {
+            JoinType::Inner => Some(plan::JoinType::Inner),
+            JoinType::LeftOuter => Some(plan::JoinType::Left),
+            JoinType::RightOuter => Some(plan::JoinType::Right),
+            JoinType::FullOuter => Some(plan::JoinType::Full),
+            JoinType::LeftSemi => Some(plan::JoinType::LeftSemi),
+            JoinType::RightSemi => Some(plan::JoinType::RightSemi),
+            JoinType::LeftAnti => Some(plan::JoinType::LeftAnti),
+            JoinType::RightAnti => Some(plan::JoinType::RightAnti),
+            JoinType::Cross => None,
         };
 
-        if is_cross_join || (join_condition.is_none() && using_columns.is_empty()) {
-            if join_condition.is_some() {
-                return Err(PlanError::invalid("cross join with join condition"));
+        match (join_type, join_criteria) {
+            (None, Some(_)) => Err(PlanError::invalid("cross join with join criteria")),
+            // When the join criteria are not specified, any join type has the semantics of a cross join.
+            (Some(_), None) | (None, None) => {
+                if join_data_type.is_some() {
+                    return Err(PlanError::invalid("cross join with join data type"));
+                }
+                Ok(LogicalPlanBuilder::from(left).cross_join(right)?.build()?)
             }
-            if !using_columns.is_empty() {
-                return Err(PlanError::invalid("cross join with using columns"));
+            (Some(_), Some(spec::JoinCriteria::Natural)) => Err(PlanError::todo("natural join")),
+            (Some(join_type), Some(spec::JoinCriteria::On(condition))) => {
+                let join_schema = Arc::new(build_join_schema(
+                    left.schema(),
+                    right.schema(),
+                    &join_type,
+                )?);
+                let condition = self
+                    .resolve_expression(condition, &join_schema, state)
+                    .await?
+                    .unalias_nested()
+                    .data;
+                let plan = LogicalPlanBuilder::from(left)
+                    .join_on(right, join_type, Some(condition))?
+                    .build()?;
+                Ok(plan)
             }
-            if join_data_type.is_some() {
-                return Err(PlanError::invalid("cross join with join data type"));
-            }
-            return Ok(LogicalPlanBuilder::from(left).cross_join(right)?.build()?);
-        }
-        if join_condition.is_some() && using_columns.is_empty() {
-            let join_schema = Arc::new(build_join_schema(
-                left.schema(),
-                right.schema(),
-                &join_type,
-            )?);
-            let condition = match join_condition {
-                Some(condition) => Some(
-                    self.resolve_expression(condition, &join_schema, state)
-                        .await?
-                        .unalias_nested()
-                        .data,
-                ),
-                None => None,
-            };
-            let plan = LogicalPlanBuilder::from(left)
-                .join_on(right, join_type, condition)?
-                .build()?;
-            Ok(plan)
-        } else if join_condition.is_none() && !using_columns.is_empty() {
-            let join_columns = using_columns
-                .iter()
-                .map(|name| {
-                    let name: &str = name.into();
-                    let left_column = self.resolve_one_column(left.schema(), name, state)?;
-                    let right_column = self.resolve_one_column(right.schema(), name, state)?;
-                    Ok((left_column, right_column))
-                })
-                .collect::<PlanResult<Vec<(_, _)>>>()?;
-            let coalesced = join_columns
-                .iter()
-                .zip(using_columns)
-                .map(|((left, right), name)| {
-                    coalesce(vec![
-                        Expr::Column(left.clone()),
-                        Expr::Column(right.clone()),
-                    ])
-                    .alias(state.register_field_name(name))
-                })
-                .collect::<Vec<_>>();
-            let (left_columns, right_columns) =
-                join_columns.into_iter().unzip::<_, _, Vec<_>, Vec<_>>();
+            (Some(join_type), Some(spec::JoinCriteria::Using(using))) => {
+                let join_columns = using
+                    .iter()
+                    .map(|name| {
+                        let left_column =
+                            self.resolve_one_column(left.schema(), name.as_ref(), state)?;
+                        let right_column =
+                            self.resolve_one_column(right.schema(), name.as_ref(), state)?;
+                        Ok((left_column, right_column))
+                    })
+                    .collect::<PlanResult<Vec<(_, _)>>>()?;
+                let coalesced = join_columns
+                    .iter()
+                    .zip(using)
+                    .map(|((left, right), name)| {
+                        coalesce(vec![
+                            Expr::Column(left.clone()),
+                            Expr::Column(right.clone()),
+                        ])
+                        .alias(state.register_field_name(name))
+                    })
+                    .collect::<Vec<_>>();
+                let (left_columns, right_columns) =
+                    join_columns.into_iter().unzip::<_, _, Vec<_>, Vec<_>>();
 
-            let plan = LogicalPlanBuilder::from(left)
-                .join_detailed(
-                    right,
-                    join_type,
-                    (left_columns.clone(), right_columns.clone()),
-                    None,
-                    false,
-                )?
-                .build()?;
-            let projections = coalesced.into_iter().chain(
-                plan.schema()
-                    .columns()
-                    .into_iter()
-                    .filter(|col| !left_columns.contains(col) && !right_columns.contains(col))
-                    .map(Expr::Column),
-            );
-            let plan = LogicalPlanBuilder::from(plan)
-                .project(projections)?
-                .build()?;
-            Ok(plan)
-        } else {
-            return Err(PlanError::invalid(
-                "expecting either join condition or using columns",
-            ));
+                let plan = LogicalPlanBuilder::from(left)
+                    .join_detailed(
+                        right,
+                        join_type,
+                        (left_columns.clone(), right_columns.clone()),
+                        None,
+                        false,
+                    )?
+                    .build()?;
+                let projections = coalesced.into_iter().chain(
+                    plan.schema()
+                        .columns()
+                        .into_iter()
+                        .filter(|col| !left_columns.contains(col) && !right_columns.contains(col))
+                        .map(Expr::Column),
+                );
+                let plan = LogicalPlanBuilder::from(plan)
+                    .project(projections)?
+                    .build()?;
+                Ok(plan)
+            }
         }
     }
 
@@ -1457,7 +1446,7 @@ impl PlanResolver<'_> {
     ) -> PlanResult<LogicalPlan> {
         Ok(LogicalPlan::SubqueryAlias(plan::SubqueryAlias::try_new(
             Arc::new(self.resolve_query_plan(input, state).await?),
-            self.resolve_table_reference(&spec::ObjectName::new_qualified(alias, qualifier))?,
+            self.resolve_table_reference(&spec::ObjectName::from(qualifier).child(alias))?,
         )?))
     }
 
@@ -1756,6 +1745,7 @@ impl PlanResolver<'_> {
             arguments,
             function,
         } = function;
+        let function_name: String = function_name.into();
         let input = self
             .resolve_query_project(Some(input), arguments, state)
             .await?;
@@ -1880,6 +1870,7 @@ impl PlanResolver<'_> {
             arguments,
             function,
         } = function;
+        let function_name: String = function_name.into();
         let function = self.resolve_python_udf(function, state)?;
         let output_fields = match function.output_type {
             adt::DataType::Struct(fields) => fields,
@@ -2014,6 +2005,7 @@ impl PlanResolver<'_> {
             arguments: _, // no arguments are passed for co-group map
             function,
         } = function;
+        let function_name: String = function_name.into();
         let function = self.resolve_python_udf(function, state)?;
         let output_fields = match function.output_type {
             adt::DataType::Struct(fields) => fields,
@@ -2242,8 +2234,7 @@ impl PlanResolver<'_> {
         let mut scope = state.enter_cte_scope();
         let state = scope.state();
         for (name, query) in ctes.into_iter() {
-            let reference =
-                self.resolve_table_reference(&spec::ObjectName::new_unqualified(name.clone()))?;
+            let reference = self.resolve_table_reference(&spec::ObjectName::bare(name.clone()))?;
             let plan = if recursive {
                 self.resolve_recursive_query_plan(query, state).await?
             } else {
@@ -2263,6 +2254,7 @@ impl PlanResolver<'_> {
         input: Option<spec::QueryPlan>,
         function: spec::ObjectName,
         arguments: Vec<spec::Expr>,
+        named_arguments: Vec<(spec::Identifier, spec::Expr)>,
         table_alias: Option<spec::ObjectName>,
         column_aliases: Option<Vec<spec::Identifier>>,
         outer: bool,
@@ -2327,8 +2319,9 @@ impl PlanResolver<'_> {
             function_name
         };
         let expression = spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-            function_name,
+            function_name: spec::ObjectName::bare(function_name),
             arguments,
+            named_arguments,
             is_distinct: false,
             is_user_defined_function: false,
             ignore_nulls: None,
@@ -2388,6 +2381,7 @@ impl PlanResolver<'_> {
             arguments,
             function,
         } = udtf;
+        let function_name: String = function_name.into();
         let function = self.resolve_python_udtf(function, state)?;
         let input = self.resolve_empty_query_plan()?;
         let arguments = self
@@ -2658,10 +2652,9 @@ impl PlanResolver<'_> {
 
         let column_defaults: Vec<(String, Expr)> = async {
             let mut results: Vec<(String, Expr)> = Vec::with_capacity(column_defaults.len());
-            for column_default in column_defaults {
-                let (name, expr) = column_default;
+            for (name, expr) in column_defaults {
                 let expr = self.resolve_expression(expr, &schema, state).await?;
-                results.push((name, expr));
+                results.push((name.into(), expr));
             }
             Ok(results) as PlanResult<_>
         }
@@ -2931,6 +2924,7 @@ impl PlanResolver<'_> {
             function,
         } = function;
 
+        let function_name: String = function_name.into();
         let function_name = function_name.to_ascii_lowercase();
         let function = self.resolve_python_udf(function, state)?;
         let udf = PySparkUnresolvedUDF::new(
@@ -2962,6 +2956,7 @@ impl PlanResolver<'_> {
             arguments: _,
             function,
         } = function;
+        let function_name: String = function_name.into();
         let function_name = function_name.to_ascii_lowercase();
         let function = self.resolve_python_udtf(function, state)?;
         let udtf = PySparkUnresolvedUDF::new(
@@ -2985,7 +2980,7 @@ impl PlanResolver<'_> {
         input: spec::QueryPlan,
         table: spec::ObjectName,
         columns: Vec<spec::Identifier>,
-        partition_spec: Vec<(String, Option<spec::Expr>)>,
+        partition_spec: Vec<(spec::Identifier, Option<spec::Expr>)>,
         overwrite: bool,
         state: &mut PlanResolverState,
     ) -> PlanResult<LogicalPlan> {
@@ -3351,12 +3346,12 @@ impl PlanResolver<'_> {
             args: vec![
                 Expr::Column(self.resolve_one_column(
                     input.schema(),
-                    (&left_column).into(),
+                    left_column.as_ref(),
                     state,
                 )?),
                 Expr::Column(self.resolve_one_column(
                     input.schema(),
-                    (&right_column).into(),
+                    right_column.as_ref(),
                     state,
                 )?),
             ],
@@ -3390,12 +3385,12 @@ impl PlanResolver<'_> {
             args: vec![
                 Expr::Column(self.resolve_one_column(
                     input.schema(),
-                    (&left_column).into(),
+                    left_column.as_ref(),
                     state,
                 )?),
                 Expr::Column(self.resolve_one_column(
                     input.schema(),
-                    (&right_column).into(),
+                    right_column.as_ref(),
                     state,
                 )?),
             ],

--- a/crates/sail-plan/src/resolver/schema.rs
+++ b/crates/sail-plan/src/resolver/schema.rs
@@ -14,14 +14,14 @@ impl PlanResolver<'_> {
         &self,
         name: &spec::ObjectName,
     ) -> PlanResult<SchemaReference> {
-        let names: Vec<&str> = name.into();
-        match names[..] {
+        let names = name.parts();
+        match names {
             [a] => Ok(SchemaReference::Bare {
-                schema: Arc::from(a),
+                schema: Arc::from(a.as_ref()),
             }),
             [a, b] => Ok(SchemaReference::Full {
-                catalog: Arc::from(a),
-                schema: Arc::from(b),
+                catalog: Arc::from(a.as_ref()),
+                schema: Arc::from(b.as_ref()),
             }),
             _ => Err(PlanError::invalid(format!("schema reference: {:?}", names))),
         }
@@ -31,33 +31,33 @@ impl PlanResolver<'_> {
         &self,
         name: &spec::ObjectName,
     ) -> PlanResult<TableReference> {
-        let names: Vec<&str> = name.into();
-        match names[..] {
+        let names = name.parts();
+        match names {
             [a] => Ok(TableReference::Bare {
-                table: Arc::from(a),
+                table: Arc::from(a.as_ref()),
             }),
             [a, b] => Ok(TableReference::Partial {
-                schema: Arc::from(a),
-                table: Arc::from(b),
+                schema: Arc::from(a.as_ref()),
+                table: Arc::from(b.as_ref()),
             }),
             [a, b, c] => Ok(TableReference::Full {
-                catalog: Arc::from(a),
-                schema: Arc::from(b),
-                table: Arc::from(c),
+                catalog: Arc::from(a.as_ref()),
+                schema: Arc::from(b.as_ref()),
+                table: Arc::from(c.as_ref()),
             }),
             _ => Err(PlanError::invalid(format!("table reference: {:?}", names))),
         }
     }
 
-    pub(super) async fn resolve_schema_projection(
+    pub(super) async fn resolve_schema_projection<T: AsRef<str>>(
         &self,
         schema: SchemaRef,
-        columns: &[spec::Identifier],
+        columns: &[T],
     ) -> PlanResult<SchemaRef> {
         let fields = columns
             .iter()
             .map(|column| {
-                let column: &str = column.into();
+                let column = column.as_ref();
                 let matches = schema
                     .fields()
                     .iter()
@@ -130,15 +130,15 @@ impl PlanResolver<'_> {
         }
     }
 
-    pub(super) fn resolve_columns(
+    pub(super) fn resolve_columns<T: AsRef<str>>(
         &self,
         schema: &DFSchemaRef,
-        names: Vec<&str>,
+        names: &[T],
         state: &mut PlanResolverState,
     ) -> PlanResult<Vec<Column>> {
         names
             .iter()
-            .map(|name| self.resolve_one_column(schema, name, state))
+            .map(|name| self.resolve_one_column(schema, name.as_ref(), state))
             .collect::<PlanResult<Vec<Column>>>()
     }
 

--- a/crates/sail-plan/src/resolver/statistic.rs
+++ b/crates/sail-plan/src/resolver/statistic.rs
@@ -29,11 +29,7 @@ impl PlanResolver<'_> {
         let columns: Vec<Column> = if columns.is_empty() {
             input.schema().columns()
         } else {
-            self.resolve_columns(
-                input.schema(),
-                columns.iter().map(|x| x.into()).collect(),
-                state,
-            )?
+            self.resolve_columns(input.schema(), &columns, state)?
         };
         let statistics: HashSet<String> = if statistics.is_empty() {
             HashSet::from([
@@ -269,11 +265,13 @@ impl PlanResolver<'_> {
         state: &mut PlanResolverState,
     ) -> PlanResult<LogicalPlan> {
         let input = self.resolve_query_plan(input, state).await?;
-        let left_column: &str = (&left_column).into();
-        let right_column: &str = (&right_column).into();
-        let cross_tab_alias = state.register_field_name(format!("{left_column}_{right_column}"));
-        let left_column = self.resolve_one_column(input.schema(), left_column, state)?;
-        let right_column = self.resolve_one_column(input.schema(), right_column, state)?;
+        let cross_tab_alias = state.register_field_name(format!(
+            "{}_{}",
+            left_column.as_ref(),
+            right_column.as_ref()
+        ));
+        let left_column = self.resolve_one_column(input.schema(), left_column.as_ref(), state)?;
+        let right_column = self.resolve_one_column(input.schema(), right_column.as_ref(), state)?;
 
         let projected_plan = LogicalPlanBuilder::from(input.clone())
             .project(vec![Expr::Cast(expr::Cast {

--- a/crates/sail-spark-connect/src/proto/expression.rs
+++ b/crates/sail-spark-connect/src/proto/expression.rs
@@ -55,11 +55,12 @@ impl TryFrom<Expression> for spec::Expr {
                 is_distinct,
                 is_user_defined_function,
             }) => Ok(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name,
+                function_name: spec::ObjectName::bare(function_name),
                 arguments: arguments
                     .into_iter()
                     .map(|x| x.try_into())
                     .collect::<SparkResult<_>>()?,
+                named_arguments: vec![],
                 is_distinct,
                 is_user_defined_function,
                 ignore_nulls: None,
@@ -329,7 +330,7 @@ impl TryFrom<CommonInlineUserDefinedFunction> for spec::CommonInlineUserDefinedF
         } = function;
         let function = function.required("common inline UDF function")?;
         Ok(spec::CommonInlineUserDefinedFunction {
-            function_name,
+            function_name: function_name.into(),
             deterministic,
             arguments: arguments
                 .into_iter()
@@ -405,7 +406,7 @@ impl TryFrom<CommonInlineUserDefinedTableFunction> for spec::CommonInlineUserDef
         } = function;
         let function = function.required("common inline UDTF function")?;
         Ok(spec::CommonInlineUserDefinedTableFunction {
-            function_name,
+            function_name: function_name.into(),
             deterministic,
             arguments: arguments
                 .into_iter()

--- a/crates/sail-spark-connect/tests/gold_data/expression/case.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/case.json
@@ -5,15 +5,21 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "when",
+            "functionName": [
+              "when"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "==",
+                  "functionName": [
+                    "=="
+                  ],
                   "arguments": [
                     {
                       "unresolvedFunction": {
-                        "functionName": "==",
+                        "functionName": [
+                          "=="
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -30,6 +36,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -45,6 +52,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -60,6 +68,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -74,15 +83,21 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "when",
+            "functionName": [
+              "when"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "==",
+                  "functionName": [
+                    "=="
+                  ],
                   "arguments": [
                     {
                       "unresolvedFunction": {
-                        "functionName": "or",
+                        "functionName": [
+                          "or"
+                        ],
                         "arguments": [
                           {
                             "unresolvedAttribute": {
@@ -101,6 +116,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -116,6 +132,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -133,11 +150,15 @@
               },
               {
                 "unresolvedFunction": {
-                  "functionName": "==",
+                  "functionName": [
+                    "=="
+                  ],
                   "arguments": [
                     {
                       "unresolvedFunction": {
-                        "functionName": "or",
+                        "functionName": [
+                          "or"
+                        ],
                         "arguments": [
                           {
                             "unresolvedAttribute": {
@@ -156,6 +177,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -171,6 +193,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -195,6 +218,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -209,11 +233,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "when",
+            "functionName": [
+              "when"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "==",
+                  "functionName": [
+                    "=="
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -231,6 +259,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -248,7 +277,9 @@
               },
               {
                 "unresolvedFunction": {
-                  "functionName": "==",
+                  "functionName": [
+                    "=="
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -266,6 +297,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -290,6 +322,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -304,11 +337,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "when",
+            "functionName": [
+              "when"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "+",
+                  "functionName": [
+                    "+"
+                  ],
                   "arguments": [
                     {
                       "literal": {
@@ -319,11 +356,15 @@
                     },
                     {
                       "unresolvedFunction": {
-                        "functionName": "when",
+                        "functionName": [
+                          "when"
+                        ],
                         "arguments": [
                           {
                             "unresolvedFunction": {
-                              "functionName": ">",
+                              "functionName": [
+                                ">"
+                              ],
                               "arguments": [
                                 {
                                   "unresolvedAttribute": {
@@ -342,6 +383,7 @@
                                   }
                                 }
                               ],
+                              "namedArguments": [],
                               "isDistinct": false,
                               "isUserDefinedFunction": false,
                               "ignoreNulls": null,
@@ -366,6 +408,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -374,6 +417,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -398,6 +442,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -412,11 +457,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "when",
+            "functionName": [
+              "when"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "==",
+                  "functionName": [
+                    "=="
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -434,6 +483,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -451,7 +501,9 @@
               },
               {
                 "unresolvedFunction": {
-                  "functionName": "==",
+                  "functionName": [
+                    "=="
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -469,6 +521,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -493,6 +546,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,

--- a/crates/sail-spark-connect/tests/gold_data/expression/current.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/current.json
@@ -5,8 +5,11 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "current_date",
+            "functionName": [
+              "current_date"
+            ],
             "arguments": [],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -21,8 +24,11 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "current_timestamp",
+            "functionName": [
+              "current_timestamp"
+            ],
             "arguments": [],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,

--- a/crates/sail-spark-connect/tests/gold_data/expression/interval.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/interval.json
@@ -5,7 +5,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -15,6 +17,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -29,7 +32,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -42,6 +47,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -56,7 +62,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -69,6 +77,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -83,7 +92,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -93,6 +104,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -107,7 +119,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -121,6 +135,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -135,7 +150,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -145,6 +162,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -159,7 +177,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -172,6 +192,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -186,7 +207,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -199,6 +222,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -213,7 +237,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -226,6 +252,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -240,7 +267,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -253,6 +282,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -267,7 +297,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -281,6 +313,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -295,7 +328,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -309,6 +344,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -323,7 +359,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -336,6 +374,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -350,7 +389,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -363,6 +404,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -377,7 +419,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -390,6 +434,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -404,7 +449,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -417,6 +464,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -431,7 +479,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -441,6 +491,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -455,7 +506,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -465,6 +518,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -479,7 +533,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -492,6 +548,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -506,7 +563,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -519,6 +578,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -533,7 +593,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -546,6 +608,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -560,7 +623,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -573,6 +638,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -587,7 +653,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -597,6 +665,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -611,7 +680,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -621,6 +692,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -635,7 +707,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -649,6 +723,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -663,7 +738,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -676,6 +753,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -690,7 +768,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -703,6 +783,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -717,7 +798,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -730,6 +813,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -744,7 +828,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -757,6 +843,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -771,7 +858,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -784,6 +873,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -798,7 +888,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -811,6 +903,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -825,7 +918,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -838,6 +933,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -852,7 +948,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -865,6 +963,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -879,7 +978,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -892,6 +993,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -906,7 +1008,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -919,6 +1023,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -933,7 +1038,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -943,6 +1050,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -957,7 +1065,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -967,6 +1077,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -981,7 +1092,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -994,6 +1107,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1008,7 +1122,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1021,6 +1137,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1035,7 +1152,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1048,6 +1167,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1062,7 +1182,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1075,6 +1197,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1089,7 +1212,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1099,6 +1224,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1113,7 +1239,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1123,6 +1251,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1137,7 +1266,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1150,6 +1281,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1164,7 +1296,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1177,6 +1311,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1191,7 +1326,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1204,6 +1341,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1218,7 +1356,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1231,6 +1371,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1245,7 +1386,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1259,6 +1402,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1273,7 +1417,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1283,6 +1429,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1297,7 +1444,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1311,6 +1460,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1325,7 +1475,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1338,6 +1490,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1352,7 +1505,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1365,6 +1520,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1379,7 +1535,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1392,6 +1550,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1406,7 +1565,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1419,6 +1580,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1433,7 +1595,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1447,6 +1611,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1461,7 +1626,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1475,6 +1642,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1489,7 +1657,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1502,6 +1672,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1516,7 +1687,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1529,6 +1702,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1543,7 +1717,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1556,6 +1732,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1570,7 +1747,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1583,6 +1762,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1597,7 +1777,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1607,6 +1789,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1621,7 +1804,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1631,6 +1816,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1645,7 +1831,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1658,6 +1846,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1672,7 +1861,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1685,6 +1876,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1699,7 +1891,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1712,6 +1906,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1726,7 +1921,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1739,6 +1936,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1753,7 +1951,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1763,6 +1963,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1777,7 +1978,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1787,6 +1990,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1801,7 +2005,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1815,6 +2021,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1829,7 +2036,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1839,6 +2048,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1853,7 +2063,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1866,6 +2078,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1880,7 +2093,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1893,6 +2108,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1907,7 +2123,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1920,6 +2138,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1934,7 +2153,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1947,6 +2168,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1961,7 +2183,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -1975,6 +2199,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1989,7 +2214,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2003,6 +2230,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2017,7 +2245,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2030,6 +2260,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2044,7 +2275,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2057,6 +2290,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2071,7 +2305,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2084,6 +2320,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2098,7 +2335,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2111,6 +2350,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2125,7 +2365,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2135,6 +2377,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2149,7 +2392,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2159,6 +2404,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2173,7 +2419,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2186,6 +2434,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2200,7 +2449,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2213,6 +2464,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2227,7 +2479,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2240,6 +2494,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2254,7 +2509,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2267,6 +2524,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2281,7 +2539,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2291,6 +2551,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2305,7 +2566,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2315,6 +2578,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2329,7 +2593,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2343,6 +2609,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2357,7 +2624,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2367,6 +2636,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2381,7 +2651,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2395,6 +2667,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2409,7 +2682,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2423,6 +2698,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2437,7 +2713,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2451,6 +2729,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2465,7 +2744,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2478,6 +2759,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2492,7 +2774,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2505,6 +2789,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2519,7 +2804,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2532,6 +2819,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2546,7 +2834,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2559,6 +2849,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2573,7 +2864,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2587,6 +2880,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2601,7 +2895,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2615,6 +2911,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2629,7 +2926,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2642,6 +2941,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2656,7 +2956,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2669,6 +2971,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2683,7 +2986,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2696,6 +3001,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2710,7 +3016,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2723,6 +3031,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2737,7 +3046,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2747,6 +3058,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2761,7 +3073,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2771,6 +3085,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2785,7 +3100,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2798,6 +3115,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2812,7 +3130,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2825,6 +3145,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2839,7 +3160,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2852,6 +3175,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2866,7 +3190,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2879,6 +3205,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2893,7 +3220,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2903,6 +3232,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2917,7 +3247,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2927,6 +3259,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2941,7 +3274,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2954,6 +3289,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2968,7 +3304,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -2981,6 +3319,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2995,7 +3334,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3008,6 +3349,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3022,7 +3364,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3035,6 +3379,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3049,7 +3394,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3062,6 +3409,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3076,7 +3424,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3089,6 +3439,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3103,7 +3454,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3116,6 +3469,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3130,7 +3484,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3143,6 +3499,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3157,7 +3514,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3170,6 +3529,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3184,7 +3544,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3197,6 +3559,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3211,7 +3574,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3221,6 +3586,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3235,7 +3601,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3245,6 +3613,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3259,7 +3628,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3272,6 +3643,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3286,7 +3658,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3299,6 +3673,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3313,7 +3688,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3326,6 +3703,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3340,7 +3718,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3353,6 +3733,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3367,7 +3748,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3377,6 +3760,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3391,7 +3775,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3401,6 +3787,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3415,7 +3802,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3428,6 +3817,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3442,7 +3832,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3455,6 +3847,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3469,7 +3862,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3482,6 +3877,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3496,7 +3892,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3509,6 +3907,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3523,7 +3922,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3536,6 +3937,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3550,7 +3952,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3564,6 +3968,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3578,7 +3983,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3592,6 +3999,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3606,7 +4014,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3619,6 +4029,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3633,7 +4044,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3646,6 +4059,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3660,7 +4074,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3673,6 +4089,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3687,7 +4104,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3700,6 +4119,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3714,7 +4134,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3724,6 +4146,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3738,7 +4161,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3748,6 +4173,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3762,7 +4188,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3775,6 +4203,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3789,7 +4218,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3802,6 +4233,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3816,7 +4248,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3829,6 +4263,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3843,7 +4278,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3856,6 +4293,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3870,7 +4308,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3880,6 +4320,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3894,7 +4335,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3904,6 +4347,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3918,7 +4362,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3928,6 +4374,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3942,7 +4389,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3956,6 +4405,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3970,7 +4420,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -3984,6 +4436,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3998,7 +4451,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4011,6 +4466,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4025,7 +4481,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4038,6 +4496,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4052,7 +4511,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4065,6 +4526,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4079,7 +4541,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4092,6 +4556,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4106,7 +4571,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4120,6 +4587,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4134,7 +4602,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4148,6 +4618,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4162,7 +4633,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4175,6 +4648,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4189,7 +4663,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4202,6 +4678,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4216,7 +4693,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4229,6 +4708,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4243,7 +4723,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4256,6 +4738,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4270,7 +4753,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4280,6 +4765,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4294,7 +4780,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4304,6 +4792,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4318,7 +4807,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4331,6 +4822,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4345,7 +4837,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4358,6 +4852,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4372,7 +4867,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4385,6 +4882,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4399,7 +4897,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4412,6 +4912,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4426,7 +4927,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4436,6 +4939,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4450,7 +4954,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4460,6 +4966,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4474,7 +4981,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4488,6 +4997,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -4502,7 +5012,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -4515,6 +5027,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,

--- a/crates/sail-spark-connect/tests/gold_data/expression/like.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/like.json
@@ -5,7 +5,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "ilike",
+            "functionName": [
+              "ilike"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -17,7 +19,9 @@
               },
               {
                 "unresolvedFunction": {
-                  "functionName": "all",
+                  "functionName": [
+                    "all"
+                  ],
                   "arguments": [
                     {
                       "literal": {
@@ -34,6 +38,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -42,6 +47,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -63,7 +69,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "ilike",
+            "functionName": [
+              "ilike"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -75,7 +83,9 @@
               },
               {
                 "unresolvedFunction": {
-                  "functionName": "any",
+                  "functionName": [
+                    "any"
+                  ],
                   "arguments": [
                     {
                       "literal": {
@@ -92,6 +102,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -100,6 +111,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -121,7 +133,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "ilike",
+            "functionName": [
+              "ilike"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -133,7 +147,9 @@
               },
               {
                 "unresolvedFunction": {
-                  "functionName": "some",
+                  "functionName": [
+                    "some"
+                  ],
                   "arguments": [
                     {
                       "literal": {
@@ -150,6 +166,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -158,6 +175,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -179,7 +197,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "like",
+            "functionName": [
+              "like"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -197,6 +217,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -211,7 +232,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "like",
+            "functionName": [
+              "like"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -236,6 +259,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -257,7 +281,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "like",
+            "functionName": [
+              "like"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -282,6 +308,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -303,7 +330,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "like",
+            "functionName": [
+              "like"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -315,7 +344,9 @@
               },
               {
                 "unresolvedFunction": {
-                  "functionName": "all",
+                  "functionName": [
+                    "all"
+                  ],
                   "arguments": [
                     {
                       "literal": {
@@ -332,6 +363,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -340,6 +372,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -361,7 +394,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "like",
+            "functionName": [
+              "like"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -373,7 +408,9 @@
               },
               {
                 "unresolvedFunction": {
-                  "functionName": "any",
+                  "functionName": [
+                    "any"
+                  ],
                   "arguments": [
                     {
                       "literal": {
@@ -390,6 +427,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -398,6 +436,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -419,7 +458,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "like",
+            "functionName": [
+              "like"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -431,7 +472,9 @@
               },
               {
                 "unresolvedFunction": {
-                  "functionName": "some",
+                  "functionName": [
+                    "some"
+                  ],
                   "arguments": [
                     {
                       "literal": {
@@ -448,6 +491,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -456,6 +500,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -477,11 +522,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "ilike",
+                  "functionName": [
+                    "ilike"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -493,7 +542,9 @@
                     },
                     {
                       "unresolvedFunction": {
-                        "functionName": "all",
+                        "functionName": [
+                          "all"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -510,6 +561,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -518,6 +570,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -526,6 +579,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -540,11 +594,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "ilike",
+                  "functionName": [
+                    "ilike"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -556,7 +614,9 @@
                     },
                     {
                       "unresolvedFunction": {
-                        "functionName": "any",
+                        "functionName": [
+                          "any"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -573,6 +633,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -581,6 +642,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -589,6 +651,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -603,11 +666,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "ilike",
+                  "functionName": [
+                    "ilike"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -619,7 +686,9 @@
                     },
                     {
                       "unresolvedFunction": {
-                        "functionName": "some",
+                        "functionName": [
+                          "some"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -636,6 +705,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -644,6 +714,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -652,6 +723,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -666,11 +738,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "like",
+                  "functionName": [
+                    "like"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -688,6 +764,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -696,6 +773,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -710,11 +788,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "like",
+                  "functionName": [
+                    "like"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -739,6 +821,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -747,6 +830,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -768,11 +852,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "like",
+                  "functionName": [
+                    "like"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -797,6 +885,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -805,6 +894,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -826,11 +916,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "like",
+                  "functionName": [
+                    "like"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -842,7 +936,9 @@
                     },
                     {
                       "unresolvedFunction": {
-                        "functionName": "all",
+                        "functionName": [
+                          "all"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -859,6 +955,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -867,6 +964,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -875,6 +973,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -889,11 +988,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "like",
+                  "functionName": [
+                    "like"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -905,7 +1008,9 @@
                     },
                     {
                       "unresolvedFunction": {
-                        "functionName": "any",
+                        "functionName": [
+                          "any"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -922,6 +1027,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -930,6 +1036,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -938,6 +1045,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -952,11 +1060,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "like",
+                  "functionName": [
+                    "like"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -968,7 +1080,9 @@
                     },
                     {
                       "unresolvedFunction": {
-                        "functionName": "some",
+                        "functionName": [
+                          "some"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -985,6 +1099,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -993,6 +1108,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -1001,6 +1117,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1015,11 +1132,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "rlike",
+                  "functionName": [
+                    "rlike"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -1037,6 +1158,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -1045,6 +1167,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1059,7 +1182,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "rlike",
+            "functionName": [
+              "rlike"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1077,6 +1202,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1091,7 +1217,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "rlike",
+            "functionName": [
+              "rlike"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1109,6 +1237,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1123,7 +1252,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "rlike",
+            "functionName": [
+              "rlike"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1141,6 +1272,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1155,7 +1287,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "rlike",
+            "functionName": [
+              "rlike"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1173,6 +1307,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1187,11 +1322,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "ilike",
+                  "functionName": [
+                    "ilike"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -1203,7 +1342,9 @@
                     },
                     {
                       "unresolvedFunction": {
-                        "functionName": "all",
+                        "functionName": [
+                          "all"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -1220,6 +1361,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -1228,6 +1370,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -1236,6 +1379,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1250,11 +1394,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "ilike",
+                  "functionName": [
+                    "ilike"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -1266,7 +1414,9 @@
                     },
                     {
                       "unresolvedFunction": {
-                        "functionName": "any",
+                        "functionName": [
+                          "any"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -1283,6 +1433,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -1291,6 +1442,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -1299,6 +1451,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1313,11 +1466,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "ilike",
+                  "functionName": [
+                    "ilike"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -1329,7 +1486,9 @@
                     },
                     {
                       "unresolvedFunction": {
-                        "functionName": "some",
+                        "functionName": [
+                          "some"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -1346,6 +1505,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -1354,6 +1514,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -1362,6 +1523,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1376,11 +1538,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "like",
+                  "functionName": [
+                    "like"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -1392,7 +1558,9 @@
                     },
                     {
                       "unresolvedFunction": {
-                        "functionName": "all",
+                        "functionName": [
+                          "all"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -1409,6 +1577,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -1417,6 +1586,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -1425,6 +1595,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1439,11 +1610,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "like",
+                  "functionName": [
+                    "like"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -1455,7 +1630,9 @@
                     },
                     {
                       "unresolvedFunction": {
-                        "functionName": "any",
+                        "functionName": [
+                          "any"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -1472,6 +1649,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -1480,6 +1658,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -1488,6 +1667,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1502,11 +1682,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "like",
+                  "functionName": [
+                    "like"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -1518,7 +1702,9 @@
                     },
                     {
                       "unresolvedFunction": {
-                        "functionName": "some",
+                        "functionName": [
+                          "some"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -1535,6 +1721,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -1543,6 +1730,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -1551,6 +1739,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,

--- a/crates/sail-spark-connect/tests/gold_data/expression/misc.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/misc.json
@@ -5,7 +5,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "!",
+            "functionName": [
+              "!"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -16,6 +18,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -32,7 +35,9 @@
           "unresolvedExtractValue": {
             "child": {
               "unresolvedFunction": {
-                "functionName": "+",
+                "functionName": [
+                  "+"
+                ],
                 "arguments": [
                   {
                     "unresolvedAttribute": {
@@ -51,6 +56,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -75,7 +81,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "struct",
+            "functionName": [
+              "struct"
+            ],
             "arguments": [
               {
                 "alias": {
@@ -110,6 +118,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -186,7 +195,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "struct",
+            "functionName": [
+              "struct"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -205,6 +216,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -221,7 +233,9 @@
           "inSubquery": {
             "expr": {
               "unresolvedFunction": {
-                "functionName": "struct",
+                "functionName": [
+                  "struct"
+                ],
                 "arguments": [
                   {
                     "unresolvedAttribute": {
@@ -240,6 +254,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -288,7 +303,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "struct",
+            "functionName": [
+              "struct"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -315,6 +332,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -331,7 +349,9 @@
           "inSubquery": {
             "expr": {
               "unresolvedFunction": {
-                "functionName": "struct",
+                "functionName": [
+                  "struct"
+                ],
                 "arguments": [
                   {
                     "unresolvedAttribute": {
@@ -358,6 +378,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -422,7 +443,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": ">",
+            "functionName": [
+              ">"
+            ],
             "arguments": [
               {
                 "scalarSubquery": {
@@ -446,7 +469,9 @@
                       "expressions": [
                         {
                           "unresolvedFunction": {
-                            "functionName": "max",
+                            "functionName": [
+                              "max"
+                            ],
                             "arguments": [
                               {
                                 "unresolvedAttribute": {
@@ -457,6 +482,7 @@
                                 }
                               }
                             ],
+                            "namedArguments": [],
                             "isDistinct": false,
                             "isUserDefinedFunction": false,
                             "ignoreNulls": null,
@@ -480,6 +506,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -496,7 +523,9 @@
           "lambdaFunction": {
             "function": {
               "unresolvedFunction": {
-                "functionName": "+",
+                "functionName": [
+                  "+"
+                ],
                 "arguments": [
                   {
                     "unresolvedAttribute": {
@@ -515,6 +544,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -543,19 +573,27 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "+",
+                  "functionName": [
+                    "+"
+                  ],
                   "arguments": [
                     {
                       "unresolvedFunction": {
-                        "functionName": "~",
+                        "functionName": [
+                          "~"
+                        ],
                         "arguments": [
                           {
                             "unresolvedFunction": {
-                              "functionName": "~",
+                              "functionName": [
+                                "~"
+                              ],
                               "arguments": [
                                 {
                                   "unresolvedAttribute": {
@@ -566,6 +604,7 @@
                                   }
                                 }
                               ],
+                              "namedArguments": [],
                               "isDistinct": false,
                               "isUserDefinedFunction": false,
                               "ignoreNulls": null,
@@ -574,6 +613,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -582,6 +622,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -590,6 +631,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -606,7 +648,9 @@
           "alias": {
             "expr": {
               "unresolvedFunction": {
-                "functionName": "+",
+                "functionName": [
+                  "+"
+                ],
                 "arguments": [
                   {
                     "literal": {
@@ -625,6 +669,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -645,7 +690,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -656,7 +703,9 @@
               },
               {
                 "unresolvedFunction": {
-                  "functionName": "f",
+                  "functionName": [
+                    "f"
+                  ],
                   "arguments": [
                     {
                       "literal": {
@@ -667,7 +716,9 @@
                     },
                     {
                       "unresolvedFunction": {
-                        "functionName": "o",
+                        "functionName": [
+                          "o"
+                        ],
                         "arguments": [
                           {
                             "unresolvedAttribute": {
@@ -678,6 +729,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -686,6 +738,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -694,6 +747,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -849,7 +903,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "select",
+            "functionName": [
+              "select"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -868,6 +924,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -909,7 +966,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": ">=",
+            "functionName": [
+              ">="
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -928,6 +987,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -942,7 +1002,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "!=",
+            "functionName": [
+              "!="
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -961,6 +1023,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -975,7 +1038,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "<=",
+            "functionName": [
+              "<="
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -994,6 +1059,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1008,7 +1074,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "%",
+            "functionName": [
+              "%"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1027,6 +1095,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1041,7 +1110,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "&",
+            "functionName": [
+              "&"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1060,6 +1131,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1074,7 +1146,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "*",
+            "functionName": [
+              "*"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1093,6 +1167,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1107,11 +1182,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "|",
+            "functionName": [
+              "|"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "*",
+                  "functionName": [
+                    "*"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -1130,6 +1209,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -1139,7 +1219,9 @@
               },
               {
                 "unresolvedFunction": {
-                  "functionName": "^",
+                  "functionName": [
+                    "^"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -1151,7 +1233,9 @@
                     },
                     {
                       "unresolvedFunction": {
-                        "functionName": "&",
+                        "functionName": [
+                          "&"
+                        ],
                         "arguments": [
                           {
                             "unresolvedAttribute": {
@@ -1163,11 +1247,15 @@
                           },
                           {
                             "unresolvedFunction": {
-                              "functionName": "+",
+                              "functionName": [
+                                "+"
+                              ],
                               "arguments": [
                                 {
                                   "unresolvedFunction": {
-                                    "functionName": "-",
+                                    "functionName": [
+                                      "-"
+                                    ],
                                     "arguments": [
                                       {
                                         "unresolvedAttribute": {
@@ -1186,6 +1274,7 @@
                                         }
                                       }
                                     ],
+                                    "namedArguments": [],
                                     "isDistinct": false,
                                     "isUserDefinedFunction": false,
                                     "ignoreNulls": null,
@@ -1195,19 +1284,27 @@
                                 },
                                 {
                                   "unresolvedFunction": {
-                                    "functionName": "*",
+                                    "functionName": [
+                                      "*"
+                                    ],
                                     "arguments": [
                                       {
                                         "unresolvedFunction": {
-                                          "functionName": "/",
+                                          "functionName": [
+                                            "/"
+                                          ],
                                           "arguments": [
                                             {
                                               "unresolvedFunction": {
-                                                "functionName": "div",
+                                                "functionName": [
+                                                  "div"
+                                                ],
                                                 "arguments": [
                                                   {
                                                     "unresolvedFunction": {
-                                                      "functionName": "%",
+                                                      "functionName": [
+                                                        "%"
+                                                      ],
                                                       "arguments": [
                                                         {
                                                           "unresolvedAttribute": {
@@ -1226,6 +1323,7 @@
                                                           }
                                                         }
                                                       ],
+                                                      "namedArguments": [],
                                                       "isDistinct": false,
                                                       "isUserDefinedFunction": false,
                                                       "ignoreNulls": null,
@@ -1242,6 +1340,7 @@
                                                     }
                                                   }
                                                 ],
+                                                "namedArguments": [],
                                                 "isDistinct": false,
                                                 "isUserDefinedFunction": false,
                                                 "ignoreNulls": null,
@@ -1258,6 +1357,7 @@
                                               }
                                             }
                                           ],
+                                          "namedArguments": [],
                                           "isDistinct": false,
                                           "isUserDefinedFunction": false,
                                           "ignoreNulls": null,
@@ -1274,6 +1374,7 @@
                                         }
                                       }
                                     ],
+                                    "namedArguments": [],
                                     "isDistinct": false,
                                     "isUserDefinedFunction": false,
                                     "ignoreNulls": null,
@@ -1282,6 +1383,7 @@
                                   }
                                 }
                               ],
+                              "namedArguments": [],
                               "isDistinct": false,
                               "isUserDefinedFunction": false,
                               "ignoreNulls": null,
@@ -1290,6 +1392,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -1298,6 +1401,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -1306,6 +1410,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1320,7 +1425,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "+",
+            "functionName": [
+              "+"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1339,6 +1446,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1353,7 +1461,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1372,6 +1482,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1386,7 +1497,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "/",
+            "functionName": [
+              "/"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1405,6 +1518,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1419,7 +1533,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "<",
+            "functionName": [
+              "<"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1438,6 +1554,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1452,7 +1569,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "<=",
+            "functionName": [
+              "<="
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1471,6 +1590,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1485,7 +1605,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "<=>",
+            "functionName": [
+              "<=>"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1504,6 +1626,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1518,7 +1641,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "!=",
+            "functionName": [
+              "!="
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1537,6 +1662,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1551,7 +1677,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "==",
+            "functionName": [
+              "=="
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1597,6 +1725,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1611,7 +1740,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "==",
+            "functionName": [
+              "=="
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1630,6 +1761,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1645,7 +1777,9 @@
         "success": {
           "isNotNull": {
             "unresolvedFunction": {
-              "functionName": "==",
+              "functionName": [
+                "=="
+              ],
               "arguments": [
                 {
                   "unresolvedAttribute": {
@@ -1664,6 +1798,7 @@
                   }
                 }
               ],
+              "namedArguments": [],
               "isDistinct": false,
               "isUserDefinedFunction": false,
               "ignoreNulls": null,
@@ -1680,7 +1815,9 @@
         "success": {
           "isNull": {
             "unresolvedFunction": {
-              "functionName": "==",
+              "functionName": [
+                "=="
+              ],
               "arguments": [
                 {
                   "unresolvedAttribute": {
@@ -1699,6 +1836,7 @@
                   }
                 }
               ],
+              "namedArguments": [],
               "isDistinct": false,
               "isUserDefinedFunction": false,
               "ignoreNulls": null,
@@ -1714,7 +1852,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "==",
+            "functionName": [
+              "=="
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1733,6 +1873,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1747,7 +1888,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": ">",
+            "functionName": [
+              ">"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1766,6 +1909,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1780,7 +1924,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": ">=",
+            "functionName": [
+              ">="
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1799,6 +1945,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1813,7 +1960,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "div",
+            "functionName": [
+              "div"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1832,6 +1981,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1846,7 +1996,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "^",
+            "functionName": [
+              "^"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1865,6 +2017,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1879,7 +2032,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "and",
+            "functionName": [
+              "and"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -1898,6 +2053,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -1912,23 +2068,33 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "and",
+            "functionName": [
+              "and"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "and",
+                  "functionName": [
+                    "and"
+                  ],
                   "arguments": [
                     {
                       "unresolvedFunction": {
-                        "functionName": "and",
+                        "functionName": [
+                          "and"
+                        ],
                         "arguments": [
                           {
                             "unresolvedFunction": {
-                              "functionName": "and",
+                              "functionName": [
+                                "and"
+                              ],
                               "arguments": [
                                 {
                                   "unresolvedFunction": {
-                                    "functionName": "and",
+                                    "functionName": [
+                                      "and"
+                                    ],
                                     "arguments": [
                                       {
                                         "unresolvedAttribute": {
@@ -1947,6 +2113,7 @@
                                         }
                                       }
                                     ],
+                                    "namedArguments": [],
                                     "isDistinct": false,
                                     "isUserDefinedFunction": false,
                                     "ignoreNulls": null,
@@ -1963,6 +2130,7 @@
                                   }
                                 }
                               ],
+                              "namedArguments": [],
                               "isDistinct": false,
                               "isUserDefinedFunction": false,
                               "ignoreNulls": null,
@@ -1979,6 +2147,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -1995,6 +2164,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -2011,6 +2181,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2025,11 +2196,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "or",
+            "functionName": [
+              "or"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "and",
+                  "functionName": [
+                    "and"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -2048,6 +2223,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -2057,7 +2233,9 @@
               },
               {
                 "unresolvedFunction": {
-                  "functionName": "and",
+                  "functionName": [
+                    "and"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -2076,6 +2254,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -2084,6 +2263,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2447,11 +2627,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "regexp",
+                  "functionName": [
+                    "regexp"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -2469,6 +2653,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -2477,6 +2662,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2491,7 +2677,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "or",
+            "functionName": [
+              "or"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -2510,6 +2698,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2524,11 +2713,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "or",
+            "functionName": [
+              "or"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "or",
+                  "functionName": [
+                    "or"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -2547,6 +2740,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -2556,7 +2750,9 @@
               },
               {
                 "unresolvedFunction": {
-                  "functionName": "and",
+                  "functionName": [
+                    "and"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -2575,6 +2771,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -2583,6 +2780,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2597,23 +2795,33 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "or",
+            "functionName": [
+              "or"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": "or",
+                  "functionName": [
+                    "or"
+                  ],
                   "arguments": [
                     {
                       "unresolvedFunction": {
-                        "functionName": "or",
+                        "functionName": [
+                          "or"
+                        ],
                         "arguments": [
                           {
                             "unresolvedFunction": {
-                              "functionName": "or",
+                              "functionName": [
+                                "or"
+                              ],
                               "arguments": [
                                 {
                                   "unresolvedFunction": {
-                                    "functionName": "or",
+                                    "functionName": [
+                                      "or"
+                                    ],
                                     "arguments": [
                                       {
                                         "unresolvedAttribute": {
@@ -2632,6 +2840,7 @@
                                         }
                                       }
                                     ],
+                                    "namedArguments": [],
                                     "isDistinct": false,
                                     "isUserDefinedFunction": false,
                                     "ignoreNulls": null,
@@ -2648,6 +2857,7 @@
                                   }
                                 }
                               ],
+                              "namedArguments": [],
                               "isDistinct": false,
                               "isUserDefinedFunction": false,
                               "ignoreNulls": null,
@@ -2664,6 +2874,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -2680,6 +2891,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -2696,6 +2908,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2710,7 +2923,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "regexp",
+            "functionName": [
+              "regexp"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -2728,6 +2943,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2742,7 +2958,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "|",
+            "functionName": [
+              "|"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -2761,6 +2979,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -2777,8 +2996,11 @@
           "alias": {
             "expr": {
               "unresolvedFunction": {
-                "functionName": "a",
+                "functionName": [
+                  "a"
+                ],
                 "arguments": [],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -2927,7 +3149,9 @@
             },
             "extraction": {
               "unresolvedFunction": {
-                "functionName": "+",
+                "functionName": [
+                  "+"
+                ],
                 "arguments": [
                   {
                     "literal": {
@@ -2944,6 +3168,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -2998,7 +3223,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "count",
+            "functionName": [
+              "count"
+            ],
             "arguments": [
               {
                 "unresolvedStar": {
@@ -3013,6 +3240,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3025,31 +3253,204 @@
     {
       "input": "encode('abc', charset => 'utf' || '-8')",
       "output": {
-        "failure": "not implemented: named function arguments"
+        "success": {
+          "unresolvedFunction": {
+            "functionName": [
+              "encode"
+            ],
+            "arguments": [
+              {
+                "literal": {
+                  "utf8": {
+                    "value": "abc"
+                  }
+                }
+              }
+            ],
+            "namedArguments": [
+              [
+                "charset",
+                {
+                  "unresolvedFunction": {
+                    "functionName": [
+                      "concat"
+                    ],
+                    "arguments": [
+                      {
+                        "literal": {
+                          "utf8": {
+                            "value": "utf"
+                          }
+                        }
+                      },
+                      {
+                        "literal": {
+                          "utf8": {
+                            "value": "-8"
+                          }
+                        }
+                      }
+                    ],
+                    "namedArguments": [],
+                    "isDistinct": false,
+                    "isUserDefinedFunction": false,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": null
+                  }
+                }
+              ]
+            ],
+            "isDistinct": false,
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
+          }
+        }
       }
     },
     {
       "input": "encode('abc', charset => 'utf-8')",
       "output": {
-        "failure": "not implemented: named function arguments"
+        "success": {
+          "unresolvedFunction": {
+            "functionName": [
+              "encode"
+            ],
+            "arguments": [
+              {
+                "literal": {
+                  "utf8": {
+                    "value": "abc"
+                  }
+                }
+              }
+            ],
+            "namedArguments": [
+              [
+                "charset",
+                {
+                  "literal": {
+                    "utf8": {
+                      "value": "utf-8"
+                    }
+                  }
+                }
+              ]
+            ],
+            "isDistinct": false,
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
+          }
+        }
       }
     },
     {
       "input": "encode(charset => 'utf-8', 'abc')",
       "output": {
-        "failure": "not implemented: named function arguments"
+        "failure": "invalid argument: positional argument after named argument"
       }
     },
     {
       "input": "encode(value => 'abc', charset => 'utf-8')",
       "output": {
-        "failure": "not implemented: named function arguments"
+        "success": {
+          "unresolvedFunction": {
+            "functionName": [
+              "encode"
+            ],
+            "arguments": [],
+            "namedArguments": [
+              [
+                "value",
+                {
+                  "literal": {
+                    "utf8": {
+                      "value": "abc"
+                    }
+                  }
+                }
+              ],
+              [
+                "charset",
+                {
+                  "literal": {
+                    "utf8": {
+                      "value": "utf-8"
+                    }
+                  }
+                }
+              ]
+            ],
+            "isDistinct": false,
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
+          }
+        }
       }
     },
     {
       "input": "encode(value => ((select '1')), charset => 'utf-8')",
       "output": {
-        "failure": "not implemented: named function arguments"
+        "success": {
+          "unresolvedFunction": {
+            "functionName": [
+              "encode"
+            ],
+            "arguments": [],
+            "namedArguments": [
+              [
+                "value",
+                {
+                  "scalarSubquery": {
+                    "subquery": {
+                      "project": {
+                        "input": {
+                          "empty": {
+                            "produceOneRow": true
+                          },
+                          "planId": null,
+                          "sourceInfo": null
+                        },
+                        "expressions": [
+                          {
+                            "literal": {
+                              "utf8": {
+                                "value": "1"
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "planId": null,
+                      "sourceInfo": null
+                    }
+                  }
+                }
+              ],
+              [
+                "charset",
+                {
+                  "literal": {
+                    "utf8": {
+                      "value": "utf-8"
+                    }
+                  }
+                }
+              ]
+            ],
+            "isDistinct": false,
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
+          }
+        }
       }
     },
     {
@@ -3078,7 +3479,9 @@
                     },
                     "condition": {
                       "unresolvedFunction": {
-                        "functionName": "==",
+                        "functionName": [
+                          "=="
+                        ],
                         "arguments": [
                           {
                             "unresolvedAttribute": {
@@ -3099,6 +3502,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -3133,7 +3537,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "first",
+            "functionName": [
+              "first"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -3144,6 +3550,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": true,
@@ -3158,7 +3565,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "first",
+            "functionName": [
+              "first"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -3169,6 +3578,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3183,8 +3593,11 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "foo",
+            "functionName": [
+              "foo"
+            ],
             "arguments": [],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3199,7 +3612,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "foo",
+            "functionName": [
+              "foo"
+            ],
             "arguments": [
               {
                 "unresolvedStar": {
@@ -3214,6 +3629,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3235,7 +3651,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "foo",
+            "functionName": [
+              "foo"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -3254,6 +3672,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3268,7 +3687,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "foo",
+            "functionName": [
+              "foo"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -3287,6 +3708,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3301,7 +3723,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "foo",
+            "functionName": [
+              "foo"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -3320,6 +3744,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": true,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3332,7 +3757,21 @@
     {
       "input": "foo.bar()",
       "output": {
-        "failure": "not supported: qualified function name"
+        "success": {
+          "unresolvedFunction": {
+            "functionName": [
+              "foo",
+              "bar"
+            ],
+            "arguments": [],
+            "namedArguments": [],
+            "isDistinct": false,
+            "isUserDefinedFunction": false,
+            "ignoreNulls": null,
+            "filter": null,
+            "orderBy": null
+          }
+        }
       }
     },
     {
@@ -3340,7 +3779,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "grouping",
+            "functionName": [
+              "grouping"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -3359,6 +3800,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": true,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3373,7 +3815,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "last",
+            "functionName": [
+              "last"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -3384,6 +3828,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": true,
@@ -3398,7 +3843,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "last",
+            "functionName": [
+              "last"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -3409,6 +3856,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3423,7 +3871,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -3434,6 +3884,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3448,11 +3899,15 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "not",
+            "functionName": [
+              "not"
+            ],
             "arguments": [
               {
                 "unresolvedFunction": {
-                  "functionName": ">",
+                  "functionName": [
+                    ">"
+                  ],
                   "arguments": [
                     {
                       "literal": {
@@ -3469,6 +3924,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -3477,6 +3933,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3499,7 +3956,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "*",
+            "functionName": [
+              "*"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -3511,7 +3970,9 @@
               },
               {
                 "unresolvedFunction": {
-                  "functionName": "+",
+                  "functionName": [
+                    "+"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -3530,6 +3991,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -3538,6 +4000,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -3554,7 +4017,9 @@
           "unresolvedExtractValue": {
             "child": {
               "unresolvedFunction": {
-                "functionName": "struct",
+                "functionName": [
+                  "struct"
+                ],
                 "arguments": [
                   {
                     "unresolvedAttribute": {
@@ -3573,6 +4038,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -3611,7 +4077,9 @@
           "lambdaFunction": {
             "function": {
               "unresolvedFunction": {
-                "functionName": "+",
+                "functionName": [
+                  "+"
+                ],
                 "arguments": [
                   {
                     "unresolvedAttribute": {
@@ -3629,6 +4097,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -3674,7 +4143,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "~",
+            "functionName": [
+              "~"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -3685,6 +4156,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,

--- a/crates/sail-spark-connect/tests/gold_data/expression/numeric.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/numeric.json
@@ -5,7 +5,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "+",
+            "functionName": [
+              "+"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -16,6 +18,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -30,7 +33,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -42,6 +47,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -63,7 +69,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "literal": {
@@ -75,6 +83,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,
@@ -89,7 +98,9 @@
       "output": {
         "success": {
           "unresolvedFunction": {
-            "functionName": "-",
+            "functionName": [
+              "-"
+            ],
             "arguments": [
               {
                 "unresolvedAttribute": {
@@ -100,6 +111,7 @@
                 }
               }
             ],
+            "namedArguments": [],
             "isDistinct": false,
             "isUserDefinedFunction": false,
             "ignoreNulls": null,

--- a/crates/sail-spark-connect/tests/gold_data/expression/window.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/window.json
@@ -7,7 +7,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -22,6 +24,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -48,7 +51,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -63,6 +68,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -106,7 +112,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -121,6 +129,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -177,7 +186,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -192,6 +203,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -235,7 +247,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -250,6 +264,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -301,7 +316,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -316,6 +333,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -376,7 +394,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -391,6 +411,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -451,7 +472,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -466,6 +489,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -526,7 +550,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -541,6 +567,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -601,7 +628,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -616,6 +645,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -676,7 +706,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -691,6 +723,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -751,7 +784,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -766,6 +801,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -805,7 +841,9 @@
                   "lower": {
                     "value": {
                       "unresolvedFunction": {
-                        "functionName": "+",
+                        "functionName": [
+                          "+"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -822,6 +860,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -845,7 +884,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -860,6 +901,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -899,7 +941,9 @@
                   "lower": {
                     "value": {
                       "unresolvedFunction": {
-                        "functionName": "+",
+                        "functionName": [
+                          "+"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -916,6 +960,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -939,7 +984,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -954,6 +1001,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -1014,7 +1062,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -1029,6 +1079,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -1089,7 +1140,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -1104,6 +1157,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -1172,7 +1226,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -1187,6 +1243,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -1247,7 +1304,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -1262,6 +1321,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -1322,7 +1382,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -1337,6 +1399,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -1397,7 +1460,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -1412,6 +1477,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -1472,7 +1538,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -1487,6 +1555,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -1526,7 +1595,9 @@
                   "lower": {
                     "value": {
                       "unresolvedFunction": {
-                        "functionName": "+",
+                        "functionName": [
+                          "+"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -1543,6 +1614,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -1566,7 +1638,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -1581,6 +1655,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -1620,7 +1695,9 @@
                   "lower": {
                     "value": {
                       "unresolvedFunction": {
-                        "functionName": "+",
+                        "functionName": [
+                          "+"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -1637,6 +1714,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -1660,7 +1738,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -1675,6 +1755,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -1735,7 +1816,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -1750,6 +1833,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -1810,7 +1894,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -1825,6 +1911,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -1865,7 +1952,9 @@
                   "upper": {
                     "value": {
                       "unresolvedFunction": {
-                        "functionName": "+",
+                        "functionName": [
+                          "+"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -1882,6 +1971,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -1904,7 +1994,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -1919,6 +2011,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -1979,7 +2072,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -1994,6 +2089,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -2046,7 +2142,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -2061,6 +2159,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -2113,7 +2212,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -2128,6 +2229,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -2188,7 +2290,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -2203,6 +2307,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -2243,7 +2348,9 @@
                   "upper": {
                     "value": {
                       "unresolvedFunction": {
-                        "functionName": "+",
+                        "functionName": [
+                          "+"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -2260,6 +2367,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -2282,7 +2390,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -2297,6 +2407,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -2357,7 +2468,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -2372,6 +2485,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -2424,7 +2538,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -2439,6 +2555,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -2491,7 +2608,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -2506,6 +2625,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -2558,7 +2678,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -2573,6 +2695,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -2625,7 +2748,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -2640,6 +2765,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -2692,7 +2818,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -2707,6 +2835,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -2767,7 +2896,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -2782,6 +2913,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -2842,7 +2974,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -2857,6 +2991,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -2917,7 +3052,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -2932,6 +3069,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -2992,7 +3130,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -3007,6 +3147,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -3067,7 +3208,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -3082,6 +3225,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -3142,7 +3286,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -3157,6 +3303,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -3196,7 +3343,9 @@
                   "lower": {
                     "value": {
                       "unresolvedFunction": {
-                        "functionName": "+",
+                        "functionName": [
+                          "+"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -3213,6 +3362,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -3236,7 +3386,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -3251,6 +3403,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -3290,7 +3443,9 @@
                   "lower": {
                     "value": {
                       "unresolvedFunction": {
-                        "functionName": "+",
+                        "functionName": [
+                          "+"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -3307,6 +3462,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -3330,7 +3486,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -3345,6 +3503,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -3405,7 +3564,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -3420,6 +3581,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -3480,7 +3642,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -3495,6 +3659,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -3563,7 +3728,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -3578,6 +3745,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -3638,7 +3806,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -3653,6 +3823,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -3713,7 +3884,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -3728,6 +3901,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -3788,7 +3962,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -3803,6 +3979,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -3863,7 +4040,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -3878,6 +4057,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -3917,7 +4097,9 @@
                   "lower": {
                     "value": {
                       "unresolvedFunction": {
-                        "functionName": "+",
+                        "functionName": [
+                          "+"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -3934,6 +4116,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -3957,7 +4140,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -3972,6 +4157,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -4011,7 +4197,9 @@
                   "lower": {
                     "value": {
                       "unresolvedFunction": {
-                        "functionName": "+",
+                        "functionName": [
+                          "+"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -4028,6 +4216,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -4051,7 +4240,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -4066,6 +4257,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -4126,7 +4318,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -4141,6 +4335,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -4201,7 +4396,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -4216,6 +4413,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -4256,7 +4454,9 @@
                   "upper": {
                     "value": {
                       "unresolvedFunction": {
-                        "functionName": "+",
+                        "functionName": [
+                          "+"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -4273,6 +4473,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -4295,7 +4496,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -4310,6 +4513,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -4370,7 +4574,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -4385,6 +4591,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -4437,7 +4644,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -4452,6 +4661,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -4504,7 +4714,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -4519,6 +4731,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -4579,7 +4792,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -4594,6 +4809,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -4634,7 +4850,9 @@
                   "upper": {
                     "value": {
                       "unresolvedFunction": {
-                        "functionName": "+",
+                        "functionName": [
+                          "+"
+                        ],
                         "arguments": [
                           {
                             "literal": {
@@ -4651,6 +4869,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -4673,7 +4892,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -4688,6 +4909,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -4748,7 +4970,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -4763,6 +4987,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -4815,7 +5040,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -4830,6 +5057,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -4882,7 +5110,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -4897,6 +5127,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -4950,7 +5181,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -4965,6 +5198,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -5004,7 +5238,9 @@
                   "lower": {
                     "value": {
                       "unresolvedFunction": {
-                        "functionName": "exp",
+                        "functionName": [
+                          "exp"
+                        ],
                         "arguments": [
                           {
                             "unresolvedAttribute": {
@@ -5015,6 +5251,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -5038,7 +5275,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -5053,6 +5292,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -5105,7 +5345,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -5120,6 +5362,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -5172,7 +5415,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -5187,6 +5432,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -5243,7 +5489,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -5258,6 +5506,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -5301,7 +5550,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -5316,6 +5567,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -5367,7 +5619,9 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "foo",
+                "functionName": [
+                  "foo"
+                ],
                 "arguments": [
                   {
                     "unresolvedStar": {
@@ -5382,6 +5636,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -5403,11 +5658,15 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "sum",
+                "functionName": [
+                  "sum"
+                ],
                 "arguments": [
                   {
                     "unresolvedFunction": {
-                      "functionName": "+",
+                      "functionName": [
+                        "+"
+                      ],
                       "arguments": [
                         {
                           "unresolvedAttribute": {
@@ -5425,6 +5684,7 @@
                           }
                         }
                       ],
+                      "namedArguments": [],
                       "isDistinct": false,
                       "isUserDefinedFunction": false,
                       "ignoreNulls": null,
@@ -5433,6 +5693,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -5446,11 +5707,15 @@
                 "partitionBy": [
                   {
                     "unresolvedFunction": {
-                      "functionName": "+",
+                      "functionName": [
+                        "+"
+                      ],
                       "arguments": [
                         {
                           "unresolvedFunction": {
-                            "functionName": "/",
+                            "functionName": [
+                              "/"
+                            ],
                             "arguments": [
                               {
                                 "unresolvedAttribute": {
@@ -5468,6 +5733,7 @@
                                 }
                               }
                             ],
+                            "namedArguments": [],
                             "isDistinct": false,
                             "isUserDefinedFunction": false,
                             "ignoreNulls": null,
@@ -5483,6 +5749,7 @@
                           }
                         }
                       ],
+                      "namedArguments": [],
                       "isDistinct": false,
                       "isUserDefinedFunction": false,
                       "ignoreNulls": null,
@@ -5518,11 +5785,15 @@
           "window": {
             "windowFunction": {
               "unresolvedFunction": {
-                "functionName": "sum",
+                "functionName": [
+                  "sum"
+                ],
                 "arguments": [
                   {
                     "unresolvedFunction": {
-                      "functionName": "+",
+                      "functionName": [
+                        "+"
+                      ],
                       "arguments": [
                         {
                           "unresolvedAttribute": {
@@ -5540,6 +5811,7 @@
                           }
                         }
                       ],
+                      "namedArguments": [],
                       "isDistinct": false,
                       "isUserDefinedFunction": false,
                       "ignoreNulls": null,
@@ -5548,6 +5820,7 @@
                     }
                   }
                 ],
+                "namedArguments": [],
                 "isDistinct": false,
                 "isUserDefinedFunction": false,
                 "ignoreNulls": null,
@@ -5561,7 +5834,9 @@
                 "partitionBy": [
                   {
                     "unresolvedFunction": {
-                      "functionName": "+",
+                      "functionName": [
+                        "+"
+                      ],
                       "arguments": [
                         {
                           "unresolvedAttribute": {
@@ -5579,6 +5854,7 @@
                           }
                         }
                       ],
+                      "namedArguments": [],
                       "isDistinct": false,
                       "isUserDefinedFunction": false,
                       "ignoreNulls": null,

--- a/crates/sail-spark-connect/tests/gold_data/plan/ddl_delete_from.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/ddl_delete_from.json
@@ -36,7 +36,9 @@
               "tableAlias": "t",
               "condition": {
                 "unresolvedFunction": {
-                  "functionName": "==",
+                  "functionName": [
+                    "=="
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -55,6 +57,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,

--- a/crates/sail-spark-connect/tests/gold_data/plan/ddl_update.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/ddl_update.json
@@ -90,7 +90,9 @@
               ],
               "condition": {
                 "unresolvedFunction": {
-                  "functionName": "==",
+                  "functionName": [
+                    "=="
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -109,6 +111,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,

--- a/crates/sail-spark-connect/tests/gold_data/plan/error_order_by.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/error_order_by.json
@@ -41,11 +41,15 @@
                       },
                       "condition": {
                         "unresolvedFunction": {
-                          "functionName": ">",
+                          "functionName": [
+                            ">"
+                          ],
                           "arguments": [
                             {
                               "unresolvedFunction": {
-                                "functionName": "-",
+                                "functionName": [
+                                  "-"
+                                ],
                                 "arguments": [
                                   {
                                     "unresolvedAttribute": {
@@ -64,6 +68,7 @@
                                     }
                                   }
                                 ],
+                                "namedArguments": [],
                                 "isDistinct": false,
                                 "isUserDefinedFunction": false,
                                 "ignoreNulls": null,
@@ -79,6 +84,7 @@
                               }
                             }
                           ],
+                          "namedArguments": [],
                           "isDistinct": false,
                           "isUserDefinedFunction": false,
                           "ignoreNulls": null,
@@ -93,7 +99,9 @@
                   "grouping": [
                     {
                       "unresolvedFunction": {
-                        "functionName": "-",
+                        "functionName": [
+                          "-"
+                        ],
                         "arguments": [
                           {
                             "unresolvedAttribute": {
@@ -112,6 +120,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,

--- a/crates/sail-spark-connect/tests/gold_data/plan/plan_group_by.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/plan_group_by.json
@@ -67,7 +67,9 @@
                   "alias": {
                     "expr": {
                       "unresolvedFunction": {
-                        "functionName": "sum",
+                        "functionName": [
+                          "sum"
+                        ],
                         "arguments": [
                           {
                             "unresolvedAttribute": {
@@ -78,6 +80,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -171,7 +174,9 @@
                   "alias": {
                     "expr": {
                       "unresolvedFunction": {
-                        "functionName": "sum",
+                        "functionName": [
+                          "sum"
+                        ],
                         "arguments": [
                           {
                             "unresolvedAttribute": {
@@ -182,6 +187,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -269,7 +275,9 @@
                   "alias": {
                     "expr": {
                       "unresolvedFunction": {
-                        "functionName": "sum",
+                        "functionName": [
+                          "sum"
+                        ],
                         "arguments": [
                           {
                             "unresolvedAttribute": {
@@ -280,6 +288,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -367,7 +376,9 @@
                   "alias": {
                     "expr": {
                       "unresolvedFunction": {
-                        "functionName": "sum",
+                        "functionName": [
+                          "sum"
+                        ],
                         "arguments": [
                           {
                             "unresolvedAttribute": {
@@ -378,6 +389,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -465,7 +477,9 @@
                   "alias": {
                     "expr": {
                       "unresolvedFunction": {
-                        "functionName": "sum",
+                        "functionName": [
+                          "sum"
+                        ],
                         "arguments": [
                           {
                             "unresolvedAttribute": {
@@ -476,6 +490,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -576,7 +591,9 @@
                   "alias": {
                     "expr": {
                       "unresolvedFunction": {
-                        "functionName": "sum",
+                        "functionName": [
+                          "sum"
+                        ],
                         "arguments": [
                           {
                             "unresolvedAttribute": {
@@ -587,6 +604,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -674,7 +692,9 @@
                   "alias": {
                     "expr": {
                       "unresolvedFunction": {
-                        "functionName": "sum",
+                        "functionName": [
+                          "sum"
+                        ],
                         "arguments": [
                           {
                             "unresolvedAttribute": {
@@ -685,6 +705,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -772,7 +793,9 @@
                   "alias": {
                     "expr": {
                       "unresolvedFunction": {
-                        "functionName": "sum",
+                        "functionName": [
+                          "sum"
+                        ],
                         "arguments": [
                           {
                             "unresolvedAttribute": {
@@ -783,6 +806,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -849,7 +873,9 @@
               ],
               "having": {
                 "unresolvedFunction": {
-                  "functionName": ">",
+                  "functionName": [
+                    ">"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -895,6 +921,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,

--- a/crates/sail-spark-connect/tests/gold_data/plan/plan_join.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/plan_join.json
@@ -56,38 +56,42 @@
                         "planId": null,
                         "sourceInfo": null
                       },
-                      "joinCondition": {
-                        "unresolvedFunction": {
-                          "functionName": "==",
-                          "arguments": [
-                            {
-                              "unresolvedAttribute": {
-                                "name": [
-                                  "s1",
-                                  "id"
-                                ],
-                                "planId": null
+                      "joinType": "inner",
+                      "joinCriteria": {
+                        "on": {
+                          "unresolvedFunction": {
+                            "functionName": [
+                              "=="
+                            ],
+                            "arguments": [
+                              {
+                                "unresolvedAttribute": {
+                                  "name": [
+                                    "s1",
+                                    "id"
+                                  ],
+                                  "planId": null
+                                }
+                              },
+                              {
+                                "unresolvedAttribute": {
+                                  "name": [
+                                    "s2",
+                                    "id"
+                                  ],
+                                  "planId": null
+                                }
                               }
-                            },
-                            {
-                              "unresolvedAttribute": {
-                                "name": [
-                                  "s2",
-                                  "id"
-                                ],
-                                "planId": null
-                              }
-                            }
-                          ],
-                          "isDistinct": false,
-                          "isUserDefinedFunction": false,
-                          "ignoreNulls": null,
-                          "filter": null,
-                          "orderBy": null
+                            ],
+                            "namedArguments": [],
+                            "isDistinct": false,
+                            "isUserDefinedFunction": false,
+                            "ignoreNulls": null,
+                            "filter": null,
+                            "orderBy": null
+                          }
                         }
                       },
-                      "joinType": "inner",
-                      "usingColumns": [],
                       "joinDataType": null
                     },
                     "planId": null,
@@ -167,9 +171,8 @@
                             "planId": null,
                             "sourceInfo": null
                           },
-                          "joinCondition": null,
                           "joinType": "inner",
-                          "usingColumns": [],
+                          "joinCriteria": null,
                           "joinDataType": null
                         },
                         "planId": null,
@@ -190,9 +193,8 @@
                         "planId": null,
                         "sourceInfo": null
                       },
-                      "joinCondition": null,
                       "joinType": "inner",
-                      "usingColumns": [],
+                      "joinCriteria": null,
                       "joinDataType": null
                     },
                     "planId": null,
@@ -213,9 +215,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "rightOuter",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -246,14 +247,74 @@
       "input": "select * from a natural cross join b",
       "exception": "\n[INCOMPATIBLE_JOIN_TYPES] The join types NATURAL and CROSS are incompatible.(line 1, pos 16)\n\n== SQL ==\nselect * from a natural cross join b\n----------------^^^\n",
       "output": {
-        "failure": "not implemented: NATURAL JOIN"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "join": {
+                  "left": {
+                    "read": {
+                      "namedTable": {
+                        "name": [
+                          "a"
+                        ],
+                        "temporal": null,
+                        "sample": null,
+                        "options": []
+                      },
+                      "isStreaming": false
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "right": {
+                    "read": {
+                      "namedTable": {
+                        "name": [
+                          "b"
+                        ],
+                        "temporal": null,
+                        "sample": null,
+                        "options": []
+                      },
+                      "isStreaming": false
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "joinType": "cross",
+                  "joinCriteria": "natural",
+                  "joinDataType": null
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedStar": {
+                    "target": null,
+                    "wildcardOptions": {
+                      "ilikePattern": null,
+                      "excludeColumns": null,
+                      "exceptColumns": null,
+                      "replaceColumns": null,
+                      "renameColumns": null
+                    }
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "select * from a natural join b on a.id = b.id",
       "exception": "\n[PARSE_SYNTAX_ERROR] Syntax error at or near 'on'.(line 1, pos 31)\n\n== SQL ==\nselect * from a natural join b on a.id = b.id\n-------------------------------^^^\n",
       "output": {
-        "failure": "not implemented: NATURAL JOIN"
+        "failure": "invalid argument: NATURAL JOIN with criteria"
       }
     },
     {
@@ -302,36 +363,40 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": {
-                    "unresolvedFunction": {
-                      "functionName": "==",
-                      "arguments": [
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "a"
-                            ],
-                            "planId": null
+                  "joinType": "leftAnti",
+                  "joinCriteria": {
+                    "on": {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "=="
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null
+                            }
+                          },
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "b"
+                              ],
+                              "planId": null
+                            }
                           }
-                        },
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "b"
-                            ],
-                            "planId": null
-                          }
-                        }
-                      ],
-                      "isDistinct": false,
-                      "isUserDefinedFunction": false,
-                      "ignoreNulls": null,
-                      "filter": null,
-                      "orderBy": null
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
                     }
                   },
-                  "joinType": "leftAnti",
-                  "usingColumns": [],
                   "joinDataType": null
                 },
                 "planId": null,
@@ -396,12 +461,13 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "leftAnti",
-                  "usingColumns": [
-                    "a",
-                    "b"
-                  ],
+                  "joinCriteria": {
+                    "using": [
+                      "a",
+                      "b"
+                    ]
+                  },
                   "joinDataType": null
                 },
                 "planId": null,
@@ -474,9 +540,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "leftAnti",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -549,9 +614,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "cross",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -624,9 +688,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "fullOuter",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -699,9 +762,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "fullOuter",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -774,9 +836,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "inner",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -849,9 +910,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "inner",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -924,9 +984,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "leftAnti",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -999,9 +1058,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "leftOuter",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -1074,9 +1132,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "leftOuter",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -1149,9 +1206,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "leftSemi",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -1224,9 +1280,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "rightOuter",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -1299,9 +1354,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "rightOuter",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -1374,9 +1428,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "leftSemi",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -1455,36 +1508,40 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": {
-                    "unresolvedFunction": {
-                      "functionName": "==",
-                      "arguments": [
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "a"
-                            ],
-                            "planId": null
+                  "joinType": "fullOuter",
+                  "joinCriteria": {
+                    "on": {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "=="
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null
+                            }
+                          },
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "b"
+                              ],
+                              "planId": null
+                            }
                           }
-                        },
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "b"
-                            ],
-                            "planId": null
-                          }
-                        }
-                      ],
-                      "isDistinct": false,
-                      "isUserDefinedFunction": false,
-                      "ignoreNulls": null,
-                      "filter": null,
-                      "orderBy": null
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
                     }
                   },
-                  "joinType": "fullOuter",
-                  "usingColumns": [],
                   "joinDataType": null
                 },
                 "planId": null,
@@ -1549,12 +1606,13 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "fullOuter",
-                  "usingColumns": [
-                    "a",
-                    "b"
-                  ],
+                  "joinCriteria": {
+                    "using": [
+                      "a",
+                      "b"
+                    ]
+                  },
                   "joinDataType": null
                 },
                 "planId": null,
@@ -1627,36 +1685,40 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": {
-                    "unresolvedFunction": {
-                      "functionName": "==",
-                      "arguments": [
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "a"
-                            ],
-                            "planId": null
+                  "joinType": "fullOuter",
+                  "joinCriteria": {
+                    "on": {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "=="
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null
+                            }
+                          },
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "b"
+                              ],
+                              "planId": null
+                            }
                           }
-                        },
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "b"
-                            ],
-                            "planId": null
-                          }
-                        }
-                      ],
-                      "isDistinct": false,
-                      "isUserDefinedFunction": false,
-                      "ignoreNulls": null,
-                      "filter": null,
-                      "orderBy": null
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
                     }
                   },
-                  "joinType": "fullOuter",
-                  "usingColumns": [],
                   "joinDataType": null
                 },
                 "planId": null,
@@ -1721,12 +1783,13 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "fullOuter",
-                  "usingColumns": [
-                    "a",
-                    "b"
-                  ],
+                  "joinCriteria": {
+                    "using": [
+                      "a",
+                      "b"
+                    ]
+                  },
                   "joinDataType": null
                 },
                 "planId": null,
@@ -1805,36 +1868,40 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": {
-                    "unresolvedFunction": {
-                      "functionName": "==",
-                      "arguments": [
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "a"
-                            ],
-                            "planId": null
+                  "joinType": "inner",
+                  "joinCriteria": {
+                    "on": {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "=="
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null
+                            }
+                          },
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "b"
+                              ],
+                              "planId": null
+                            }
                           }
-                        },
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "b"
-                            ],
-                            "planId": null
-                          }
-                        }
-                      ],
-                      "isDistinct": false,
-                      "isUserDefinedFunction": false,
-                      "ignoreNulls": null,
-                      "filter": null,
-                      "orderBy": null
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
                     }
                   },
-                  "joinType": "inner",
-                  "usingColumns": [],
                   "joinDataType": null
                 },
                 "planId": null,
@@ -1899,12 +1966,13 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "inner",
-                  "usingColumns": [
-                    "a",
-                    "b"
-                  ],
+                  "joinCriteria": {
+                    "using": [
+                      "a",
+                      "b"
+                    ]
+                  },
                   "joinDataType": null
                 },
                 "planId": null,
@@ -1989,36 +2057,40 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": {
-                    "unresolvedFunction": {
-                      "functionName": "==",
-                      "arguments": [
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "a"
-                            ],
-                            "planId": null
+                  "joinType": "inner",
+                  "joinCriteria": {
+                    "on": {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "=="
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null
+                            }
+                          },
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "b"
+                              ],
+                              "planId": null
+                            }
                           }
-                        },
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "b"
-                            ],
-                            "planId": null
-                          }
-                        }
-                      ],
-                      "isDistinct": false,
-                      "isUserDefinedFunction": false,
-                      "ignoreNulls": null,
-                      "filter": null,
-                      "orderBy": null
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
                     }
                   },
-                  "joinType": "inner",
-                  "usingColumns": [],
                   "joinDataType": null
                 },
                 "planId": null,
@@ -2083,12 +2155,13 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "inner",
-                  "usingColumns": [
-                    "a",
-                    "b"
-                  ],
+                  "joinCriteria": {
+                    "using": [
+                      "a",
+                      "b"
+                    ]
+                  },
                   "joinDataType": null
                 },
                 "planId": null,
@@ -2161,36 +2234,40 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": {
-                    "unresolvedFunction": {
-                      "functionName": "==",
-                      "arguments": [
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "a"
-                            ],
-                            "planId": null
+                  "joinType": "leftAnti",
+                  "joinCriteria": {
+                    "on": {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "=="
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null
+                            }
+                          },
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "b"
+                              ],
+                              "planId": null
+                            }
                           }
-                        },
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "b"
-                            ],
-                            "planId": null
-                          }
-                        }
-                      ],
-                      "isDistinct": false,
-                      "isUserDefinedFunction": false,
-                      "ignoreNulls": null,
-                      "filter": null,
-                      "orderBy": null
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
                     }
                   },
-                  "joinType": "leftAnti",
-                  "usingColumns": [],
                   "joinDataType": null
                 },
                 "planId": null,
@@ -2255,12 +2332,13 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "leftAnti",
-                  "usingColumns": [
-                    "a",
-                    "b"
-                  ],
+                  "joinCriteria": {
+                    "using": [
+                      "a",
+                      "b"
+                    ]
+                  },
                   "joinDataType": null
                 },
                 "planId": null,
@@ -2339,36 +2417,40 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": {
-                    "unresolvedFunction": {
-                      "functionName": "==",
-                      "arguments": [
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "a"
-                            ],
-                            "planId": null
+                  "joinType": "leftOuter",
+                  "joinCriteria": {
+                    "on": {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "=="
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null
+                            }
+                          },
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "b"
+                              ],
+                              "planId": null
+                            }
                           }
-                        },
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "b"
-                            ],
-                            "planId": null
-                          }
-                        }
-                      ],
-                      "isDistinct": false,
-                      "isUserDefinedFunction": false,
-                      "ignoreNulls": null,
-                      "filter": null,
-                      "orderBy": null
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
                     }
                   },
-                  "joinType": "leftOuter",
-                  "usingColumns": [],
                   "joinDataType": null
                 },
                 "planId": null,
@@ -2433,12 +2515,13 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "leftOuter",
-                  "usingColumns": [
-                    "a",
-                    "b"
-                  ],
+                  "joinCriteria": {
+                    "using": [
+                      "a",
+                      "b"
+                    ]
+                  },
                   "joinDataType": null
                 },
                 "planId": null,
@@ -2517,36 +2600,40 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": {
-                    "unresolvedFunction": {
-                      "functionName": "==",
-                      "arguments": [
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "a"
-                            ],
-                            "planId": null
+                  "joinType": "leftOuter",
+                  "joinCriteria": {
+                    "on": {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "=="
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null
+                            }
+                          },
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "b"
+                              ],
+                              "planId": null
+                            }
                           }
-                        },
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "b"
-                            ],
-                            "planId": null
-                          }
-                        }
-                      ],
-                      "isDistinct": false,
-                      "isUserDefinedFunction": false,
-                      "ignoreNulls": null,
-                      "filter": null,
-                      "orderBy": null
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
                     }
                   },
-                  "joinType": "leftOuter",
-                  "usingColumns": [],
                   "joinDataType": null
                 },
                 "planId": null,
@@ -2611,12 +2698,13 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "leftOuter",
-                  "usingColumns": [
-                    "a",
-                    "b"
-                  ],
+                  "joinCriteria": {
+                    "using": [
+                      "a",
+                      "b"
+                    ]
+                  },
                   "joinDataType": null
                 },
                 "planId": null,
@@ -2689,36 +2777,40 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": {
-                    "unresolvedFunction": {
-                      "functionName": "==",
-                      "arguments": [
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "a"
-                            ],
-                            "planId": null
+                  "joinType": "leftSemi",
+                  "joinCriteria": {
+                    "on": {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "=="
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null
+                            }
+                          },
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "b"
+                              ],
+                              "planId": null
+                            }
                           }
-                        },
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "b"
-                            ],
-                            "planId": null
-                          }
-                        }
-                      ],
-                      "isDistinct": false,
-                      "isUserDefinedFunction": false,
-                      "ignoreNulls": null,
-                      "filter": null,
-                      "orderBy": null
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
                     }
                   },
-                  "joinType": "leftSemi",
-                  "usingColumns": [],
                   "joinDataType": null
                 },
                 "planId": null,
@@ -2783,12 +2875,13 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "leftSemi",
-                  "usingColumns": [
-                    "a",
-                    "b"
-                  ],
+                  "joinCriteria": {
+                    "using": [
+                      "a",
+                      "b"
+                    ]
+                  },
                   "joinDataType": null
                 },
                 "planId": null,
@@ -2861,36 +2954,40 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": {
-                    "unresolvedFunction": {
-                      "functionName": "==",
-                      "arguments": [
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "a"
-                            ],
-                            "planId": null
+                  "joinType": "rightOuter",
+                  "joinCriteria": {
+                    "on": {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "=="
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null
+                            }
+                          },
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "b"
+                              ],
+                              "planId": null
+                            }
                           }
-                        },
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "b"
-                            ],
-                            "planId": null
-                          }
-                        }
-                      ],
-                      "isDistinct": false,
-                      "isUserDefinedFunction": false,
-                      "ignoreNulls": null,
-                      "filter": null,
-                      "orderBy": null
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
                     }
                   },
-                  "joinType": "rightOuter",
-                  "usingColumns": [],
                   "joinDataType": null
                 },
                 "planId": null,
@@ -2955,12 +3052,13 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "rightOuter",
-                  "usingColumns": [
-                    "a",
-                    "b"
-                  ],
+                  "joinCriteria": {
+                    "using": [
+                      "a",
+                      "b"
+                    ]
+                  },
                   "joinDataType": null
                 },
                 "planId": null,
@@ -3033,36 +3131,40 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": {
-                    "unresolvedFunction": {
-                      "functionName": "==",
-                      "arguments": [
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "a"
-                            ],
-                            "planId": null
+                  "joinType": "rightOuter",
+                  "joinCriteria": {
+                    "on": {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "=="
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null
+                            }
+                          },
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "b"
+                              ],
+                              "planId": null
+                            }
                           }
-                        },
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "b"
-                            ],
-                            "planId": null
-                          }
-                        }
-                      ],
-                      "isDistinct": false,
-                      "isUserDefinedFunction": false,
-                      "ignoreNulls": null,
-                      "filter": null,
-                      "orderBy": null
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
                     }
                   },
-                  "joinType": "rightOuter",
-                  "usingColumns": [],
                   "joinDataType": null
                 },
                 "planId": null,
@@ -3127,12 +3229,13 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "rightOuter",
-                  "usingColumns": [
-                    "a",
-                    "b"
-                  ],
+                  "joinCriteria": {
+                    "using": [
+                      "a",
+                      "b"
+                    ]
+                  },
                   "joinDataType": null
                 },
                 "planId": null,
@@ -3205,36 +3308,40 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": {
-                    "unresolvedFunction": {
-                      "functionName": "==",
-                      "arguments": [
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "a"
-                            ],
-                            "planId": null
+                  "joinType": "leftSemi",
+                  "joinCriteria": {
+                    "on": {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "=="
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null
+                            }
+                          },
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "b"
+                              ],
+                              "planId": null
+                            }
                           }
-                        },
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "b"
-                            ],
-                            "planId": null
-                          }
-                        }
-                      ],
-                      "isDistinct": false,
-                      "isUserDefinedFunction": false,
-                      "ignoreNulls": null,
-                      "filter": null,
-                      "orderBy": null
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
                     }
                   },
-                  "joinType": "leftSemi",
-                  "usingColumns": [],
                   "joinDataType": null
                 },
                 "planId": null,
@@ -3299,12 +3406,13 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "leftSemi",
-                  "usingColumns": [
-                    "a",
-                    "b"
-                  ],
+                  "joinCriteria": {
+                    "using": [
+                      "a",
+                      "b"
+                    ]
+                  },
                   "joinDataType": null
                 },
                 "planId": null,
@@ -3334,49 +3442,657 @@
     {
       "input": "select * from t tt natural full join u as uu",
       "output": {
-        "failure": "not implemented: NATURAL JOIN"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "join": {
+                  "left": {
+                    "tableAlias": {
+                      "input": {
+                        "read": {
+                          "namedTable": {
+                            "name": [
+                              "t"
+                            ],
+                            "temporal": null,
+                            "sample": null,
+                            "options": []
+                          },
+                          "isStreaming": false
+                        },
+                        "planId": null,
+                        "sourceInfo": null
+                      },
+                      "name": "tt",
+                      "columns": []
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "right": {
+                    "tableAlias": {
+                      "input": {
+                        "read": {
+                          "namedTable": {
+                            "name": [
+                              "u"
+                            ],
+                            "temporal": null,
+                            "sample": null,
+                            "options": []
+                          },
+                          "isStreaming": false
+                        },
+                        "planId": null,
+                        "sourceInfo": null
+                      },
+                      "name": "uu",
+                      "columns": []
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "joinType": "fullOuter",
+                  "joinCriteria": "natural",
+                  "joinDataType": null
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedStar": {
+                    "target": null,
+                    "wildcardOptions": {
+                      "ilikePattern": null,
+                      "excludeColumns": null,
+                      "exceptColumns": null,
+                      "replaceColumns": null,
+                      "renameColumns": null
+                    }
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "select * from t tt natural full outer join u as uu",
       "output": {
-        "failure": "not implemented: NATURAL JOIN"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "join": {
+                  "left": {
+                    "tableAlias": {
+                      "input": {
+                        "read": {
+                          "namedTable": {
+                            "name": [
+                              "t"
+                            ],
+                            "temporal": null,
+                            "sample": null,
+                            "options": []
+                          },
+                          "isStreaming": false
+                        },
+                        "planId": null,
+                        "sourceInfo": null
+                      },
+                      "name": "tt",
+                      "columns": []
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "right": {
+                    "tableAlias": {
+                      "input": {
+                        "read": {
+                          "namedTable": {
+                            "name": [
+                              "u"
+                            ],
+                            "temporal": null,
+                            "sample": null,
+                            "options": []
+                          },
+                          "isStreaming": false
+                        },
+                        "planId": null,
+                        "sourceInfo": null
+                      },
+                      "name": "uu",
+                      "columns": []
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "joinType": "fullOuter",
+                  "joinCriteria": "natural",
+                  "joinDataType": null
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedStar": {
+                    "target": null,
+                    "wildcardOptions": {
+                      "ilikePattern": null,
+                      "excludeColumns": null,
+                      "exceptColumns": null,
+                      "replaceColumns": null,
+                      "renameColumns": null
+                    }
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "select * from t tt natural inner join u as uu",
       "output": {
-        "failure": "not implemented: NATURAL JOIN"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "join": {
+                  "left": {
+                    "tableAlias": {
+                      "input": {
+                        "read": {
+                          "namedTable": {
+                            "name": [
+                              "t"
+                            ],
+                            "temporal": null,
+                            "sample": null,
+                            "options": []
+                          },
+                          "isStreaming": false
+                        },
+                        "planId": null,
+                        "sourceInfo": null
+                      },
+                      "name": "tt",
+                      "columns": []
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "right": {
+                    "tableAlias": {
+                      "input": {
+                        "read": {
+                          "namedTable": {
+                            "name": [
+                              "u"
+                            ],
+                            "temporal": null,
+                            "sample": null,
+                            "options": []
+                          },
+                          "isStreaming": false
+                        },
+                        "planId": null,
+                        "sourceInfo": null
+                      },
+                      "name": "uu",
+                      "columns": []
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "joinType": "inner",
+                  "joinCriteria": "natural",
+                  "joinDataType": null
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedStar": {
+                    "target": null,
+                    "wildcardOptions": {
+                      "ilikePattern": null,
+                      "excludeColumns": null,
+                      "exceptColumns": null,
+                      "replaceColumns": null,
+                      "renameColumns": null
+                    }
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "select * from t tt natural join u as uu",
       "output": {
-        "failure": "not implemented: NATURAL JOIN"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "join": {
+                  "left": {
+                    "tableAlias": {
+                      "input": {
+                        "read": {
+                          "namedTable": {
+                            "name": [
+                              "t"
+                            ],
+                            "temporal": null,
+                            "sample": null,
+                            "options": []
+                          },
+                          "isStreaming": false
+                        },
+                        "planId": null,
+                        "sourceInfo": null
+                      },
+                      "name": "tt",
+                      "columns": []
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "right": {
+                    "tableAlias": {
+                      "input": {
+                        "read": {
+                          "namedTable": {
+                            "name": [
+                              "u"
+                            ],
+                            "temporal": null,
+                            "sample": null,
+                            "options": []
+                          },
+                          "isStreaming": false
+                        },
+                        "planId": null,
+                        "sourceInfo": null
+                      },
+                      "name": "uu",
+                      "columns": []
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "joinType": "inner",
+                  "joinCriteria": "natural",
+                  "joinDataType": null
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedStar": {
+                    "target": null,
+                    "wildcardOptions": {
+                      "ilikePattern": null,
+                      "excludeColumns": null,
+                      "exceptColumns": null,
+                      "replaceColumns": null,
+                      "renameColumns": null
+                    }
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "select * from t tt natural left join u as uu",
       "output": {
-        "failure": "not implemented: NATURAL JOIN"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "join": {
+                  "left": {
+                    "tableAlias": {
+                      "input": {
+                        "read": {
+                          "namedTable": {
+                            "name": [
+                              "t"
+                            ],
+                            "temporal": null,
+                            "sample": null,
+                            "options": []
+                          },
+                          "isStreaming": false
+                        },
+                        "planId": null,
+                        "sourceInfo": null
+                      },
+                      "name": "tt",
+                      "columns": []
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "right": {
+                    "tableAlias": {
+                      "input": {
+                        "read": {
+                          "namedTable": {
+                            "name": [
+                              "u"
+                            ],
+                            "temporal": null,
+                            "sample": null,
+                            "options": []
+                          },
+                          "isStreaming": false
+                        },
+                        "planId": null,
+                        "sourceInfo": null
+                      },
+                      "name": "uu",
+                      "columns": []
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "joinType": "leftOuter",
+                  "joinCriteria": "natural",
+                  "joinDataType": null
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedStar": {
+                    "target": null,
+                    "wildcardOptions": {
+                      "ilikePattern": null,
+                      "excludeColumns": null,
+                      "exceptColumns": null,
+                      "replaceColumns": null,
+                      "renameColumns": null
+                    }
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "select * from t tt natural left outer join u as uu",
       "output": {
-        "failure": "not implemented: NATURAL JOIN"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "join": {
+                  "left": {
+                    "tableAlias": {
+                      "input": {
+                        "read": {
+                          "namedTable": {
+                            "name": [
+                              "t"
+                            ],
+                            "temporal": null,
+                            "sample": null,
+                            "options": []
+                          },
+                          "isStreaming": false
+                        },
+                        "planId": null,
+                        "sourceInfo": null
+                      },
+                      "name": "tt",
+                      "columns": []
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "right": {
+                    "tableAlias": {
+                      "input": {
+                        "read": {
+                          "namedTable": {
+                            "name": [
+                              "u"
+                            ],
+                            "temporal": null,
+                            "sample": null,
+                            "options": []
+                          },
+                          "isStreaming": false
+                        },
+                        "planId": null,
+                        "sourceInfo": null
+                      },
+                      "name": "uu",
+                      "columns": []
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "joinType": "leftOuter",
+                  "joinCriteria": "natural",
+                  "joinDataType": null
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedStar": {
+                    "target": null,
+                    "wildcardOptions": {
+                      "ilikePattern": null,
+                      "excludeColumns": null,
+                      "exceptColumns": null,
+                      "replaceColumns": null,
+                      "renameColumns": null
+                    }
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "select * from t tt natural right join u as uu",
       "output": {
-        "failure": "not implemented: NATURAL JOIN"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "join": {
+                  "left": {
+                    "tableAlias": {
+                      "input": {
+                        "read": {
+                          "namedTable": {
+                            "name": [
+                              "t"
+                            ],
+                            "temporal": null,
+                            "sample": null,
+                            "options": []
+                          },
+                          "isStreaming": false
+                        },
+                        "planId": null,
+                        "sourceInfo": null
+                      },
+                      "name": "tt",
+                      "columns": []
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "right": {
+                    "tableAlias": {
+                      "input": {
+                        "read": {
+                          "namedTable": {
+                            "name": [
+                              "u"
+                            ],
+                            "temporal": null,
+                            "sample": null,
+                            "options": []
+                          },
+                          "isStreaming": false
+                        },
+                        "planId": null,
+                        "sourceInfo": null
+                      },
+                      "name": "uu",
+                      "columns": []
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "joinType": "rightOuter",
+                  "joinCriteria": "natural",
+                  "joinDataType": null
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedStar": {
+                    "target": null,
+                    "wildcardOptions": {
+                      "ilikePattern": null,
+                      "excludeColumns": null,
+                      "exceptColumns": null,
+                      "replaceColumns": null,
+                      "renameColumns": null
+                    }
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "select * from t tt natural right outer join u as uu",
       "output": {
-        "failure": "not implemented: NATURAL JOIN"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "join": {
+                  "left": {
+                    "tableAlias": {
+                      "input": {
+                        "read": {
+                          "namedTable": {
+                            "name": [
+                              "t"
+                            ],
+                            "temporal": null,
+                            "sample": null,
+                            "options": []
+                          },
+                          "isStreaming": false
+                        },
+                        "planId": null,
+                        "sourceInfo": null
+                      },
+                      "name": "tt",
+                      "columns": []
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "right": {
+                    "tableAlias": {
+                      "input": {
+                        "read": {
+                          "namedTable": {
+                            "name": [
+                              "u"
+                            ],
+                            "temporal": null,
+                            "sample": null,
+                            "options": []
+                          },
+                          "isStreaming": false
+                        },
+                        "planId": null,
+                        "sourceInfo": null
+                      },
+                      "name": "uu",
+                      "columns": []
+                    },
+                    "planId": null,
+                    "sourceInfo": null
+                  },
+                  "joinType": "rightOuter",
+                  "joinCriteria": "natural",
+                  "joinDataType": null
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedStar": {
+                    "target": null,
+                    "wildcardOptions": {
+                      "ilikePattern": null,
+                      "excludeColumns": null,
+                      "exceptColumns": null,
+                      "replaceColumns": null,
+                      "renameColumns": null
+                    }
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
@@ -3419,9 +4135,8 @@
                         "planId": null,
                         "sourceInfo": null
                       },
-                      "joinCondition": null,
                       "joinType": "inner",
-                      "usingColumns": [],
+                      "joinCriteria": null,
                       "joinDataType": null
                     },
                     "planId": null,
@@ -3459,46 +4174,49 @@
                         "planId": null,
                         "sourceInfo": null
                       },
-                      "joinCondition": {
-                        "unresolvedFunction": {
-                          "functionName": "==",
-                          "arguments": [
-                            {
-                              "unresolvedAttribute": {
-                                "name": [
-                                  "t1",
-                                  "col1"
-                                ],
-                                "planId": null
+                      "joinType": "inner",
+                      "joinCriteria": {
+                        "on": {
+                          "unresolvedFunction": {
+                            "functionName": [
+                              "=="
+                            ],
+                            "arguments": [
+                              {
+                                "unresolvedAttribute": {
+                                  "name": [
+                                    "t1",
+                                    "col1"
+                                  ],
+                                  "planId": null
+                                }
+                              },
+                              {
+                                "unresolvedAttribute": {
+                                  "name": [
+                                    "t2",
+                                    "col2"
+                                  ],
+                                  "planId": null
+                                }
                               }
-                            },
-                            {
-                              "unresolvedAttribute": {
-                                "name": [
-                                  "t2",
-                                  "col2"
-                                ],
-                                "planId": null
-                              }
-                            }
-                          ],
-                          "isDistinct": false,
-                          "isUserDefinedFunction": false,
-                          "ignoreNulls": null,
-                          "filter": null,
-                          "orderBy": null
+                            ],
+                            "namedArguments": [],
+                            "isDistinct": false,
+                            "isUserDefinedFunction": false,
+                            "ignoreNulls": null,
+                            "filter": null,
+                            "orderBy": null
+                          }
                         }
                       },
-                      "joinType": "inner",
-                      "usingColumns": [],
                       "joinDataType": null
                     },
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "cross",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -3567,9 +4285,8 @@
                             "planId": null,
                             "sourceInfo": null
                           },
-                          "joinCondition": null,
                           "joinType": "cross",
-                          "usingColumns": [],
+                          "joinCriteria": null,
                           "joinDataType": null
                         },
                         "planId": null,
@@ -3590,38 +4307,42 @@
                         "planId": null,
                         "sourceInfo": null
                       },
-                      "joinCondition": {
-                        "unresolvedFunction": {
-                          "functionName": "==",
-                          "arguments": [
-                            {
-                              "unresolvedAttribute": {
-                                "name": [
-                                  "t3",
-                                  "id"
-                                ],
-                                "planId": null
+                      "joinType": "inner",
+                      "joinCriteria": {
+                        "on": {
+                          "unresolvedFunction": {
+                            "functionName": [
+                              "=="
+                            ],
+                            "arguments": [
+                              {
+                                "unresolvedAttribute": {
+                                  "name": [
+                                    "t3",
+                                    "id"
+                                  ],
+                                  "planId": null
+                                }
+                              },
+                              {
+                                "unresolvedAttribute": {
+                                  "name": [
+                                    "t1",
+                                    "id"
+                                  ],
+                                  "planId": null
+                                }
                               }
-                            },
-                            {
-                              "unresolvedAttribute": {
-                                "name": [
-                                  "t1",
-                                  "id"
-                                ],
-                                "planId": null
-                              }
-                            }
-                          ],
-                          "isDistinct": false,
-                          "isUserDefinedFunction": false,
-                          "ignoreNulls": null,
-                          "filter": null,
-                          "orderBy": null
+                            ],
+                            "namedArguments": [],
+                            "isDistinct": false,
+                            "isUserDefinedFunction": false,
+                            "ignoreNulls": null,
+                            "filter": null,
+                            "orderBy": null
+                          }
                         }
                       },
-                      "joinType": "inner",
-                      "usingColumns": [],
                       "joinDataType": null
                     },
                     "planId": null,
@@ -3642,38 +4363,42 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": {
-                    "unresolvedFunction": {
-                      "functionName": "==",
-                      "arguments": [
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "t4",
-                              "id"
-                            ],
-                            "planId": null
+                  "joinType": "inner",
+                  "joinCriteria": {
+                    "on": {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "=="
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "t4",
+                                "id"
+                              ],
+                              "planId": null
+                            }
+                          },
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "t1",
+                                "id"
+                              ],
+                              "planId": null
+                            }
                           }
-                        },
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "t1",
-                              "id"
-                            ],
-                            "planId": null
-                          }
-                        }
-                      ],
-                      "isDistinct": false,
-                      "isUserDefinedFunction": false,
-                      "ignoreNulls": null,
-                      "filter": null,
-                      "orderBy": null
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
                     }
                   },
-                  "joinType": "inner",
-                  "usingColumns": [],
                   "joinDataType": null
                 },
                 "planId": null,
@@ -3755,44 +4480,47 @@
                         "planId": null,
                         "sourceInfo": null
                       },
-                      "joinCondition": {
-                        "unresolvedFunction": {
-                          "functionName": "==",
-                          "arguments": [
-                            {
-                              "unresolvedAttribute": {
-                                "name": [
-                                  "col3"
-                                ],
-                                "planId": null
+                      "joinType": "inner",
+                      "joinCriteria": {
+                        "on": {
+                          "unresolvedFunction": {
+                            "functionName": [
+                              "=="
+                            ],
+                            "arguments": [
+                              {
+                                "unresolvedAttribute": {
+                                  "name": [
+                                    "col3"
+                                  ],
+                                  "planId": null
+                                }
+                              },
+                              {
+                                "unresolvedAttribute": {
+                                  "name": [
+                                    "col2"
+                                  ],
+                                  "planId": null
+                                }
                               }
-                            },
-                            {
-                              "unresolvedAttribute": {
-                                "name": [
-                                  "col2"
-                                ],
-                                "planId": null
-                              }
-                            }
-                          ],
-                          "isDistinct": false,
-                          "isUserDefinedFunction": false,
-                          "ignoreNulls": null,
-                          "filter": null,
-                          "orderBy": null
+                            ],
+                            "namedArguments": [],
+                            "isDistinct": false,
+                            "isUserDefinedFunction": false,
+                            "ignoreNulls": null,
+                            "filter": null,
+                            "orderBy": null
+                          }
                         }
                       },
-                      "joinType": "inner",
-                      "usingColumns": [],
                       "joinDataType": null
                     },
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "inner",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -3874,71 +4602,79 @@
                         "planId": null,
                         "sourceInfo": null
                       },
-                      "joinCondition": {
-                        "unresolvedFunction": {
-                          "functionName": "==",
-                          "arguments": [
-                            {
-                              "unresolvedAttribute": {
-                                "name": [
-                                  "col3"
-                                ],
-                                "planId": null
+                      "joinType": "inner",
+                      "joinCriteria": {
+                        "on": {
+                          "unresolvedFunction": {
+                            "functionName": [
+                              "=="
+                            ],
+                            "arguments": [
+                              {
+                                "unresolvedAttribute": {
+                                  "name": [
+                                    "col3"
+                                  ],
+                                  "planId": null
+                                }
+                              },
+                              {
+                                "unresolvedAttribute": {
+                                  "name": [
+                                    "col2"
+                                  ],
+                                  "planId": null
+                                }
                               }
-                            },
-                            {
-                              "unresolvedAttribute": {
-                                "name": [
-                                  "col2"
-                                ],
-                                "planId": null
-                              }
-                            }
-                          ],
-                          "isDistinct": false,
-                          "isUserDefinedFunction": false,
-                          "ignoreNulls": null,
-                          "filter": null,
-                          "orderBy": null
+                            ],
+                            "namedArguments": [],
+                            "isDistinct": false,
+                            "isUserDefinedFunction": false,
+                            "ignoreNulls": null,
+                            "filter": null,
+                            "orderBy": null
+                          }
                         }
                       },
-                      "joinType": "inner",
-                      "usingColumns": [],
                       "joinDataType": null
                     },
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": {
-                    "unresolvedFunction": {
-                      "functionName": "==",
-                      "arguments": [
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "col3"
-                            ],
-                            "planId": null
+                  "joinType": "inner",
+                  "joinCriteria": {
+                    "on": {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "=="
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "col3"
+                              ],
+                              "planId": null
+                            }
+                          },
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "col1"
+                              ],
+                              "planId": null
+                            }
                           }
-                        },
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "col1"
-                            ],
-                            "planId": null
-                          }
-                        }
-                      ],
-                      "isDistinct": false,
-                      "isUserDefinedFunction": false,
-                      "ignoreNulls": null,
-                      "filter": null,
-                      "orderBy": null
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
                     }
                   },
-                  "joinType": "inner",
-                  "usingColumns": [],
                   "joinDataType": null
                 },
                 "planId": null,
@@ -4020,44 +4756,47 @@
                         "planId": null,
                         "sourceInfo": null
                       },
-                      "joinCondition": null,
                       "joinType": "inner",
-                      "usingColumns": [],
+                      "joinCriteria": null,
                       "joinDataType": null
                     },
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": {
-                    "unresolvedFunction": {
-                      "functionName": "==",
-                      "arguments": [
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "col3"
-                            ],
-                            "planId": null
+                  "joinType": "inner",
+                  "joinCriteria": {
+                    "on": {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "=="
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "col3"
+                              ],
+                              "planId": null
+                            }
+                          },
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "col2"
+                              ],
+                              "planId": null
+                            }
                           }
-                        },
-                        {
-                          "unresolvedAttribute": {
-                            "name": [
-                              "col2"
-                            ],
-                            "planId": null
-                          }
-                        }
-                      ],
-                      "isDistinct": false,
-                      "isUserDefinedFunction": false,
-                      "ignoreNulls": null,
-                      "filter": null,
-                      "orderBy": null
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
                     }
                   },
-                  "joinType": "inner",
-                  "usingColumns": [],
                   "joinDataType": null
                 },
                 "planId": null,
@@ -4146,46 +4885,49 @@
                         "planId": null,
                         "sourceInfo": null
                       },
-                      "joinCondition": {
-                        "unresolvedFunction": {
-                          "functionName": "==",
-                          "arguments": [
-                            {
-                              "unresolvedAttribute": {
-                                "name": [
-                                  "t1",
-                                  "col1"
-                                ],
-                                "planId": null
+                      "joinType": "inner",
+                      "joinCriteria": {
+                        "on": {
+                          "unresolvedFunction": {
+                            "functionName": [
+                              "=="
+                            ],
+                            "arguments": [
+                              {
+                                "unresolvedAttribute": {
+                                  "name": [
+                                    "t1",
+                                    "col1"
+                                  ],
+                                  "planId": null
+                                }
+                              },
+                              {
+                                "unresolvedAttribute": {
+                                  "name": [
+                                    "t2",
+                                    "col2"
+                                  ],
+                                  "planId": null
+                                }
                               }
-                            },
-                            {
-                              "unresolvedAttribute": {
-                                "name": [
-                                  "t2",
-                                  "col2"
-                                ],
-                                "planId": null
-                              }
-                            }
-                          ],
-                          "isDistinct": false,
-                          "isUserDefinedFunction": false,
-                          "ignoreNulls": null,
-                          "filter": null,
-                          "orderBy": null
+                            ],
+                            "namedArguments": [],
+                            "isDistinct": false,
+                            "isUserDefinedFunction": false,
+                            "ignoreNulls": null,
+                            "filter": null,
+                            "orderBy": null
+                          }
                         }
                       },
-                      "joinType": "inner",
-                      "usingColumns": [],
                       "joinDataType": null
                     },
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "cross",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,

--- a/crates/sail-spark-connect/tests/gold_data/plan/plan_order_by.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/plan_order_by.json
@@ -16,7 +16,9 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "PERCENTILE_CONT",
+                    "functionName": [
+                      "PERCENTILE_CONT"
+                    ],
                     "arguments": [
                       {
                         "literal": {
@@ -28,6 +30,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
@@ -72,7 +75,9 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "PERCENTILE_CONT",
+                    "functionName": [
+                      "PERCENTILE_CONT"
+                    ],
                     "arguments": [
                       {
                         "literal": {
@@ -84,6 +89,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
@@ -128,7 +134,9 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "PERCENTILE_CONT",
+                    "functionName": [
+                      "PERCENTILE_CONT"
+                    ],
                     "arguments": [
                       {
                         "literal": {
@@ -140,12 +148,15 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
                     "filter": {
                       "unresolvedFunction": {
-                        "functionName": ">",
+                        "functionName": [
+                          ">"
+                        ],
                         "arguments": [
                           {
                             "unresolvedAttribute": {
@@ -163,6 +174,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,
@@ -210,7 +222,9 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "PERCENTILE_DISC",
+                    "functionName": [
+                      "PERCENTILE_DISC"
+                    ],
                     "arguments": [
                       {
                         "literal": {
@@ -222,6 +236,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
@@ -266,7 +281,9 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "PERCENTILE_DISC",
+                    "functionName": [
+                      "PERCENTILE_DISC"
+                    ],
                     "arguments": [
                       {
                         "literal": {
@@ -278,6 +295,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
@@ -322,7 +340,9 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "PERCENTILE_DISC",
+                    "functionName": [
+                      "PERCENTILE_DISC"
+                    ],
                     "arguments": [
                       {
                         "literal": {
@@ -334,12 +354,15 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
                     "filter": {
                       "unresolvedFunction": {
-                        "functionName": ">",
+                        "functionName": [
+                          ">"
+                        ],
                         "arguments": [
                           {
                             "unresolvedAttribute": {
@@ -357,6 +380,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "isDistinct": false,
                         "isUserDefinedFunction": false,
                         "ignoreNulls": null,

--- a/crates/sail-spark-connect/tests/gold_data/plan/plan_select.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/plan_select.json
@@ -403,8 +403,11 @@
                                 "expressions": [
                                   {
                                     "unresolvedFunction": {
-                                      "functionName": "current_date",
+                                      "functionName": [
+                                        "current_date"
+                                      ],
                                       "arguments": [],
+                                      "namedArguments": [],
                                       "isDistinct": false,
                                       "isUserDefinedFunction": false,
                                       "ignoreNulls": null,
@@ -468,8 +471,11 @@
                       "timestamp": {
                         "value": {
                           "unresolvedFunction": {
-                            "functionName": "current_date",
+                            "functionName": [
+                              "current_date"
+                            ],
                             "arguments": [],
+                            "namedArguments": [],
                             "isDistinct": false,
                             "isUserDefinedFunction": false,
                             "ignoreNulls": null,
@@ -700,8 +706,11 @@
                                 "expressions": [
                                   {
                                     "unresolvedFunction": {
-                                      "functionName": "current_date",
+                                      "functionName": [
+                                        "current_date"
+                                      ],
                                       "arguments": [],
+                                      "namedArguments": [],
                                       "isDistinct": false,
                                       "isUserDefinedFunction": false,
                                       "ignoreNulls": null,
@@ -765,8 +774,11 @@
                       "timestamp": {
                         "value": {
                           "unresolvedFunction": {
-                            "functionName": "current_date",
+                            "functionName": [
+                              "current_date"
+                            ],
                             "arguments": [],
+                            "namedArguments": [],
                             "isDistinct": false,
                             "isUserDefinedFunction": false,
                             "ignoreNulls": null,
@@ -997,8 +1009,11 @@
                                 "expressions": [
                                   {
                                     "unresolvedFunction": {
-                                      "functionName": "current_date",
+                                      "functionName": [
+                                        "current_date"
+                                      ],
                                       "arguments": [],
+                                      "namedArguments": [],
                                       "isDistinct": false,
                                       "isUserDefinedFunction": false,
                                       "ignoreNulls": null,
@@ -1062,8 +1077,11 @@
                       "timestamp": {
                         "value": {
                           "unresolvedFunction": {
-                            "functionName": "current_date",
+                            "functionName": [
+                              "current_date"
+                            ],
                             "arguments": [],
+                            "namedArguments": [],
                             "isDistinct": false,
                             "isUserDefinedFunction": false,
                             "ignoreNulls": null,
@@ -1294,8 +1312,11 @@
                                 "expressions": [
                                   {
                                     "unresolvedFunction": {
-                                      "functionName": "current_date",
+                                      "functionName": [
+                                        "current_date"
+                                      ],
                                       "arguments": [],
+                                      "namedArguments": [],
                                       "isDistinct": false,
                                       "isUserDefinedFunction": false,
                                       "ignoreNulls": null,
@@ -1415,8 +1436,11 @@
                       "timestamp": {
                         "value": {
                           "unresolvedFunction": {
-                            "functionName": "current_date",
+                            "functionName": [
+                              "current_date"
+                            ],
                             "arguments": [],
+                            "namedArguments": [],
                             "isDistinct": false,
                             "isUserDefinedFunction": false,
                             "ignoreNulls": null,
@@ -1600,6 +1624,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "options": []
                       },
                       "isStreaming": false
@@ -1657,6 +1682,7 @@
                             }
                           }
                         ],
+                        "namedArguments": [],
                         "options": []
                       },
                       "isStreaming": false
@@ -1870,7 +1896,9 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "overlay",
+                    "functionName": [
+                      "overlay"
+                    ],
                     "arguments": [
                       {
                         "literal": {
@@ -1901,6 +1929,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
@@ -1932,7 +1961,9 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "overlay",
+                    "functionName": [
+                      "overlay"
+                    ],
                     "arguments": [
                       {
                         "literal": {
@@ -1956,6 +1987,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
@@ -1987,7 +2019,9 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "overlay",
+                    "functionName": [
+                      "overlay"
+                    ],
                     "arguments": [
                       {
                         "literal": {
@@ -2011,6 +2045,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
@@ -2042,7 +2077,9 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "overlay",
+                    "functionName": [
+                      "overlay"
+                    ],
                     "arguments": [
                       {
                         "literal": {
@@ -2073,6 +2110,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
@@ -2111,7 +2149,9 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "trim",
+                    "functionName": [
+                      "trim"
+                    ],
                     "arguments": [
                       {
                         "literal": {
@@ -2128,6 +2168,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
@@ -2159,7 +2200,9 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "trim",
+                    "functionName": [
+                      "trim"
+                    ],
                     "arguments": [
                       {
                         "literal": {
@@ -2176,6 +2219,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
@@ -2207,7 +2251,9 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "trim",
+                    "functionName": [
+                      "trim"
+                    ],
                     "arguments": [
                       {
                         "literal": {
@@ -2217,6 +2263,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
@@ -2248,7 +2295,9 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "ltrim",
+                    "functionName": [
+                      "ltrim"
+                    ],
                     "arguments": [
                       {
                         "literal": {
@@ -2265,6 +2314,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
@@ -2296,7 +2346,9 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "ltrim",
+                    "functionName": [
+                      "ltrim"
+                    ],
                     "arguments": [
                       {
                         "literal": {
@@ -2306,6 +2358,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
@@ -2337,7 +2390,9 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "rtrim",
+                    "functionName": [
+                      "rtrim"
+                    ],
                     "arguments": [
                       {
                         "literal": {
@@ -2354,6 +2409,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
@@ -2385,7 +2441,9 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "rtrim",
+                    "functionName": [
+                      "rtrim"
+                    ],
                     "arguments": [
                       {
                         "literal": {
@@ -2395,6 +2453,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
@@ -2426,12 +2485,15 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "abs",
+                    "functionName": [
+                      "abs"
+                    ],
                     "arguments": [
                       {
                         "placeholder": ":1Abc"
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
@@ -2463,12 +2525,15 @@
               "expressions": [
                 {
                   "unresolvedFunction": {
-                    "functionName": "abs",
+                    "functionName": [
+                      "abs"
+                    ],
                     "arguments": [
                       {
                         "placeholder": "?"
                       }
                     ],
+                    "namedArguments": [],
                     "isDistinct": false,
                     "isUserDefinedFunction": false,
                     "ignoreNulls": null,
@@ -2719,7 +2784,9 @@
                             "expressions": [
                               {
                                 "unresolvedFunction": {
-                                  "functionName": "max",
+                                  "functionName": [
+                                    "max"
+                                  ],
                                   "arguments": [
                                     {
                                       "unresolvedAttribute": {
@@ -2730,6 +2797,7 @@
                                       }
                                     }
                                   ],
+                                  "namedArguments": [],
                                   "isDistinct": false,
                                   "isUserDefinedFunction": false,
                                   "ignoreNulls": null,
@@ -2796,6 +2864,7 @@
                           }
                         }
                       ],
+                      "namedArguments": [],
                       "tableAlias": [
                         "expl"
                       ],
@@ -2826,6 +2895,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "tableAlias": [
                     "jtup"
                   ],
@@ -2957,6 +3027,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "options": []
                   },
                   "isStreaming": false
@@ -2988,50 +3059,446 @@
     {
       "input": "select * from my_tvf(2, arg1 => 'value1', arg2 => true)",
       "output": {
-        "failure": "not implemented: named function arguments"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "read": {
+                  "udtf": {
+                    "name": [
+                      "my_tvf"
+                    ],
+                    "arguments": [
+                      {
+                        "literal": {
+                          "int32": {
+                            "value": 2
+                          }
+                        }
+                      }
+                    ],
+                    "namedArguments": [
+                      [
+                        "arg1",
+                        {
+                          "literal": {
+                            "utf8": {
+                              "value": "value1"
+                            }
+                          }
+                        }
+                      ],
+                      [
+                        "arg2",
+                        {
+                          "literal": {
+                            "boolean": {
+                              "value": true
+                            }
+                          }
+                        }
+                      ]
+                    ],
+                    "options": []
+                  },
+                  "isStreaming": false
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedStar": {
+                    "target": null,
+                    "wildcardOptions": {
+                      "ilikePattern": null,
+                      "excludeColumns": null,
+                      "exceptColumns": null,
+                      "replaceColumns": null,
+                      "renameColumns": null
+                    }
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "select * from my_tvf(2, table (v1), arg1 => table (select 1))",
       "output": {
-        "failure": "not implemented: named function arguments"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "read": {
+                  "udtf": {
+                    "name": [
+                      "my_tvf"
+                    ],
+                    "arguments": [
+                      {
+                        "literal": {
+                          "int32": {
+                            "value": 2
+                          }
+                        }
+                      },
+                      {
+                        "table": {
+                          "expr": {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "v1"
+                              ],
+                              "planId": null
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "namedArguments": [
+                      [
+                        "arg1",
+                        {
+                          "table": {
+                            "expr": {
+                              "scalarSubquery": {
+                                "subquery": {
+                                  "project": {
+                                    "input": {
+                                      "empty": {
+                                        "produceOneRow": true
+                                      },
+                                      "planId": null,
+                                      "sourceInfo": null
+                                    },
+                                    "expressions": [
+                                      {
+                                        "literal": {
+                                          "int32": {
+                                            "value": 1
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "planId": null,
+                                  "sourceInfo": null
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    ],
+                    "options": []
+                  },
+                  "isStreaming": false
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedStar": {
+                    "target": null,
+                    "wildcardOptions": {
+                      "ilikePattern": null,
+                      "excludeColumns": null,
+                      "exceptColumns": null,
+                      "replaceColumns": null,
+                      "renameColumns": null
+                    }
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "select * from my_tvf(arg1 => 'value1', 2, arg2 => true)",
       "output": {
-        "failure": "not implemented: named function arguments"
+        "failure": "invalid argument: positional argument after named argument"
       }
     },
     {
       "input": "select * from my_tvf(arg1 => 'value1', arg2 => true)",
       "output": {
-        "failure": "not implemented: named function arguments"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "read": {
+                  "udtf": {
+                    "name": [
+                      "my_tvf"
+                    ],
+                    "arguments": [],
+                    "namedArguments": [
+                      [
+                        "arg1",
+                        {
+                          "literal": {
+                            "utf8": {
+                              "value": "value1"
+                            }
+                          }
+                        }
+                      ],
+                      [
+                        "arg2",
+                        {
+                          "literal": {
+                            "boolean": {
+                              "value": true
+                            }
+                          }
+                        }
+                      ]
+                    ],
+                    "options": []
+                  },
+                  "isStreaming": false
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedStar": {
+                    "target": null,
+                    "wildcardOptions": {
+                      "ilikePattern": null,
+                      "excludeColumns": null,
+                      "exceptColumns": null,
+                      "replaceColumns": null,
+                      "renameColumns": null
+                    }
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "select * from my_tvf(arg1 => table (v1), 2, arg2 => true)",
       "output": {
-        "failure": "not implemented: named function arguments"
+        "failure": "invalid argument: positional argument after named argument"
       }
     },
     {
       "input": "select * from my_tvf(arg1 => table (v1), arg2 => table (select 1))",
       "output": {
-        "failure": "not implemented: named function arguments"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "read": {
+                  "udtf": {
+                    "name": [
+                      "my_tvf"
+                    ],
+                    "arguments": [],
+                    "namedArguments": [
+                      [
+                        "arg1",
+                        {
+                          "table": {
+                            "expr": {
+                              "unresolvedAttribute": {
+                                "name": [
+                                  "v1"
+                                ],
+                                "planId": null
+                              }
+                            }
+                          }
+                        }
+                      ],
+                      [
+                        "arg2",
+                        {
+                          "table": {
+                            "expr": {
+                              "scalarSubquery": {
+                                "subquery": {
+                                  "project": {
+                                    "input": {
+                                      "empty": {
+                                        "produceOneRow": true
+                                      },
+                                      "planId": null,
+                                      "sourceInfo": null
+                                    },
+                                    "expressions": [
+                                      {
+                                        "literal": {
+                                          "int32": {
+                                            "value": 1
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  },
+                                  "planId": null,
+                                  "sourceInfo": null
+                                }
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    ],
+                    "options": []
+                  },
+                  "isStreaming": false
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedStar": {
+                    "target": null,
+                    "wildcardOptions": {
+                      "ilikePattern": null,
+                      "excludeColumns": null,
+                      "exceptColumns": null,
+                      "replaceColumns": null,
+                      "renameColumns": null
+                    }
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "select * from my_tvf(arg1 => table v1)",
       "exception": "\n[INVALID_SQL_SYNTAX.INVALID_TABLE_FUNCTION_IDENTIFIER_ARGUMENT_MISSING_PARENTHESES] Invalid SQL syntax: Syntax error: call to table-valued function is invalid because parentheses are missing around the provided TABLE argument `v1`; please surround this with parentheses and try again.(line 1, pos 29)\n\n== SQL ==\nselect * from my_tvf(arg1 => table v1)\n-----------------------------^^^\n",
       "output": {
-        "failure": "not implemented: named function arguments"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "read": {
+                  "udtf": {
+                    "name": [
+                      "my_tvf"
+                    ],
+                    "arguments": [],
+                    "namedArguments": [
+                      [
+                        "arg1",
+                        {
+                          "table": {
+                            "expr": {
+                              "unresolvedAttribute": {
+                                "name": [
+                                  "v1"
+                                ],
+                                "planId": null
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    ],
+                    "options": []
+                  },
+                  "isStreaming": false
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedStar": {
+                    "target": null,
+                    "wildcardOptions": {
+                      "ilikePattern": null,
+                      "excludeColumns": null,
+                      "exceptColumns": null,
+                      "replaceColumns": null,
+                      "renameColumns": null
+                    }
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
       "input": "select * from my_tvf(group => 'abc')",
       "output": {
-        "failure": "not implemented: named function arguments"
+        "success": {
+          "query": {
+            "project": {
+              "input": {
+                "read": {
+                  "udtf": {
+                    "name": [
+                      "my_tvf"
+                    ],
+                    "arguments": [],
+                    "namedArguments": [
+                      [
+                        "group",
+                        {
+                          "literal": {
+                            "utf8": {
+                              "value": "abc"
+                            }
+                          }
+                        }
+                      ]
+                    ],
+                    "options": []
+                  },
+                  "isStreaming": false
+                },
+                "planId": null,
+                "sourceInfo": null
+              },
+              "expressions": [
+                {
+                  "unresolvedStar": {
+                    "target": null,
+                    "wildcardOptions": {
+                      "ilikePattern": null,
+                      "excludeColumns": null,
+                      "exceptColumns": null,
+                      "replaceColumns": null,
+                      "renameColumns": null
+                    }
+                  }
+                }
+              ]
+            },
+            "planId": null,
+            "sourceInfo": null
+          }
+        }
       }
     },
     {
@@ -3090,6 +3557,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "options": []
                   },
                   "isStreaming": false
@@ -3139,6 +3607,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "options": []
                   },
                   "isStreaming": false
@@ -3191,6 +3660,7 @@
                         }
                       }
                     ],
+                    "namedArguments": [],
                     "options": []
                   },
                   "isStreaming": false
@@ -3313,9 +3783,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "cross",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -3385,6 +3854,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "tableAlias": [
                     "expl"
                   ],
@@ -3453,6 +3923,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "tableAlias": [
                     "posexpl"
                   ],
@@ -3588,7 +4059,9 @@
                 "cast": {
                   "expr": {
                     "unresolvedFunction": {
-                      "functionName": "/",
+                      "functionName": [
+                        "/"
+                      ],
                       "arguments": [
                         {
                           "literal": {
@@ -3605,6 +4078,7 @@
                           }
                         }
                       ],
+                      "namedArguments": [],
                       "isDistinct": false,
                       "isUserDefinedFunction": false,
                       "ignoreNulls": null,
@@ -3889,7 +4363,9 @@
                   },
                   "condition": {
                     "unresolvedFunction": {
-                      "functionName": "==",
+                      "functionName": [
+                        "=="
+                      ],
                       "arguments": [
                         {
                           "unresolvedAttribute": {
@@ -3935,6 +4411,7 @@
                           }
                         }
                       ],
+                      "namedArguments": [],
                       "isDistinct": false,
                       "isUserDefinedFunction": false,
                       "ignoreNulls": null,
@@ -4290,7 +4767,9 @@
               ],
               "having": {
                 "unresolvedFunction": {
-                  "functionName": "<",
+                  "functionName": [
+                    "<"
+                  ],
                   "arguments": [
                     {
                       "unresolvedAttribute": {
@@ -4308,6 +4787,7 @@
                       }
                     }
                   ],
+                  "namedArguments": [],
                   "isDistinct": false,
                   "isUserDefinedFunction": false,
                   "ignoreNulls": null,
@@ -4349,7 +4829,9 @@
                   },
                   "condition": {
                     "unresolvedFunction": {
-                      "functionName": ">=",
+                      "functionName": [
+                        ">="
+                      ],
                       "arguments": [
                         {
                           "unresolvedAttribute": {
@@ -4367,6 +4849,7 @@
                           }
                         }
                       ],
+                      "namedArguments": [],
                       "isDistinct": false,
                       "isUserDefinedFunction": false,
                       "ignoreNulls": null,
@@ -4429,7 +4912,9 @@
                   },
                   "condition": {
                     "unresolvedFunction": {
-                      "functionName": "<=",
+                      "functionName": [
+                        "<="
+                      ],
                       "arguments": [
                         {
                           "unresolvedAttribute": {
@@ -4447,6 +4932,7 @@
                           }
                         }
                       ],
+                      "namedArguments": [],
                       "isDistinct": false,
                       "isUserDefinedFunction": false,
                       "ignoreNulls": null,
@@ -4509,7 +4995,9 @@
                   },
                   "condition": {
                     "unresolvedFunction": {
-                      "functionName": "<",
+                      "functionName": [
+                        "<"
+                      ],
                       "arguments": [
                         {
                           "unresolvedAttribute": {
@@ -4527,6 +5015,7 @@
                           }
                         }
                       ],
+                      "namedArguments": [],
                       "isDistinct": false,
                       "isUserDefinedFunction": false,
                       "ignoreNulls": null,

--- a/crates/sail-spark-connect/tests/gold_data/plan/unpivot_join.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/unpivot_join.json
@@ -78,9 +78,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "inner",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -185,9 +184,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "inner",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -292,9 +290,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "inner",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -416,17 +413,15 @@
                         "planId": null,
                         "sourceInfo": null
                       },
-                      "joinCondition": null,
                       "joinType": "inner",
-                      "usingColumns": [],
+                      "joinCriteria": null,
                       "joinDataType": null
                     },
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "cross",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,

--- a/crates/sail-spark-connect/tests/gold_data/plan/unpivot_select.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/unpivot_select.json
@@ -949,9 +949,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "cross",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -1056,9 +1055,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "cross",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,
@@ -1163,9 +1161,8 @@
                     "planId": null,
                     "sourceInfo": null
                   },
-                  "joinCondition": null,
                   "joinType": "cross",
-                  "usingColumns": [],
+                  "joinCriteria": null,
                   "joinDataType": null
                 },
                 "planId": null,

--- a/crates/sail-sql-analyzer/src/expression.rs
+++ b/crates/sail-sql-analyzer/src/expression.rs
@@ -94,6 +94,7 @@ fn negated(expr: spec::Expr) -> spec::Expr {
     })
 }
 
+#[allow(clippy::type_complexity)]
 pub(crate) fn from_ast_function_arguments(
     args: impl IntoIterator<Item = FunctionArgument>,
 ) -> SqlResult<(Vec<spec::Expr>, Vec<(spec::Identifier, spec::Expr)>)> {

--- a/crates/sail-sql-analyzer/src/expression.rs
+++ b/crates/sail-sql-analyzer/src/expression.rs
@@ -83,8 +83,9 @@ impl TryFrom<Vec<WindowModifier>> for WindowModifiers {
 }
 fn negated(expr: spec::Expr) -> spec::Expr {
     spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-        function_name: "not".to_string(),
+        function_name: spec::ObjectName::bare("not"),
         arguments: vec![expr],
+        named_arguments: vec![],
         is_distinct: false,
         is_user_defined_function: false,
         ignore_nulls: None,
@@ -93,11 +94,29 @@ fn negated(expr: spec::Expr) -> spec::Expr {
     })
 }
 
-pub(crate) fn from_ast_function_argument(arg: FunctionArgument) -> SqlResult<spec::Expr> {
-    match arg {
-        FunctionArgument::Unnamed(arg) => from_ast_expression(arg),
-        FunctionArgument::Named(_, _, _) => Err(SqlError::todo("named function arguments")),
+pub(crate) fn from_ast_function_arguments(
+    args: impl IntoIterator<Item = FunctionArgument>,
+) -> SqlResult<(Vec<spec::Expr>, Vec<(spec::Identifier, spec::Expr)>)> {
+    let mut arguments = vec![];
+    let mut named_arguments = vec![];
+    for arg in args {
+        match arg {
+            FunctionArgument::Named(name, _, expr) => {
+                let expr = from_ast_expression(expr)?;
+                named_arguments.push((name.value.into(), expr));
+            }
+            FunctionArgument::Unnamed(expr) => {
+                if !named_arguments.is_empty() {
+                    return Err(SqlError::invalid(
+                        "positional argument after named argument",
+                    ));
+                }
+                let expr = from_ast_expression(expr)?;
+                arguments.push(expr);
+            }
+        }
     }
+    Ok((arguments, named_arguments))
 }
 
 pub fn from_ast_object_name(name: ObjectName) -> SqlResult<spec::ObjectName> {
@@ -222,8 +241,9 @@ pub fn from_ast_expression(expr: Expr) -> SqlResult<spec::Expr> {
         Expr::Atom(atom) => from_ast_atom_expression(atom),
         Expr::UnaryOperator(op, expr) => {
             Ok(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: from_ast_unary_operator(op)?,
+                function_name: spec::ObjectName::bare(from_ast_unary_operator(op)?),
                 arguments: vec![from_ast_expression(*expr)?],
+                named_arguments: vec![],
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -234,8 +254,9 @@ pub fn from_ast_expression(expr: Expr) -> SqlResult<spec::Expr> {
         Expr::BinaryOperator(left, op, right) => {
             let op = from_ast_binary_operator(op)?;
             Ok(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: op,
+                function_name: spec::ObjectName::bare(op),
                 arguments: vec![from_ast_expression(*left)?, from_ast_expression(*right)?],
+                named_arguments: vec![],
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -261,14 +282,14 @@ pub fn from_ast_expression(expr: Expr) -> SqlResult<spec::Expr> {
             match expr {
                 spec::Expr::UnresolvedAttribute { name, plan_id } => {
                     Ok(spec::Expr::UnresolvedAttribute {
-                        name: name.child(field.value.into()),
+                        name: name.child(field.value),
                         plan_id,
                     })
                 }
                 _ => Ok(spec::Expr::UnresolvedExtractValue {
                     child: Box::new(expr),
                     extraction: Box::new(spec::Expr::UnresolvedAttribute {
-                        name: spec::ObjectName::new_unqualified(field.value.into()),
+                        name: spec::ObjectName::bare(field.value),
                         plan_id: None,
                     }),
                 }),
@@ -371,8 +392,9 @@ pub fn from_ast_expression(expr: Expr) -> SqlResult<spec::Expr> {
                 arguments.push(LiteralValue(escape.to_string()).try_into()?);
             };
             let expr = spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: "like".to_string(),
+                function_name: spec::ObjectName::bare("like"),
                 arguments,
+                named_arguments: vec![],
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -393,8 +415,9 @@ pub fn from_ast_expression(expr: Expr) -> SqlResult<spec::Expr> {
                 arguments.push(LiteralValue(escape.to_string()).try_into()?);
             };
             let expr = spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: "ilike".to_string(),
+                function_name: spec::ObjectName::bare("ilike"),
                 arguments,
+                named_arguments: vec![],
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -411,8 +434,9 @@ pub fn from_ast_expression(expr: Expr) -> SqlResult<spec::Expr> {
             let expr = from_ast_expression(*expr)?;
             let pattern = from_ast_expression(*pattern)?;
             let expr = spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: "rlike".to_string(),
+                function_name: spec::ObjectName::bare("rlike"),
                 arguments: vec![expr, pattern],
+                named_arguments: vec![],
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -429,8 +453,9 @@ pub fn from_ast_expression(expr: Expr) -> SqlResult<spec::Expr> {
             let expr = from_ast_expression(*expr)?;
             let pattern = from_ast_expression(*pattern)?;
             let expr = spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: "regexp".to_string(),
+                function_name: spec::ObjectName::bare("regexp"),
                 arguments: vec![expr, pattern],
+                named_arguments: vec![],
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -494,7 +519,7 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
             let arguments = arguments
                 .into_iter()
                 .map(|arg| spec::UnresolvedNamedLambdaVariable {
-                    name: spec::ObjectName::new_unqualified(arg.value.into()),
+                    name: spec::ObjectName::bare(arg.value),
                 })
                 .collect();
             let function = from_ast_expression(*body)?;
@@ -510,8 +535,9 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
                 .map(from_ast_named_expression)
                 .collect::<SqlResult<Vec<_>>>()?;
             Ok(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: "struct".to_string(),
+                function_name: spec::ObjectName::bare("struct"),
                 arguments,
+                named_arguments: vec![],
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -525,8 +551,9 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
                 .map(from_ast_named_expression)
                 .collect::<SqlResult<Vec<_>>>()?;
             Ok(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: "struct".to_string(),
+                function_name: spec::ObjectName::bare("struct"),
                 arguments,
+                named_arguments: vec![],
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -556,8 +583,9 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
                     let condition = from_ast_expression(condition)?;
                     let condition = if let Some(ref operand) = operand {
                         spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                            function_name: "==".to_string(),
+                            function_name: spec::ObjectName::bare("=="),
                             arguments: vec![operand.clone(), condition],
+                            named_arguments: vec![],
                             is_distinct: false,
                             is_user_defined_function: false,
                             ignore_nulls: None,
@@ -576,8 +604,9 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
                 arguments.push(from_ast_expression(result)?);
             }
             Ok(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: "when".to_string(),
+                function_name: spec::ObjectName::bare("when"),
                 arguments,
+                named_arguments: vec![],
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -591,11 +620,12 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
         }),
         AtomExpr::Extract(_, _, ident, _, expr, _) => {
             Ok(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: "extract".to_string(),
+                function_name: spec::ObjectName::bare("extract"),
                 arguments: vec![
                     LiteralValue(ident.value).try_into()?,
                     from_ast_expression(*expr)?,
                 ],
+                named_arguments: vec![],
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -612,8 +642,9 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
                 arguments.push(from_ast_expression(*len)?);
             }
             Ok(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: "substring".to_string(),
+                function_name: spec::ObjectName::bare("substring"),
                 arguments,
+                named_arguments: vec![],
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -640,8 +671,9 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
                 ),
             };
             Ok(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: name.to_string(),
+                function_name: spec::ObjectName::bare(name),
                 arguments,
+                named_arguments: vec![],
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -659,8 +691,9 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
                 arguments.push(from_ast_expression(*len)?);
             }
             Ok(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: "overlay".to_string(),
+                function_name: spec::ObjectName::bare("overlay"),
                 arguments,
+                named_arguments: vec![],
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -670,8 +703,9 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
         }
         AtomExpr::Position(_, _, what, _, e, _) => {
             Ok(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: "strpos".to_string(),
+                function_name: spec::ObjectName::bare("strpos"),
                 arguments: vec![from_ast_expression(*e)?, from_ast_expression(*what)?],
+                named_arguments: vec![],
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -681,8 +715,9 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
         }
         AtomExpr::CurrentUser(_, _) => {
             Ok(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: "current_user".to_string(),
+                function_name: spec::ObjectName::bare("current_user"),
                 arguments: vec![],
+                named_arguments: vec![],
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -692,8 +727,9 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
         }
         AtomExpr::CurrentTimestamp(_, _) => {
             Ok(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: "current_timestamp".to_string(),
+                function_name: spec::ObjectName::bare("current_timestamp"),
                 arguments: vec![],
+                named_arguments: vec![],
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -703,8 +739,9 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
         }
         AtomExpr::CurrentDate(_, _) => {
             Ok(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: "current_date".to_string(),
+                function_name: spec::ObjectName::bare("current_date"),
                 arguments: vec![],
+                named_arguments: vec![],
                 is_distinct: false,
                 is_user_defined_function: false,
                 ignore_nulls: None,
@@ -726,7 +763,7 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
         ),
         AtomExpr::Function(function) => {
             let FunctionExpr {
-                name: ObjectName(name),
+                name,
                 arguments,
                 null_treatment,
                 within_group,
@@ -740,16 +777,9 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
                 null_treatment: inner_null_treatment,
                 right: _,
             } = arguments;
-            if !name.tail.is_empty() {
-                return Err(SqlError::unsupported("qualified function name"));
-            }
-            let function_name = name.head.value;
-            let arguments = arguments
-                .map(|x| {
-                    x.into_items()
-                        .map(from_ast_function_argument)
-                        .collect::<SqlResult<Vec<_>>>()
-                })
+            let function_name = from_ast_object_name(name)?;
+            let (arguments, named_arguments) = arguments
+                .map(|x| from_ast_function_arguments(x.into_items()))
                 .transpose()?
                 .unwrap_or_default();
             let is_distinct = match duplicate_treatment {
@@ -799,6 +829,7 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
             let function = spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
                 function_name,
                 arguments,
+                named_arguments,
                 is_distinct,
                 is_user_defined_function: false,
                 ignore_nulls,
@@ -865,7 +896,7 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
         )?)),
         AtomExpr::Placeholder(variable) => Ok(spec::Expr::Placeholder(variable.value)),
         AtomExpr::Identifier(x) => Ok(spec::Expr::UnresolvedAttribute {
-            name: spec::ObjectName::new_unqualified(x.value.into()),
+            name: spec::ObjectName::bare(x.value),
             plan_id: None,
         }),
     }
@@ -942,8 +973,9 @@ fn from_ast_quantified_pattern(
         })
         .collect::<SqlResult<Vec<_>>>()?;
     Ok(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-        function_name: quantifier.to_string(),
+        function_name: spec::ObjectName::bare(quantifier),
         arguments,
+        named_arguments: vec![],
         is_distinct: false,
         is_user_defined_function: false,
         ignore_nulls: None,

--- a/crates/sail-sql-parser/src/ast/query.rs
+++ b/crates/sail-sql-parser/src/ast/query.rs
@@ -420,8 +420,8 @@ pub enum UnpivotColumns {
 pub struct TableFunction {
     pub name: ObjectName,
     pub left: LeftParenthesis,
-    #[parser(function = |e, o| sequence(compose(e, o), unit(o)))]
-    pub arguments: Sequence<FunctionArgument, Comma>,
+    #[parser(function = |e, o| sequence(compose(e, o), unit(o)).or_not())]
+    pub arguments: Option<Sequence<FunctionArgument, Comma>>,
     pub right: RightParenthesis,
 }
 
@@ -473,8 +473,8 @@ pub struct LateralViewClause {
     pub outer: Option<Outer>,
     pub function: ObjectName,
     pub left: LeftParenthesis,
-    #[parser(function = |e, o| sequence(e, unit(o)).or_not())]
-    pub arguments: Option<Sequence<Expr, Comma>>,
+    #[parser(function = |e, o| sequence(compose(e, o), unit(o)).or_not())]
+    pub arguments: Option<Sequence<FunctionArgument, Comma>>,
     pub right: RightParenthesis,
     // FIXME: When both the table alias and the `AS` keyword are omitted,
     //   the column aliases cannot be parsed correctly.


### PR DESCRIPTION
1. Add spec for named function arguments.
2. Add spec for natural join.
3. Improve helper functions for `Identifier` and `ObjectName` in the spec.