### PR TITLE
feat: map_concat func, args check for map(k, v) func

### DIFF
--- a/crates/sail-spark-connect/tests/gold_data/function/map.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/map.json
@@ -51,7 +51,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: map_concat"
+        "success": "ok"
       }
     },
     {


### PR DESCRIPTION
implement `map_concat` function:
https://spark.apache.org/docs/latest/api/sql/index.html#map_concat
supports type coersion for concatenated keys and values

`map(k, v)` improvements:
- return readable error when called with odd number of args instead of panic
- simplify args to key-value pairs transform

part of #307 