### PR TITLE
feat: add zeroifnull and nullifzero functions

### DIFF
--- a/crates/sail-plan/src/function/scalar/conditional.rs
+++ b/crates/sail-plan/src/function/scalar/conditional.rs
@@ -1,5 +1,6 @@
 use datafusion::functions::expr_fn;
-use datafusion_expr::expr;
+use datafusion_common::ScalarValue;
+use datafusion_expr::{expr, lit};
 
 use crate::error::PlanResult;
 use crate::function::common::{ScalarFunction, ScalarFunctionInput};
@@ -44,8 +45,16 @@ pub(super) fn list_built_in_conditional_functions() -> Vec<(&'static str, Scalar
         ("ifnull", F::binary(expr_fn::nvl)),
         ("nanvl", F::binary(expr_fn::nanvl)),
         ("nullif", F::binary(expr_fn::nullif)),
+        (
+            "nullifzero",
+            F::unary(|arg| expr_fn::nullif(arg, lit(ScalarValue::Int32(Some(0))))),
+        ),
         ("nvl", F::binary(expr_fn::nvl)),
         ("nvl2", F::ternary(expr_fn::nvl2)),
+        (
+            "zeroifnull",
+            F::unary(|arg| expr_fn::nvl(arg, lit(ScalarValue::Int32(Some(0))))),
+        ),
         ("when", F::custom(case)),
         ("case", F::custom(case)),
     ]

--- a/crates/sail-spark-connect/tests/gold_data/function/conditional.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/conditional.json
@@ -221,7 +221,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: nullifzero"
+        "success": "ok"
       }
     },
     {
@@ -243,7 +243,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: nullifzero"
+        "success": "ok"
       }
     },
     {
@@ -313,7 +313,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: zeroifnull"
+        "success": "ok"
       }
     },
     {
@@ -335,7 +335,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: zeroifnull"
+        "success": "ok"
       }
     }
   ]


### PR DESCRIPTION
Support zeroifnull and nullifzero functions for feature parity with spark 4.0.0
https://spark.apache.org/docs/latest/api/sql/index.html#nullifzero
https://spark.apache.org/docs/latest/api/sql/index.html#zeroifnull
Part of #557