### PR TITLE
perf: collect_set and array_agg functions

### DIFF
--- a/crates/sail-plan/src/function/aggregate.rs
+++ b/crates/sail-plan/src/function/aggregate.rs
@@ -7,11 +7,10 @@ use datafusion::functions_aggregate::{
     correlation, count, covariance, first_last, grouping, median, min_max, regr, stddev, sum,
     variance,
 };
-use datafusion::functions_nested::expr_fn;
 use datafusion::sql::sqlparser::ast::NullTreatment;
 use datafusion_common::ScalarValue;
 use datafusion_expr::expr::{AggregateFunction, AggregateFunctionParams};
-use datafusion_expr::{expr, lit, AggregateUDF};
+use datafusion_expr::{expr, AggregateUDF};
 use lazy_static::lazy_static;
 
 use crate::error::{PlanError, PlanResult};

--- a/crates/sail-plan/src/function/aggregate.rs
+++ b/crates/sail-plan/src/function/aggregate.rs
@@ -225,21 +225,29 @@ fn count_if(input: AggFunctionInput) -> PlanResult<expr::Expr> {
 }
 
 fn collect_set(input: AggFunctionInput) -> PlanResult<expr::Expr> {
-    use crate::function::common::AggFunctionBuilder as F;
-
-    Ok(expr_fn::array_remove(
-        expr_fn::array_distinct(F::default(array_agg::array_agg_udaf)(input)?),
-        lit(ScalarValue::Null),
-    ))
+    Ok(expr::Expr::AggregateFunction(AggregateFunction {
+        func: array_agg::array_agg_udaf(),
+        params: AggregateFunctionParams {
+            args: input.arguments.clone(),
+            distinct: true,
+            order_by: input.order_by,
+            filter: input.filter,
+            null_treatment: get_null_treatment(Some(true)),
+        },
+    }))
 }
 
 fn array_agg_compacted(input: AggFunctionInput) -> PlanResult<expr::Expr> {
-    use crate::function::common::AggFunctionBuilder as F;
-
-    Ok(expr_fn::array_remove_all(
-        F::default(array_agg::array_agg_udaf)(input)?,
-        lit(ScalarValue::Null),
-    ))
+    Ok(expr::Expr::AggregateFunction(AggregateFunction {
+        func: array_agg::array_agg_udaf(),
+        params: AggregateFunctionParams {
+            args: input.arguments.clone(),
+            distinct: input.distinct,
+            order_by: input.order_by,
+            filter: input.filter,
+            null_treatment: get_null_treatment(Some(true)),
+        },
+    }))
 }
 
 fn list_built_in_aggregate_functions() -> Vec<(&'static str, AggFunction)> {


### PR DESCRIPTION
Found out that some of my solutions are sub-optimal and can be rewritten without external function calls:

`collect_set` is `array_agg_udaf` with `distinct` and `ignore_nulls` required
`array_agg` is `array_agg_udaf` with `ignore_nulls` required

array_distinct and array_remove that could slow down the queries on big arrays are not needed anymore

Behaviour is not changed, tests are still passed