### PR TITLE
fix: flatten function inconsistent null behaviour

### DIFF
--- a/crates/sail-plan/src/function/scalar/array.rs
+++ b/crates/sail-plan/src/function/scalar/array.rs
@@ -3,7 +3,8 @@ use datafusion::functions::expr_fn::{coalesce, nvl};
 use datafusion::functions_nested::expr_fn;
 use datafusion::functions_nested::position::array_position as datafusion_array_position;
 use datafusion_common::ScalarValue;
-use datafusion_expr::{expr, lit, BinaryExpr, Operator};
+use datafusion_expr::{expr, lit, not, BinaryExpr, ExprSchemable, Operator};
+use datafusion_functions_nested::make_array::make_array;
 use datafusion_functions_nested::string::ArrayToString;
 
 use crate::error::{PlanError, PlanResult};
@@ -148,6 +149,31 @@ fn array_position(array: expr::Expr, element: expr::Expr) -> expr::Expr {
     ])
 }
 
+fn flatten(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
+    let ScalarFunctionInput {
+        arguments,
+        function_context,
+    } = input;
+
+    let array = arguments.one()?;
+
+    let same_type_null_only_array = expr::Expr::Cast(expr::Cast {
+        expr: Box::new(make_array(vec![lit(ScalarValue::Null)])),
+        data_type: array.get_type(function_context.schema)?,
+    });
+
+    let array_has_null = expr_fn::array_has_any(array.clone(), same_type_null_only_array);
+
+    Ok(expr::Expr::Case(expr::Case {
+        expr: None,
+        when_then_expr: vec![(
+            Box::new(not(array_has_null)),
+            Box::new(expr_fn::flatten(array)),
+        )],
+        else_expr: None,
+    }))
+}
+
 pub(super) fn list_built_in_array_functions() -> Vec<(&'static str, ScalarFunction)> {
     use crate::function::common::ScalarFunctionBuilder as F;
 
@@ -171,7 +197,7 @@ pub(super) fn list_built_in_array_functions() -> Vec<(&'static str, ScalarFuncti
         ("array_union", F::binary(expr_fn::array_union)),
         ("arrays_overlap", F::binary(expr_fn::array_has_any)),
         ("arrays_zip", F::unknown("arrays_zip")),
-        ("flatten", F::unary(expr_fn::flatten)),
+        ("flatten", F::custom(flatten)),
         ("get", F::binary(array_element)),
         ("sequence", F::udf(SparkSequence::new())),
         ("shuffle", F::unknown("shuffle")),


### PR DESCRIPTION
return NULL if any of sub-arrays is NULL like spark does

```python
from pysail.spark import SparkConnectServer
from pyspark.sql import SparkSession

server = SparkConnectServer()
server.start()
_, port = server.listening_address

spark = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
#spark = SparkSession.builder.appName("test").getOrCreate()

spark.sql("""SELECT flatten(array(null, array(1, 2), array(3, 4)))""").show()
```
```
+----------------------------------------------+
|flatten(array(NULL, array(1, 2), array(3, 4)))|
+----------------------------------------------+
|                                          NULL|
+----------------------------------------------+
```

closes #641