### PR TITLE
Hide a few config options temporarily

### DIFF
--- a/crates/sail-common/src/config/application.yaml
+++ b/crates/sail-common/src/config/application.yaml
@@ -143,6 +143,7 @@
   description: |
     The retry strategy for driver and worker RPC requests.
     Valid values are `fixed` and `exponential_backoff`.
+  hidden: true
   experimental: true
 
 - key: cluster.rpc_retry_strategy.fixed.max_count
@@ -151,6 +152,7 @@
   description: |
     The maximum number of retries for RPC requests
     when using the `fixed` retry strategy.
+  hidden: true
   experimental: true
 
 - key: cluster.rpc_retry_strategy.fixed.delay_secs
@@ -159,6 +161,7 @@
   description: |
     The delay in seconds between retries for RPC requests
     when using the `fixed` retry strategy.
+  hidden: true
   experimental: true
 
 - key: cluster.rpc_retry_strategy.exponential_backoff.max_count
@@ -167,6 +170,7 @@
   description: |
     The maximum number of retries for RPC requests
     when using the `exponential_backoff` retry strategy.
+  hidden: true
   experimental: true
 
 - key: cluster.rpc_retry_strategy.exponential_backoff.initial_delay_secs
@@ -175,6 +179,7 @@
   description: |
     The initial delay in seconds between retries for RPC requests
     when using the `exponential_backoff` retry strategy.
+  hidden: true
   experimental: true
 
 - key: cluster.rpc_retry_strategy.exponential_backoff.max_delay_secs
@@ -183,6 +188,7 @@
   description: |
     The maximum delay in seconds between retries for RPC requests
     when using the `exponential_backoff` retry strategy.
+  hidden: true
   experimental: true
 
 - key: cluster.rpc_retry_strategy.exponential_backoff.factor
@@ -191,6 +197,7 @@
   description: |
     The factor by which the delay increases after each retry
     when using the `exponential_backoff` retry strategy.
+  hidden: true
   experimental: true
 
 - key: execution.batch_size
@@ -290,6 +297,7 @@
   default: "1048576"
   description: |
     (Writing) The best-effort maximum size of a data page in bytes.
+  hidden: true
   experimental: true
 
 - key: parquet.write_batch_size
@@ -305,6 +313,7 @@
   description: |
     (Writing) The Parquet writer version.
     Valid values are `"1.0"` and `"2.0"`.
+  hidden: true
   experimental: true
 
 - key: parquet.skip_arrow_metadata
@@ -363,6 +372,7 @@
   default: "64"
   description: |
     (Writing) The column index truncate length for the Parquet writer.
+  hidden: true
   experimental: true
 
 - key: parquet.statistics_truncate_length
@@ -372,6 +382,7 @@
     (Writing) The statistics truncate length for the Parquet writer.
     
     If the value is `0`, no truncation is applied.
+  hidden: true
   experimental: true
 
 - key: parquet.data_page_row_count_limit
@@ -393,6 +404,7 @@
     
     An empty value can also be used, which allows the Parquet writer to choose
     the encoding for each column to achieve good performance.
+  hidden: true
   experimental: true
 
 - key: parquet.bloom_filter_on_read


### PR DESCRIPTION
We'd like to deploy the docs site but there are a few configuration options that have changed in the `main` branch since the 0.2.6 release. So we need to hide them for now.