### PR TITLE
fix: from values containing NaN cast error

### DIFF
--- a/crates/sail-plan/src/resolver/plan.rs
+++ b/crates/sail-plan/src/resolver/plan.rs
@@ -3597,8 +3597,7 @@ fn resolve_values_nan_types(
             .iter()
             .try_fold(false, |has_float64, t| match t {
                 adt::DataType::Utf8 | adt::DataType::LargeUtf8 => Err(PlanError::invalid(format!(
-                    "Found invalid input types in {:?}",
-                    schema.field_names()[idx]
+                    "Found incompatible types in column number {idx:?}"
                 ))),
                 adt::DataType::Float64
                 | adt::DataType::Decimal128(..)

--- a/crates/sail-plan/src/resolver/plan.rs
+++ b/crates/sail-plan/src/resolver/plan.rs
@@ -2346,6 +2346,7 @@ impl PlanResolver<'_> {
                 let value = self.resolve_expressions(value, &schema, state).await?;
                 results.push(value);
             }
+            let _changed_column_indices = resolve_values_nan_types(&mut results, &schema)?;
             Ok(results) as PlanResult<_>
         }
         .await?;
@@ -3555,6 +3556,69 @@ fn rebase_expression(expr: Expr, base: &[Expr], plan: &LogicalPlan) -> PlanResul
             }
         })
         .data()?)
+}
+
+fn resolve_values_nan_types(
+    values: &mut Vec<Vec<Expr>>,
+    schema: &DFSchemaRef,
+) -> PlanResult<HashSet<usize>> {
+    let mut nan_positions = HashSet::new();
+    for value in values.iter() {
+        value.iter().enumerate().for_each(|(idx, expr)| {
+            if let Expr::Cast(cast) = expr {
+                if let Expr::Literal(sv, _) = cast.expr.as_ref() {
+                    if let Some(true) = sv
+                        .try_as_str()
+                        .flatten()
+                        .map(|s| s.to_uppercase() == "NAN" && cast.data_type.is_numeric())
+                    {
+                        nan_positions.insert(idx);
+                    }
+                }
+            }
+        });
+    }
+
+    for idx in nan_positions.clone() {
+        let override_types = values
+            .iter()
+            .map(|result| {
+                Ok(match result[idx].get_type(&schema)? {
+                    adt::DataType::Utf8 | adt::DataType::LargeUtf8 => adt::DataType::Utf8,
+                    adt::DataType::Float64
+                    | adt::DataType::Decimal128(..)
+                    | adt::DataType::Decimal256(..) => adt::DataType::Float64,
+                    _ => adt::DataType::Float32,
+                })
+            })
+            .collect::<Result<Vec<_>, PlanError>>()?;
+
+        let target_type = override_types
+            .iter()
+            .try_fold(false, |has_float64, t| match t {
+                adt::DataType::Utf8 | adt::DataType::LargeUtf8 => Err(PlanError::invalid(format!(
+                    "Found invalid input types in {:?}",
+                    schema.field_names()[idx]
+                ))),
+                adt::DataType::Float64
+                | adt::DataType::Decimal128(..)
+                | adt::DataType::Decimal256(..) => Ok(true),
+                _ => Ok(has_float64),
+            })
+            .map(|has_float64| {
+                if has_float64 {
+                    adt::DataType::Float64
+                } else {
+                    adt::DataType::Float32
+                }
+            })?;
+
+        for value in &mut *values {
+            value[idx] = cast(value[idx].clone(), target_type.clone());
+        }
+    }
+
+    Ok(nan_positions)
 }
 
 struct CoGroupMapData {


### PR DESCRIPTION
provide support for NaN values in VALUES like in spark

```python
from pysail.spark import SparkConnectServer
from pyspark.sql import SparkSession
import pyspark.sql.functions as F

server = SparkConnectServer()
server.start()
_, port = server.listening_address

print(port)
spark = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
#spark = SparkSession.builder.appName("test").getOrCreate()

spark.sql("select * from values (NULL), (DOUBLE('NAN')), (1.5f)").toArrow()
spark.sql("select * from values (NULL), (FLOAT('NAN')), (1.5)").toArrow()
spark.sql("select * from values (NULL), (FLOAT('NAN')), (1.5f)").toArrow()
spark.sql("select * from values (NULL), (DOUBLE('NAN')), (cast(1 as long))").toArrow()
spark.sql("select * from values (NULL), (FLOAT('NAN')), (cast(1000000005 as long))").toArrow()
spark.sql("select * from values (NULL), (FLOAT('NaN')), (1.5), ('')").toArrow()
```

last query throws like in spark:
```
IllegalArgumentException: invalid argument: Found incompatible types in column number 0
```
other work fine now

closes #738