### PR TITLE
fix: array_append and array_prepend inconsistent NULL behaviour

### DIFF
--- a/crates/sail-plan/src/function/scalar/array.rs
+++ b/crates/sail-plan/src/function/scalar/array.rs
@@ -67,8 +67,26 @@ fn sort_array(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     Ok(expr_fn::array_sort(array, sort, nulls))
 }
 
+fn array_append(array: expr::Expr, element: expr::Expr) -> expr::Expr {
+    expr::Expr::Case(expr::Case {
+        expr: None,
+        when_then_expr: vec![(
+            Box::new(expr::Expr::IsNotNull(Box::new(array.clone()))),
+            Box::new(expr_fn::array_append(array, element)),
+        )],
+        else_expr: None,
+    })
+}
+
 fn array_prepend(array: expr::Expr, element: expr::Expr) -> expr::Expr {
-    expr_fn::array_prepend(element, array)
+    expr::Expr::Case(expr::Case {
+        expr: None,
+        when_then_expr: vec![(
+            Box::new(expr::Expr::IsNotNull(Box::new(array.clone()))),
+            Box::new(expr_fn::array_prepend(element, array)),
+        )],
+        else_expr: None,
+    })
 }
 
 fn array_element(array: expr::Expr, element: expr::Expr) -> expr::Expr {
@@ -106,7 +124,7 @@ pub(super) fn list_built_in_array_functions() -> Vec<(&'static str, ScalarFuncti
 
     vec![
         ("array", F::udf(SparkArray::new())),
-        ("array_append", F::binary(expr_fn::array_append)),
+        ("array_append", F::binary(array_append)),
         ("array_compact", F::unary(array_compact)),
         ("array_contains", F::binary(array_contains)),
         ("array_contains_all", F::binary(array_contains_all)),


### PR DESCRIPTION
array_append and array_prepend now return NULL if input array is NULL, like in spark
```python
from pysail.spark import SparkConnectServer
from pyspark.sql import SparkSession

server = SparkConnectServer()
server.start()
_, port = server.listening_address

spark = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
#spark = SparkSession.builder.appName("test").getOrCreate()


from pyspark.sql import functions as sf
from pyspark.sql.types import ArrayType, IntegerType, StructType, StructField
schema = StructType([
  StructField("data", ArrayType(IntegerType()), True)
])
df = spark.createDataFrame([(None,)], schema=schema)
df.select(sf.array_append(df.data, 4)).show()
df.select(sf.array_prepend(df.data, 4)).show()
```
```
+---------------------+
|array_append(data, 4)|
+---------------------+
|                 NULL|
+---------------------+

+----------------------+
|array_prepend(data, 4)|
+----------------------+
|                  NULL|
+----------------------+
```
passes spark-tests
closes #622