### PR TITLE
feat: support Delta codec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5628,32 +5628,23 @@ dependencies = [
 name = "sail-delta-lake"
 version = "0.3.2"
 dependencies = [
- "arrow-buffer",
  "arrow-schema",
  "async-trait",
  "bytes",
  "chrono",
- "dashmap",
  "datafusion",
  "datafusion-common",
- "datafusion-execution",
- "datafusion-expr",
- "datafusion-physical-optimizer",
  "delta_kernel",
  "deltalake",
- "either",
  "futures",
  "indexmap 2.10.0",
- "itertools 0.14.0",
  "log",
  "object_store",
  "parquet",
- "percent-encoding",
  "sail-common",
  "sail-common-datafusion",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
  "tokio",
  "url",
  "uuid",
@@ -5677,6 +5668,7 @@ dependencies = [
  "rand 0.9.2",
  "sail-common",
  "sail-common-datafusion",
+ "sail-delta-lake",
  "sail-object-store",
  "sail-plan",
  "sail-python-udf",
@@ -5687,6 +5679,7 @@ dependencies = [
  "tonic 0.12.3",
  "tonic-build",
  "tonic-types",
+ "url",
 ]
 
 [[package]]

--- a/crates/sail-common-datafusion/src/datasource.rs
+++ b/crates/sail-common-datafusion/src/datasource.rs
@@ -11,6 +11,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion_common::{plan_err, Constraints, DFSchema, Result};
 use datafusion_expr::expr::Sort;
 use datafusion_expr::Expr;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd)]
 pub enum SinkMode {
@@ -143,7 +144,7 @@ pub fn get_partition_columns_and_file_schema(
 }
 
 /// Options that control the behavior of Delta Lake tables.
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct TableDeltaOptions {
     pub replace_where: Option<String>,
     pub merge_schema: bool,

--- a/crates/sail-delta-lake/Cargo.toml
+++ b/crates/sail-delta-lake/Cargo.toml
@@ -4,7 +4,6 @@ version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-# Core sail dependencies
 sail-common = { path = "../sail-common" }
 sail-common-datafusion = { path = "../sail-common-datafusion" }
 
@@ -12,21 +11,14 @@ sail-common-datafusion = { path = "../sail-common-datafusion" }
 deltalake = { workspace = true }
 delta_kernel = { workspace = true }
 
-dashmap = { workspace = true }
-
 # DataFusion dependencies
 datafusion = { workspace = true }
 datafusion-common = { workspace = true }
-datafusion-expr = { workspace = true }
-datafusion-execution = { workspace = true }
-datafusion-physical-optimizer = { workspace = true }
 
 # Arrow dependencies
-arrow-buffer = { workspace = true }
 arrow-schema = { workspace = true }
 
 # Essential utilities
-thiserror = { workspace = true }
 async-trait = { workspace = true }
 object_store = { workspace = true }
 chrono = { workspace = true }
@@ -34,14 +26,11 @@ serde_json = { workspace = true }
 url = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-either.workspace = true
-itertools = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
 parquet = { workspace = true }
 bytes = { workspace = true }
 indexmap = { workspace = true }
-percent-encoding = { workspace = true }
 log = { workspace = true }
 
 [lints]

--- a/crates/sail-delta-lake/src/delta_format/sink.rs
+++ b/crates/sail-delta-lake/src/delta_format/sink.rs
@@ -66,6 +66,34 @@ impl DeltaDataSink {
         }
     }
 
+    pub fn table_url(&self) -> &Url {
+        &self.table_url
+    }
+
+    pub fn options(&self) -> &TableDeltaOptions {
+        &self.options
+    }
+
+    pub fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    pub fn partition_columns(&self) -> &[String] {
+        &self.partition_columns
+    }
+
+    pub fn initial_actions(&self) -> &[Action] {
+        &self.initial_actions
+    }
+
+    pub fn operation(&self) -> Option<&DeltaOperation> {
+        self.operation.as_ref()
+    }
+
+    pub fn table_exists(&self) -> bool {
+        self.table_exists
+    }
+
     /// Get object store from TaskContext
     fn get_object_store(
         &self,
@@ -357,12 +385,6 @@ impl DataSink for DeltaDataSink {
 
         let storage_config = StorageConfig::default();
         let object_store = self.get_object_store(context)?;
-
-        use crate::delta_datafusion::create_object_store_url;
-        let object_store_url = create_object_store_url(&self.table_url);
-        context
-            .runtime_env()
-            .register_object_store(object_store_url.as_ref(), object_store.clone());
 
         let table = if self.table_exists {
             open_table_with_object_store(

--- a/crates/sail-execution/Cargo.toml
+++ b/crates/sail-execution/Cargo.toml
@@ -13,6 +13,7 @@ sail-server = { path = "../sail-server" }
 sail-plan = { path = "../sail-plan" }
 sail-python-udf = { path = "../sail-python-udf" }
 sail-object-store = { path = "../sail-object-store" }
+sail-delta-lake = { path = "../sail-delta-lake" }
 
 thiserror = { workspace = true }
 tokio = { workspace = true }
@@ -30,6 +31,7 @@ serde_json = { workspace = true }
 kube = { workspace = true }
 k8s-openapi = { workspace = true }
 rand = { workspace = true }
+url = { workspace = true }
 
 [build-dependencies]
 prost-build = { workspace = true }

--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -26,6 +26,7 @@ message ExtendedPhysicalPlanNode {
     RecursiveQueryExecNode recursive_query = 12;
     SortMergeJoinExecNode sort_merge_join = 13;
     PartialSortExecNode partial_sort = 14;
+    DeltaSinkExecNode delta_sink = 15;
   }
 }
 
@@ -286,6 +287,23 @@ message PartialSortExecNode {
   LexOrdering expr = 1;
   bytes input = 2;
   uint64 common_prefix_length = 3;
+}
+
+message DeltaSinkExecNode {
+  bytes input = 1;
+  DeltaSink sink = 2;
+  bytes sink_schema = 3;
+  optional bytes sort_order = 4;
+}
+
+message DeltaSink {
+  string table_url = 1;
+  string options = 2;
+  bytes schema = 3;
+  repeated string partition_columns = 4;
+  string initial_actions = 5;
+  optional string operation = 6;
+  bool table_exists = 7;
 }
 
 message JoinOn {

--- a/crates/sail-server/Cargo.toml
+++ b/crates/sail-server/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sail-server"
-version.workspace = true
-edition.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/sail-sql-macro/Cargo.toml
+++ b/crates/sail-sql-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sail-sql-macro"
-version.workspace = true
-edition.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
 
 [lints]
 workspace = true


### PR DESCRIPTION
1. Support cluster mode codec for `DeltaDataSink`. (`DeltaScan` does not seem part of the physical plan so the codec is not added.)
2. Remove the logic for `delta-rs://` URLs since it breaks the reader when running in cluster mode. (The registered object store for `delta-rs://` URLs is not available in the worker.) I've adjusted the file group logic in `DeltaScanBuilder::build()` so that we do not need to rely on `delta-rs://` URLs (which is IMO a hack that we inherited from the Delta library).