### PR TITLE
feat: to_utc_timestamp function

### DIFF
--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -43,7 +43,7 @@ message ExtendedScalarUdf {
     SparkWeekOfYearUdf spark_week_of_year = 10;
     TimestampNowUdf timestamp_now = 11;
     SparkTimestampUdf spark_timestamp = 12;
-    SparkFromUtcTimestampUdf spark_from_utc_timestamp = 13;
+    SparkFromToUtcTimestampUdf spark_from_to_utc_timestamp = 13;
   }
 }
 
@@ -124,8 +124,9 @@ message SparkTimestampUdf {
   optional string timezone = 1;
 }
 
-message SparkFromUtcTimestampUdf {
+message SparkFromToUtcTimestampUdf {
   string time_unit = 1;
+  bool is_to = 2;
 }
 
 message StandardUdaf {}

--- a/crates/sail-plan/src/extension/function/datetime/mod.rs
+++ b/crates/sail-plan/src/extension/function/datetime/mod.rs
@@ -1,7 +1,7 @@
 mod datetime_utils;
 pub mod spark_date;
 pub mod spark_date_part;
-pub mod spark_from_utc_timestamp;
+pub mod spark_from_to_utc_timestamp;
 pub mod spark_interval;
 pub mod spark_last_day;
 pub mod spark_make_timestamp;

--- a/crates/sail-plan/src/extension/function/datetime/spark_from_to_utc_timestamp.rs
+++ b/crates/sail-plan/src/extension/function/datetime/spark_from_to_utc_timestamp.rs
@@ -222,10 +222,6 @@ impl ScalarUDFImpl for SparkFromToUtcTimestamp {
             ("SST", "Pacific/Guadalcanal"),
             ("VST", "Asia/Saigon"),
         ]);
-        //let error_strs = [
-        //    ,
-        //];
-        //let err = || exec_err!("{:?} {:?} {:?}", error_strs[0], tz_str, error_strs[1])
 
         let from_to_utc_timestamp_func = |inputs: (Option<i64>, Option<&str>)| match inputs {
             (Some(ts_nanos), Some(tz_str)) => {

--- a/crates/sail-spark-connect/tests/gold_data/function/datetime.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/datetime.json
@@ -2526,7 +2526,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: to_utc_timestamp"
+        "success": "ok"
       }
     },
     {


### PR DESCRIPTION
implement `to_utc_timestamp` function 
https://spark.apache.org/docs/latest/api/sql/index.html#to_utc_timestamp
reuse `from_utc_timestamp` code
rename the class and refactor error checks
no logic duplication

part of #505