### PR TITLE
fix: case when else expr inconsistent eager evaluation

### DIFF
--- a/crates/sail-plan/src/function/scalar/conditional.rs
+++ b/crates/sail-plan/src/function/scalar/conditional.rs
@@ -11,19 +11,18 @@ fn case(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     let ScalarFunctionInput { arguments, .. } = input;
     let mut when_then_expr = Vec::new();
     let mut iter = arguments.into_iter();
-    let mut else_expr: Option<Box<expr::Expr>> = None;
     while let Some(condition) = iter.next() {
         if let Some(result) = iter.next() {
             when_then_expr.push((Box::new(condition), Box::new(result)));
         } else {
-            else_expr = Some(Box::new(condition));
+            when_then_expr.push((Box::new(lit(true)), Box::new(condition)));
             break;
         }
     }
     Ok(expr::Expr::Case(expr::Case {
         expr: None, // Expr::Case in from_ast_expression incorporates into when_then_expr
         when_then_expr,
-        else_expr,
+        else_expr: None,
     }))
 }
 


### PR DESCRIPTION
now `case when ... else this` or `when(...).otherwise(this)`  is lazy evaluated like in spark:
```python
from pysail.spark import SparkConnectServer
from pyspark.sql import SparkSession

server = SparkConnectServer()
server.start()
_, port = server.listening_address

spark = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
#spark = SparkSession.builder.appName("test").getOrCreate()

from pyspark.sql import functions as sf
df = spark.createDataFrame([(2, "Alice"), (5, "Bob")], ["age", "name"])
result = df.select(
    df.name, sf.when(sf.lit(True), 1).otherwise(
        sf.raise_error("unreachable")).alias("when"))
result.show()
```
```
+-----+----+
| name|when|
+-----+----+
|Alice|   1|
|  Bob|   1|
+-----+----+
```

passes spark-test
closes #648