### PR TITLE
Feature/listagg function

### DIFF
--- a/crates/sail-plan/src/function/aggregate.rs
+++ b/crates/sail-plan/src/function/aggregate.rs
@@ -1,16 +1,18 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use arrow::datatypes::Field;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::functions_aggregate::{
     approx_distinct, approx_percentile_cont, array_agg, average, bit_and_or_xor, bool_and_or,
     correlation, count, covariance, first_last, grouping, median, min_max, regr, stddev, sum,
     variance,
 };
+use datafusion::functions_nested::string::array_to_string;
 use datafusion::sql::sqlparser::ast::NullTreatment;
 use datafusion_common::ScalarValue;
 use datafusion_expr::expr::{AggregateFunction, AggregateFunctionParams};
-use datafusion_expr::{expr, AggregateUDF};
+use datafusion_expr::{expr, lit, when, AggregateUDF, ExprSchemable};
 use lazy_static::lazy_static;
 
 use crate::error::{PlanError, PlanResult};
@@ -249,6 +251,48 @@ fn array_agg_compacted(input: AggFunctionInput) -> PlanResult<expr::Expr> {
     }))
 }
 
+fn listagg(input: AggFunctionInput) -> PlanResult<expr::Expr> {
+    let schema = input.function_context.schema;
+    let (agg_col, other_args) = input.arguments.at_least_one()?;
+    if agg_col.get_type(schema)? == DataType::Null {
+        return Ok(lit(ScalarValue::Null));
+    }
+    let delim = other_args.first().cloned().unwrap_or_else(|| lit(""));
+
+    let agg = expr::Expr::AggregateFunction(AggregateFunction {
+        func: array_agg::array_agg_udaf(),
+        params: AggregateFunctionParams {
+            args: vec![agg_col.clone()],
+            distinct: input.distinct,
+            order_by: if input.distinct {
+                Some(vec![agg_col.clone().sort(true, true)])
+            } else {
+                input.order_by
+            },
+            filter: input.filter,
+            null_treatment: get_null_treatment(Some(true)),
+        },
+    });
+
+    let string_agg = array_to_string(
+        agg.cast_to(
+            &DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+            schema,
+        )?,
+        delim.cast_to(&DataType::Utf8, schema)?,
+    );
+
+    let casted_agg = match agg_col.get_type(schema)? {
+        DataType::Binary | DataType::BinaryView => string_agg.cast_to(&DataType::Binary, schema)?,
+        DataType::LargeBinary => string_agg.cast_to(&DataType::LargeBinary, schema)?,
+        _ => string_agg,
+    };
+
+    Ok(when(casted_agg.clone().is_not_null(), casted_agg)
+        .when(lit(true), lit(ScalarValue::Null))
+        .end()?)
+}
+
 fn list_built_in_aggregate_functions() -> Vec<(&'static str, AggFunction)> {
     use crate::function::common::AggFunctionBuilder as F;
 
@@ -291,6 +335,7 @@ fn list_built_in_aggregate_functions() -> Vec<(&'static str, AggFunction)> {
         ("kurtosis", F::custom(kurtosis)),
         ("last", F::custom(last_value)),
         ("last_value", F::custom(last_value)),
+        ("listagg", F::custom(listagg)),
         ("max", F::default(min_max::max_udaf)),
         ("max_by", F::custom(max_by)),
         ("mean", F::default(average::avg_udaf)),
@@ -318,6 +363,7 @@ fn list_built_in_aggregate_functions() -> Vec<(&'static str, AggFunction)> {
         ("stddev", F::default(stddev::stddev_udaf)),
         ("stddev_pop", F::default(stddev::stddev_pop_udaf)),
         ("stddev_samp", F::default(stddev::stddev_udaf)),
+        ("string_agg", F::custom(listagg)),
         ("sum", F::default(sum::sum_udaf)),
         ("try_avg", F::unknown("try_avg")),
         ("try_sum", F::unknown("try_sum")),

--- a/crates/sail-spark-connect/tests/gold_data/function/agg.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/agg.json
@@ -1247,7 +1247,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: listagg"
+        "success": "ok"
       }
     },
     {
@@ -1269,7 +1269,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: listagg"
+        "success": "ok"
       }
     },
     {
@@ -1291,7 +1291,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: listagg"
+        "success": "ok"
       }
     },
     {
@@ -1313,7 +1313,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: listagg"
+        "success": "ok"
       }
     },
     {
@@ -1335,7 +1335,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: listagg"
+        "success": "ok"
       }
     },
     {
@@ -1357,7 +1357,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: listagg"
+        "success": "ok"
       }
     },
     {
@@ -1379,7 +1379,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: listagg"
+        "success": "ok"
       }
     },
     {
@@ -3303,7 +3303,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: string_agg"
+        "success": "ok"
       }
     },
     {
@@ -3325,7 +3325,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: string_agg"
+        "success": "ok"
       }
     },
     {
@@ -3347,7 +3347,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: string_agg"
+        "success": "ok"
       }
     },
     {
@@ -3369,7 +3369,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: string_agg"
+        "success": "ok"
       }
     },
     {
@@ -3391,7 +3391,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: string_agg"
+        "success": "ok"
       }
     },
     {
@@ -3413,7 +3413,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: string_agg"
+        "success": "ok"
       }
     },
     {
@@ -3435,7 +3435,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: string_agg"
+        "success": "ok"
       }
     },
     {


### PR DESCRIPTION
introduce listagg and string_agg functions:
https://spark.apache.org/docs/latest/api/sql/index.html#listagg
https://spark.apache.org/docs/latest/api/sql/index.html#string_agg (alias of listagg)

part of #309
(the functions are not mentioned in that list)

passes spark-connect tests

doesn't pass spark-functions tests unfortunately
the results are correct, but the final name of the unaliased function is not equal so there is diff in the output:

```
1876     Example 1: Using listagg function
1877 
1878     >>> from pyspark.sql import functions as sf
1879     >>> df = spark.createDataFrame([('a',), ('b',), (None,), ('c',)], ['strings'])
1880     >>> df.select(sf.listagg('strings')).show()
Differences (unified diff with -expected +actual):
    @@ -1,5 +1,6 @@
    -+----------------------+
    -|listagg(strings, NULL)|
    -+----------------------+
    -|                   abc|
    -+----------------------+
    ++----------------+
    +|listagg(strings)|
    ++----------------+
    +|             abc|
    ++----------------+
    +<BLANKLINE>
```