### PR TITLE
fix: catalog get table command

### DIFF
--- a/crates/sail-catalog/src/command.rs
+++ b/crates/sail-catalog/src/command.rs
@@ -295,8 +295,8 @@ impl CatalogCommand {
                 build_record_batch(schema, &rows)
             }
             CatalogCommand::GetTable { table } => {
-                // We are supposed to return an error if the table does not exist.
-                let table = manager.get_table(&table).await?;
+                // We are supposed to return an error if the table or view does not exist.
+                let table = manager.get_table_or_view(&table).await?;
                 let table = D::table(table);
                 build_record_batch(schema, &[table])
             }


### PR DESCRIPTION
According to the Spark documentation, `pyspark.sql.Catalog.getTable()` should return tables, views, or temporary views. This PR fixes the catalog command to make it adhere to this behavior.

This also fixes the issue with the `describe_view` MCP tool.