### PR TITLE
feat: make_valid_utf8 func

### DIFF
--- a/crates/sail-execution/src/codec.rs
+++ b/crates/sail-execution/src/codec.rs
@@ -106,6 +106,7 @@ use sail_plan::extension::function::spark_to_string::{
 };
 use sail_plan::extension::function::spark_xxhash64::SparkXxhash64;
 use sail_plan::extension::function::string::levenshtein::Levenshtein;
+use sail_plan::extension::function::string::make_valid_utf8::MakeValidUtf8;
 use sail_plan::extension::function::string::spark_base64::{SparkBase64, SparkUnbase64};
 use sail_plan::extension::function::string::spark_encode_decode::{SparkDecode, SparkEncode};
 use sail_plan::extension::function::string::spark_mask::SparkMask;
@@ -780,6 +781,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             "greatest" => Ok(Arc::new(ScalarUDF::from(Greatest::new()))),
             "least" => Ok(Arc::new(ScalarUDF::from(Least::new()))),
             "levenshtein" => Ok(Arc::new(ScalarUDF::from(Levenshtein::new()))),
+            "make_valid_utf8" => Ok(Arc::new(ScalarUDF::from(MakeValidUtf8::new()))),
             "map" => Ok(Arc::new(ScalarUDF::from(MapFunction::new()))),
             "multi_expr" => Ok(Arc::new(ScalarUDF::from(MultiExpr::new()))),
             "raise_error" => Ok(Arc::new(ScalarUDF::from(RaiseError::new()))),
@@ -890,6 +892,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node.inner().as_any().is::<Greatest>()
             || node.inner().as_any().is::<Least>()
             || node.inner().as_any().is::<Levenshtein>()
+            || node.inner().as_any().is::<MakeValidUtf8>()
             || node.inner().as_any().is::<MapFunction>()
             || node.inner().as_any().is::<MultiExpr>()
             || node.inner().as_any().is::<RaiseError>()

--- a/crates/sail-plan/src/extension/function/string/make_valid_utf8.rs
+++ b/crates/sail-plan/src/extension/function/string/make_valid_utf8.rs
@@ -1,0 +1,99 @@
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef, LargeStringArray, StringArray};
+use datafusion::arrow::datatypes::DataType;
+use datafusion_common::cast::{
+    as_binary_array, as_binary_view_array, as_fixed_size_binary_array, as_large_binary_array,
+};
+use datafusion_common::{exec_err, Result};
+use datafusion_expr::function::Hint;
+use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+use datafusion_functions::utils::make_scalar_function;
+
+#[derive(Debug)]
+pub struct MakeValidUtf8 {
+    signature: Signature,
+}
+
+impl Default for MakeValidUtf8 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MakeValidUtf8 {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::any(1, Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for MakeValidUtf8 {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "make_valid_utf8"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        match arg_types.first() {
+            Some(data_type) => match data_type {
+                DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Ok(data_type.clone()),
+                DataType::Binary | DataType::BinaryView | DataType::FixedSizeBinary(_) => {
+                    Ok(DataType::Utf8)
+                }
+                DataType::LargeBinary => Ok(DataType::LargeUtf8),
+                _ => exec_err!("expected string array for `make_valid_utf8`"),
+            },
+            None => exec_err!("expected single argument for `make_valid_utf8`"),
+        }
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(make_valid_utf8_inner, vec![Hint::AcceptsSingular])(
+            args.args.as_slice(),
+        )
+    }
+}
+
+fn make_valid_utf8_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    match args.first() {
+        Some(array) => match array.data_type() {
+            DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Ok(array.clone()),
+            DataType::Binary => Ok(Arc::new(
+                as_binary_array(&array)?
+                    .iter()
+                    .map(|x| x.map(String::from_utf8_lossy))
+                    .collect::<StringArray>(),
+            )),
+            DataType::BinaryView => Ok(Arc::new(
+                as_binary_view_array(&array)?
+                    .iter()
+                    .map(|x| x.map(String::from_utf8_lossy))
+                    .collect::<StringArray>(),
+            )),
+            DataType::FixedSizeBinary(_) => Ok(Arc::new(
+                as_fixed_size_binary_array(&array)?
+                    .iter()
+                    .map(|x| x.map(String::from_utf8_lossy))
+                    .collect::<StringArray>(),
+            )),
+            DataType::LargeBinary => Ok(Arc::new(
+                as_large_binary_array(&array)?
+                    .iter()
+                    .map(|x| x.map(String::from_utf8_lossy))
+                    .collect::<LargeStringArray>(),
+            )),
+            _ => exec_err!("expected string array for `make_valid_utf8`"),
+        },
+        None => exec_err!("expected single argument for `make_valid_utf8`"),
+    }
+}

--- a/crates/sail-plan/src/extension/function/string/mod.rs
+++ b/crates/sail-plan/src/extension/function/string/mod.rs
@@ -1,4 +1,5 @@
 pub mod levenshtein;
+pub mod make_valid_utf8;
 pub mod spark_base64;
 pub mod spark_encode_decode;
 pub mod spark_mask;

--- a/crates/sail-plan/src/function/scalar/string.rs
+++ b/crates/sail-plan/src/function/scalar/string.rs
@@ -11,6 +11,7 @@ use datafusion_expr::{cast, expr, lit, try_cast, ExprSchemable, ScalarUDF};
 
 use crate::error::{PlanError, PlanResult};
 use crate::extension::function::string::levenshtein::Levenshtein;
+use crate::extension::function::string::make_valid_utf8::MakeValidUtf8;
 use crate::extension::function::string::spark_base64::{SparkBase64, SparkUnbase64};
 use crate::extension::function::string::spark_encode_decode::{SparkDecode, SparkEncode};
 use crate::extension::function::string::spark_mask::SparkMask;
@@ -322,6 +323,13 @@ fn is_valid_utf8(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     Ok(try_validate_utf8(input)?.is_not_null())
 }
 
+fn make_valid_utf8(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
+    Ok(expr::Expr::ScalarFunction(expr::ScalarFunction {
+        func: Arc::new(ScalarUDF::from(MakeValidUtf8::new())),
+        args: input.arguments.clone(),
+    }))
+}
+
 pub(super) fn list_built_in_string_functions() -> Vec<(&'static str, ScalarFunction)> {
     use crate::function::common::ScalarFunctionBuilder as F;
 
@@ -359,6 +367,7 @@ pub(super) fn list_built_in_string_functions() -> Vec<(&'static str, ScalarFunct
             F::var_arg(|args| expr_fn::ltrim(args.into_iter().rev().collect())),
         ),
         ("luhn_check", F::unknown("luhn_check")),
+        ("make_valid_utf8", F::custom(make_valid_utf8)),
         ("mask", F::udf(SparkMask::new())),
         ("octet_length", F::unary(octet_length)),
         ("overlay", F::custom(overlay)),

--- a/crates/sail-spark-connect/tests/gold_data/function/string.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/string.json
@@ -1689,7 +1689,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: make_valid_utf8"
+        "success": "ok"
       }
     },
     {
@@ -1711,7 +1711,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: make_valid_utf8"
+        "success": "ok"
       }
     },
     {
@@ -1733,7 +1733,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: make_valid_utf8"
+        "success": "ok"
       }
     },
     {
@@ -1755,7 +1755,7 @@
         }
       },
       "output": {
-        "failure": "not supported: unknown function: make_valid_utf8"
+        "success": "ok"
       }
     },
     {


### PR DESCRIPTION
implement make_valid_utf8 function:
https://spark.apache.org/docs/latest/api/sql/index.html#make_valid_utf8

part of #508
new in 4.0.0