### PR TITLE
feat: add array_insert function

### DIFF
--- a/crates/sail-plan/src/function/common.rs
+++ b/crates/sail-plan/src/function/common.rs
@@ -332,3 +332,19 @@ pub(crate) fn get_null_treatment(ignore_nulls: Option<bool>) -> Option<NullTreat
         None => None,
     }
 }
+
+#[macro_export]
+/// Helper macro to create Case expression boilerplate from when-then pairs and NULL otherwise
+macro_rules! when_then_or_null {
+    ($($when:expr => $then:expr),* $(,)?) => {
+        expr::Expr::Case(expr::Case {
+            expr: None,
+            when_then_expr: vec![
+                $(
+                    (Box::new($when.clone()), Box::new($then.clone()))
+                ),*
+            ],
+            else_expr: None,
+        })
+    };
+}

--- a/crates/sail-plan/src/function/common.rs
+++ b/crates/sail-plan/src/function/common.rs
@@ -332,19 +332,3 @@ pub(crate) fn get_null_treatment(ignore_nulls: Option<bool>) -> Option<NullTreat
         None => None,
     }
 }
-
-#[macro_export]
-/// Helper macro to create Case expression boilerplate from when-then pairs and NULL otherwise
-macro_rules! when_then_or_null {
-    ($($when:expr => $then:expr),* $(,)?) => {
-        expr::Expr::Case(expr::Case {
-            expr: None,
-            when_then_expr: vec![
-                $(
-                    (Box::new($when.clone()), Box::new($then.clone()))
-                ),*
-            ],
-            else_expr: None,
-        })
-    };
-}

--- a/crates/sail-plan/src/function/scalar/array.rs
+++ b/crates/sail-plan/src/function/scalar/array.rs
@@ -12,6 +12,7 @@ use crate::extension::function::array::spark_array_min_max::{ArrayMax, ArrayMin}
 use crate::extension::function::array::spark_sequence::SparkSequence;
 use crate::function::common::{ScalarFunction, ScalarFunctionInput};
 use crate::utils::ItemTaker;
