### PR TITLE
feat: try_validate_utf8, validate_utf8, is_valid_utf8 funcs

### DIFF
--- a/crates/sail-spark-connect/tests/gold_data/function/string.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/string.json
@@ -4307,7 +4307,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: try_validate_utf8"
+        "success": "ok"
       }
     },
     {
@@ -4329,7 +4329,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: try_validate_utf8"
+        "success": "ok"
       }
     },
     {
@@ -4351,7 +4351,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: try_validate_utf8"
+        "success": "ok"
       }
     },
     {
@@ -4373,7 +4373,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: try_validate_utf8"
+        "success": "ok"
       }
     },
     {
@@ -4461,7 +4461,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: validate_utf8"
+        "success": "ok"
       }
     },
     {
@@ -4483,7 +4483,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: validate_utf8"
+        "success": "ok"
       }
     },
     {


### PR DESCRIPTION
implement:
`try_validate_utf8` function:
https://spark.apache.org/docs/latest/api/sql/index.html#try_validate_utf8

`validate_utf8` function:
https://spark.apache.org/docs/latest/api/sql/index.html#validate_utf8

`is_valid_utf8` function:
https://spark.apache.org/docs/latest/api/sql/index.html#is_valid_utf8
works with both small and large bytestrings and strings

part of #508
new in spark 4.0.0, so not mentioned in list