### PR TITLE
fix: date_part('seconds', col) inconsistent type and value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ datafusion-common = { version = "48.0.0", features = ["object_store", "avro"] }
 datafusion-expr = { version = "48.0.0" }
 datafusion-expr-common = { version = "48.0.0" }
 datafusion-proto = { version = "48.0.0" }
+datafusion-functions = { version = "48.0.0" }
 datafusion-functions-nested = { version = "48.0.0" }
 datafusion-spark = { version = "48.0.0" }
 datafusion-functions-json = { git = "https://github.com/lakehq/datafusion-functions-json.git", rev = "c4f4298" }

--- a/crates/sail-plan/Cargo.toml
+++ b/crates/sail-plan/Cargo.toml
@@ -17,6 +17,7 @@ datafusion = { workspace = true }
 datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
 datafusion-expr-common = { workspace = true }
+datafusion-functions = { workspace = true }
 datafusion-functions-nested = { workspace = true }
 datafusion-spark = { workspace = true }
 datafusion-functions-json = { workspace = true }

--- a/crates/sail-plan/src/extension/function/datetime/mod.rs
+++ b/crates/sail-plan/src/extension/function/datetime/mod.rs
@@ -1,5 +1,6 @@
 mod datetime_utils;
 pub mod spark_date;
+pub mod spark_date_part;
 pub mod spark_from_utc_timestamp;
 pub mod spark_interval;
 pub mod spark_last_day;

--- a/crates/sail-plan/src/extension/function/datetime/spark_date_part.rs
+++ b/crates/sail-plan/src/extension/function/datetime/spark_date_part.rs
@@ -1,0 +1,137 @@
+use std::any::Any;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use arrow::array::Decimal128Array;
+use arrow::compute::kernels::cast_utils::IntervalUnit;
+use arrow::datatypes::{DataType, Field, FieldRef};
+use datafusion_common::utils::take_function_args;
+use datafusion_common::{exec_err, Result, ScalarValue};
+use datafusion_expr::{
+    ColumnarValue, Documentation, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+};
+use datafusion_functions::datetime::date_part::DatePartFunc;
+
+#[derive(Debug)]
+pub struct SparkDatePart {
+    inner: DatePartFunc,
+}
+
+impl Default for SparkDatePart {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SparkDatePart {
+    pub fn new() -> Self {
+        Self {
+            inner: DatePartFunc::new(),
+        }
+    }
+
+    fn invoke_seconds(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let ScalarFunctionArgs {
+            args,
+            arg_fields,
+            number_rows,
+            return_field,
+        } = args;
+
+        args.get(1).map_or_else(
+            || exec_err!(
+                "Spark `date_part` function requires 2 arguments, got {}",
+                arg_fields.len()
+            ),
+            |second_arg| {
+                self.inner.invoke_with_args(ScalarFunctionArgs {
+                    args: vec![
+                        ColumnarValue::Scalar(ScalarValue::Utf8(Some("microseconds".to_string()))),
+                        second_arg.clone(),
+                    ],
+                    arg_fields: arg_fields.clone(),
+                    number_rows,
+                    return_field: Arc::new(Field::new(
+                        return_field.name(),
+                        DataType::Int32,
+                        true,
+                    )),
+                })
+                .and_then(|value| value.cast_to(&DataType::Decimal128(8, 0), None))
+                .and_then(|value| {
+                    let is_scalar = matches!(value, ColumnarValue::Scalar(_));
+                    let array = match value {
+                        ColumnarValue::Array(array) => Arc::clone(&array),
+                        ColumnarValue::Scalar(scalar) => scalar.to_array()?,
+                    };
+                    array
+                        .as_any()
+                        .downcast_ref::<Decimal128Array>()
+                        .and_then(|arr| arr.clone().with_precision_and_scale(8, 6).ok())
+                        .map_or_else(
+                            || exec_err!("Spark `date_part`: Error when cast microseconds to decimal"),
+                            |divided| {
+                                if is_scalar {
+                                    Ok(ColumnarValue::Scalar(ScalarValue::try_from_array(&divided, 0)?))
+                                } else {
+                                    Ok(ColumnarValue::Array(Arc::new(divided)))
+                                }
+                            }
+                        )
+                })
+            }
+        )
+    }
+}
+
+impl ScalarUDFImpl for SparkDatePart {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn signature(&self) -> &Signature {
+        self.inner.signature()
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        self.inner.return_type(arg_types)
+    }
+
+    fn return_field_from_args(&self, args: ReturnFieldArgs) -> Result<FieldRef> {
+        let [field, _] = take_function_args(self.name(), args.scalar_arguments)?;
+
+        field
+            .and_then(|sv| sv.try_as_str())
+            .flatten()
+            .filter(|part| !part.is_empty())
+            .filter(|part| {
+                IntervalUnit::from_str(part).is_ok_and(|unit| matches!(unit, IntervalUnit::Second))
+            })
+            .map(|_| {
+                Ok(Arc::new(Field::new(
+                    self.name(),
+                    DataType::Decimal128(8, 6),
+                    true,
+                )))
+            })
+            .unwrap_or_else(|| self.inner.return_field_from_args(args))
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        match args.return_field.data_type() {
+            DataType::Decimal128(8, 6) => self.invoke_seconds(args),
+            _ => self.inner.invoke_with_args(args),
+        }
+    }
+
+    fn aliases(&self) -> &[String] {
+        self.inner.aliases()
+    }
+    fn documentation(&self) -> Option<&Documentation> {
+        self.inner.documentation()
+    }
+}


### PR DESCRIPTION
date_part('seconds', col) now is consistent with spark: 
change return type to decimal(8,6)
value contains seconds and microseconds splitted by fixed point

```python
import datetime
from pyspark.sql import functions as sf
df = spark.createDataFrame([(datetime.datetime(2015, 4, 8, 13, 8, 15, 1001),)], ['ts'])
df.select(
    '*',
    sf.date_part(sf.lit('YEAR'), 'ts').alias('year'),
    sf.date_part(sf.lit('month'), 'ts').alias('month'),
    sf.date_part(sf.lit('WEEK'), 'ts').alias('week'),
    sf.date_part(sf.lit('D'), df.ts).alias('day'),
    sf.date_part(sf.lit('M'), df.ts).alias('minute'),
    sf.date_part(sf.lit('S'), df.ts).alias('second'),
).toArrow()
```
```
pyarrow.Table
ts: timestamp[us, tz=UTC]
year: int32
month: int32
week: int32
day: int32
minute: int32
second: decimal128(8, 6)
----
ts: [[2015-04-08 10:08:15.001001Z]]
year: [[2015]]
month: [[4]]
week: [[15]]
day: [[8]]
minute: [[8]]
second: [[15.001001]]
```

closes #603