### PR TITLE
fix: adjust default session timeout and update docs

### DIFF
--- a/crates/sail-common/src/config/application.yaml
+++ b/crates/sail-common/src/config/application.yaml
@@ -585,5 +585,5 @@
 
 - key: spark.session_timeout_secs
   type: number
-  default: "120"
+  default: "900"
   description: The Spark session timeout in seconds.

--- a/docs/.vitepress/theme/layouts/MainLayout.vue
+++ b/docs/.vitepress/theme/layouts/MainLayout.vue
@@ -12,9 +12,19 @@
           theme.externalLinkIcon && 'external-link-icon-enabled',
         ]"
       >
+        <div v-if="!isDevGuide" class="info custom-block !pt-2 !pb-2">
+          <p>
+            <span class="mr-1">&#127873;</span
+            ><span class="font-semibold">Using Sail?</span> Tell us your story
+            and
+            <a href="https://lakesail.com/share-story" target="_blank"
+              >get free merch</a
+            >!
+          </p>
+        </div>
         <div
           v-if="version !== 'latest' && !isDevGuide"
-          class="warning custom-block py-4"
+          class="warning custom-block !pt-2 !pb-2"
         >
           <p>
             This is
@@ -28,7 +38,7 @@
         </div>
         <div
           v-if="version !== 'main' && isDevGuide"
-          class="warning custom-block py-4"
+          class="warning custom-block !pt-2 !pb-2"
         >
           <p>
             This is a snapshot of the development guide for a released Sail
@@ -39,7 +49,7 @@
         </div>
         <div
           v-if="version === 'main' && isDevGuide"
-          class="info custom-block py-4"
+          class="info custom-block !pt-2 !pb-2"
         >
           <p>
             This guide is up-to-date with the

--- a/docs/introduction/getting-started/index.md
+++ b/docs/introduction/getting-started/index.md
@@ -35,7 +35,7 @@ pip install "pyspark[connect]==3.5.5
 
 ::: info
 
-- `pyspark-client` is a lightweight PySpark client introduced in Spark 4.0 while `pyspark` remains as the full PySpark package containing all the JARs. The lightweight client cannot execute queries by itself, and can only connect to a Spark Connect server.
+- `pyspark-client` is a lightweight PySpark client introduced in Spark 4.0 while `pyspark` remains as the full PySpark package. The lightweight client does not contain the Spark JARs that are not needed for running the Sail Spark Connect server.
 - `pyspark[connect]` installs extra dependencies needed for Spark Connect. This is supported since Spark 3.4.
 - Since Spark 4.0, there is also a wrapper package `pyspark-connect` that you can use, which is equivalent to `pyspark[connect]`.
 
@@ -83,6 +83,20 @@ spark = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
 
 spark.sql("SELECT 1 + 1").show()
 ```
+
+::: info
+
+If you use Sail in a notebook, you can adjust the session timeout to avoid ending the session due to inactivity. For example, the following code snippet sets the session timeout to 1 hour. The environment variable needs to be set before creating the `SparkConnectServer` instance.
+
+```python
+import os
+
+os.environ["SAIL_SPARK__SESSION_TIMEOUT_SECS"] = "3600"
+```
+
+You can refer to the [Configuration](/guide/configuration/) guide for more information about configuring Sail.
+
+:::
 
 ## Running the Sail Spark Connect Server
 


### PR DESCRIPTION
1. Change default session timeout to 15 minutes and add docs. This is based on user feedback in #736 and #747.
2. Update the docs about `pyspark-client`. This is based on user feedback for <https://github.com/mwc360/LakeBench/pull/37#issuecomment-3183968000>.
3. Add banner for merch.