### PR TITLE
fix: map_function DataType::Null inputs

### DIFF
--- a/crates/sail-plan/src/extension/function/map/map_function.rs
+++ b/crates/sail-plan/src/extension/function/map/map_function.rs
@@ -154,11 +154,6 @@ impl ScalarUDFImpl for MapFunction {
             .values()
             .any(|dt| (dt != value_type) && (dt != &DataType::Null))
         {
-            println!(
-                "VALUE_TYPES: CHOSEN: {:?}, ALL: {:?}",
-                value_type,
-                arg_types.values().collect::<Vec<_>>()
-            );
             return exec_err!("map requires all value types to be the same");
         }
         Ok(DataType::Map(


### PR DESCRIPTION
1) create empty map()
2) create map(key, NULL, ...)

```python
from pyspark.sql import SparkSession
spark = SparkSession.builder.appName("test").getOrCreate()
spark.sql("SELECT map() from values (1), (2), (3)").show()
spark.sql("SELECT map(1, null, 2, col1) as data from values (1), (2), (3)").show()
```
```
+-----+
|map()|
+-----+
|   {}|
|   {}|
|   {}|
+-----+

+-------------------+
|               data|
+-------------------+
|{1 -> NULL, 2 -> 1}|
|{1 -> NULL, 2 -> 2}|
|{1 -> NULL, 2 -> 3}|
+-------------------+
```
closes #665