### PR TITLE
fix: concat function behaviour on some subset of input types

### DIFF
--- a/crates/sail-plan/src/extension/function/collection/spark_concat.rs
+++ b/crates/sail-plan/src/extension/function/collection/spark_concat.rs
@@ -166,7 +166,7 @@ impl ScalarUDFImpl for SparkConcat {
 
         let concatenated_array = match concatenated {
             ColumnarValue::Array(arr) => arr,
-            ColumnarValue::Scalar(s) => s.to_array()?, // преобразуем скаляр в массив
+            ColumnarValue::Scalar(s) => s.to_array()?,
         };
 
         Ok(ColumnarValue::Array(nullif(


### PR DESCRIPTION
fix concat behaviour for various types:
binary -> binary (casts to strings and uses string concat but casts result to binary)
primitive (coerce to string) -> string 
string and primitive -> string
any NULL input -> NULL output

passes spark-tests
closes #646 (if it's ok to create another issue about passing input arrays with different but coercible types)