### PR TITLE
fix: codec for `from_csv`

### DIFF
--- a/crates/sail-execution/src/codec.rs
+++ b/crates/sail-execution/src/codec.rs
@@ -876,6 +876,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node.inner().as_any().is::<SparkArray>()
             || node.inner().as_any().is::<SparkConcat>()
             || node.inner().as_any().is::<SparkHex>()
+            || node.inner().as_any().is::<SparkFromCSV>()
             || node.inner().as_any().is::<SparkUnHex>()
             || node.inner().as_any().is::<SparkMurmur3Hash>()
             || node.inner().as_any().is::<SparkReverse>()


### PR DESCRIPTION
When I merged the main branch into mine earlier, I didn’t see this line and it caught my attention. After reviewing it again later, I confirmed it wasn’t there before.
If this line isn't necessary, feel free to close the PR. Thanks!

