### PR TITLE
feat: map_from_entries, unify all ways to create a map in MapFunction

### DIFF
--- a/crates/sail-plan/src/extension/function/map/map_function.rs
+++ b/crates/sail-plan/src/extension/function/map/map_function.rs
@@ -2,127 +2,16 @@ use std::any::Any;
 use std::collections::HashSet;
 use std::sync::Arc;
 
-use datafusion::arrow::array::{Array, ArrayRef, BooleanBuilder, MapArray, NullArray, StructArray};
+use datafusion::arrow::array::{Array, ArrayRef, BooleanBuilder, MapArray, StructArray};
 use datafusion::arrow::buffer::OffsetBuffer;
-use datafusion::arrow::compute::{cast, filter, interleave};
+use datafusion::arrow::compute::filter;
 use datafusion::arrow::datatypes::{DataType, Field, Fields};
-use datafusion_common::{exec_err, Result, ScalarValue};
-use datafusion_expr::{
-    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
-};
+use datafusion_common::cast::as_list_array;
+use datafusion_common::{exec_err, plan_err, Result, ScalarValue};
+use datafusion_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
+use datafusion_functions::utils::make_scalar_function;
 
-trait KeyValue<T>
-where
-    T: 'static,
-{
-    fn keys(&self) -> impl Iterator<Item = &T>;
-    fn values(&self) -> impl Iterator<Item = &T>;
-}
-
-impl<T> KeyValue<T> for &[T]
-where
-    T: 'static,
-{
-    fn keys(&self) -> impl Iterator<Item = &T> {
-        self.iter().step_by(2)
-    }
-
-    fn values(&self) -> impl Iterator<Item = &T> {
-        self.iter().skip(1).step_by(2)
-    }
-}
-
-fn to_map_array(args: &[ArrayRef], num_rows: usize) -> Result<ArrayRef> {
-    if !args.len().is_multiple_of(2) {
-        return exec_err!("map requires an even number of arguments");
-    }
-    let num_entries = args.len() / 2;
-    if args.iter().any(|a| a.len() != num_rows) {
-        return exec_err!("map requires all arrays to have the same length");
-    }
-    let key_type = args
-        .first()
-        .map(|a| a.data_type())
-        .unwrap_or(&DataType::Null);
-    let value_type = args
-        .values()
-        .map(|a| a.data_type())
-        .find(|dt| *dt != &DataType::Null)
-        .unwrap_or(&DataType::Null);
-    let keys = args.keys().map(|a| a.as_ref()).collect::<Vec<_>>();
-    let arc_values = args
-        .values()
-        .map(|a| match a.data_type() {
-            &DataType::Null => Ok(cast(a, value_type)?),
-            _ => Ok(a.clone()),
-        })
-        .collect::<Result<Vec<_>>>()?;
-    let values = arc_values.iter().map(|a| a.as_ref()).collect::<Vec<_>>();
-    if keys.iter().any(|a| a.data_type() != key_type) {
-        return exec_err!("map requires all key types to be the same");
-    }
-    if values.iter().any(|a| a.data_type() != value_type) {
-        return exec_err!("map requires all value types to be the same");
-    }
-
-    let (keys, values, offsets) = match (key_type, value_type) {
-        (&DataType::Null, &DataType::Null) => {
-            let keys = Arc::new(NullArray::new(0)) as ArrayRef;
-            let values = Arc::new(NullArray::new(0)) as ArrayRef;
-            (keys, values, vec![0, 0])
-        }
-        _ => {
-            // TODO: avoid materializing the indices
-            let indices = (0..num_rows)
-                .flat_map(|i| (0..num_entries).map(move |j| (j, i)))
-                .collect::<Vec<_>>();
-            let keys = interleave(keys.as_slice(), indices.as_slice())?;
-            let values = interleave(values.as_slice(), indices.as_slice())?;
-
-            let mut offsets = Vec::with_capacity(num_rows + 1);
-            offsets.push(0);
-            let mut last_offset = 0;
-
-            let mut needed_rows_builder = BooleanBuilder::new();
-            for row_num in 0..num_rows {
-                let keys_slice = keys.slice(row_num * num_entries, num_entries);
-                let mut seen_keys = HashSet::new();
-                let mut needed_rows_one = [false].repeat(num_entries);
-                for index in (0..num_entries).rev() {
-                    let key = ScalarValue::try_from_array(&keys_slice, index)?.compacted();
-                    if seen_keys.contains(&key) {
-                        // TODO: implement configuration and logic for spark.sql.mapKeyDedupPolicy=EXCEPTION (this is default spark-config)
-                        // exec_err!("invalid argument: duplicate keys in map")
-                        // https://github.com/apache/spark/blob/cf3a34e19dfcf70e2d679217ff1ba21302212472/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L4961
-                    } else {
-                        // This code implements deduplication logic for spark.sql.mapKeyDedupPolicy=LAST_WIN (this is NOT default spark-config)
-                        needed_rows_one[index] = true;
-                        seen_keys.insert(key);
-                        last_offset += 1;
-                    }
-                }
-                needed_rows_builder.append_array(&needed_rows_one.into());
-                offsets.push(last_offset);
-            }
-            let needed_rows = needed_rows_builder.finish();
-            let needed_keys = filter(&keys, &needed_rows)?;
-            let needed_values = filter(&values, &needed_rows)?;
-            (needed_keys, needed_values, offsets)
-        }
-    };
-    let offsets = OffsetBuffer::new(offsets.into());
-    let fields = Fields::from(vec![
-        Field::new("key", key_type.clone(), false),
-        Field::new("value", value_type.clone(), true),
-    ]);
-    let entries = StructArray::try_new(fields.clone(), vec![keys, values], None)?;
-    let field = Arc::new(Field::new("entries", DataType::Struct(fields), false));
-    Ok(Arc::new(MapArray::try_new(
-        field, offsets, entries, None, false,
-    )?))
-}
-
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct MapFunction {
     signature: Signature,
 }
