### PR TITLE
fix: inconsistent size, array_size and cardinality logic

### DIFF
--- a/crates/sail-execution/src/codec.rs
+++ b/crates/sail-execution/src/codec.rs
@@ -48,6 +48,7 @@ use sail_plan::extension::function::array::spark_array_item_with_position::Array
 use sail_plan::extension::function::array::spark_array_min_max::{ArrayMax, ArrayMin};
 use sail_plan::extension::function::array::spark_map_to_array::MapToArray;
 use sail_plan::extension::function::array::spark_sequence::SparkSequence;
+use sail_plan::extension::function::collection::deep_size::DeepSize;
 use sail_plan::extension::function::collection::spark_concat::SparkConcat;
 use sail_plan::extension::function::collection::spark_reverse::SparkReverse;
 use sail_plan::extension::function::collection::spark_size::SparkSize;
@@ -763,8 +764,12 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             "randn" => Ok(Arc::new(ScalarUDF::from(Randn::new()))),
             "random" | "rand" => Ok(Arc::new(ScalarUDF::from(Random::new()))),
             "spark_size" | "size" | "spark_cardinality" | "cardinality" => {
-                Ok(Arc::new(ScalarUDF::from(SparkSize::new())))
+                Ok(Arc::new(ScalarUDF::from(SparkSize::new(false, false))))
             }
+            "spark_array_size" | "array_size" => {
+                Ok(Arc::new(ScalarUDF::from(SparkSize::new(true, false))))
+            }
+            "deep_size" => Ok(Arc::new(ScalarUDF::from(DeepSize::new()))),
             "spark_array" | "spark_make_array" | "array" => {
                 Ok(Arc::new(ScalarUDF::from(SparkArray::new())))
             }

