### PR TITLE
fix: array_agg null values treatment

### DIFF
--- a/crates/sail-plan/src/function/aggregate.rs
+++ b/crates/sail-plan/src/function/aggregate.rs
@@ -233,6 +233,15 @@ fn collect_set(input: AggFunctionInput) -> PlanResult<expr::Expr> {
     ))
 }
 
+fn array_agg_compacted(input: AggFunctionInput) -> PlanResult<expr::Expr> {
+    use crate::function::common::AggFunctionBuilder as F;
+
+    Ok(expr_fn::array_remove_all(
+        F::default(array_agg::array_agg_udaf)(input)?,
+        lit(ScalarValue::Null),
+    ))
+}
+
 fn list_built_in_aggregate_functions() -> Vec<(&'static str, AggFunction)> {
     use crate::function::common::AggFunctionBuilder as F;
 
@@ -247,7 +256,7 @@ fn list_built_in_aggregate_functions() -> Vec<(&'static str, AggFunction)> {
             "approx_percentile",
             F::default(approx_percentile_cont::approx_percentile_cont_udaf),
         ),
-        ("array_agg", F::default(array_agg::array_agg_udaf)),
+        ("array_agg", F::custom(array_agg_compacted)),
         ("avg", F::default(average::avg_udaf)),
         ("bit_and", F::default(bit_and_or_xor::bit_and_udaf)),
         ("bit_or", F::default(bit_and_or_xor::bit_or_udaf)),


### PR DESCRIPTION
now all nulls are removed from result list, like in spark:

```python
from pysail.spark import SparkConnectServer
from pyspark.sql import SparkSession

server = SparkConnectServer()
server.start()
_, port = server.listening_address

spark = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
#spark = SparkSession.builder.appName("test").getOrCreate()

from pyspark.sql import functions as sf
df = spark.createDataFrame([[1],[None],[2]], ["c"])
df.agg(sf.sort_array(sf.array_agg('c')).alias('sorted_list')).show()

df = spark.createDataFrame([[None],[None],[None]], "c int")
df.agg(sf.sort_array(sf.array_agg('c')).alias('sorted_list')).show()
```

```
+-----------+
|sorted_list|
+-----------+
|     [1, 2]|
+-----------+

+-----------+
|sorted_list|
+-----------+
|         []|
+-----------+
```

closes #639