### PR TITLE
feat: try_cast column method

### DIFF
--- a/crates/sail-common/src/spec/expression.rs
+++ b/crates/sail-common/src/spec/expression.rs
@@ -32,6 +32,7 @@ pub enum Expr {
         cast_to_type: DataType,
         /// Whether to rename the expression to `CAST(... AS ...)`.
         rename: bool,
+        is_try: bool,
     },
     UnresolvedRegex {
         /// The regular expression to match column names.

--- a/crates/sail-spark-connect/src/proto/expression.rs
+++ b/crates/sail-spark-connect/src/proto/expression.rs
@@ -12,7 +12,7 @@ use sail_sql_analyzer::parser::{
 use sail_sql_analyzer::query::from_ast_named_expression;
 
 use crate::error::{ProtoFieldExt, SparkError, SparkResult};
-use crate::spark::connect::expression::cast::CastToType;
+use crate::spark::connect::expression::cast::{CastToType, EvalMode};
 use crate::spark::connect::expression::sort_order::{NullOrdering, SortDirection};
 use crate::spark::connect::expression::window::window_frame::frame_boundary::Boundary;
 use crate::spark::connect::expression::window::window_frame::{FrameBoundary, FrameType};
@@ -133,7 +133,7 @@ impl TryFrom<Expression> for spec::Expr {
             ExprType::Cast(cast) => {
                 let Cast {
                     expr,
-                    eval_mode: _, // TODO: support eval mode
+                    eval_mode, // TODO: support eval mode
                     cast_to_type,
                 } = *cast;
                 let expr = expr.required("cast expression")?;
@@ -146,6 +146,7 @@ impl TryFrom<Expression> for spec::Expr {
                     expr: Box::new((*expr).try_into()?),
                     cast_to_type,
                     rename: false,
+                    is_try: matches!(EvalMode::try_from(eval_mode), Ok(EvalMode::Try)),
                 })
             }
             ExprType::UnresolvedRegex(UnresolvedRegex { col_name, plan_id }) => {

--- a/crates/sail-spark-connect/tests/gold_data/expression/cast.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/cast.json
@@ -20,7 +20,8 @@
                 "nullable": true
               }
             },
-            "rename": true
+            "rename": true,
+            "isTry": false
           }
         }
       }
@@ -40,7 +41,8 @@
               }
             },
             "castToType": "int32",
-            "rename": true
+            "rename": true,
+            "isTry": false
           }
         }
       }
@@ -65,7 +67,8 @@
                 "timestampType": "configured"
               }
             },
-            "rename": true
+            "rename": true,
+            "isTry": false
           }
         }
       }
@@ -87,11 +90,13 @@
                   }
                 },
                 "castToType": "int32",
-                "rename": true
+                "rename": true,
+                "isTry": false
               }
             },
             "castToType": "int64",
-            "rename": true
+            "rename": true,
+            "isTry": false
           }
         }
       }

--- a/crates/sail-spark-connect/tests/gold_data/plan/plan_select.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/plan_select.json
@@ -4034,7 +4034,8 @@
                     }
                   },
                   "castToType": "int32",
-                  "rename": true
+                  "rename": true,
+                  "isTry": false
                 }
               }
             },

--- a/crates/sail-sql-analyzer/src/expression.rs
+++ b/crates/sail-sql-analyzer/src/expression.rs
@@ -325,6 +325,7 @@ pub fn from_ast_expression(expr: Expr) -> SqlResult<spec::Expr> {
                 expr: Box::new(expr),
                 cast_to_type: from_ast_data_type(data_type)?,
                 rename: false,
+                is_try: false,
             })
         }
         Expr::IsFalse(expr, _, not, _) => {
@@ -649,6 +650,7 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
             expr: Box::new(from_ast_expression(*expr)?),
             cast_to_type: from_ast_data_type(data_type)?,
             rename: true,
+            is_try: false,
         }),
         AtomExpr::Extract(_, _, ident, _, expr, _) => {
             Ok(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {


### PR DESCRIPTION
implement `try_cast` column method:
https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.Column.try_cast.html#pyspark.sql.Column.try_cast

the overriden cast cases need to be further checked for correctness in terms of try_cast and adjusted accordingly
but it passes the spark-test, so basic functionality is provided