### PR TITLE
docs: update storage guide

### DIFF
--- a/docs/.vitepress/theme/app.css
+++ b/docs/.vitepress/theme/app.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   --vp-sidebar-width: 280px;
 }
@@ -34,4 +36,8 @@ dl dd {
 .pycon-prompt {
   /* The prompt is not selectable so that it is easier to copy code. */
   @apply select-none;
+}
+
+code span.placeholder {
+  @apply text-red-700 italic dark:text-red-200;
 }

--- a/docs/development/recipes/object-store.md
+++ b/docs/development/recipes/object-store.md
@@ -110,7 +110,7 @@ spark.sql("SELECT 1").write.parquet(path)
 spark.read.parquet(path).show()
 
 # Google Cloud Storage
-# Note: There is no working emulator for GCS, so we read from a public bucket for testing
+# Note: There is no working emulator for GCS, so we read from a public bucket for testing.
 path = "gs://anaconda-public-data/nyc-taxi/nyc.parquet/part.0.parquet"
 spark.read.parquet(path).show()
 ```

--- a/docs/guide/storage/azure.md
+++ b/docs/guide/storage/azure.md
@@ -1,331 +1,289 @@
 ---
-title: Azure Storage
+title: Azure
 rank: 5
 ---
 
-# Azure Storage
+# Azure
 
 Sail supports reading from and writing to Azure storage services.
 
 ## URI Formats
 
-Sail supports the following access patterns for Azure and Azure-compatible object storage:
+Sail supports the following URI formats for Azure storage services:
 
-### Azure protocol:
+<ul>
+  <li>
+    Azure protocol
+    <ul>
+      <li>
+        <code
+          >azure://<span class="placeholder">container</span>/<span
+            class="placeholder"
+            >path</span
+          ></code
+        >
+      </li>
+    </ul>
+  </li>
+  <li>
+    AZ protocol
+    <ul>
+      <li>
+        <code
+          >az://<span class="placeholder">container</span>/<span
+            class="placeholder"
+            >path</span
+          ></code
+        >
+      </li>
+    </ul>
+  </li>
+  <li>
+    Azure Blob File System (ABFS) and secure ABFS (ABFSS) protocols
+    <ul>
+      <li>
+        <code
+          >abfs&lbrack;s&rbrack;<span>:</span>//<span class="placeholder"
+            >container</span
+          >/<span class="placeholder">path</span></code
+        >
+        (fsspec convention)
+      </li>
+      <li>
+        <code
+          >abfs&lbrack;s&rbrack;<span>:</span>//<span class="placeholder"
+            >container</span
+          >@<span class="placeholder">account</span
+          >.dfs.core.windows.net/<span class="placeholder">path</span></code
+        >
+        (Hadoop driver convention)
+      </li>
+      <li>
+        <code
+          >abfs&lbrack;s&rbrack;<span>:</span>//<span class="placeholder"
+            >container</span
+          >@<span class="placeholder">account</span
+          >.dfs.fabric.windows.net/<span class="placeholder">path</span></code
+        >
+        (Hadoop driver convention with Microsoft Fabric)
+      </li>
+    </ul>
+  </li>
+  <li>
+    ADL protocol
+    <ul>
+      <li>
+        <code
+          >adl://<span class="placeholder">container</span>/<span
+            class="placeholder"
+            >path</span
+          ></code
+        >
+      </li>
+    </ul>
+  </li>
+  <li>
+    HTTPS endpoints
+    <ul>
+      <li>
+        <code
+          >https://<span class="placeholder">account</span
+          >.dfs.core.windows.net/<span class="placeholder">container</span
+          >/<span class="placeholder">path</span></code
+        >
+        (Azure Data Lake Storage Gen2)
+      </li>
+      <li>
+        <code
+          >https://<span class="placeholder">account</span
+          >.blob.core.windows.net/<span class="placeholder">container</span
+          >/<span class="placeholder">path</span></code
+        >
+        (Azure Blob Storage)
+      </li>
+      <li>
+        <code
+          >https://<span class="placeholder">account</span
+          >.dfs.fabric.microsoft.com/<span class="placeholder">workspace</span
+          >/<span class="placeholder">path</span></code
+        >
+      </li>
+      <li>
+        <code
+          >https://<span class="placeholder">account</span
+          >.blob.fabric.microsoft.com/<span class="placeholder"
+            >workspace</span
+          >/<span class="placeholder">path</span></code
+        >
+      </li>
+      <li>
+        <code
+          >https://<span>onelake.dfs.fabric.microsoft.com</span>/<span
+            class="placeholder"
+            >workspace</span
+          >/<span class="placeholder">item</span>.<span class="placeholder"
+            >item-type</span
+          >/<span class="placeholder">path</span></code
+        >
+      </li>
+      <li>
+        <code
+          >https://<span>onelake.dfs.fabric.microsoft.com</span>/<span
+            class="placeholder"
+            >workspace-guid</span
+          >/<span class="placeholder">item-guid</span>/<span
+            class="placeholder"
+            >path</span
+          ></code
+        >
+      </li>
+    </ul>
+  </li>
+</ul>
 
-- `azure://`
+## Configuration
 
-### AZ protocol:
+You can use environment variables to configure Azure storage services in Sail.
+Some configuration options can be set using different environment variables.
 
-- `az://`
+::: warning
+The environment variables to configure Azure storage services are experimental and may change in future versions of Sail.
+:::
 
-### ABFS protocol:
+### Security Configuration
 
-- `abfs://`
+- `AZURE_STORAGE_ACCOUNT_NAME`
 
-### ABFSS protocol (secure):
+  The name of the Azure storage account, if not specified in the URI.
 
-- `abfss://`
+- `AZURE_STORAGE_ACCOUNT_KEY`, `AZURE_STORAGE_ACCESS_KEY`, `AZURE_STORAGE_MASTER_KEY`
 
-### HTTPS endpoints:
+  The master key for accessing the storage account.
 
-- `https://account-name.dfs.core.windows.net/container-name/path`
-- `https://account-name.blob.core.windows.net/container-name/path`
-- `https://account-name.dfs.fabric.microsoft.com/workspace/path`
-- `https://account-name.blob.fabric.microsoft.com/workspace/path`
+- `AZURE_STORAGE_CLIENT_ID`, `AZURE_CLIENT_ID`
 
-### ADL protocol:
+  The service principal client ID for authorizing requests.
 
-- `adl://`
+- `AZURE_STORAGE_CLIENT_SECRET`, `AZURE_CLIENT_SECRET`
 
-## Azure Protocol
+  The service principal client secret for authorizing requests.
 
-`azure://container-name/path/to/object`
+- `AZURE_STORAGE_TENANT_ID`, `AZURE_STORAGE_AUTHORITY_ID`, `AZURE_TENANT_ID`, `AZURE_AUTHORITY_ID`
 
-### DataFrame
+  The tenant ID used in OAuth flows.
+
+- `AZURE_STORAGE_AUTHORITY_HOST`, `AZURE_AUTHORITY_HOST`
+
+  The authority host used in OAuth flows.
+
+- `AZURE_STORAGE_SAS_KEY`, `AZURE_STORAGE_SAS_TOKEN`
+
+  The shared access signature (SAS) key or token. The signature should be percent-encoded.
+
+- `AZURE_STORAGE_TOKEN`
+
+  The bearer token for authorizing requests.
+
+- `AZURE_MSI_ENDPOINT`, `AZURE_IDENTITY_ENDPOINT`
+
+  The endpoint for acquiring a managed identity token.
+
+- `AZURE_OBJECT_ID`
+
+  The object ID for use with managed identity authentication.
+
+- `AZURE_MSI_RESOURCE_ID`
+
+  The MSI resource ID for use with managed identity authentication.
+
+- `AZURE_FEDERATED_TOKEN_FILE`
+
+  The file containing a token for Azure AD workload identity federation.
+
+- `AZURE_USE_AZURE_CLI`
+
+  Whether to use the Azure CLI for acquiring an access token.
+
+- `AZURE_SKIP_SIGNATURE`
+
+  Whether to skip signing requests.
+
+### Storage Configuration
+
+- `AZURE_CONTAINER_NAME`
+
+  The name of the Azure storage container, if not specified in the URI.
+
+- `AZURE_STORAGE_ENDPOINT`, `AZURE_ENDPOINT`
+
+  The endpoint used to communicate with blob storage. This overrides the default endpoint.
+
+- `AZURE_USE_FABRIC_ENDPOINT`
+
+  Whether to use the Microsoft Fabric URL scheme.
+
+- `AZURE_DISABLE_TAGGING`
+
+  Whether to disable tagging objects.
+
+- `AZURE_STORAGE_USE_EMULATOR`, `AZURE_USE_EMULATOR`
+
+  Whether to use the Azurite storage emulator.
+
+### Microsoft Fabric Configuration
+
+- `AZURE_FABRIC_TOKEN_SERVICE_URL`
+
+  The URL for the Fabric token service.
+
+- `AZURE_FABRIC_WORKLOAD_HOST`
+
+  The host for the Fabric workload.
+
+- `AZURE_FABRIC_SESSION_TOKEN`
+
+  The session token for Fabric.
+
+- `AZURE_FABRIC_CLUSTER_IDENTIFIER`
+
+  The cluster identifier for Fabric.
+
+::: info
+For configuration options that accept boolean values, you can specify `1`, `true`, `on`, `yes`, or `y` for a true value, and specify `0`, `false`, `off`, `no`, or `n` for a false value.
+The boolean values are case-insensitive.
+:::
+
+## Examples
+
+<!--@include: ../_common/spark-session.md-->
+
+### Spark DataFrame API
 
 ```python
-spark.sql("SELECT 1").write.parquet("azure://my-container/path")
-df = spark.read.parquet("azure://my-container/path").show()
+# You can use any valid URI format for Azure storage services
+# to specify the path to read or write data.
+path = "azure://my-container/path/to/data"
+
+df = spark.createDataFrame([(1, "Alice"), (2, "Bob")], schema="id INT, name STRING")
+df.write.parquet(path)
+
+df = spark.read.parquet(path)
+df.show()
 ```
 
-### SQL
+### Spark SQL
 
 ```python
+# You can use any valid URI format for Azure storage services
+# to specify the location of the table.
 sql = """
-CREATE TABLE azure_table
+CREATE TABLE my_table (id INT, name STRING)
 USING parquet
-LOCATION 'azure://my-container/path';
+LOCATION 'azure://my-container/path/to/data'
 """
 spark.sql(sql)
-spark.sql("SELECT * FROM azure_table;").show()
+spark.sql("SELECT * FROM my_table").show()
 
-spark.sql("INSERT INTO azure_table VALUES (3, 'Charlie'), (4, 'Jessica');")
-spark.sql("SELECT * FROM azure_table;").show()
-```
-
-## AZ Protocol
-
-`az://container-name/path/to/object`
-
-### DataFrame
-
-```python
-spark.sql("SELECT 1").write.parquet("az://my-container/path")
-df = spark.read.parquet("az://my-container/path").show()
-```
-
-### SQL
-
-```python
-sql = """
-CREATE TABLE az_table
-USING parquet
-LOCATION 'az://my-container/path';
-"""
-spark.sql(sql)
-spark.sql("SELECT * FROM az_table;").show()
-
-spark.sql("INSERT INTO az_table VALUES (3, 'Charlie'), (4, 'Jessica');")
-spark.sql("SELECT * FROM az_table;").show()
-```
-
-## ABFS Protocol
-
-### FSSpec Convention
-
-`abfs://container-name/path/to/object`
-
-### DataFrame
-
-```python
-spark.sql("SELECT 1").write.parquet("abfs://my-container/path")
-df = spark.read.parquet("abfs://my-container/path").show()
-```
-
-### SQL
-
-```python
-sql = """
-CREATE TABLE abfs_table
-USING parquet
-LOCATION 'abfs://my-container/path';
-"""
-spark.sql(sql)
-spark.sql("SELECT * FROM abfs_table;").show()
-
-spark.sql("INSERT INTO abfs_table VALUES (3, 'Charlie'), (4, 'Jessica');")
-spark.sql("SELECT * FROM abfs_table;").show()
-```
-
-### Hadoop Driver Convention
-
-`abfs://file-system@account-name.dfs.core.windows.net/path`
-
-### DataFrame
-
-```python
-spark.sql("SELECT 1").write.parquet("abfs://myfilesystem@myaccount.dfs.core.windows.net/path")
-df = spark.read.parquet("abfs://myfilesystem@myaccount.dfs.core.windows.net/path").show()
-```
-
-### SQL
-
-```python
-sql = """
-CREATE TABLE abfs_hadoop_table
-USING parquet
-LOCATION 'abfs://myfilesystem@myaccount.dfs.core.windows.net/path';
-"""
-spark.sql(sql)
-spark.sql("SELECT * FROM abfs_hadoop_table;").show()
-
-spark.sql("INSERT INTO abfs_hadoop_table VALUES (3, 'Charlie'), (4, 'Jessica');")
-spark.sql("SELECT * FROM abfs_hadoop_table;").show()
-```
-
-## ABFSS Protocol (Secure)
-
-### FSSpec Convention
-
-`abfss://container-name/path/to/object`
-
-### DataFrame
-
-```python
-spark.sql("SELECT 1").write.parquet("abfss://my-container/path")
-df = spark.read.parquet("abfss://my-container/path").show()
-```
-
-### SQL
-
-```python
-sql = """
-CREATE TABLE abfss_table
-USING parquet
-LOCATION 'abfss://my-container/path';
-"""
-spark.sql(sql)
-spark.sql("SELECT * FROM abfss_table;").show()
-
-spark.sql("INSERT INTO abfss_table VALUES (3, 'Charlie'), (4, 'Jessica');")
-spark.sql("SELECT * FROM abfss_table;").show()
-```
-
-### Hadoop Driver Convention
-
-`abfss://file-system@account-name.dfs.core.windows.net/path`
-
-### DataFrame
-
-```python
-spark.sql("SELECT 1").write.parquet("abfss://myfilesystem@myaccount.dfs.core.windows.net/path")
-df = spark.read.parquet("abfss://myfilesystem@myaccount.dfs.core.windows.net/path").show()
-```
-
-### SQL
-
-```python
-sql = """
-CREATE TABLE abfss_hadoop_table
-USING parquet
-LOCATION 'abfss://myfilesystem@myaccount.dfs.core.windows.net/path';
-"""
-spark.sql(sql)
-spark.sql("SELECT * FROM abfss_hadoop_table;").show()
-
-spark.sql("INSERT INTO abfss_hadoop_table VALUES (3, 'Charlie'), (4, 'Jessica');")
-spark.sql("SELECT * FROM abfss_hadoop_table;").show()
-```
-
-## HTTPS Endpoints
-
-### Azure Data Lake Storage Gen2 (DFS)
-
-`https://account-name.dfs.core.windows.net/container-name/path`
-
-### DataFrame
-
-```python
-spark.sql("SELECT 1").write.parquet("https://myaccount.dfs.core.windows.net/my-container/path")
-df = spark.read.parquet("https://myaccount.dfs.core.windows.net/my-container/path").show()
-```
-
-### SQL
-
-```python
-sql = """
-CREATE TABLE dfs_https_table
-USING parquet
-LOCATION 'https://myaccount.dfs.core.windows.net/my-container/path';
-"""
-spark.sql(sql)
-spark.sql("SELECT * FROM dfs_https_table;").show()
-
-spark.sql("INSERT INTO dfs_https_table VALUES (3, 'Charlie'), (4, 'Jessica');")
-spark.sql("SELECT * FROM dfs_https_table;").show()
-```
-
-### Azure Blob Storage
-
-`https://account-name.blob.core.windows.net/container-name/path`
-
-### DataFrame
-
-```python
-spark.sql("SELECT 1").write.parquet("https://myaccount.blob.core.windows.net/my-container/path")
-df = spark.read.parquet("https://myaccount.blob.core.windows.net/my-container/path").show()
-```
-
-### SQL
-
-```python
-sql = """
-CREATE TABLE blob_https_table
-USING parquet
-LOCATION 'https://myaccount.blob.core.windows.net/my-container/path';
-"""
-spark.sql(sql)
-spark.sql("SELECT * FROM blob_https_table;").show()
-
-spark.sql("INSERT INTO blob_https_table VALUES (3, 'Charlie'), (4, 'Jessica');")
-spark.sql("SELECT * FROM blob_https_table;").show()
-```
-
-### Microsoft Fabric OneLake (DFS)
-
-`https://account-name.dfs.fabric.microsoft.com/workspace/path`
-
-### DataFrame
-
-```python
-spark.sql("SELECT 1").write.parquet("https://onelake.dfs.fabric.microsoft.com/workspace-guid/item-guid/Files/path")
-df = spark.read.parquet("https://onelake.dfs.fabric.microsoft.com/workspace-guid/item-guid/Files/path").show()
-```
-
-### SQL
-
-```python
-sql = """
-CREATE TABLE fabric_dfs_table
-USING parquet
-LOCATION 'https://onelake.dfs.fabric.microsoft.com/workspace-guid/item-guid/Files/path';
-"""
-spark.sql(sql)
-spark.sql("SELECT * FROM fabric_dfs_table;").show()
-
-spark.sql("INSERT INTO fabric_dfs_table VALUES (3, 'Charlie'), (4, 'Jessica');")
-spark.sql("SELECT * FROM fabric_dfs_table;").show()
-```
-
-### Microsoft Fabric OneLake (Blob)
-
-`https://account-name.blob.fabric.microsoft.com/workspace/path`
-
-### DataFrame
-
-```python
-spark.sql("SELECT 1").write.parquet("https://onelake.blob.fabric.microsoft.com/workspace/item.itemtype/path")
-df = spark.read.parquet("https://onelake.blob.fabric.microsoft.com/workspace/item.itemtype/path").show()
-```
-
-### SQL
-
-```python
-sql = """
-CREATE TABLE fabric_blob_table
-USING parquet
-LOCATION 'https://onelake.blob.fabric.microsoft.com/workspace/item.itemtype/path';
-"""
-spark.sql(sql)
-spark.sql("SELECT * FROM fabric_blob_table;").show()
-
-spark.sql("INSERT INTO fabric_blob_table VALUES (3, 'Charlie'), (4, 'Jessica');")
-spark.sql("SELECT * FROM fabric_blob_table;").show()
-```
-
-## ADL Protocol
-
-`adl://container-name/path/to/object`
-
-### DataFrame
-
-```python
-spark.sql("SELECT 1").write.parquet("adl://my-container/path")
-df = spark.read.parquet("adl://my-container/path").show()
-```
-
-### SQL
-
-```python
-sql = """
-CREATE TABLE adl_table
-USING parquet
-LOCATION 'adl://my-container/path';
-"""
-spark.sql(sql)
-spark.sql("SELECT * FROM adl_table;").show()
-
-spark.sql("INSERT INTO adl_table VALUES (3, 'Charlie'), (4, 'Jessica');")
-spark.sql("SELECT * FROM adl_table;").show()
+spark.sql("INSERT INTO my_table VALUES (3, 'Charlie'), (4, 'David')")
+spark.sql("SELECT * FROM my_table").show()
 ```

--- a/docs/guide/storage/gcs.md
+++ b/docs/guide/storage/gcs.md
@@ -11,29 +11,63 @@ Sail supports reading from and writing to Google Cloud Storage (GCS) buckets.
 
 Google Cloud Storage uses the `gs://` URI scheme.
 
+## Configuration
+
+You can use environment variables to configure GCS in Sail.
+Some configuration options can be set using different environment variables.
+
+::: warning
+The environment variables to configure GCS are experimental and may change in future versions of Sail.
+:::
+
+- `GOOGLE_SERVICE_ACCOUNT`, `GOOGLE_SERVICE_ACCOUNT_PATH`
+
+  The path to the service account file used for authentication.
+
+- `GOOGLE_SERVICE_ACCOUNT_KEY`
+
+  The serialized service account key.
+
+- `GOOGLE_APPLICATION_CREDENTIALS`
+
+  The path to the application credentials file.
+
+- `GOOGLE_SKIP_SIGNATURE`
+
+  Whether to skip signing requests. This is useful for public buckets.
+
+::: info
+For configuration options that accept boolean values, you can specify `1`, `true`, `on`, `yes`, or `y` for a true value, and specify `0`, `false`, `off`, `no`, or `n` for a false value.
+The boolean values are case-insensitive.
+:::
+
 ## Examples
 
-### DataFrame
+<!--@include: ../_common/spark-session.md-->
+
+### Spark DataFrame API
 
 ```python
-df = spark.createDataFrame([(1, "Alice"), (2, "Bob")], ["id", "name"])
-df.write.parquet("gs://my-bucket/path")
+path = "gs://my-bucket/path/to/data"
 
-users_df = spark.read.parquet("gs://my-bucket/path")
-users_df.show()
+df = spark.createDataFrame([(1, "Alice"), (2, "Bob")], schema="id INT, name STRING")
+df.write.parquet(path)
+
+df = spark.read.parquet(path)
+df.show()
 ```
 
-### SQL
+### Spark SQL
 
 ```python
 sql = """
-CREATE TABLE gcs_table
+CREATE TABLE my_table (id INT, name STRING)
 USING parquet
-LOCATION 'gs://my-bucket/path';
+LOCATION 'gs://my-bucket/path/to/data'
 """
 spark.sql(sql)
-spark.sql("SELECT * FROM gcs_table;").show()
+spark.sql("SELECT * FROM my_table").show()
 
-spark.sql("INSERT INTO gcs_table VALUES (3, 'Charlie'), (4, 'Alice');")
-spark.sql("SELECT * FROM gcs_table;").show()
+spark.sql("INSERT INTO my_table VALUES (3, 'Charlie'), (4, 'David')")
+spark.sql("SELECT * FROM my_table").show()
 ```

--- a/docs/guide/storage/index.md
+++ b/docs/guide/storage/index.md
@@ -12,23 +12,24 @@ Sail provides a unified interface for reading and writing data across various st
 ```python
 # Local file system
 df = spark.read.parquet("/path/to/local/data")
+df = spark.read.parquet("file:///path/to/local/data")
 
 # Cloud storage
 df = spark.read.parquet("s3://bucket/data")
-df = spark.read.parquet("gs://bucket/data")
 df = spark.read.parquet("azure://container/data")
+df = spark.read.parquet("gs://bucket/data")
 
 # In-memory storage
 df = spark.read.parquet("memory:///cached/data")
 
-# HTTP endpoints
+# HTTP/HTTPS endpoints
 df = spark.read.json("https://api.example.com/data.json")
 
 # Create tables from any storage
 spark.sql("""
-    CREATE TABLE my_table
-    USING parquet
-    LOCATION 's3://bucket/path/to/data'
+CREATE TABLE my_table (id INT, name STRING)
+USING parquet
+LOCATION 's3://bucket/path/to/data'
 """)
 ```
 
@@ -41,7 +42,7 @@ Here is a summary of the supported (:white_check_mark:) and unsupported (:x:) st
 | [File Systems](./fs)                      | :white_check_mark: | :white_check_mark: |
 | [Memory](./memory)                        | :white_check_mark: | :white_check_mark: |
 | [AWS S3](./s3)                            | :white_check_mark: | :white_check_mark: |
-| [Cloudflare R2](./s3#cloudflare-r2)       | :white_check_mark: | :white_check_mark: |
+| [Cloudflare R2](./s3)                     | :white_check_mark: | :white_check_mark: |
 | [Azure Data Lake Storage (ADLS)](./azure) | :white_check_mark: | :white_check_mark: |
 | [Azure Blob Storage](./azure)             | :white_check_mark: | :white_check_mark: |
 | [Google Cloud Storage](./gcs)             | :white_check_mark: | :white_check_mark: |
@@ -54,7 +55,7 @@ Here is a summary of the supported (:white_check_mark:) and unsupported (:x:) st
 
 Some HTTPS URLs are automatically recognized as cloud storage:
 
-- **Azure**: URLs containing `dfs.core.windows.net`, `blob.core.windows.net`, `dfs.fabric.microsoft.com`, or `blob.fabric.microsoft.com`
-- **S3**: URLs containing `amazonaws.com` or `r2.cloudflarestorage.com`
+- **S3**: URLs containing `amazonaws.com` or `r2.cloudflarestorage.com`.
+- **Azure**: URLs containing `dfs.core.windows.net`, `blob.core.windows.net`, `dfs.fabric.microsoft.com`, or `blob.fabric.microsoft.com`.
 
 These URLs will use the appropriate cloud storage backend instead of the generic HTTP store.

--- a/docs/guide/storage/memory.md
+++ b/docs/guide/storage/memory.md
@@ -1,9 +1,9 @@
 ---
-title: Memory Storage
+title: Memory
 rank: 8
 ---
 
-# Memory Storage
+# Memory
 
 Sail provides an in-memory storage backend that stores data entirely in RAM. This is particularly useful for testing, development, and scenarios where you need temporary storage without persisting to disk.
 
@@ -13,27 +13,31 @@ Memory storage uses the `memory://` URI scheme.
 
 ## Examples
 
-### DataFrame
+<!--@include: ../_common/spark-session.md-->
+
+### Spark DataFrame API
 
 ```python
-df = spark.createDataFrame([(1, "Alice"), (2, "Bob")], ["id", "name"])
-df.write.parquet("memory:///users")
+path = "memory:///users"
 
-users_df = spark.read.parquet("memory:///users")
-users_df.show()
+df = spark.createDataFrame([(1, "Alice"), (2, "Bob")], schema="id INT, name STRING")
+df.write.parquet(path)
+
+df = spark.read.parquet(path)
+df.show()
 ```
 
-### SQL
+### Spark SQL
 
 ```python
 sql = """
-CREATE TABLE memory_table
+CREATE TABLE my_table (id INT, name STRING)
 USING parquet
-LOCATION 'memory:///users';
+LOCATION 'memory:///users'
 """
 spark.sql(sql)
-spark.sql("SELECT * FROM memory_table;").show()
+spark.sql("SELECT * FROM my_table").show()
 
-spark.sql("INSERT INTO memory_table VALUES (3::int64, 'Charlie'), (4::int64, 'David');")
-spark.sql("SELECT * FROM memory_table;").show()
+spark.sql("INSERT INTO my_table VALUES (3, 'Charlie'), (4, 'David')")
+spark.sql("SELECT * FROM my_table").show()
 ```

--- a/docs/guide/storage/s3.md
+++ b/docs/guide/storage/s3.md
@@ -5,8 +5,7 @@ rank: 2
 
 # AWS S3
 
-Sail supports reading and writing data to AWS S3 and S3-compatible object storage services using the `s3://`, `s3a://`, or `https://` URI schemes.
-The URI can also refer to data stored in S3-compatible object storage services, such as [MinIO](https://min.io/) or services provided by other vendors.
+Sail supports reading and writing data to AWS S3 and S3-compatible object storage services (such as [MinIO](https://min.io/) or Cloudflare R2) using the `s3://`, `s3a://`, or `https://` URI schemes.
 
 For example, `s3://bucket/path/to/data` refers to the `path/to/data` path in the `bucket` bucket.
 Sail determines whether the path refers to a single object or a key prefix.
@@ -14,243 +13,131 @@ If the path turns out to be a key prefix, we assume the key prefix is followed b
 
 ## URI Formats
 
-Sail supports the following access patterns for S3 and S3-compatible object storage:
-
-### S3 Scheme:
-
-- `s3://`
-
-### S3a Scheme:
-
-- `s3a://`
-
-### Virtual-Hosted Style Requests:
-
-- `https://bucket-name.s3.region-code.amazonaws.com/key-name`
-- `https://bucket-name.s3.amazonaws.com/key-name`
-
-### Transfer Acceleration:
-
-- `https://bucket-name.s3-accelerate.amazonaws.com/key-name`
-- `https://bucket-name.s3-accelerate.dualstack.amazonaws.com/key-name`
-
-### S3 Express:
-
-- `s3://bucket-name/key-name`
-- `s3a://bucket-name/key-name`
-- `https://bucket-name.s3express-zone-id.region-code.amazonaws.com/key-name`
-
-#### Path-Style Requests:
-
-- `https://s3.region-code.amazonaws.com/bucket-name/key-name`
-- `https://s3.amazonaws.com/bucket-name/key-name`
-
-## S3 Scheme
-
-`s3://bucket-name/key-name`
-
-### DataFrame
-
-```python
-spark.sql("SELECT 1").write.parquet("s3://bucket-name/key-name")
-df = spark.read.parquet("s3://bucket-name/key-name").show()
-```
-
-### SQL
-
-```python
-sql = """
-CREATE TABLE s3_table
-USING parquet
-LOCATION 's3://bucket-name/key-name';
-"""
-spark.sql(sql)
-spark.sql("SELECT * FROM s3_table;").show()
-
-spark.sql("INSERT INTO s3_table VALUES (3, 'Charlie'), (4, 'Jessica');")
-spark.sql("SELECT * FROM s3_table;").show()
-```
-
-## S3a Scheme
-
-`s3a://bucket-name/path/to/object`
-
-### DataFrame
-
-```python
-spark.sql("SELECT 1").write.parquet("s3a://bucket-name/key-name")
-df = spark.read.parquet("s3a://bucket-name/key-name").show()
-```
-
-### SQL
-
-```python
-sql = """
-CREATE TABLE s3a_table
-USING parquet
-LOCATION 's3a://bucket-name/key-name';
-"""
-spark.sql(sql)
-spark.sql("SELECT * FROM s3a_table;").show()
-
-spark.sql("INSERT INTO s3a_table VALUES (3, 'Charlie'), (4, 'Jessica');")
-spark.sql("SELECT * FROM s3a_table;").show()
-```
-
-## Virtual-Hosted Style Requests
-
-#### Region
-
-`https://bucket-name.s3.region-code.amazonaws.com/key-name`
-
-#### No Region
-
-`https://bucket-name.s3.amazonaws.com/key-name`
-
-### DataFrame
-
-```python
-spark.sql("SELECT 1").write.parquet("https://bucket-name.s3.region-code.amazonaws.com/key-name")
-df = spark.read.parquet("https://bucket-name.s3.region-code.amazonaws.com/key-name").show()
-```
-
-### SQL
-
-```python
-sql = """
-CREATE TABLE s3_vh_table
-USING parquet
-LOCATION 'https://bucket-name.s3.region-code.amazonaws.com/key-name';
-"""
-spark.sql(sql)
-spark.sql("SELECT * FROM s3_vh_table;").show()
-
-spark.sql("INSERT INTO s3_vh_table VALUES (3, 'Charlie'), (4, 'Jessica');")
-spark.sql("SELECT * FROM s3_vh_table;").show()
-```
-
-## Transfer Acceleration
-
-#### Standard
-
-`https://bucket-name.s3-accelerate.amazonaws.com/key-name`
-
-#### Dual-Stack
-
-`https://bucket-name.s3-accelerate.dualstack.amazonaws.com/key-name`
-
-### DataFrame
-
-```python
-# Standard Transfer Acceleration
-spark.sql("SELECT 1").write.parquet("https://bucket-name.s3-accelerate.amazonaws.com/key-name")
-df = spark.read.parquet("https://bucket-name.s3-accelerate.amazonaws.com/key-name").show()
-
-# Dual-Stack Transfer Acceleration
-spark.sql("SELECT 1").write.parquet("https://bucket-name.s3-accelerate.dualstack.amazonaws.com/key-name")
-df = spark.read.parquet("https://bucket-name.s3-accelerate.dualstack.amazonaws.com/key-name").show()
-```
-
-### SQL
-
-```python
-sql = """
-CREATE TABLE s3_accel_table
-USING parquet
-LOCATION 'https://bucket-name.s3-accelerate.amazonaws.com/key-name';
-"""
-spark.sql(sql)
-spark.sql("SELECT * FROM s3_accel_table;").show()
-
-spark.sql("INSERT INTO s3_accel_table VALUES (3, 'Charlie'), (4, 'Jessica');")
-spark.sql("SELECT * FROM s3_accel_table;").show()
-```
-
-## S3 Express
-
-#### S3 and S3a Schemes
-
-`s3://bucket-name/key-name` or `s3a://bucket-name/key-name`
-
-#### HTTPS URL
-
-`https://bucket-name.s3express-zone-id.region-code.amazonaws.com/key-name`
-
-### DataFrame
-
-```python
-# S3 and S3a Schemes
-spark.sql("SELECT 1").write.parquet("s3://bucket-name/key-name")
-df = spark.read.parquet("s3a://bucket-name/key-name").show()
-
-# HTTPS URL
-spark.sql("SELECT 1").write.parquet("https://bucket-name.s3express-zone-id.region-code.amazonaws.com/key-name")
-df = spark.read.parquet("https://bucket-name.s3express-zone-id.region-code.amazonaws.com/key-name").show()
-```
-
-### SQL
-
-```python
-# S3 and S3a Schemes
-sql = """
-CREATE TABLE s3_table
-USING parquet
-LOCATION 's3://bucket-name/key-name';
-"""
-spark.sql(sql)
-spark.sql("SELECT * FROM s3_table;").show()
-
-# HTTPS URL
-sql = """
-CREATE TABLE s3_table
-USING parquet
-LOCATION 'https://bucket-name.s3express-zone-id.region-code.amazonaws.com/key-name';
-"""
-spark.sql(sql)
-spark.sql("SELECT * FROM s3_table;").show()
-
-spark.sql("INSERT INTO s3_table VALUES (3, 'Charlie'), (4, 'Jessica');")
-spark.sql("SELECT * FROM s3_table;").show()
-```
-
-## Path-Style Requests
-
-#### Region
-
-`https://s3.region-code.amazonaws.com/bucket-name/key-name`
-
-#### No Region
-
-`https://s3.amazonaws.com/bucket-name/key-name`
+Sail supports the following URL formats for S3 and S3-compatible object storage services:
+
+<ul>
+  <li>
+    <code>s3</code> and <code>s3a</code> protocols
+    <ul>
+      <li>
+        <code
+          >s3://<span class="placeholder">bucket</span>/<span
+            class="placeholder"
+            >key</span
+          ></code
+        >
+      </li>
+      <li>
+        <code
+          >s3a://<span class="placeholder">bucket</span>/<span
+            class="placeholder"
+            >key</span
+          ></code
+        >
+      </li>
+    </ul>
+  </li>
+  <li>
+    HTTPS endpoints for AWS S3 virtual-hosted style requests
+    <ul>
+      <li>
+        <code
+          >https://<span class="placeholder">bucket</span>.s3.<span
+            class="placeholder"
+            >region</span
+          >.amazonaws.com/<span class="placeholder">key</span></code
+        >
+      </li>
+      <li>
+        <code
+          >https://<span class="placeholder">bucket</span
+          >.s3.amazonaws.com/<span class="placeholder">key</span></code
+        >
+      </li>
+    </ul>
+  </li>
+  <li>
+    HTTPS endpoints for AWS S3 path-style requests
+    <ul>
+      <li>
+        <code
+          >https://<span>s3.</span
+          ><span class="placeholder">region</span>.amazonaws.com/<span
+            class="placeholder"
+            >bucket</span
+          >/<span class="placeholder">key</span></code
+        >
+      </li>
+      <li>
+        <code
+          >https://<span>s3.amazonaws.com/</span
+          ><span class="placeholder">bucket</span>/<span class="placeholder"
+            >key</span
+          ></code
+        >
+      </li>
+    </ul>
+  </li>
+  <li>
+    HTTPS endpoint for AWS S3 Express One Zone
+    <ul>
+      <li>
+        <code
+          >https://<span class="placeholder">bucket</span>.<span
+            class="placeholder"
+            >s3express-zone-id</span
+          >.<span class="placeholder">region</span>.amazonaws.com/<span
+            class="placeholder"
+            >key</span
+          ></code
+        >
+      </li>
+    </ul>
+  </li>
+  <li>
+    HTTPS endpoints for AWS S3 Transfer Acceleration
+    <ul>
+      <li>
+        <code
+          >https://<span class="placeholder">bucket</span
+          >.s3-accelerate.amazonaws.com/<span class="placeholder"
+            >key</span
+          ></code
+        >
+      </li>
+      <li>
+        <code
+          >https://<span class="placeholder">bucket</span
+          >.s3-accelerate.dualstack.amazonaws.com/<span class="placeholder"
+            >key</span
+          ></code
+        >
+      </li>
+    </ul>
+  </li>
+</ul>
+
+<code><span class="placeholder">bucket</span></code> is the bucket name.
+<code><span class="placeholder">key</span></code> can refer to a single object
+or a key prefix. <code><span class="placeholder">region</span></code> is the
+name of the AWS region where the bucket is located, such as `us-east-1`.
+
+<code><span class="placeholder">s3express-zone-id</span></code> is the
+availability zone ID where the S3 Express One Zone bucket is located, such as
+`use1-az4`. Note that S3 Express One Zone bucket name follows a specific
+format. For example, `my-bucket--use1-az4--x-s3` is a valid bucket name in the
+`use1-az4` availability zone in the `us-east-1` region.
 
 ::: info
-AWS has discontinued support for path-style requests for new buckets created after September 30, 2020.
-For more information, see [Amazon S3 Path Deprecation Plan – The Rest of the Story](https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/) in the AWS News Blog.
+
+1. The `s3a` URI scheme has no difference from the `s3` URI scheme in Sail. The `s3a` scheme is provided for compatibility with Spark applications that use the Hadoop S3A connector.
+2. The `s3` and `s3a` URI schemes are also applicable to AWS S3 Express One Zone buckets.
+3. AWS has discontinued support for path-style requests for new buckets created after September 30, 2020.
+   For more information, see [Amazon S3 Path Deprecation Plan – The Rest of the Story](https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/) in the AWS News Blog.
+
 :::
 
-### DataFrame
-
-```python
-spark.sql("SELECT 1").write.parquet("https://s3.region-code.amazonaws.com/bucket-name/key-name")
-df = spark.read.parquet("https://s3.region-code.amazonaws.com/bucket-name/key-name").show()
-```
-
-### SQL
-
-```python
-sql = """
-CREATE TABLE s3_path_table
-USING parquet
-LOCATION 'https://s3.region-code.amazonaws.com/bucket-name/key-name';
-"""
-spark.sql(sql)
-spark.sql("SELECT * FROM s3_path_table;").show()
-
-spark.sql("INSERT INTO s3_path_table VALUES (3, 'Charlie'), (4, 'Jessica');")
-spark.sql("SELECT * FROM s3_path_table;").show()
-```
-
-## Credentials
+## AWS Credentials
 
 All AWS credential providers work out-of-box in Sail.
 You can authenticate with AWS S3 using any of the supported methods, including AWS `config` and `credentials` files,
@@ -263,25 +150,24 @@ You can refer to the [AWS documentation](https://docs.aws.amazon.com/sdkref/late
 for more details about the credential providers.
 :::
 
-## Region Configuration
+## AWS Region Configuration
 
-### Single Region
+You can configure the AWS region via the `AWS_REGION` environment variable. In this case, if the region is not explicitly set in the URI, the S3 bucket must be in the configured region.
 
-If the AWS region is configured, all S3 buckets must be in the same region. Otherwise, an error will be returned when accessing the data.
+For example, if you configure the AWS region using the following command, an error will be returned when accessing an S3 bucket not in the `us-east-1` region.
 
 ```bash
 export AWS_REGION="us-east-1"
 ```
 
-### Multi-Region Access
-
-To allow inferring regions for S3 buckets and accessing S3 data in all regions, you can set the `AWS_REGION` environment variable to an empty string.
+If you set the `AWS_REGION` environment variable to an empty string, the region for the S3 bucket will be inferred automatically.
+In this way, you can access S3 data in all regions without explicitly specifying the region in the URI.
 
 ```bash
 export AWS_REGION=""
 ```
 
-## Public Datasets
+## Public Datasets on AWS
 
 Some datasets on S3 allow public access without an AWS account.
 You can skip retrieving AWS credentials by setting the environment variable `AWS_SKIP_SIGNATURE=true`.
@@ -291,27 +177,68 @@ export AWS_SKIP_SIGNATURE=true
 ```
 
 ```python
-df = spark.read.parquet("s3://public-bucket-name/path/")
+df = spark.read.parquet("s3://some-public-bucket/path/to/data")
 ```
 
 ::: info
 `AWS_SKIP_SIGNATURE` is a Sail-specific environment variable, not part of standard AWS SDKs.
 :::
 
-## S3-Compatible Storage
+## S3-Compatible Services
 
 ### Cloudflare R2
+
+You can configure the endpoint and credentials for Cloudflare R2 using environment variables. Here is an example.
 
 ```bash
 export AWS_ACCESS_KEY_ID="smooth"
 export AWS_SECRET_ACCESS_KEY="sailing"
-export AWS_ENDPOINT="https://[account-id].r2.cloudflarestorage.com"
+export AWS_ENDPOINT="https://my-account-id.r2.cloudflarestorage.com"
 ```
 
-### MinIO and Other S3-Compatible Services
+### MinIO
+
+You can configure the endpoint and credentials for MinIO using environment variables. Here is an example.
 
 ```bash
 export AWS_ACCESS_KEY_ID="smooth"
 export AWS_SECRET_ACCESS_KEY="sailing"
 export AWS_ENDPOINT="http://localhost:9000"
+```
+
+Other storage services that are compatible with the AWS S3 API may be configured similarly. You can refer to the service documentation for more details.
+
+## Examples
+
+<!--@include: ../_common/spark-session.md-->
+
+### Spark DataFrame API
+
+```python
+# You can use any valid URI format for S3 or S3-compatible services
+# to specify the path to read or write data.
+path = "s3://my-bucket/path/to/data"
+
+df = spark.createDataFrame([(1, "Alice"), (2, "Bob")], schema="id INT, name STRING")
+df.write.parquet(path)
+
+df = spark.read.parquet(path)
+df.show()
+```
+
+### Spark SQL
+
+```python
+# You can use any valid URI format for S3 or S3-compatible services
+# to specify the location of the table.
+sql = """
+CREATE TABLE my_table (id INT, name STRING)
+USING parquet
+LOCATION 's3://my-bucket/path/to/data'
+"""
+spark.sql(sql)
+spark.sql("SELECT * FROM my_table").show()
+
+spark.sql("INSERT INTO my_table VALUES (3, 'Charlie'), (4, 'David')")
+spark.sql("SELECT * FROM my_table").show()
 ```


### PR DESCRIPTION
1. Add configuration docs for Azure and GCS. This is mostly from the object_store documentation.
2. Improve the URL format docs for S3 and Azure. Similar code examples are removed, so that the reader can get the high-level idea more easily.

This PR also fixes the dark mode issue (possibly due to previous major version upgrades of the dependencies).