### PR TITLE
feat: map_entries func, map keys deduplication logic

### DIFF
--- a/crates/sail-plan/src/function/scalar/map.rs
+++ b/crates/sail-plan/src/function/scalar/map.rs
@@ -18,7 +18,7 @@ pub(super) fn list_built_in_map_functions() -> Vec<(&'static str, ScalarFunction
         ("map", F::udf(MapFunction::new())),
         ("map_concat", F::unknown("map_concat")),
         ("map_contains_key", F::binary(map_contains_key)),
-        ("map_entries", F::unknown("map_entries")),
+        ("map_entries", F::unary(expr_fn::map_entries)),
         ("map_from_arrays", F::scalar_udf(map_udf)),
         ("map_from_entries", F::unknown("map_from_entries")),
         ("map_keys", F::unary(expr_fn::map_keys)),

--- a/crates/sail-spark-connect/tests/gold_data/function/map.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/map.json
@@ -137,7 +137,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: map_entries"
+        "success": "ok"
       }
     },
     {


### PR DESCRIPTION
implement `map_entries` function by calling datafusion `expr_fn::map_entries`:
https://spark.apache.org/docs/latest/api/sql/index.html#map_entries

implement deduplication logic for map keys on insertion:
https://github.com/apache/spark/blob/cf3a34e19dfcf70e2d679217ff1ba21302212472/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L4961

NOTE: 
this code passes spark tests, and it will work fine for everyday cases
but it is not the spark default behaviour, which is to raise exception on duplicate keys
to be fully consistent with spark, map functions need to be configurable with spark configuration , which is not implemented yet