### PR TITLE
fix: maxRecordsPerBatch negative and zero value

### DIFF
--- a/crates/sail-spark-connect/src/config.rs
+++ b/crates/sail-spark-connect/src/config.rs
@@ -260,10 +260,12 @@ impl TryFrom<&SparkRuntimeConfig> for PySparkUdfConfig {
 
         if let Some(value) = config
             .get(SPARK_SQL_EXECUTION_ARROW_MAX_RECORDS_PER_BATCH)?
-            .map(|x| x.parse::<usize>())
+            .map(|x| x.parse::<i128>())
             .transpose()?
         {
-            output.arrow_max_records_per_batch = value;
+            output.arrow_max_records_per_batch = (value <= 0 || value > usize::MAX as i128)
+                .then(|| usize::MAX)
+                .unwrap_or(value as usize);
         }
 
         Ok(output)


### PR DESCRIPTION
spark.sql.execution.arrow.maxRecordsPerBatch: 
negative and zero value -> unlimited batch size (u64::MAX in our case)

https://github.com/apache/spark/blob/ecfbaa89166f799ee252ef8c7aec83fe7a78c977/python/pyspark/sql/tests/arrow/test_arrow.py#L1671
https://issues.apache.org/jira/browse/SPARK-47068

closes #651