### PR TITLE
fix: column output naming

### DIFF
--- a/crates/sail-plan/src/formatter.rs
+++ b/crates/sail-plan/src/formatter.rs
@@ -597,7 +597,7 @@ impl PlanFormatter for DefaultPlanFormatter {
             "count" => {
                 let arguments = arguments.join(", ");
                 if is_distinct {
-                    Ok(format!("{name}(DISTINCT {})", arguments))
+                    Ok(format!("{name}(DISTINCT {arguments})"))
                 } else if arguments.as_str() == "*" {
                     Ok("count(1)".to_string())
                 } else {

--- a/crates/sail-plan/src/formatter.rs
+++ b/crates/sail-plan/src/formatter.rs
@@ -549,17 +549,21 @@ impl PlanFormatter for DefaultPlanFormatter {
                 let sep = *list.first().unwrap_or(&"NULL");
                 Ok(format!("{name}({arg}, {sep})"))
             }
-            "ltrim" => {
-                let (value, tr) = arguments.two()?;
-                Ok(format!("TRIM(LEADING {tr} FROM {value})"))
-            }
-            "rtrim" => {
-                let (value, tr) = arguments.two()?;
-                Ok(format!("TRIM(TRAILING {tr} FROM {value})"))
-            }
-            "trim" => {
-                let (value, tr) = arguments.two()?;
-                Ok(format!("TRIM(BOTH {tr} FROM {value})"))
+            "ltrim" | "rtrim" | "trim" => {
+                let (value, list) = arguments.at_least_one()?;
+                let what = if name == "ltrim" {
+                    "LEADING"
+                } else if name == "rtrim" {
+                    "TRAILING"
+                } else {
+                    "BOTH"
+                };
+                let res_format = list
+                    .first()
+                    .map(|s| format!("TRIM({what} {value} FROM {s})"))
+                    .unwrap_or(format!("{name}({value})"));
+
+                Ok(res_format)
             }
             "round" | "bround" => {
                 let (value, list) = arguments.at_least_one()?;


### PR DESCRIPTION
rename output column names for spark functions
confirms correct results for some functions implemented earlier
for other functions reveals new errors which were obfuscated by naming problem
closes #602