+use crate::when_then_or_null;
 
 fn array_repeat(element: expr::Expr, count: expr::Expr) -> expr::Expr {
     let count = expr::Expr::Cast(expr::Cast {
@@ -148,6 +149,44 @@ fn array_position(array: expr::Expr, element: expr::Expr) -> expr::Expr {
     ])
 }
 
+fn array_insert(array: expr::Expr, position: expr::Expr, value: expr::Expr) -> expr::Expr {
+    let array_len = expr::Expr::Cast(expr::Cast {
+        expr: Box::new(expr_fn::array_length(array.clone())),
+        data_type: DataType::Int64,
+    });
+
+    let pos_from_zero = when_then_or_null!(
+        position.clone().gt(lit(0)) => position.clone() - lit(1),
+        position.clone().lt(lit(0)) => array_len.clone() + position + lit(1),
+    );
+
+    when_then_or_null!(
+        array.clone().is_null() => array.clone(),
+        // This causes datafusion exception, so the spark failing behaviour on position == 0 is saved
+        pos_from_zero.clone().is_null() => expr_fn::array_concat(vec![]),
+        pos_from_zero.clone().lt(lit(0)) => expr_fn::array_concat(vec![
+            expr_fn::array_repeat(value.clone(), lit(1)),
+            expr_fn::array_repeat(lit(ScalarValue::Null), -pos_from_zero.clone()),
+            array.clone(),
+        ]),
+        pos_from_zero.clone().eq(lit(0)) => expr_fn::array_prepend(value.clone(), array.clone()),
+        pos_from_zero.clone().between(lit(1), array_len.clone() - lit(1)) => expr_fn::array_concat(vec![
+            expr_fn::array_slice(array.clone(), lit(1), pos_from_zero.clone(), None),
+            expr_fn::array_repeat(value.clone(), lit(1)),
+            expr_fn::array_slice(array.clone(), pos_from_zero.clone() + lit(1), array_len.clone(), None),
+        ]),
+        pos_from_zero.clone().eq(array_len.clone()) => expr_fn::array_append(array.clone(), value.clone()),
+        pos_from_zero.clone().gt(array_len.clone()) => expr_fn::array_concat(vec![
+            array.clone(),
+            expr_fn::array_repeat(
+                lit(ScalarValue::Null),
+                pos_from_zero - array_len,
+            ),
+            expr_fn::array_repeat(value, lit(1)),
+        ]),
+    )
+}
+
 pub(super) fn list_built_in_array_functions() -> Vec<(&'static str, ScalarFunction)> {
     use crate::function::common::ScalarFunctionBuilder as F;
 
@@ -159,7 +198,7 @@ pub(super) fn list_built_in_array_functions() -> Vec<(&'static str, ScalarFuncti
         ("array_contains_all", F::binary(array_contains_all)),
         ("array_distinct", F::unary(expr_fn::array_distinct)),
         ("array_except", F::binary(expr_fn::array_except)),
-        ("array_insert", F::unknown("array_insert")),
+        ("array_insert", F::ternary(array_insert)),
         ("array_intersect", F::binary(expr_fn::array_intersect)),
         ("array_join", F::udf(ArrayToString::new())),
         ("array_max", F::udf(ArrayMax::new())),

--- a/crates/sail-plan/src/function/scalar/array.rs
+++ b/crates/sail-plan/src/function/scalar/array.rs
@@ -3,7 +3,7 @@ use datafusion::functions::expr_fn::{coalesce, nvl};
 use datafusion::functions_nested::expr_fn;
 use datafusion::functions_nested::position::array_position as datafusion_array_position;
 use datafusion_common::ScalarValue;
-use datafusion_expr::{expr, lit, not, BinaryExpr, ExprSchemable, Operator};
+use datafusion_expr::{expr, lit, not, when, BinaryExpr, ExprSchemable, Operator};
 use datafusion_functions_nested::make_array::make_array;
 use datafusion_functions_nested::string::ArrayToString;
 
@@ -13,7 +13,6 @@ use crate::extension::function::array::spark_array_min_max::{ArrayMax, ArrayMin}
 use crate::extension::function::array::spark_sequence::SparkSequence;
 use crate::function::common::{ScalarFunction, ScalarFunctionInput};
 use crate::utils::ItemTaker;
-use crate::when_then_or_null;
 
 fn array_repeat(element: expr::Expr, count: expr::Expr) -> expr::Expr {
     let count = expr::Expr::Cast(expr::Cast {
@@ -150,42 +149,67 @@ fn array_position(array: expr::Expr, element: expr::Expr) -> expr::Expr {
     ])
 }
 
-fn array_insert(array: expr::Expr, position: expr::Expr, value: expr::Expr) -> expr::Expr {
+fn array_insert(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
+    let (array, position, value) = input.arguments.three()?;
+
     let array_len = expr::Expr::Cast(expr::Cast {
         expr: Box::new(expr_fn::array_length(array.clone())),
         data_type: DataType::Int64,
     });
 
-    let pos_from_zero = when_then_or_null!(
-        position.clone().gt(lit(0)) => position.clone() - lit(1),
-        position.clone().lt(lit(0)) => array_len.clone() + position + lit(1),
-    );
+    let pos_from_zero = when(position.clone().gt(lit(0)), position.clone() - lit(1))
+        .when(
+            position.clone().lt(lit(0)),
+            array_len.clone() + position + lit(1),
+        )
+        .end()?;
 
-    when_then_or_null!(
-        array.clone().is_null() => array.clone(),
+    Ok(when(array.clone().is_null(), array.clone())
         // This causes datafusion exception, so the spark failing behaviour on position == 0 is saved
-        pos_from_zero.clone().is_null() => expr_fn::array_concat(vec![]),
-        pos_from_zero.clone().lt(lit(0)) => expr_fn::array_concat(vec![
-            expr_fn::array_repeat(value.clone(), lit(1)),
-            expr_fn::array_repeat(lit(ScalarValue::Null), -pos_from_zero.clone()),
-            array.clone(),
-        ]),
-        pos_from_zero.clone().eq(lit(0)) => expr_fn::array_prepend(value.clone(), array.clone()),
-        pos_from_zero.clone().between(lit(1), array_len.clone() - lit(1)) => expr_fn::array_concat(vec![
-            expr_fn::array_slice(array.clone(), lit(1), pos_from_zero.clone(), None),
-            expr_fn::array_repeat(value.clone(), lit(1)),
-            expr_fn::array_slice(array.clone(), pos_from_zero.clone() + lit(1), array_len.clone(), None),
-        ]),
-        pos_from_zero.clone().eq(array_len.clone()) => expr_fn::array_append(array.clone(), value.clone()),
-        pos_from_zero.clone().gt(array_len.clone()) => expr_fn::array_concat(vec![
-            array.clone(),
-            expr_fn::array_repeat(
-                lit(ScalarValue::Null),
-                pos_from_zero - array_len,
-            ),
-            expr_fn::array_repeat(value, lit(1)),
-        ]),
-    )
+        .when(
+            pos_from_zero.clone().is_null(),
+            expr_fn::array_concat(vec![]),
+        )
+        .when(
+            pos_from_zero.clone().lt(lit(0)),
+            expr_fn::array_concat(vec![
+                expr_fn::array_repeat(value.clone(), lit(1)),
+                expr_fn::array_repeat(lit(ScalarValue::Null), -pos_from_zero.clone()),
+                array.clone(),
+            ]),
+        )
+        .when(
+            pos_from_zero.clone().eq(lit(0)),
+            expr_fn::array_prepend(value.clone(), array.clone()),
+        )
+        .when(
+            pos_from_zero
+                .clone()
+                .between(lit(1), array_len.clone() - lit(1)),
+            expr_fn::array_concat(vec![
+                expr_fn::array_slice(array.clone(), lit(1), pos_from_zero.clone(), None),
+                expr_fn::array_repeat(value.clone(), lit(1)),
+                expr_fn::array_slice(
+                    array.clone(),
+                    pos_from_zero.clone() + lit(1),
+                    array_len.clone(),
+                    None,
+                ),
+            ]),
+        )
+        .when(
+            pos_from_zero.clone().eq(array_len.clone()),
+            expr_fn::array_append(array.clone(), value.clone()),
+        )
+        .when(
+            pos_from_zero.clone().gt(array_len.clone()),
+            expr_fn::array_concat(vec![
+                array.clone(),
+                expr_fn::array_repeat(lit(ScalarValue::Null), pos_from_zero - array_len),
+                expr_fn::array_repeat(value, lit(1)),
+            ]),
+        )
+        .end()?)
 }
 
 fn flatten(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
@@ -224,7 +248,7 @@ pub(super) fn list_built_in_array_functions() -> Vec<(&'static str, ScalarFuncti
         ("array_contains_all", F::binary(array_contains_all)),
         ("array_distinct", F::unary(expr_fn::array_distinct)),
         ("array_except", F::binary(expr_fn::array_except)),
-        ("array_insert", F::ternary(array_insert)),
+        ("array_insert", F::custom(array_insert)),
         ("array_intersect", F::binary(expr_fn::array_intersect)),
         ("array_join", F::udf(ArrayToString::new())),
         ("array_max", F::udf(ArrayMax::new())),

--- a/crates/sail-spark-connect/tests/gold_data/function/array.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/array.json
@@ -253,7 +253,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: array_insert"
+        "success": "ok"
       }
     },
     {
@@ -279,7 +279,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: array_insert"
+        "success": "ok"
       }
     },
     {
@@ -305,7 +305,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: array_insert"
+        "success": "ok"
       }
     },
     {


### PR DESCRIPTION
Add `array_insert` function implementation:
https://spark.apache.org/docs/latest/api/sql/index.html#array_insert
using only datafusion expressions

passes spark-tests
please tell if there is duplicate expression elimination in Sail, because the plan creates a lot of them

raises exception if position is zero, like spark does
but the exception message is not informative in this case
because cannot override datafusion runtime exceptions at the plan level
so I just found some datafusion method that is always raising exception and call it in case of 0

part of #220