@@ -136,10 +25,7 @@ impl Default for MapFunction {
 impl MapFunction {
     pub fn new() -> Self {
         Self {
-            signature: Signature::one_of(
-                vec![TypeSignature::VariadicAny, TypeSignature::Nullary],
-                Volatility::Immutable,
-            ),
+            signature: Signature::user_defined(Volatility::Immutable),
         }
     }
 }
@@ -158,27 +44,12 @@ impl ScalarUDFImpl for MapFunction {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        if !arg_types.len().is_multiple_of(2) {
-            return exec_err!("map requires an even number of arguments");
-        }
-        if arg_types.keys().any(|dt| dt == &DataType::Null) {
-            return exec_err!("map cannot contain null key type");
-        }
-        let key_type = arg_types.first().unwrap_or(&DataType::Null);
-        let value_type = arg_types
-            .values()
-            .find(|dt| *dt != &DataType::Null)
-            .unwrap_or(&DataType::Null);
-        // TODO: support type coercion
-        if arg_types.keys().any(|dt| dt != key_type) {
-            return exec_err!("map requires all key types to be the same");
-        }
-        if arg_types
-            .values()
-            .any(|dt| (dt != value_type) && (dt != &DataType::Null))
-        {
-            return exec_err!("map requires all value types to be the same");
-        }
+        let (key_type, value_type) = match arg_types.len() {
+            1 => get_list_struct_key_value_types(&arg_types[0]),
+            2 => Ok((get_element_type(&arg_types[0])?, get_element_type(&arg_types[1])?)),
+            _ => plan_err!("create_map: expected array<struct<key, value>> or (array<key>, array<value>), got {:?}", arg_types)
+        }?;
+
         Ok(DataType::Map(
             Arc::new(Field::new(
                 "entries",
@@ -193,14 +64,128 @@ impl ScalarUDFImpl for MapFunction {
         ))
     }
 
-    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        let ScalarFunctionArgs {
-            args, number_rows, ..
-        } = args;
-        let arrays = ColumnarValue::values_to_arrays(&args)?;
-        Ok(ColumnarValue::Array(to_map_array(
-            arrays.as_slice(),
-            number_rows,
-        )?))
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        // MapArray stores entries in List type with i32 offset only
+        // So cast LargeList or FixedSizeList args to List to simplify logic
+        arg_types
+            .iter()
+            .map(|data_type| Ok(DataType::List(get_list_field(data_type)?.clone())))
+            .collect()
+    }
+
+    fn invoke_with_args(&self, args: datafusion_expr::ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(map_from_arrays_inner, vec![])(&args.args)
+    }
+}
+
+fn map_from_arrays_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let lists = args
+        .iter()
+        .map(|list_arc| as_list_array(list_arc.as_ref()))
+        .collect::<Result<Vec<_>>>()?;
+
+    let (keys, values, offsets) = match lists.len() {
+        1 => {
+           match lists[0]
+                    .values()
+                    .as_any()
+                    .downcast_ref::<StructArray>() {
+                Some(a) => Ok((a.column(0), a.column(1), lists[0].offsets())),
+                None => exec_err!(
+                    "create_map: expected array<struct<key, value>> or (array<key>, array<value>), got {:?}", 
+                    lists[0].data_type()
+                )
+            }
+        }
+        2 => Ok((lists[0].values(), lists[1].values(), lists[0].offsets())),
+        wrong_cnt => exec_err!("create_map: expected array<struct<key, value>> or (array<key>, array<value>), got {wrong_cnt} args")
+    }?;
+
+    let (keys, values, offsets) = map_deduplicate_keys(keys, values, offsets)?;
+
+    let fields = Fields::from(vec![
+        Field::new("key", keys.data_type().clone(), false),
+        Field::new("value", values.data_type().clone(), true),
+    ]);
+    let entries = StructArray::try_new(fields.clone(), vec![keys, values], None)?;
+    let field = Arc::new(Field::new("entries", DataType::Struct(fields), false));
+    Ok(Arc::new(MapArray::try_new(
+        field, offsets, entries, None, false,
+    )?))
+}
+
+pub fn map_deduplicate_keys(
+    keys: &ArrayRef,
+    values: &ArrayRef,
+    offsets: &[i32],
+) -> Result<(ArrayRef, ArrayRef, OffsetBuffer<i32>)> {
+    let num_rows = offsets.len() - 1;
+    let mut new_offsets = Vec::with_capacity(num_rows + 1);
+    new_offsets.push(0);
+    let mut last_offset = 0;
+
+    let mut needed_rows_builder = BooleanBuilder::new();
+    for row_num in 0..num_rows {
+        let cur_offset = offsets[row_num] as usize;
+        let next_offset = offsets[row_num + 1] as usize;
+        let num_entries = next_offset - cur_offset;
+        let keys_slice = keys.slice(cur_offset, num_entries);
+        let mut seen_keys = HashSet::new();
+        let mut needed_rows_one = [false].repeat(num_entries);
+        for index in (0..num_entries).rev() {
+            let key = ScalarValue::try_from_array(&keys_slice, index)?.compacted();
+            if seen_keys.contains(&key) {
+                // TODO: implement configuration and logic for spark.sql.mapKeyDedupPolicy=EXCEPTION (this is default spark-config)
+                // exec_err!("invalid argument: duplicate keys in map")
+                // https://github.com/apache/spark/blob/cf3a34e19dfcf70e2d679217ff1ba21302212472/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L4961
+            } else {
+                // This code implements deduplication logic for spark.sql.mapKeyDedupPolicy=LAST_WIN (this is NOT default spark-config)
+                needed_rows_one[index] = true;
+                seen_keys.insert(key);
+                last_offset += 1;
+            }
+        }
+        needed_rows_builder.append_array(&needed_rows_one.into());
+        new_offsets.push(last_offset);
+    }
+    let needed_rows = needed_rows_builder.finish();
+    let needed_keys = filter(&keys, &needed_rows)?;
+    let needed_values = filter(&values, &needed_rows)?;
+    let offsets = OffsetBuffer::new(new_offsets.into());
+    Ok((needed_keys, needed_values, offsets))
+}
+
+fn get_list_field(data_type: &DataType) -> Result<&Arc<Field>> {
+    match data_type {
+        DataType::List(element)
+        | DataType::LargeList(element)
+        | DataType::FixedSizeList(element, _) => Ok(element),
+        _ => exec_err!(
+            "create_map: expected array<struct<key, value>> or (array<key>, array<value>), got {:?}",
+            data_type
+        ),
+    }
+}
+
+fn get_element_type(data_type: &DataType) -> Result<&DataType> {
+    get_list_field(data_type).map(|field| field.data_type())
+}
+
+fn get_list_struct_key_value_types(data_type: &DataType) -> Result<(&DataType, &DataType)> {
+    let err = |wrong_type| {
+        exec_err!(
+            "create_map: expected array<struct<key, value>> or (array<key>, array<value>), got {:?}",
+            wrong_type
+        )
+    };
+
+    match data_type {
+        DataType::List(element) => match element.data_type() {
+            DataType::Struct(fields) if fields.len() == 2 => {
+                Ok((fields[0].data_type(), fields[1].data_type()))
+            }
+            _ => err(data_type),
+        },
+        _ => err(data_type),
     }
 }

--- a/crates/sail-plan/src/function/common.rs
+++ b/crates/sail-plan/src/function/common.rs
@@ -155,6 +155,7 @@ impl ScalarFunctionBuilder {
         )
     }
 
