### PR TITLE
fix: turn off bloom filter for Parquet write by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5561,6 +5561,7 @@ dependencies = [
 name = "sail-common"
 version = "0.3.2"
 dependencies = [
+ "arrow",
  "arrow-buffer",
  "arrow-schema",
  "figment",

--- a/crates/sail-data-source/src/options/resolver.rs
+++ b/crates/sail-data-source/src/options/resolver.rs
@@ -377,6 +377,14 @@ impl<'a> DataSourceOptionsResolver<'a> {
         for opt in options {
             apply_parquet_write_options(load_options(opt)?, &mut parquet_options)?;
         }
+        // When the FPP or NDV is set, the parquet writer will enable bloom filter implicitly.
+        // This is not desired since we want those values to take effect only when the bloom filter
+        // is explicitly enabled on write.
+        // So here we set FPP and NDV to `None` if the bloom filter is not enabled on write.
+        if !parquet_options.global.bloom_filter_on_write {
+            parquet_options.global.bloom_filter_fpp = None;
+            parquet_options.global.bloom_filter_ndv = None;
+        }
         Ok(parquet_options)
     }
 

--- a/python/pysail/tests/spark/test_parquet.py
+++ b/python/pysail/tests/spark/test_parquet.py
@@ -1,0 +1,57 @@
+from pysail.tests.spark.utils import get_data_directory_size
+
+
+def test_parquet_write_with_bloom_filter(spark, tmpdir):
+    def size(p):
+        return get_data_directory_size(p, extension=".parquet")
+
+    # The bloom filter size is determined by a formula of FPP and NDV,
+    # and then rounded up to the nearest power of two.
+    # When the data is small, the bloom filter dominates the file size if enabled,
+    # and one bloom filter is created for each column.
+    # The file size in the assertions below are rough estimates.
+
+    path = str(tmpdir / "default")
+    spark.sql("SELECT 1").write.parquet(path)
+    # The Parquet file without bloom filter is small (less than 1 kB).
+    assert size(path) < 1024  # noqa: PLR2004
+
+    path = str(tmpdir / "bloom_filter_off_explicit")
+    (
+        spark.sql("SELECT 1")
+        .write.option("bloom_filter_on_write", "false")
+        .option("bloom_filter_fpp", "0.05")
+        .option("bloom_filter_ndv", "10000")
+        .parquet(path)
+    )
+    assert size(path) < 1024  # noqa: PLR2004
+
+    path = str(tmpdir / "bloom_filter_off_implicit")
+    (
+        spark.sql("SELECT 1")
+        # The default configuration does not enable bloom filters on write.
+        .write.option("bloom_filter_fpp", "0.05")
+        .option("bloom_filter_ndv", "10000")
+        .parquet(path)
+    )
+    assert size(path) < 1024  # noqa: PLR2004
+
+    path = str(tmpdir / "bloom_filter_on")
+    (
+        spark.sql("SELECT 1")
+        .write.option("bloom_filter_on_write", "true")
+        .option("bloom_filter_fpp", "0.05")
+        .option("bloom_filter_ndv", "10000")
+        .parquet(path)
+    )
+    assert 16384 < size(path) < 16384 + 1024  # noqa: PLR2004
+
+    path = str(tmpdir / "bloom_filter_on_with_multiple_columns")
+    (
+        spark.sql("SELECT 1, 2")
+        .write.option("bloom_filter_on_write", "true")
+        .option("bloom_filter_fpp", "0.05")
+        .option("bloom_filter_ndv", "10000")
+        .parquet(path)
+    )
+    assert 32768 < size(path) < 32768 + 1024  # noqa: PLR2004

--- a/python/pysail/tests/spark/utils.py
+++ b/python/pysail/tests/spark/utils.py
@@ -99,6 +99,10 @@ def get_data_files(path: str, extension: str = ".parquet") -> list[str]:
     return sorted(data_files)
 
 
+def get_data_directory_size(path: str, extension: str = ".parquet") -> int:
+    return sum(os.path.getsize(os.path.join(str(path), f)) for f in os.listdir(path) if f.endswith(extension))
+
+
 def get_partition_structure(path: str) -> set[str]:
     """Get partition structure."""
     partitions = set()


### PR DESCRIPTION
This fixes #718.

The problem became obvious when I used the tool to inspect Parquet data file content: `pqrs schema --detailed <path>`. The large file size is due to the bloom filter for each column.

It turns out that the Parquet writer enables bloom filter when related options (FPP or NDV) are set, even if the bloom filter is not explicitly enabled. This is documented in `properties.rs` in the `parquet` crate but this information is hard to find.

This PR adjusted our configuration processing logic to make sure the bloom filter is turned off on write by default.