### PR TITLE
Fix rustup clippy installation issue

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -14,6 +14,7 @@ runs:
     # The Rust nightly toolchain is needed for features used in e.g. code formatting.
     - name: Install Rust toolchains
       run: |
+        rustup self update
         rustup toolchain install stable --component rustfmt clippy
         rustup toolchain install nightly --component rustfmt
       shell: bash

--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -14,9 +14,10 @@ runs:
     # The Rust nightly toolchain is needed for features used in e.g. code formatting.
     - name: Install Rust toolchains
       run: |
-        rustup self update
-        rustup toolchain install stable --component rustfmt clippy
-        rustup toolchain install nightly --component rustfmt
+        rustup toolchain install stable
+        rustup toolchain install nightly
+        rustup component add --toolchain stable rustfmt clippy
+        rustup component add --toolchain nightly rustfmt
       shell: bash
 
     - name: Show versions


### PR DESCRIPTION
We started getting the following error in GitHub Actions for Rust setup. This PR tries to fix the issue.

```text
error: invalid value 'clippy' for '[TOOLCHAIN]...': invalid toolchain name: 'clippy'
```