### PR TITLE
feat: spark_to_chrono_fmt and to_unix_timestamp funcs

### DIFF
--- a/crates/sail-execution/src/codec.rs
+++ b/crates/sail-execution/src/codec.rs
@@ -63,6 +63,7 @@ use sail_plan::extension::function::datetime::spark_make_timestamp::SparkMakeTim
 use sail_plan::extension::function::datetime::spark_make_ym_interval::SparkMakeYmInterval;
 use sail_plan::extension::function::datetime::spark_next_day::SparkNextDay;
 use sail_plan::extension::function::datetime::spark_timestamp::SparkTimestamp;
+use sail_plan::extension::function::datetime::spark_to_chrono_fmt::SparkToChronoFmt;
 use sail_plan::extension::function::datetime::spark_try_to_timestamp::SparkTryToTimestamp;
 use sail_plan::extension::function::datetime::spark_unix_timestamp::SparkUnixTimestamp;
 use sail_plan::extension::function::datetime::timestamp_now::TimestampNow;
@@ -852,6 +853,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             "spark_calendar_interval" => {
                 Ok(Arc::new(ScalarUDF::from(SparkCalendarInterval::new())))
             }
+            "spark_to_chrono_fmt" => Ok(Arc::new(ScalarUDF::from(SparkToChronoFmt::new()))),
             "spark_try_to_timestamp" | "try_to_timestamp" => {
                 Ok(Arc::new(ScalarUDF::from(SparkTryToTimestamp::new())))
             }
@@ -934,6 +936,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node.inner().as_any().is::<SparkYearMonthInterval>()
             || node.inner().as_any().is::<SparkDayTimeInterval>()
             || node.inner().as_any().is::<SparkCalendarInterval>()
+            || node.inner().as_any().is::<SparkToChronoFmt>()
             || node.inner().as_any().is::<SparkTryToTimestamp>()
             || node.inner().as_any().is::<SparkBin>()
             || node.inner().as_any().is::<SparkExpm1>()

--- a/crates/sail-plan/src/extension/function/datetime/mod.rs
+++ b/crates/sail-plan/src/extension/function/datetime/mod.rs
@@ -8,6 +8,7 @@ pub mod spark_make_timestamp;
 pub mod spark_make_ym_interval;
 pub mod spark_next_day;
 pub mod spark_timestamp;
+pub mod spark_to_chrono_fmt;
 pub mod spark_try_to_timestamp;
 pub mod spark_unix_timestamp;
 pub mod timestamp_now;

--- a/crates/sail-plan/src/extension/function/datetime/spark_to_chrono_fmt.rs
+++ b/crates/sail-plan/src/extension/function/datetime/spark_to_chrono_fmt.rs
@@ -49,7 +49,7 @@ impl ScalarUDFImpl for SparkToChronoFmt {
     }
 
     fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
-        Ok(DataType::Date32)
+        Ok(DataType::Utf8)
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {

--- a/crates/sail-plan/src/extension/function/datetime/spark_to_chrono_fmt.rs
+++ b/crates/sail-plan/src/extension/function/datetime/spark_to_chrono_fmt.rs
@@ -1,0 +1,90 @@
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow::array::StringArray;
+use datafusion::arrow::datatypes::DataType;
+use datafusion_common::cast::{as_large_string_array, as_string_array, as_string_view_array};
+use datafusion_common::types::logical_string;
+use datafusion_common::{exec_err, Result, ScalarValue};
+use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+use datafusion_expr_common::signature::{Coercion, TypeSignatureClass};
+
+use crate::utils::{spark_datetime_format_to_chrono_strftime, ItemTaker};
+
+#[derive(Debug)]
+pub struct SparkToChronoFmt {
+    signature: Signature,
+}
+
+impl Default for SparkToChronoFmt {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SparkToChronoFmt {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::coercible(
+                vec![Coercion::new_exact(TypeSignatureClass::Native(
+                    logical_string(),
+                ))],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for SparkToChronoFmt {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "spark_to_chrono_fmt"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Date32)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let ScalarFunctionArgs { args, .. } = args;
+        let arg = args.one()?;
+        match arg {
+            ColumnarValue::Array(array) => {
+                let array = match array.data_type() {
+                    DataType::Utf8 => as_string_array(&array)?
+                        .iter()
+                        .map(|x| x.map(spark_datetime_format_to_chrono_strftime).transpose())
+                        .collect::<Result<StringArray>>()?,
+                    DataType::LargeUtf8 => as_large_string_array(&array)?
+                        .iter()
+                        .map(|x| x.map(spark_datetime_format_to_chrono_strftime).transpose())
+                        .collect::<Result<StringArray>>()?,
+                    DataType::Utf8View => as_string_view_array(&array)?
+                        .iter()
+                        .map(|x| x.map(spark_datetime_format_to_chrono_strftime).transpose())
+                        .collect::<Result<StringArray>>()?,
+                    _ => return exec_err!("expected string array for `spark_to_chrono_fmt`"),
+                };
+                Ok(ColumnarValue::Array(Arc::new(array)))
+            }
+            ColumnarValue::Scalar(scalar) => {
+                let value = match scalar.try_as_str() {
+                    Some(x) => x
+                        .map(spark_datetime_format_to_chrono_strftime)
+                        .transpose()?,
+                    _ => {
+                        return exec_err!("expected string scalar for `spark_to_chrono_fmt`");
+                    }
+                };
+                Ok(ColumnarValue::Scalar(ScalarValue::Utf8(value)))
+            }
+        }
+    }
+}

--- a/crates/sail-plan/src/formatter.rs
+++ b/crates/sail-plan/src/formatter.rs
@@ -471,6 +471,14 @@ impl PlanFormatter for SparkPlanFormatter {
                 Ok(result)
             }
             "timestamp" | "date" => Ok(arguments.one()?.to_string()),
+            "to_unix_timestamp" => {
+                let mut argv = arguments.clone();
+                if argv.len() == 1 {
+                    argv.push("yyyy-MM-dd HH:mm:ss")
+                }
+                let args = argv.join(", ");
+                Ok(format!("{name}({args})"))
+            }
             "dateadd" => {
                 let arguments = arguments.join(", ");
                 Ok(format!("date_add({arguments})"))

--- a/crates/sail-spark-connect/tests/gold_data/function/datetime.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/datetime.json
@@ -2504,7 +2504,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: to_unix_timestamp"
+        "success": "ok"
       }
     },
     {


### PR DESCRIPTION
implement spark_to_chrono_fmt func as UDF(column)
instead of parsing ScalarValue to str on planner side

implement to_unix_timestamp function:
https://spark.apache.org/docs/latest/api/sql/index.html#to_unix_timestamp

part of #505