### PR TITLE
feat: string split to array by delim function

### DIFF
--- a/crates/sail-plan/src/function/scalar/string.rs
+++ b/crates/sail-plan/src/function/scalar/string.rs
@@ -5,6 +5,7 @@ use datafusion::functions;
 use datafusion::functions::expr_fn;
 use datafusion::functions::regex::regexpcount::RegexpCountFunc;
 use datafusion::functions::string::contains::ContainsFunc;
+use datafusion::functions_array::string::string_to_array;
 use datafusion_common::ScalarValue;
 use datafusion_expr::{expr, lit, ExprSchemable, ScalarUDF};
 
@@ -347,7 +348,10 @@ pub(super) fn list_built_in_string_functions() -> Vec<(&'static str, ScalarFunct
         ("sentences", F::unknown("sentences")),
         ("soundex", F::unknown("soundex")),
         ("space", F::unary(space)),
-        ("split", F::unknown("split")),
+        (
+            "split",
+            F::binary(|arg1, arg2| string_to_array(arg1, arg2, lit(ScalarValue::Utf8(None)))),
+        ),
         ("split_part", F::ternary(expr_fn::split_part)),
         ("startswith", F::binary(startswith)),
         ("substr", F::custom(substr)),


### PR DESCRIPTION
Implementation of basic spark split function usecase:
Given str1 and str2, split str1 to array of strings using str2 as delimiter

Doesn't provide full feature parity with https://spark.apache.org/docs/latest/api/sql/index.html#split
And doesn't pass any doctests
But is still useful for splitting string by delim to array of strings, and this works like in vanilla spark

Usage:
```python
from pysail.spark import SparkConnectServer
from pyspark.sql import SparkSession

server = SparkConnectServer()
server.start()
_, port = server.listening_address

spark = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()

one = spark.sql("SELECT split('a,b,c,d,e,', ',')").toArrow()
two = spark.sql("SELECT split('a12b12c12d1e12', '12')").toArrow()
print("one:", one)
print("two:", two)
```
```
one: pyarrow.Table
split(a,b,c,d,e,, ,): list<element: string>
  child 0, element: string
----
split(a,b,c,d,e,, ,): [[["a","b","c","d","e",""]]]
two: pyarrow.Table
split(a12b12c12d1e12, 12): list<element: string>
  child 0, element: string
----
split(a12b12c12d1e12, 12): [[["a","b","c","d1e",""]]]
```

Closes #572