### PR TITLE
fix: timestamp and interval cast from and to numeric

### DIFF
--- a/crates/sail-plan/src/resolver/expression.rs
+++ b/crates/sail-plan/src/resolver/expression.rs
@@ -16,7 +16,7 @@ use datafusion::sql::unparser::expr_to_sql;
 use datafusion_common::{Column, DFSchemaRef, DataFusionError, TableReference};
 use datafusion_expr::expr::{FieldMetadata, ScalarFunction, WindowFunctionParams};
 use datafusion_expr::{
-    col, expr, expr_fn, lit, window_frame, AggregateUDF, BinaryExpr, ExprSchemable, Operator,
+    cast, col, expr, expr_fn, lit, window_frame, AggregateUDF, BinaryExpr, ExprSchemable, Operator,
     ScalarUDF,
 };
 use datafusion_functions_nested::expr_fn::array_element;
@@ -1056,15 +1056,25 @@ impl PlanResolver<'_> {
                 | DataType::Struct(_)
                 | DataType::Map(_, _)
         );
-        let expr = match (expr_type, cast_to_type) {
-            (from, DataType::Timestamp(time_unit, tz)) if from.is_numeric() => int64_to_timestamp(
-                expr::Expr::Cast(expr::Cast::new(Box::new(expr), DataType::Int64)),
-                time_unit,
-                tz,
-            ),
-            (DataType::Timestamp(time_unit, _), to) if to.is_numeric() => expr::Expr::Cast(
-                expr::Cast::new(Box::new(timestamp_to_int64(expr, &time_unit)), to),
-            ),
+        let expr = match (expr_type, cast_to_type.clone()) {
+            (from, DataType::Timestamp(time_unit, _) | DataType::Duration(time_unit))
+                if from.is_numeric() =>
+            {
+                cast(
+                    expr.mul(lit(time_unit_to_multiplier(&time_unit))),
+                    cast_to_type,
+                )
+            }
+            (DataType::Timestamp(time_unit, _) | DataType::Duration(time_unit), to)
+                if to.is_numeric() =>
+            {
+                cast(
+                    lit(1.0)
+                        .div(lit(time_unit_to_multiplier(&time_unit)))
+                        .mul(cast(expr, DataType::Int64)),
+                    to,
+                )
+            }
             (
                 DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View,
                 DataType::Interval(IntervalUnit::YearMonth),
@@ -1093,7 +1103,7 @@ impl PlanResolver<'_> {
             (_, DataType::Utf8View) if override_string_cast => {
                 ScalarUDF::new_from_impl(SparkToUtf8View::new()).call(vec![expr])
             }
-            (_, to) => expr::Expr::Cast(expr::Cast::new(Box::new(expr), to)),
+            (_, to) => cast(expr, to),
         };
         Ok(NamedExpr::new(name, expr))
     }
@@ -2202,29 +2212,12 @@ fn qualifier_matches(qualifier: Option<&TableReference>, target: Option<&TableRe
     }
 }
 
-fn int64_to_timestamp(expr: expr::Expr, time_unit: TimeUnit, tz: Option<Arc<str>>) -> expr::Expr {
-    let expr = match time_unit {
-        TimeUnit::Second => expr,
-        TimeUnit::Millisecond => expr.mul(lit(1000i64)),
-        TimeUnit::Microsecond => expr.mul(lit(1_000_000i64)),
-        TimeUnit::Nanosecond => expr.mul(lit(1_000_000_000i64)),
-    };
-    expr::Expr::Cast(expr::Cast {
-        expr: Box::new(expr),
-        data_type: DataType::Timestamp(time_unit, tz),
-    })
-}
-
-fn timestamp_to_int64(expr: expr::Expr, time_unit: &TimeUnit) -> expr::Expr {
-    let expr = expr::Expr::Cast(expr::Cast {
-        expr: Box::new(expr),
-        data_type: DataType::Int64,
-    });
+fn time_unit_to_multiplier(time_unit: &TimeUnit) -> i64 {
     match time_unit {
-        TimeUnit::Second => expr,
-        TimeUnit::Millisecond => expr.div(lit(1_000i64)),
-        TimeUnit::Microsecond => expr.div(lit(1_000_000i64)),
-        TimeUnit::Nanosecond => expr.div(lit(1_000_000_000i64)),
+        TimeUnit::Second => 1i64,
+        TimeUnit::Millisecond => 1000i64,
+        TimeUnit::Microsecond => 1_000_000i64,
+        TimeUnit::Nanosecond => 1_000_000_000i64,
     }
 }
 


### PR DESCRIPTION
fixes cast from float to timestamp and back (closes #689)
fixes cast from int to interval and back (closes #690)

TimeUnit::Second is used almost never (because default is Microsecond)
so aligned this case with others to simplify the code, even if it does not need to be multiplied or divided 