### PR TITLE
Support aliased expressions for `GROUP BY`

### DIFF
--- a/crates/sail-plan/src/resolver/plan.rs
+++ b/crates/sail-plan/src/resolver/plan.rs
@@ -64,7 +64,7 @@ use crate::function::{
 };
 use crate::resolver::expression::NamedExpr;
 use crate::resolver::function::PythonUdtf;
-use crate::resolver::state::PlanResolverState;
+use crate::resolver::state::{AggregateState, PlanResolverState};
 use crate::resolver::tree::explode::ExplodeRewriter;
 use crate::resolver::tree::window::WindowRewriter;
 use crate::resolver::tree::PlanRewriter;
@@ -1446,13 +1446,28 @@ impl PlanResolver<'_> {
         let projections = self
             .resolve_named_expressions(projections, schema, state)
             .await?;
-        let grouping = self
-            .resolve_named_expressions(grouping, schema, state)
-            .await?;
-        let having = match having {
-            Some(having) => Some(self.resolve_expression(having, schema, state).await?),
-            None => None,
+
+        let grouping = {
+            let mut scope = state.enter_aggregate_scope(AggregateState::Grouping {
+                projections: projections.clone(),
+            });
+            let state = scope.state();
+            self.resolve_named_expressions(grouping, schema, state)
+                .await?
         };
+        let having = {
+            let mut scope = state.enter_aggregate_scope(AggregateState::Having {
+                projections: projections.clone(),
+                grouping: grouping.clone(),
+            });
+            let state = scope.state();
+            match having {
+                Some(having) => Some(self.resolve_expression(having, schema, state).await?),
+                None => None,
+            }
+        };
+
+        dbg!(&having);
 
         self.rewrite_aggregate(
             input,
@@ -3520,7 +3535,7 @@ impl PlanResolver<'_> {
         Ok(())
     }
 
-    fn resolve_expressions_positions(
+    fn resolve_grouping_positions(
         &self,
         exprs: Vec<NamedExpr>,
         projections: &[NamedExpr],
@@ -3636,7 +3651,7 @@ impl PlanResolver<'_> {
         with_grouping_expressions: bool,
         state: &mut PlanResolverState,
     ) -> PlanResult<LogicalPlan> {
-        let grouping = self.resolve_expressions_positions(grouping, &projections)?;
+        let grouping = self.resolve_grouping_positions(grouping, &projections)?;
         let mut aggregate_candidates = projections
             .iter()
             .map(|x| x.expr.clone())

--- a/python/pysail/tests/spark/test_group_by_alias.txt
+++ b/python/pysail/tests/spark/test_group_by_alias.txt
@@ -1,0 +1,94 @@
+>>> spark.sql("SELECT a AS b FROM VALUES (1), (2) AS t(a) GROUP BY b ORDER BY b").show()
++---+
+|  b|
++---+
+|  1|
+|  2|
++---+
+
+>>> spark.sql("SELECT a AS b FROM VALUES (1), (2) AS t(a) GROUP BY a ORDER BY b").show()
++---+
+|  b|
++---+
+|  1|
+|  2|
++---+
+
+>>> spark.sql("SELECT a AS b FROM VALUES (1), (2) AS t(a) GROUP BY t.a ORDER BY b").show()
++---+
+|  b|
++---+
+|  1|
+|  2|
++---+
+
+>>> spark.sql("SELECT count(b) AS a FROM VALUES (1, 1), (1, 2) AS t(a, b) GROUP BY a").show()
++---+
+|  a|
++---+
+|  2|
++---+
+
+>>> spark.sql("SELECT count(b) AS a FROM VALUES (1, 1), (1, 2) AS t(a, b) GROUP BY a HAVING a > 1").show()
++---+
+|  a|
++---+
++---+
+
+>>> spark.sql("SELECT count(b) as a FROM VALUES (1, 1), (1, 2) as t(a, b) GROUP BY a HAVING count(b) > 1").show()
++---+
+|  a|
++---+
+|  2|
++---+
+
+>>> spark.sql("SELECT count(b) AS a FROM VALUES (1, 1), (1, 2) AS t(a, b) GROUP BY b").show()
++---+
+|  a|
++---+
+|  1|
+|  1|
++---+
+
+>>> spark.sql("SELECT count(b) AS b FROM VALUES (1, 1), (1, 2) AS t(a, b) GROUP BY b").show()
++---+
+|  b|
++---+
+|  1|
+|  1|
++---+
+
+>>> spark.sql("SELECT count(b) AS a FROM VALUES (1, 1), (1, 2) AS t(a, b) GROUP BY b HAVING a > 1").show()
++---+
+|  a|
++---+
++---+
+
+>>> spark.sql("SELECT count(a) AS a FROM VALUES (1, 1), (1, 2) AS t(a, b) GROUP BY b").show()
++---+
+|  a|
++---+
+|  1|
+|  1|
++---+
+
+>>> spark.sql("SELECT count(b) AS a FROM VALUES (1, 1), (1, 2), (2, 2) AS t(a, b) WHERE a > 1 GROUP BY b").show()
++---+
+|  a|
++---+
+|  1|
++---+
+
+>>> spark.sql("SELECT count(b) AS a FROM VALUES (1, 1), (1, 2), (2, 2) AS t(a, b) GROUP BY b HAVING a > 1").show()
++---+
+|  a|
++---+
+|  2|
++---+
+
+>>> spark.sql("SELECT count(b) AS a FROM VALUES (1, 1), (1, 2), (2, 2) AS t(a, b) GROUP BY b HAVING b > 1").show()
++---+
+|  a|
++---+
+|  2|
++---+


### PR DESCRIPTION
This PR allows `GROUP BY` and `HAVING` clauses to refer to aliased expressions in the `SELECT` clause. Ambiguity is handled properly when the same name is used in both the input plan and the aggregated output.