--- a/crates/sail-plan/src/extension/function/collection/deep_size.rs
+++ b/crates/sail-plan/src/extension/function/collection/deep_size.rs
@@ -1,0 +1,130 @@
+/// [Credit]: <https://github.com/apache/datafusion/blob/b10b820acb6ad92b5d69810e3d4de0ef6f2d6a87/datafusion/functions-nested/src/cardinality.rs>
+use std::any::Any;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait, UInt64Array};
+use datafusion::arrow::datatypes::DataType;
+use datafusion_common::cast::{as_large_list_array, as_list_array, as_map_array};
+use datafusion_common::{exec_err, plan_datafusion_err, plan_err, Result};
+use datafusion_expr::{
+    ArrayFunctionSignature, ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    TypeSignature, Volatility,
+};
+use datafusion_expr_common::signature::ArrayFunctionArgument;
+
+use crate::extension::function::functions_nested_utils::{
+    compute_array_dims, make_scalar_function,
+};
+
+// expr_fn::cardinality doesn't fully match expected behavior.
+// Spark's cardinality function seems to be the same as the size function.
+// `cardinality`: https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.cardinality.html
+// `size`: https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.size.html
+#[derive(Debug)]
+pub struct DeepSize {
+    signature: Signature,
+}
+
+impl Default for DeepSize {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DeepSize {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::one_of(
+                vec![
+                    TypeSignature::ArraySignature(ArrayFunctionSignature::Array {
+                        arguments: vec![ArrayFunctionArgument::Array],
+                        array_coercion: None,
+                    }),
+                    TypeSignature::ArraySignature(ArrayFunctionSignature::MapArray),
+                ],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for DeepSize {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "deep_size"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        Ok(match arg_types[0] {
+            DataType::List(_)
+            | DataType::LargeList(_)
+            | DataType::FixedSizeList(_, _)
+            | DataType::Map(_, _) => DataType::UInt64,
+            _ => {
+                return plan_err!(
+                    "The deep_size function can only accept List/LargeList/FixedSizeList/Map."
+                );
+            }
+        })
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let ScalarFunctionArgs { args, .. } = args;
+        make_scalar_function(size_inner)(&args)
+    }
+}
+
+pub fn size_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    if args.len() != 1 {
+        return exec_err!("deep_size expects one argument");
+    }
+    match &args[0].data_type() {
+        DataType::List(_) => {
+            let list_array = as_list_array(&args[0])?;
+            generic_list_deep_size::<i32>(list_array)
+        }
+        DataType::LargeList(_) => {
+            let list_array = as_large_list_array(&args[0])?;
+            generic_list_deep_size::<i64>(list_array)
+        }
+        DataType::Map(_, _) => {
+            let map_array = as_map_array(&args[0])?;
+            let result: UInt64Array = map_array
+                .iter()
+                .map(|opt_arr| opt_arr.map(|arr| arr.len() as u64))
+                .collect();
+            Ok(Arc::new(result))
+        }
+        other => {
+            exec_err!("deep_size does not support type '{:?}'", other)
+        }
+    }
+}
+
+fn generic_list_deep_size<O: OffsetSizeTrait>(array: &GenericListArray<O>) -> Result<ArrayRef> {
+    let result = array
+        .iter()
+        .map(|arr| match compute_array_dims(arr)? {
+            Some(vector) => {
+                let product = vector
+                    .iter()
+                    .map(|x| {
+                        x.ok_or_else(|| {
+                            plan_datafusion_err!("Unexpected None in compute_array_dims result")
+                        })
+                    })
+                    .product::<Result<u64>>()?;
+                Ok(Some(product))
+            }
+            None => Ok(Some(0)),
+        })
+        .collect::<Result<UInt64Array>>()?;
+    Ok(Arc::new(result) as ArrayRef)
+}

--- a/crates/sail-plan/src/extension/function/collection/mod.rs
+++ b/crates/sail-plan/src/extension/function/collection/mod.rs
@@ -1,3 +1,4 @@
+pub mod deep_size;
 pub mod spark_concat;
 pub mod spark_reverse;
 pub mod spark_size;

--- a/crates/sail-plan/src/extension/function/collection/spark_size.rs
+++ b/crates/sail-plan/src/extension/function/collection/spark_size.rs
@@ -2,19 +2,16 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use datafusion::arrow::array::{Array, ArrayRef, GenericListArray, OffsetSizeTrait, UInt64Array};
+use arrow::array::{Int32Array, Int64Array};
+use datafusion::arrow::array::{Array, ArrayRef};
 use datafusion::arrow::datatypes::DataType;
 use datafusion_common::cast::{as_large_list_array, as_list_array, as_map_array};
-use datafusion_common::{exec_err, plan_datafusion_err, plan_err, Result};
+use datafusion_common::{exec_err, plan_err, Result, ScalarValue};
 use datafusion_expr::{
     ArrayFunctionSignature, ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature,
     TypeSignature, Volatility,
 };
 use datafusion_expr_common::signature::ArrayFunctionArgument;
-
-use crate::extension::function::functions_nested_utils::{
-    compute_array_dims, make_scalar_function,
-};
 
 // expr_fn::cardinality doesn't fully match expected behavior.
 // Spark's cardinality function seems to be the same as the size function.
@@ -23,16 +20,18 @@ use crate::extension::function::functions_nested_utils::{
 #[derive(Debug)]
 pub struct SparkSize {
     signature: Signature,
+    is_array_size: bool,
+    is_legacy_cardinality: bool,
 }
 
 impl Default for SparkSize {
     fn default() -> Self {
-        Self::new()
+        Self::new(false, false)
     }
 }
 
 impl SparkSize {
-    pub fn new() -> Self {
+    pub fn new(is_array_size: bool, is_legacy_cardinality: bool) -> Self {
         Self {
             signature: Signature::one_of(
                 vec![
@@ -44,6 +43,8 @@ impl SparkSize {
                 ],
                 Volatility::Immutable,
             ),
+            is_array_size,
+            is_legacy_cardinality,
         }
     }
 }
@@ -62,14 +63,22 @@ impl ScalarUDFImpl for SparkSize {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        Ok(match arg_types[0] {
-            DataType::List(_)
-            | DataType::LargeList(_)
-            | DataType::FixedSizeList(_, _)
-            | DataType::Map(_, _) => DataType::UInt64,
-            _ => {
+        Ok(match (self.is_array_size, &arg_types[0]) {
+            (_, DataType::List(_))
+            | (_, DataType::FixedSizeList(_, _))
+            | (_, DataType::ListView(_))
+            | (false, DataType::Map(_, _)) => DataType::Int32,
+            (false, DataType::LargeList(_)) | (false, DataType::LargeListView(_)) => {
+                DataType::Int64
+            }
+            (false, _) => {
                 return plan_err!(
-                    "The size function can only accept List/LargeList/FixedSizeList/Map."
+                    "The size function can only accept List/LargeList/FixedSizeList/Map"
+                );
+            }
+            (true, _) => {
+                return plan_err!(
+                    "The array_size function can only accept List/ListView/FixedSizeList"
                 );
             }
         })
@@ -77,54 +86,46 @@ impl ScalarUDFImpl for SparkSize {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
-        make_scalar_function(size_inner)(&args)
-    }
-}
+        if args.len() != 1 {
+            return exec_err!("size expects one argument");
+        }
+        let is_scalar = matches!(args.first(), Some(ColumnarValue::Scalar(_)));
+        let args = ColumnarValue::values_to_arrays(&args)?;
 
-pub fn size_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
-    if args.len() != 1 {
-        return exec_err!("size expects one argument");
-    }
-    match &args[0].data_type() {
-        DataType::List(_) => {
-            let list_array = as_list_array(&args[0])?;
-            generic_list_size::<i32>(list_array)
-        }
-        DataType::LargeList(_) => {
-            let list_array = as_large_list_array(&args[0])?;
-            generic_list_size::<i64>(list_array)
-        }
-        DataType::Map(_, _) => {
-            let map_array = as_map_array(&args[0])?;
-            let result: UInt64Array = map_array
-                .iter()
-                .map(|opt_arr| opt_arr.map(|arr| arr.len() as u64))
-                .collect();
-            Ok(Arc::new(result))
-        }
-        other => {
-            exec_err!("size does not support type '{:?}'", other)
-        }
-    }
-}
+        let legacy_cardinality = self.is_legacy_cardinality.then_some(-1);
 
-fn generic_list_size<O: OffsetSizeTrait>(array: &GenericListArray<O>) -> Result<ArrayRef> {
-    let result = array
-        .iter()
-        .map(|arr| match compute_array_dims(arr)? {
-            Some(vector) => {
-                let product = vector
-                    .iter()
-                    .map(|x| {
-                        x.ok_or_else(|| {
-                            plan_datafusion_err!("Unexpected None in compute_array_dims result")
-                        })
-                    })
-                    .product::<Result<u64>>()?;
-                Ok(Some(product))
+        let result = match &args[0].data_type() {
+            DataType::List(_) | DataType::FixedSizeList(_, _) | DataType::ListView(_) => {
+                Ok(Arc::new(
+                    as_list_array(&args[0])?
+                        .iter()
+                        .map(|opt_arr| opt_arr.map(|arr| arr.len() as i32).or(legacy_cardinality))
+                        .collect::<Int32Array>(),
+                ) as ArrayRef)
             }
-            None => Ok(Some(0)),
-        })
-        .collect::<Result<UInt64Array>>()?;
-    Ok(Arc::new(result) as ArrayRef)
+            DataType::Map(_, _) => Ok(Arc::new(
+                as_map_array(&args[0])?
+                    .iter()
+                    .map(|opt_arr| opt_arr.map(|arr| arr.len() as i32).or(legacy_cardinality))
+                    .collect::<Int32Array>(),
+            ) as ArrayRef),
+            DataType::LargeList(_) | DataType::LargeListView(_) => Ok(Arc::new(
+                as_large_list_array(&args[0])?
+                    .iter()
+                    .map(|opt_arr| opt_arr.map(|arr| arr.len() as i64))
+                    .collect::<Int64Array>(),
+            ) as ArrayRef),
+            other => {
+                exec_err!("size does not support type '{:?}'", other)
+            }
+        };
+
+        if is_scalar {
+            // If all inputs are scalar, keeps output as scalar
+            let result = result.and_then(|arr| ScalarValue::try_from_array(&arr, 0));
+            result.map(ColumnarValue::Scalar)
+        } else {
+            result.map(ColumnarValue::Array)
+        }
+    }
 }

--- a/crates/sail-plan/src/function/scalar/collection.rs
+++ b/crates/sail-plan/src/function/scalar/collection.rs
@@ -1,5 +1,4 @@
-use datafusion::functions_nested::expr_fn;
-
+use crate::extension::function::collection::deep_size::DeepSize;
 use crate::extension::function::collection::spark_concat::SparkConcat;
 use crate::extension::function::collection::spark_reverse::SparkReverse;
 use crate::extension::function::collection::spark_size::SparkSize;
@@ -9,9 +8,13 @@ pub(super) fn list_built_in_collection_functions() -> Vec<(&'static str, ScalarF
     use crate::function::common::ScalarFunctionBuilder as F;
 
     vec![
-        ("array_size", F::unary(expr_fn::cardinality)),
-        ("cardinality", F::udf(SparkSize::new())),
-        ("size", F::udf(SparkSize::new())),
+        ("array_size", F::udf(SparkSize::new(true, false))),
+        // TODO: set second argument true
+        // if spark.sql.ansi.enabled is false and spark.sql.legacy.sizeOfNull is true
+        // https://spark.apache.org/docs/latest/api/sql/index.html#cardinality
+        ("cardinality", F::udf(SparkSize::new(false, false))),
+        ("deep_size", F::udf(DeepSize::new())),
+        ("size", F::udf(SparkSize::new(false, false))),
         ("concat", F::udf(SparkConcat::new())),
         ("reverse", F::udf(SparkReverse::new())),
     ]


### PR DESCRIPTION
fix return type for input types:
For List | ListView | FixedSizeList | Map -> `Int32` (Spark-compartible)
For LargeList | LargeListView -> `Int64` (Beyond spark functionality)

```python
from pysail.spark import SparkConnectServer
from pyspark.sql import SparkSession

server = SparkConnectServer()
server.start()
_, port = server.listening_address

#spark = SparkSession.builder.appName("test").getOrCreate()
spark = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()

from pyspark.sql import functions as sf
df = spark.createDataFrame([([[2, 1], [3, 4]],)], ['data'])
df.select(sf.cardinality(df.data), sf.array_size(df.data), sf.size(df.data)).toArrow()
```
```
pyarrow.Table
cardinality(data): int32
array_size(data): int32
size(data): int32
----
cardinality(data): [[2]]
array_size(data): [[2]]
size(data): [[2]]
```

`array_size` for `Map` input now returns exec_error like in spark
also introduce parameter for supporting legacy mode, but this needs external spark configuration to be applied
https://spark.apache.org/docs/latest/api/sql/index.html#cardinality
the legacy configuration logic is not implemented for now

Closes #614

Also move existing code that calcs nested lengths sum to deep_size function
so it can be used like this:
```python
from pyspark.sql import functions as sf
df = spark.createDataFrame([([[2, 1], [3, 4]],)], ['data']).createOrReplaceTempView("v")
spark.sql("select deep_size(data) from v").show()
```
```
+---------------+
|deep_size(data)|
+---------------+
|              4|
+---------------+
```