### PR TITLE
fix: resolver logic for overwrite conditions

### DIFF
--- a/crates/sail-common-datafusion/src/utils.rs
+++ b/crates/sail-common-datafusion/src/utils.rs
@@ -51,7 +51,7 @@ pub fn write_record_batches(batches: &[RecordBatch], schema: &Schema) -> Result<
     Ok(output)
 }
 
-pub fn rename_schema(schema: &SchemaRef, names: &[String]) -> Result<SchemaRef> {
+pub fn rename_schema(schema: &Schema, names: &[String]) -> Result<SchemaRef> {
     if schema.fields().len() != names.len() {
         return plan_err!(
             "cannot rename fields for schema with {} fields using {} names",

--- a/crates/sail-plan/src/resolver/command/write_v1.rs
+++ b/crates/sail-plan/src/resolver/command/write_v1.rs
@@ -1,10 +1,9 @@
 use datafusion_expr::LogicalPlan;
 use sail_common::spec;
-use sail_common_datafusion::datasource::SinkMode;
 
 use crate::error::PlanResult;
 use crate::resolver::command::write::{
-    WriteColumnMatch, WritePlanBuilder, WriteTableAction, WriteTarget,
+    WriteColumnMatch, WriteMode, WritePlanBuilder, WriteTableAction, WriteTarget,
 };
 use crate::resolver::state::PlanResolverState;
 use crate::resolver::PlanResolver;
@@ -45,10 +44,10 @@ impl PlanResolver<'_> {
         match save_type {
             SaveType::Path(location) => {
                 let mode = match mode {
-                    Some(SaveMode::ErrorIfExists) | None => SinkMode::ErrorIfExists,
-                    Some(SaveMode::IgnoreIfExists) => SinkMode::IgnoreIfExists,
-                    Some(SaveMode::Append) => SinkMode::Append,
-                    Some(SaveMode::Overwrite) => SinkMode::Overwrite,
+                    Some(SaveMode::ErrorIfExists) | None => WriteMode::ErrorIfExists,
+                    Some(SaveMode::IgnoreIfExists) => WriteMode::IgnoreIfExists,
+                    Some(SaveMode::Append) => WriteMode::Append,
+                    Some(SaveMode::Overwrite) => WriteMode::Overwrite,
                 };
                 builder = builder
                     .with_target(WriteTarget::Path { location })
@@ -64,7 +63,7 @@ impl PlanResolver<'_> {
                             table,
                             action: WriteTableAction::Create,
                         })
-                        .with_mode(SinkMode::ErrorIfExists);
+                        .with_mode(WriteMode::ErrorIfExists);
                 }
                 Some(SaveMode::IgnoreIfExists) => {
                     builder = builder
@@ -72,7 +71,7 @@ impl PlanResolver<'_> {
                             table,
                             action: WriteTableAction::Create,
                         })
-                        .with_mode(SinkMode::IgnoreIfExists);
+                        .with_mode(WriteMode::IgnoreIfExists);
                 }
                 Some(SaveMode::Append) => {
                     builder = builder
@@ -80,7 +79,7 @@ impl PlanResolver<'_> {
                             table,
                             column_match: WriteColumnMatch::ByName,
                         })
-                        .with_mode(SinkMode::Append);
+                        .with_mode(WriteMode::Append);
                 }
                 Some(SaveMode::Overwrite) => {
                     builder = builder
@@ -88,7 +87,7 @@ impl PlanResolver<'_> {
                             table,
                             action: WriteTableAction::CreateOrReplace,
                         })
-                        .with_mode(SinkMode::Overwrite);
+                        .with_mode(WriteMode::Overwrite);
                 }
             },
             SaveType::Table {
@@ -96,8 +95,8 @@ impl PlanResolver<'_> {
                 save_method: TableSaveMethod::InsertInto,
             } => {
                 let mode = match mode {
-                    Some(SaveMode::Overwrite) => SinkMode::Overwrite,
-                    _ => SinkMode::Append,
+                    Some(SaveMode::Overwrite) => WriteMode::Overwrite,
+                    _ => WriteMode::Append,
                 };
                 builder = builder
                     .with_target(WriteTarget::ExistingTable {


### PR DESCRIPTION
The write plan resolver incorrectly uses the input schema instead of the table schema to resolve overwrite conditions (used for the `INSERT ... REPLACE WHERE ...` SQL statement and the `.overwrite()` method for the v2 writer API). This PR fixes this issue.

I tried the following example after this fix:

```python
spark.sql(f"CREATE OR REPLACE TABLE foo (id INT, name STRING) USING DELTA")
spark.sql(f"""
INSERT INTO TABLE foo
REPLACE WHERE name = 'A'
SELECT * FROM VALUES (5, 'A'), (6, 'A')
""")
```

The server now returns the following error, which is expected:

```text
pyspark.errors.exceptions.connect.UnsupportedOperationException: unsupported sink mode for Delta: OverwriteIf { condition: BinaryExpr { left: Column { name: "name", index: 1 }, op: Eq, right: Literal { value: Utf8("A"), field: Field { name: "lit", data_type: Utf8, nullable: false, dict_id: 0, dict_is_ordered: false, metadata: {} } }, fail_on_overflow: false } }
```