### PR TITLE
Implement Hugging Face object store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,6 +2014,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2028,6 +2062,21 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "env_filter"
@@ -2169,6 +2218,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2530,10 +2594,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hf-hub"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc03dcb0b0a83ae3f3363ec811014ae669f083e4e499c66602f447c4828737a1"
+dependencies = [
+ "dirs",
+ "futures",
+ "indicatif",
+ "libc",
+ "log",
+ "num_cpus",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "hmac"
@@ -2750,6 +2841,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2948,6 +3055,19 @@ checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
 ]
 
 [[package]]
@@ -3329,6 +3449,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.9.0",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3476,6 +3606,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 
 [[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3557,6 +3704,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3576,6 +3733,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -3631,10 +3794,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openssl"
+version = "0.10.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -3698,6 +3899,12 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -4456,6 +4663,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4492,12 +4710,13 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
  "h2 0.4.8",
@@ -4506,11 +4725,13 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-rustls 0.27.5",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -4523,7 +4744,9 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
+ "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.26.2",
  "tokio-util",
  "tower 0.5.2",
@@ -4841,6 +5064,7 @@ dependencies = [
  "aes",
  "aes-gcm",
  "async-recursion",
+ "async-stream",
  "async-trait",
  "aws-config",
  "aws-credential-types",
@@ -4858,6 +5082,7 @@ dependencies = [
  "futures",
  "half",
  "hdfs-native-object-store",
+ "hf-hub",
  "html-escape",
  "lazy_static",
  "num",
@@ -4866,6 +5091,7 @@ dependencies = [
  "rand_chacha 0.9.0",
  "rand_distr",
  "regex",
+ "reqwest",
  "ryu",
  "sail-common",
  "sail-common-datafusion",
@@ -5424,6 +5650,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5591,6 +5838,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -6025,6 +6282,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6232,33 +6495,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -6312,11 +6580,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -6332,6 +6616,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6342,6 +6632,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6356,10 +6652,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6374,6 +6682,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6384,6 +6698,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6398,6 +6718,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6408,6 +6734,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5085,6 +5085,7 @@ dependencies = [
  "hf-hub",
  "html-escape",
  "lazy_static",
+ "log",
  "num",
  "object_store",
  "rand 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,8 @@ half = { version = "2.4.1", features = ["serde", "num-traits", "zerocopy"] }
 iana-time-zone = "0.1.61"
 chumsky = { version = "=1.0.0-alpha.7", default-features = false, features = ["pratt", "label"] }
 num = "0.4.3"
+hf-hub = { version = "0.4.2", default-features = false, features = ["tokio"] }
+reqwest = "0.12.14"
 
 ######
 # The versions of the following dependencies are managed manually.

--- a/crates/sail-plan/Cargo.toml
+++ b/crates/sail-plan/Cargo.toml
@@ -19,6 +19,7 @@ tonic = { workspace = true }
 tokio-stream = { workspace = true }
 async-trait = { workspace = true }
 async-recursion = { workspace = true }
+async-stream = { workspace = true }
 lazy_static = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
@@ -45,6 +46,8 @@ cbc = { workspace = true }
 base64 = { workspace = true }
 half = { workspace = true }
 num = { workspace = true }
+hf-hub = { workspace = true }
+reqwest = { workspace = true }
 
 [features]
 hdfs = ["dep:hdfs-native-object-store"]

--- a/crates/sail-plan/Cargo.toml
+++ b/crates/sail-plan/Cargo.toml
@@ -48,6 +48,7 @@ half = { workspace = true }
 num = { workspace = true }
 hf-hub = { workspace = true }
 reqwest = { workspace = true }
+log = { workspace = true }
 
 [features]
 hdfs = ["dep:hdfs-native-object-store"]

--- a/crates/sail-plan/src/object_store/hugging_face.rs
+++ b/crates/sail-plan/src/object_store/hugging_face.rs
@@ -1,0 +1,317 @@
+use std::fmt::Display;
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use chrono::{DateTime, TimeZone, Utc};
+use futures::stream;
+use futures::stream::BoxStream;
+use hf_hub::api::tokio::{Api, ApiBuilder, ApiError, ApiRepo};
+use hf_hub::{Repo, RepoType};
+use lazy_static::lazy_static;
+use object_store::local::LocalFileSystem;
+use object_store::path::Path;
+use object_store::{
+    path, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore, PutMultipartOpts, PutOptions, PutPayload, PutResult,
+};
+use regex::Regex;
+use tonic::codegen::http;
+
+lazy_static! {
+    static ref HF_PATH_PATTERN: Regex = Regex::new(
+        r"^(?P<username>[^/]+)/(?P<dataset>[^/@]+)(@(?P<revision>[^/]+))?/(?P<path>.*)$"
+    )
+    .unwrap();
+}
+
+#[derive(Debug, thiserror::Error)]
+enum HuggingFaceError {
+    #[error("HuggingFace API error: {0}")]
+    ApiError(#[from] ApiError),
+    #[error("date/time parse error: {0}")]
+    DateTimeParseError(#[from] chrono::format::ParseError),
+    #[error("HTTP request error: {0}")]
+    RequestError(#[from] reqwest::Error),
+    #[error("invalid path: {0}")]
+    InvalidPath(PathBuf),
+}
+
+impl From<HuggingFaceError> for object_store::Error {
+    fn from(value: HuggingFaceError) -> Self {
+        const OBJECT_STORE_NAME: &str = "HuggingFace object store";
+
+        match value {
+            HuggingFaceError::ApiError(error) => match error {
+                ApiError::MissingHeader(_)
+                | ApiError::InvalidHeader(_)
+                | ApiError::InvalidHeaderValue(_)
+                | ApiError::ToStr(_)
+                | ApiError::RequestError(_)
+                | ApiError::ParseIntError(_)
+                | ApiError::IoError(_)
+                | ApiError::TooManyRetries(_)
+                | ApiError::TryAcquireError(_)
+                | ApiError::AcquireError(_)
+                | ApiError::LockAcquisition(_) => object_store::Error::Generic {
+                    store: OBJECT_STORE_NAME,
+                    source: Box::new(error),
+                },
+                ApiError::Join(e) => object_store::Error::JoinError { source: e },
+            },
+            HuggingFaceError::DateTimeParseError(error) => object_store::Error::Generic {
+                store: OBJECT_STORE_NAME,
+                source: Box::new(error),
+            },
+            HuggingFaceError::RequestError(error) => object_store::Error::Generic {
+                store: OBJECT_STORE_NAME,
+                source: Box::new(error),
+            },
+            HuggingFaceError::InvalidPath(path) => object_store::Error::InvalidPath {
+                source: path::Error::InvalidPath { path },
+            },
+        }
+    }
+}
+
+#[derive(Debug)]
+struct HuggingFacePath {
+    username: String,
+    dataset: String,
+    revision: Option<String>,
+    path: String,
+}
+
+impl HuggingFacePath {
+    fn parse(path: &Path) -> object_store::Result<Self> {
+        let Some(captures) = HF_PATH_PATTERN.captures(path.as_ref()) else {
+            Err(HuggingFaceError::InvalidPath(path.as_ref().into()))?
+        };
+        let username = captures.name("username").unwrap().as_str().to_string();
+        let dataset = captures.name("dataset").unwrap().as_str().to_string();
+        let revision = captures.name("revision").map(|m| m.as_str().to_string());
+        let path = captures.name("path").unwrap().as_str().to_string();
+        Ok(Self {
+            username,
+            dataset,
+            revision,
+            path,
+        })
+    }
+
+    fn parse_optional(path: Option<&Path>) -> object_store::Result<Self> {
+        let Some(path) = path else {
+            Err(HuggingFaceError::InvalidPath(Default::default()))?
+        };
+        Self::parse(path)
+    }
+
+    fn repo(&self) -> Repo {
+        let repo_id = format!("{}/{}", self.username, self.dataset);
+        if let Some(revision) = &self.revision {
+            Repo::with_revision(repo_id, RepoType::Dataset, revision.clone())
+        } else {
+            Repo::new(repo_id, RepoType::Dataset)
+        }
+    }
+
+    fn base_path(&self) -> String {
+        if let Some(revision) = &self.revision {
+            format!("{}/{}@{}", self.username, self.dataset, revision)
+        } else {
+            format!("{}/{}", self.username, self.dataset)
+        }
+    }
+
+    fn matches(&self, filename: &str) -> bool {
+        filename.starts_with(&self.path)
+    }
+}
+
+#[derive(Debug)]
+pub struct HuggingFaceObjectStore {
+    api: Api,
+    local: LocalFileSystem,
+}
+
+impl HuggingFaceObjectStore {
+    pub fn try_new() -> object_store::Result<Self> {
+        Ok(Self {
+            api: ApiBuilder::from_env()
+                .with_progress(false)
+                .build()
+                .map_err(HuggingFaceError::from)?,
+            local: LocalFileSystem::new(),
+        })
+    }
+
+    async fn get_meta(
+        &self,
+        repo: &ApiRepo,
+        base_path: &str,
+        filename: &str,
+    ) -> object_store::Result<ObjectMeta> {
+        let location = Path::parse(format!("{base_path}/{filename}"))?;
+        let response = self
+            .api
+            .client()
+            .head(repo.url(filename))
+            .send()
+            .await
+            .map_err(HuggingFaceError::from)?
+            .error_for_status()
+            .map_err(HuggingFaceError::from)?;
+        let headers = response.headers();
+
+        let size = headers
+            .get(http::header::CONTENT_LENGTH)
+            .map(|x| Ok::<_, ApiError>(x.to_str()?.parse()?))
+            .transpose()
+            .map_err(HuggingFaceError::from)?
+            .ok_or_else(|| {
+                HuggingFaceError::from(ApiError::MissingHeader(http::header::CONTENT_LENGTH))
+            })?;
+
+        let last_modified = headers
+            .get(http::header::LAST_MODIFIED)
+            .map(|x| -> object_store::Result<_> {
+                let s = x
+                    .to_str()
+                    .map_err(|x| HuggingFaceError::from(ApiError::ToStr(x)))?;
+                let dt = DateTime::parse_from_rfc2822(s).map_err(HuggingFaceError::from)?;
+                Ok(dt.with_timezone(&Utc))
+            })
+            .transpose()?
+            .unwrap_or(Utc.timestamp_nanos(0));
+
+        let e_tag = headers
+            .get(http::header::ETAG)
+            .map(|x| -> object_store::Result<_> {
+                Ok(x.to_str()
+                    .map_err(|x| HuggingFaceError::from(ApiError::ToStr(x)))?
+                    .to_string())
+            })
+            .transpose()?;
+
+        Ok(ObjectMeta {
+            location,
+            last_modified,
+            size,
+            e_tag,
+            version: None,
+        })
+    }
+}
+
+impl Display for HuggingFaceObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "HuggingFaceObjectStore")
+    }
+}
+
+#[async_trait]
+impl ObjectStore for HuggingFaceObjectStore {
+    async fn put_opts(
+        &self,
+        _location: &Path,
+        _payload: PutPayload,
+        _opts: PutOptions,
+    ) -> object_store::Result<PutResult> {
+        Err(object_store::Error::NotImplemented)
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        _location: &Path,
+        _opts: PutMultipartOpts,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        Err(object_store::Error::NotImplemented)
+    }
+
+    async fn get_opts(
+        &self,
+        location: &Path,
+        options: GetOptions,
+    ) -> object_store::Result<GetResult> {
+        let GetOptions {
+            if_match,
+            if_none_match,
+            if_modified_since,
+            if_unmodified_since,
+            range,
+            version,
+            head,
+        } = options;
+        if if_match.is_some()
+            || if_none_match.is_some()
+            || if_modified_since.is_some()
+            || if_unmodified_since.is_some()
+            || version.is_some()
+        {
+            return Err(object_store::Error::NotImplemented);
+        }
+        let path = HuggingFacePath::parse(location)?;
+        let repo = self.api.repo(path.repo());
+        if head {
+            let meta = self
+                .get_meta(&repo, &path.base_path(), path.path.as_str())
+                .await?;
+            Ok(GetResult {
+                payload: GetResultPayload::Stream(Box::pin(stream::empty())),
+                meta,
+                range: 0..0,
+                attributes: Default::default(),
+            })
+        } else {
+            let location = repo
+                .get(path.path.as_str())
+                .await
+                .map_err(HuggingFaceError::from)?;
+            self.local
+                .get_opts(
+                    &Path::from_filesystem_path(location)?,
+                    GetOptions {
+                        range,
+                        ..GetOptions::default()
+                    },
+                )
+                .await
+        }
+    }
+
+    async fn delete(&self, _location: &Path) -> object_store::Result<()> {
+        Err(object_store::Error::NotImplemented)
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'_, object_store::Result<ObjectMeta>> {
+        let path = match HuggingFacePath::parse_optional(prefix) {
+            Ok(x) => x,
+            Err(e) => return Box::pin(stream::once(async { Err(e) })),
+        };
+        let stream = async_stream::try_stream! {
+            let repo = self.api.repo(path.repo());
+            let info = repo.info().await.map_err(HuggingFaceError::from)?;
+            for sibling in info.siblings {
+                let filename = sibling.rfilename.as_str();
+                if path.matches(filename) {
+                    yield self.get_meta(&repo, &path.base_path(), filename).await?;
+                }
+            }
+        };
+        Box::pin(stream)
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        _prefix: Option<&Path>,
+    ) -> object_store::Result<ListResult> {
+        Err(object_store::Error::NotImplemented)
+    }
+
+    async fn copy(&self, _from: &Path, _to: &Path) -> object_store::Result<()> {
+        Err(object_store::Error::NotImplemented)
+    }
+
+    async fn copy_if_not_exists(&self, _from: &Path, _to: &Path) -> object_store::Result<()> {
+        Err(object_store::Error::NotImplemented)
+    }
+}

--- a/crates/sail-plan/src/object_store/mod.rs
+++ b/crates/sail-plan/src/object_store/mod.rs
@@ -1,4 +1,5 @@
 mod config;
+mod hugging_face;
 mod registry;
 mod s3;
 

--- a/crates/sail-plan/src/object_store/registry.rs
+++ b/crates/sail-plan/src/object_store/registry.rs
@@ -85,7 +85,10 @@ impl DynamicObjectStoreRegistry {
             }
             "hf" => {
                 if key.authority != "datasets" {
-                    return plan_err!("unsupported HuggingFace repository type: {}", key.authority);
+                    return plan_err!(
+                        "unsupported Hugging Face repository type: {}",
+                        key.authority
+                    );
                 }
                 Ok(Arc::new(HuggingFaceObjectStore::try_new()?))
             }

--- a/crates/sail-plan/src/object_store/registry.rs
+++ b/crates/sail-plan/src/object_store/registry.rs
@@ -11,6 +11,7 @@ use object_store::ObjectStore;
 use url::Url;
 
 use crate::object_store::config::OBJECT_STORE_CONFIG;
+use crate::object_store::hugging_face::HuggingFaceObjectStore;
 use crate::object_store::s3::S3CredentialProvider;
 
 #[derive(Debug, Eq, PartialEq, Hash)]
@@ -81,6 +82,12 @@ impl DynamicObjectStoreRegistry {
                     None => HdfsObjectStore::with_url(url.as_str())?,
                 };
                 Ok(Arc::new(store))
+            }
+            "hf" => {
+                if key.authority != "datasets" {
+                    return plan_err!("unsupported HuggingFace repository type: {}", key.authority);
+                }
+                Ok(Arc::new(HuggingFaceObjectStore::try_new()?))
             }
             _ => {
                 plan_err!("unsupported object store URL: {url}")

--- a/docs/guide/tasks/data-access.md
+++ b/docs/guide/tasks/data-access.md
@@ -24,6 +24,10 @@ Relative file paths
 
 : These are paths in HDFS, such as `hdfs://namenode:port/path/to/data`.
 
+`hf://` URIs
+
+: These are paths for Hugging Face datasets, such as `hf://datasets/username/dataset@~parquet/train`.
+
 ::: info
 
 - For local file systems, the path can refer to a file or a directory.
@@ -58,3 +62,12 @@ AWS_REGION=us-east-1
 `AWS_SKIP_SIGNATURE` is not a standard environment variable used by AWS SDKs.
 It is an environment variable recognized by Sail.
 :::
+
+## Configuring Hugging Face
+
+Files in Hugging Face datasets are cached locally once downloaded.
+The cache is shared with other Hugging Face Python tools.
+The cache directory is `$HF_HOME/hub` where `$HF_HOME` is an environment variable with the default value `~/.cache/huggingface`.
+You can set the `HF_HOME` environment variable to use a different cache directory.
+
+You can set the `HF_ENDPOINT` environment variable to use a different Hugging Face API endpoint (e.g. a mirror). The default endpoint is `https://huggingface.co`.


### PR DESCRIPTION
This PR implements the Hugging Face object store so that we can load datasets via the `hf://` protocol.

I used the official `hf-hub` library to make HTTP requests to the Hugging Face Hub. Compared with other implementations (e.g. OpenDAL), the `hf-hub` library has a nice feature that the downloaded files are kept in a local cache. The local cache is compatible with the cache used by the Hugging Face Python library. This avoids unnecessary download operations and allows for cache sharing among Sail and other Hugging Face Python tools.