### PR TITLE
[WIP] Add Support for Kubernetes Deploy Variables (Initial Implementation)

### DIFF
--- a/crates/sail-execution/src/driver/options.rs
+++ b/crates/sail-execution/src/driver/options.rs
@@ -50,7 +50,8 @@ impl DriverOptions {
                     image_pull_policy: config.kubernetes.image_pull_policy.clone(),
                     namespace: config.kubernetes.namespace.clone(),
                     driver_pod_name: config.kubernetes.driver_pod_name.clone(),
-                    worker_pod_name_prefix: config.kubernetes.worker_pod_name_prefix.clone(),
+                    worker_pod_name_prefix: std::env::var("KUBERNETES_WORKER_POD_NAME_PREFIX")
+                        .unwrap_or(config.kubernetes.worker_pod_name_prefix.clone()),
                     worker_service_account_name: config
                         .kubernetes
                         .worker_service_account_name


### PR DESCRIPTION
This PR introduces a configuration variable to enable the use of deployment variables in Kubernetes.
I have added only one variable as a proof of concept to confirm if this is the correct approach. If approved, I will proceed to add the remaining variables accordingly.
Not change the variable:
<img width="259" alt="Captura de pantalla 2025-05-18 a las 19 19 52" src="https://github.com/user-attachments/assets/4e29dc12-5cbf-4194-b838-3a941ed916a4" />
Changing the variable:
in k8s/sail.yaml:
```yaml
...
          imagePullPolicy: IfNotPresent
          env:
            - name: KUBERNETES_WORKER_POD_NAME_PREFIX
              value: "mi-pod-job-insert"
            - name: RUST_LOG
              value: info
...
```
<img width="316" alt="Captura de pantalla 2025-05-18 a las 19 21 18" src="https://github.com/user-attachments/assets/b9b02b15-4c68-40b0-988f-4aa52fa05ee6" />
