### PR TITLE
chore!: remove `spark` extra for Python

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,8 +280,7 @@ jobs:
             mkdir -p 'C:\Temp'
             export TEMP='C:\Temp'
           fi
-          pip install 'pysail[spark]=='"${RELEASE_VERSION}" -v -f dist --no-binary pysail
-          pip install pytest
+          pip install 'pysail[test]=='"${RELEASE_VERSION}" -v -f dist --no-binary pysail
 
       - name: Verify Package
         shell: python
@@ -323,8 +322,7 @@ jobs:
       - name: Install Package
         shell: bash
         run: |
-          pip install 'pysail[spark]=='"${RELEASE_VERSION}" -v -f dist --only-binary pysail
-          pip install pytest
+          pip install 'pysail[test]=='"${RELEASE_VERSION}" -v -f dist --only-binary pysail
 
       - name: Verify Package
         shell: python

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Currently, Sail features a drop-in replacement for Spark SQL and the Spark DataF
 Sail is available as a Python package on PyPI. You can install it using `pip`.
 
 ```bash
-pip install "pysail[spark]"
+pip install pysail
+pip install "pyspark[connect]"
 ```
 
 Alternatively, you can install Sail from source for better performance for your hardware architecture.

--- a/README.md
+++ b/README.md
@@ -8,19 +8,21 @@
 The mission of Sail is to unify stream processing, batch processing, and compute-intensive (AI) workloads.
 Currently, Sail features a drop-in replacement for Spark SQL and the Spark DataFrame API in both single-host and distributed settings.
 
