### PR TITLE
Fix gold data test issue

### DIFF
--- a/crates/sail-common/src/config/application.rs
+++ b/crates/sail-common/src/config/application.rs
@@ -11,7 +11,6 @@ use crate::error::{CommonError, CommonResult};
 const APP_CONFIG: &str = include_str!("application.yaml");
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct AppConfig {
     pub mode: ExecutionMode,
     pub runtime: RuntimeConfig,


### PR DESCRIPTION
We need to be more permissive when loading `AppConfig` from environment variables. We need to ignore unknown environment variables starting with `SAIL_` since they may be used in tests (e.g. `SAIL_UPDATE_GOLD_DATA`).