### PR TITLE
fix: array_position inconsistent result and internal_error in some cases

### DIFF
--- a/crates/sail-plan/src/function/scalar/array.rs
+++ b/crates/sail-plan/src/function/scalar/array.rs
@@ -1,7 +1,7 @@
 use datafusion::arrow::datatypes::DataType;
 use datafusion::functions::expr_fn::{coalesce, nvl};
 use datafusion::functions_nested::expr_fn;
-use datafusion::functions_nested::position::array_position_udf;
+use datafusion::functions_nested::position::array_position as datafusion_array_position;
 use datafusion_common::ScalarValue;
 use datafusion_expr::{expr, lit, BinaryExpr, Operator};
 use datafusion_functions_nested::string::ArrayToString;
@@ -101,6 +101,35 @@ fn array_contains_all(array: expr::Expr, element: expr::Expr) -> expr::Expr {
     )
 }
 
+fn array_position(array: expr::Expr, element: expr::Expr) -> expr::Expr {
+    coalesce(vec![
+        datafusion_array_position(
+            expr::Expr::Case(expr::Case {
+                expr: None,
+                when_then_expr: vec![(
+                    Box::new(expr::Expr::BinaryExpr(BinaryExpr {
+                        left: Box::new(expr_fn::cardinality(array.clone())),
+                        op: Operator::Gt,
+                        right: Box::new(lit(ScalarValue::UInt64(Some(0)))),
+                    })),
+                    Box::new(array.clone()),
+                )],
+                else_expr: None, // datafusion panics if from_index > array_len
+            }), // So if the inner array_len == 0, search in NULL array instead
+            element,
+            lit(ScalarValue::Int32(Some(1))),
+        ),
+        expr::Expr::Case(expr::Case {
+            expr: None,
+            when_then_expr: vec![(
+                Box::new(expr::Expr::IsNotNull(Box::new(array.clone()))),
+                Box::new(lit(ScalarValue::Int32(Some(0)))),
+            )], // if Array is not NULL, but elem not found, need to return 0
+            else_expr: None, // On NULL array still return NULL
+        }),
+    ])
+}
+
 pub(super) fn list_built_in_array_functions() -> Vec<(&'static str, ScalarFunction)> {
     use crate::function::common::ScalarFunctionBuilder as F;
 
@@ -117,7 +146,7 @@ pub(super) fn list_built_in_array_functions() -> Vec<(&'static str, ScalarFuncti
         ("array_join", F::udf(ArrayToString::new())),
         ("array_max", F::udf(ArrayMax::new())),
         ("array_min", F::udf(ArrayMin::new())),
-        ("array_position", F::scalar_udf(array_position_udf)),
+        ("array_position", F::binary(array_position)),
         ("array_prepend", F::binary(array_prepend)),
         ("array_remove", F::binary(expr_fn::array_remove_all)),
         ("array_repeat", F::binary(array_repeat)),


### PR DESCRIPTION
array_position:
1) return NULL only if input array is NULL
otherwise, if element not found, return 0
2) Fix panic on empty array

```python
from pysail.spark import SparkConnectServer
from pyspark.sql import SparkSession
import pyspark.sql.functions as F

server = SparkConnectServer()
server.start()
_, port = server.listening_address
port = 50051

spark = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
#spark = SparkSession.builder.appName("test").getOrCreate()

from pyspark.sql import functions as sf
from pyspark.sql.types import ArrayType, StringType, StructField, StructType
schema = StructType([StructField("data", ArrayType(StringType()), True)])

df = spark.createDataFrame([
    (["a", "c"],), (["c"],), ([None],), (None,), 
], schema=schema)
df.createOrReplaceTempView("v1")
spark.sql("select array_position(data, 'c') from v1").show()

df = spark.createDataFrame([
    ([],)
], schema=schema)
df.createOrReplaceTempView("v2")

spark.sql("select array_position(data, 'c') from v2").show()
```
result:
```
+-----------------------+
|array_position(data, c)|
+-----------------------+
|                      2|
|                      1|
|                      0|
|                   NULL|
+-----------------------+

+-----------------------+
|array_position(data, c)|
+-----------------------+
|                      0|
+-----------------------+
```
passes spark-tests
closes #620