-**✨News✨: Please check out our [MCP server](https://lakesail.com/blog/spark-mcp-server/) that brings data analytics in Spark to both LLM agents and humans!**
+**✨Please check out our [MCP server](https://lakesail.com/blog/spark-mcp-server/) that brings data analytics in Spark to both LLM agents and humans!✨**
 
 ## Installation
 
-Sail is available as a Python package on PyPI. You can install it using `pip`.
+Sail is available as a Python package on PyPI. You can install it along with PySpark in your Python environment.
 
 ```bash
 pip install pysail
 pip install "pyspark[connect]"
 ```
 
-Alternatively, you can install Sail from source for better performance for your hardware architecture.
-You can follow the [Installation](https://docs.lakesail.com/sail/latest/introduction/installation/) guide for more information.
+Alternatively, you can install the lightweight client package `pyspark-client` since Spark 4.0.
+The `pyspark-connect` package, which is equivalent to `pyspark[connect]`, is also available since Spark 4.0.
+
+The [Installation](https://docs.lakesail.com/sail/latest/introduction/installation/) guide contains more information about installing Sail from source for better performance for your hardware architecture.
 
 ## Getting Started
 

--- a/docker/quickstart/Dockerfile
+++ b/docker/quickstart/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.11-slim
 
 ARG PYSAIL_VERSION
+ARG PYSPARK_VERSION=4.0.0
 
-RUN python3 -m pip install --no-cache-dir "pysail[spark]==${PYSAIL_VERSION}"
+RUN python3 -m pip install --no-cache-dir "pysail==${PYSAIL_VERSION}"
+RUN python3 -m pip install --no-cache-dir "pyspark[connect]==${PYSPARK_VERSION}"
 
 ENTRYPOINT ["/usr/local/bin/sail"]

--- a/docs/guide/integrations/mcp-server.md
+++ b/docs/guide/integrations/mcp-server.md
@@ -35,8 +35,8 @@ Replace `/path/to/sail` with the absolute path to the Sail CLI on your system.
 If you have installed Sail via `pip` in a Python virtual environment, the path is `$VENV/bin/sail` where `$VENV` is the absolute path to the virtual environment.
 Please note that you must install the PySail library with MCP dependencies.
 
-```bash
-pip install "pysail[spark,mcp]"
+```bash-vue
+pip install "pysail[mcp]=={{ libVersion }}" "pyspark-client==4.0.0"
 ```
 
 ::: info
@@ -64,3 +64,12 @@ For remote data sources, we also recommend that you use credentials with read-on
 ## Cleaning Up
 
 To remove the Sail MCP server from Claude for Desktop, remove the content from the configuration file and restart Claude for Desktop.
+
+<script setup>
+import { useData } from "vitepress";
+import { computed } from "vue";
+
+const { site } = useData();
+
+const libVersion = computed(() => site.value.contentProps?.libVersion);
+</script>

--- a/docs/introduction/getting-started/index.md
+++ b/docs/introduction/getting-started/index.md
@@ -6,20 +6,24 @@ rank: 3
 # Getting Started
 
 In this guide, you will see how to use Sail as the compute engine for PySpark.
+The Spark session communicates with the Sail server using the Spark Connect protocol.
+You can refer to the [Spark documentation](https://spark.apache.org/docs/latest/spark-connect-overview.html) for more information about Spark Connect.
+
+## Package Installation
 
 Install the required packages in your Python environment.
 You can choose the Spark version you want.
 
 ::: code-group
 
-```bash-vue [Spark 4.0]
-pip install "pysail=={{ libVersion }}"
-pip install "pyspark[connect]==4.0.0"
-```
-
 ```bash-vue [Spark 4.0 (Client) ]
 pip install "pysail=={{ libVersion }}"
 pip install "pyspark-client==4.0.0"
+```
+
+```bash-vue [Spark 4.0]
+pip install "pysail=={{ libVersion }}"
+pip install "pyspark[connect]==4.0.0"
 ```
 
 ```bash-vue [Spark 3.5]
@@ -30,12 +34,20 @@ pip install "pyspark[connect]==3.5.5
 :::
 
 ::: info
-Please refer to the [Installation](/introduction/installation/) page for more information about installing Sail.
+
+- `pyspark-client` is a lightweight PySpark client introduced in Spark 4.0 while `pyspark` remains as the full PySpark package containing all the JARs. The lightweight client cannot execute queries by itself, and can only connect to a Spark Connect server.
+- `pyspark[connect]` installs extra dependencies needed for Spark Connect. This is supported since Spark 3.4.
+- Since Spark 4.0, there is also a wrapper package `pyspark-connect` that you can use, which is equivalent to `pyspark[connect]`.
+
 :::
 
-::: info
-The way to invoke Sail has changed since Sail 0.1. In Sail 0.2, we have introduced the `sail` command-line interface (CLI) to interact with Sail.
-:::
+You can refer to the [Installation](/introduction/installation/) page for more information about installing Sail.
+
+::: details Migrating from Earlier Versions of Sail
+
+- Since Sail 0.2, the `sail` command-line interface (CLI) became the new way to interact with Sail.
+- Since Sail 0.3, you can no longer run `pip install pysail[spark]` to install PySail along with PySpark (the `spark` "extra"). You must explicitly install PySpark and choose the version you want to use.
+  :::
 
 ## Using the Sail PySpark Shell
 
@@ -45,16 +57,13 @@ You can start a PySpark shell from Sail, using the following command.
 sail spark shell
 ```
 
+You will see the banner and prompt similar to a regular PySpark shell.
+The `SparkSession` instance is available as the `spark` local variable.
+You can run Spark SQL queries or use the DataFrame API in the shell.
+The `SparkSession` instance communicates with the Sail server started in the same Python interpreter process. The Sail server runs in the background.
+
 ::: info
 The `sail` command is installed as an executable script as part of the `pysail` Python package. You can also invoke the Sail CLI via `python -m pysail`.
-:::
-
-You will see the banner and prompt similar to a regular PySpark shell.
-The `SparkSession` is available as the `spark` local variable.
-You can run Spark SQL queries or use the DataFrame API in the shell.
-
-::: info
-Spark uses the [Spark Connect](https://spark.apache.org/docs/latest/spark-connect-overview.html) protocol to communicate with Sail, which runs as a Spark Connect server in the background, in the same process.
 :::
 
 ## Using the Sail Library
@@ -98,10 +107,9 @@ In another terminal, you can connect to the Sail Spark Connect server using PySp
 env SPARK_CONNECT_MODE_ENABLED=1 SPARK_REMOTE="sc://localhost:50051" pyspark
 ```
 
-::: info
+::: warning
 
-1. The `pyspark` shell is not available if PySpark is installed via `pyspark-client`. To use the `pyspark` shell, you need to install `pyspark[connect]`.
-2. You can refer to the [Spark documentation](https://spark.apache.org/docs/latest/spark-connect-overview.html) for more information about Spark Connect.
+The `pyspark` shell is not available if PySpark is installed via `pyspark-client`. To use the `pyspark` shell, you need to install `pyspark[connect]`.
 
 :::
 

--- a/docs/introduction/getting-started/index.md
+++ b/docs/introduction/getting-started/index.md
@@ -8,10 +8,26 @@ rank: 3
 In this guide, you will see how to use Sail as the compute engine for PySpark.
 
 Install the required packages in your Python environment.
+You can choose the Spark version you want.
 
-```bash-vue
-pip install "pysail[spark]=={{ libVersion }}"
+::: code-group
+
+```bash-vue [Spark 4.0]
+pip install "pysail=={{ libVersion }}"
+pip install "pyspark[connect]==4.0.0"
 ```
+
+```bash-vue [Spark 4.0 (Client) ]
+pip install "pysail=={{ libVersion }}"
+pip install "pyspark-client==4.0.0"
+```
+
+```bash-vue [Spark 3.5]
+pip install "pysail=={{ libVersion }}"
+pip install "pyspark[connect]==3.5.5
+```
+
+:::
 
 ::: info
 Please refer to the [Installation](/introduction/installation/) page for more information about installing Sail.
@@ -83,8 +99,10 @@ env SPARK_CONNECT_MODE_ENABLED=1 SPARK_REMOTE="sc://localhost:50051" pyspark
 ```
 
 ::: info
-You can refer to the [Spark documentation](https://spark.apache.org/docs/latest/spark-connect-overview.html)
-for more information about Spark Connect.
+
+1. The `pyspark` shell is not available if PySpark is installed via `pyspark-client`. To use the `pyspark` shell, you need to install `pyspark[connect]`.
+2. You can refer to the [Spark documentation](https://spark.apache.org/docs/latest/spark-connect-overview.html) for more information about Spark Connect.
+
 :::
 
 <script setup>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,11 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-spark = [
+test = [
+    # The dependencies for testing the installed package.
     "pyspark-client>=4.0,<5",
     "duckdb>=1.0,<2",
+    "pytest>=8.4,<9",
 ]
 mcp = [
     "mcp>=1.0.0,<2",


### PR DESCRIPTION
This breaking change removes the `spark` optional dependencies (aka "extra") in the PySail Python package so that the user can choose the PySpark version for their installation.