+    #[allow(dead_code)]
     pub fn scalar_udf<F>(f: F) -> ScalarFunction
     where
         F: Fn() -> Arc<ScalarUDF> + Send + Sync + 'static,

--- a/crates/sail-plan/src/function/scalar/map.rs
+++ b/crates/sail-plan/src/function/scalar/map.rs
@@ -1,10 +1,33 @@
 use datafusion::functions_nested::expr_fn;
 use datafusion_expr::expr;
-use datafusion_functions_nested::map::map_udf;
 
+use crate::error::PlanResult;
 use crate::extension::function::map::map_function::MapFunction;
 use crate::extension::function::map::spark_element_at::{SparkElementAt, SparkTryElementAt};
-use crate::function::common::ScalarFunction;
+use crate::function::common::{ScalarFunction, ScalarFunctionInput};
+
+fn map(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
+    use crate::function::common::ScalarFunctionBuilder as F;
+
+    let keys = input
+        .arguments
+        .chunks(2)
+        .map(|key_value| key_value[0].clone())
+        .collect();
+
+    let values = input
+        .arguments
+        .chunks(2)
+        .map(|key_value| key_value[1].clone())
+        .collect();
+
+    let keys = expr_fn::make_array(keys);
+    let values = expr_fn::make_array(values);
+    F::udf(MapFunction::new())(ScalarFunctionInput {
+        arguments: vec![keys, values],
+        function_context: input.function_context,
+    })
+}
 
 fn map_contains_key(map: expr::Expr, key: expr::Expr) -> expr::Expr {
     expr_fn::array_has(expr_fn::map_keys(map), key)
@@ -15,12 +38,12 @@ pub(super) fn list_built_in_map_functions() -> Vec<(&'static str, ScalarFunction
 
     vec![
         ("element_at", F::udf(SparkElementAt::new())),
-        ("map", F::udf(MapFunction::new())),
+        ("map", F::custom(map)),
         ("map_concat", F::unknown("map_concat")),
         ("map_contains_key", F::binary(map_contains_key)),
         ("map_entries", F::unary(expr_fn::map_entries)),
-        ("map_from_arrays", F::scalar_udf(map_udf)),
-        ("map_from_entries", F::unknown("map_from_entries")),
+        ("map_from_arrays", F::udf(MapFunction::new())),
+        ("map_from_entries", F::udf(MapFunction::new())),
         ("map_keys", F::unary(expr_fn::map_keys)),
         ("map_values", F::unary(expr_fn::map_values)),
         ("str_to_map", F::unknown("str_to_map")),

--- a/crates/sail-spark-connect/tests/gold_data/function/map.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/map.json
@@ -191,7 +191,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: map_from_entries"
+        "success": "ok"
       }
     },
     {


### PR DESCRIPTION
implement `map_from_entries`
https://spark.apache.org/docs/latest/api/sql/index.html#map_from_entries

unify all ways to create a map in MapFunction:
- `map(k1,v1,k2,v2,..)`  (now done with some additional lightweight expression logic)
- `map_from_arrays`
- `map_from_entries`

remove usage of datafusion `map_udf` because it is not consistent with spark in many ways

all types of keys and values are coerced with datafusion `make_array` logic which works well for spark-tests
no more need to implicitly cast anything

now all maps are deduplicated on creation
and the code can be easily adjusted to change behavior when spark config will be implemented
closes #667
part of #307