### PR TITLE
Fix issue with task error reporting

### DIFF
--- a/crates/sail-execution/src/driver/actor/output.rs
+++ b/crates/sail-execution/src/driver/actor/output.rs
@@ -12,10 +12,17 @@ use crate::id::JobId;
 
 pub(super) enum JobOutput {
     Pending {
+        /// The sender for the signal of job completion,
+        /// or [`None`] if the signal has already been sent.
+        tx: Option<oneshot::Sender<Option<String>>>,
+        /// The receiver for the signal of job completion.
+        rx: oneshot::Receiver<Option<String>>,
         result: oneshot::Sender<ExecutionResult<SendableRecordBatchStream>>,
     },
     Running {
-        signal: oneshot::Sender<String>,
+        /// The sender for the signal of job completion,
+        /// or [`None`] if the signal has already been sent.
+        tx: Option<oneshot::Sender<Option<String>>>,
     },
 }
 
@@ -25,24 +32,23 @@ impl JobOutput {
         job_id: JobId,
         stream: SendableRecordBatchStream,
         sender: mpsc::Sender<Result<RecordBatch>>,
+        tx: Option<oneshot::Sender<Option<String>>>,
+        rx: oneshot::Receiver<Option<String>>,
     ) -> Self {
-        let (tx, rx) = oneshot::channel();
         let handle = ctx.handle().clone();
         ctx.spawn(Self::output(handle, job_id, stream, rx, sender));
-        JobOutput::Running { signal: tx }
+        JobOutput::Running { tx }
     }
 
     async fn output(
         handle: ActorHandle<DriverActor>,
         job_id: JobId,
         stream: SendableRecordBatchStream,
-        signal: oneshot::Receiver<String>,
+        signal: oneshot::Receiver<Option<String>>,
         sender: mpsc::Sender<Result<RecordBatch>>,
     ) {
-        tokio::select! {
-            _ = Self::read(stream, sender.clone()) => {},
-            _ = Self::stop(signal, sender) => {},
-        }
+        Self::read(stream, sender.clone()).await;
+        Self::wait(signal, sender).await;
         if let Err(e) = handle.send(DriverEvent::RemoveJobOutput { job_id }).await {
             error!("failed to remove job output: {e}");
         }
@@ -60,8 +66,11 @@ impl JobOutput {
         }
     }
 
-    async fn stop(signal: oneshot::Receiver<String>, sender: mpsc::Sender<Result<RecordBatch>>) {
-        if let Ok(reason) = signal.await {
+    async fn wait(
+        signal: oneshot::Receiver<Option<String>>,
+        sender: mpsc::Sender<Result<RecordBatch>>,
+    ) {
+        if let Ok(Some(reason)) = signal.await {
             if let Err(e) = sender.send(exec_err!("{reason}")).await {
                 error!("failed to send job output stop signal: {e}");
             }
@@ -70,11 +79,39 @@ impl JobOutput {
 
     pub fn fail(self, reason: String) {
         match self {
-            JobOutput::Pending { result } => {
+            JobOutput::Pending {
+                result,
+                tx: _,
+                rx: _,
+            } => {
                 let _ = result.send(Err(ExecutionError::InternalError(reason)));
+                // There is no need to send the failure to `tx` since `rx` is being dropped.
             }
-            JobOutput::Running { signal } => {
-                let _ = signal.send(reason);
+            JobOutput::Running { tx } => {
+                if let Some(tx) = tx {
+                    let _ = tx.send(Some(reason));
+                }
+            }
+        }
+    }
+
+    pub fn succeed(self) -> Option<Self> {
+        match self {
+            JobOutput::Pending { result, tx, rx } => {
+                if let Some(tx) = tx {
+                    let _ = tx.send(None);
+                }
+                Some(JobOutput::Pending {
+                    result,
+                    tx: None,
+                    rx,
+                })
+            }
+            JobOutput::Running { tx } => {
+                if let Some(tx) = tx {
+                    let _ = tx.send(None);
+                }
+                None
             }
         }
     }

--- a/crates/sail-execution/src/driver/state.rs
+++ b/crates/sail-execution/src/driver/state.rs
@@ -224,6 +224,18 @@ impl DriverState {
         task.state = state;
     }
 
+    pub fn has_job_succeeded(&self, job_id: JobId) -> Option<bool> {
+        let job = self.jobs.get(&job_id)?;
+        let value = job.stages.iter().all(|stage| {
+            stage.tasks.iter().all(|task_id| {
+                self.tasks
+                    .get(task_id)
+                    .is_some_and(|task| matches!(task.state, TaskState::Succeeded { .. }))
+            })
+        });
+        Some(value)
+    }
+
     pub fn find_active_tasks_for_job(&self, job_id: JobId) -> Vec<(TaskId, &TaskDescriptor)> {
         let Some(job) = self.jobs.get(&job_id) else {
             return vec![];

--- a/docs/development/recipes/debugger.md
+++ b/docs/development/recipes/debugger.md
@@ -18,7 +18,7 @@ In **Run** > **Edit Configurations**, add a new **Cargo** configuration with the
      project
      path. **This must be an absolute path.**)
    - (optional) `RUST_BACKTRACE`: `full`
-   - (optional) `RUST_LOG`: `sail_spark_connect=debug`
+   - (optional) `RUST_LOG`: `sail=debug`
 
 When entering environment variables, you can click on the button on the right side of the input box to open the dialog
 and add the environment variables one by one.


### PR DESCRIPTION
In distributed query execution, the task should return the error in the control flow and let the driver fail the job, but before this happens, in the data flow, the task stream may have been closed so the driver thinks the execution is successful with empty output.

This PR fixes this issue. In the longer term, we may want to consider whether the data flow should have the capability of returning errors from tasks, so that we can avoid such a race condition.