### PR TITLE
fix: clippy 1.89 warnings

### DIFF
--- a/crates/sail-plan/src/extension/function/url/url_decode.rs
+++ b/crates/sail-plan/src/extension/function/url/url_decode.rs
@@ -196,7 +196,7 @@ mod tests {
             None,
         ]);
 
-        let result = spark_url_decode(&[input.clone()])?;
+        let result = spark_url_decode(&[input as ArrayRef])?;
         let result = as_string_array(&result)?;
 
         assert_eq!(&expected, result);

--- a/crates/sail-plan/src/extension/function/url/url_encode.rs
+++ b/crates/sail-plan/src/extension/function/url/url_encode.rs
@@ -131,7 +131,7 @@ mod tests {
             None,
         ]);
 
-        let result = spark_url_encode(&[input.clone()])?;
+        let result = spark_url_encode(&[input as ArrayRef])?;
         let result = as_string_array(&result)?;
 
         assert_eq!(&expected, result);


### PR DESCRIPTION
fixes this without disabling warnings:
```
error: this call to `clone` can be replaced with `std::slice::from_ref`
   --> crates/sail-plan/src/extension/function/url/url_decode.rs:199:39
    |
199 |         let result = spark_url_decode(&[input.clone()])?;
    |                                       ^^^^^^^^^^^^^^^^ help: try: `std::slice::from_ref(&input)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cloned_ref_to_slice_refs
    = note: `-D clippy::cloned-ref-to-slice-refs` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::cloned_ref_to_slice_refs)]`

error: this call to `clone` can be replaced with `std::slice::from_ref`
   --> crates/sail-plan/src/extension/function/url/url_encode.rs:134:39
    |
134 |         let result = spark_url_encode(&[input.clone()])?;
    |                                       ^^^^^^^^^^^^^^^^ help: try: `std::slice::from_ref(&input)`
```