### PR TITLE
chore: refactor array and collection modules

### DIFF
--- a/crates/sail-plan/src/error.rs
+++ b/crates/sail-plan/src/error.rs
@@ -8,6 +8,22 @@ use thiserror::Error;
 
 pub type PlanResult<T> = Result<T, PlanError>;
 
+pub trait IntoPlanResult<T> {
+    fn into_plan_result(self) -> PlanResult<T>;
+}
+
+impl<T> IntoPlanResult<T> for T {
+    fn into_plan_result(self) -> PlanResult<T> {
+        Ok(self)
+    }
+}
+
+impl<T> IntoPlanResult<T> for PlanResult<T> {
+    fn into_plan_result(self) -> PlanResult<T> {
+        self
+    }
+}
+
 #[derive(Debug, Error)]
 #[allow(clippy::large_enum_variant)]
 pub enum PlanError {

--- a/crates/sail-plan/src/function/common.rs
+++ b/crates/sail-plan/src/function/common.rs
@@ -11,7 +11,7 @@ use datafusion_expr::{
 };
 
 use crate::config::PlanConfig;
-use crate::error::{PlanError, PlanResult};
+use crate::error::{IntoPlanResult, PlanError, PlanResult};
 use crate::utils::ItemTaker;
 
 pub struct FunctionContextInput<'a> {
@@ -38,9 +38,10 @@ pub(crate) type ScalarFunction =
 pub(crate) struct ScalarFunctionBuilder;
 
 impl ScalarFunctionBuilder {
-    pub fn nullary<F>(f: F) -> ScalarFunction
+    pub fn nullary<F, R>(f: F) -> ScalarFunction
     where
-        F: Fn() -> expr::Expr + Send + Sync + 'static,
+        F: Fn() -> R + Send + Sync + 'static,
+        R: IntoPlanResult<expr::Expr>,
     {
         Arc::new(
             move |ScalarFunctionInput {
@@ -48,26 +49,28 @@ impl ScalarFunctionBuilder {
                       function_context: _,
                   }| {
                 arguments.zero()?;
-                Ok(f())
+                f().into_plan_result()
             },
         )
     }
 
-    pub fn unary<F>(f: F) -> ScalarFunction
+    pub fn unary<F, R>(f: F) -> ScalarFunction
     where
-        F: Fn(expr::Expr) -> expr::Expr + Send + Sync + 'static,
+        F: Fn(expr::Expr) -> R + Send + Sync + 'static,
+        R: IntoPlanResult<expr::Expr>,
     {
         Arc::new(
             move |ScalarFunctionInput {
                       arguments,
                       function_context: _,
-                  }| Ok(f(arguments.one()?)),
+                  }| f(arguments.one()?).into_plan_result(),
         )
     }
 
-    pub fn binary<F>(f: F) -> ScalarFunction
+    pub fn binary<F, R>(f: F) -> ScalarFunction
     where
-        F: Fn(expr::Expr, expr::Expr) -> expr::Expr + Send + Sync + 'static,
+        F: Fn(expr::Expr, expr::Expr) -> R + Send + Sync + 'static,
+        R: IntoPlanResult<expr::Expr>,
     {
         Arc::new(
             move |ScalarFunctionInput {
@@ -75,14 +78,15 @@ impl ScalarFunctionBuilder {
                       function_context: _,
                   }| {
                 let (left, right) = arguments.two()?;
-                Ok(f(left, right))
+                f(left, right).into_plan_result()
             },
         )
     }
 
-    pub fn ternary<F>(f: F) -> ScalarFunction
+    pub fn ternary<F, R>(f: F) -> ScalarFunction
     where
-        F: Fn(expr::Expr, expr::Expr, expr::Expr) -> expr::Expr + Send + Sync + 'static,
+        F: Fn(expr::Expr, expr::Expr, expr::Expr) -> R + Send + Sync + 'static,
+        R: IntoPlanResult<expr::Expr>,
     {
         Arc::new(
             move |ScalarFunctionInput {
@@ -90,20 +94,21 @@ impl ScalarFunctionBuilder {
                       function_context: _,
                   }| {
                 let (first, second, third) = arguments.three()?;
-                Ok(f(first, second, third))
+                f(first, second, third).into_plan_result()
             },
         )
     }
 
-    pub fn var_arg<F>(f: F) -> ScalarFunction
+    pub fn var_arg<F, R>(f: F) -> ScalarFunction
     where
-        F: Fn(Vec<expr::Expr>) -> expr::Expr + Send + Sync + 'static,
+        F: Fn(Vec<expr::Expr>) -> R + Send + Sync + 'static,
+        R: IntoPlanResult<expr::Expr>,
     {
         Arc::new(
             move |ScalarFunctionInput {
                       arguments,
                       function_context: _,
-                  }| Ok(f(arguments)),
+                  }| f(arguments).into_plan_result(),
         )
     }
 
@@ -128,12 +133,7 @@ impl ScalarFunctionBuilder {
             move |ScalarFunctionInput {
                       arguments,
                       function_context: _,
-                  }| {
-                Ok(expr::Expr::Cast(expr::Cast {
-                    expr: Box::new(arguments.one()?),
-                    data_type: data_type.clone(),
-                }))
-            },
+                  }| { Ok(cast(arguments.one()?, data_type.clone())) },
         )
     }
 
@@ -141,17 +141,12 @@ impl ScalarFunctionBuilder {
     where
         F: ScalarUDFImpl + Send + Sync + 'static,
     {
-        let func = Arc::new(ScalarUDF::from(f));
+        let func = ScalarUDF::from(f);
         Arc::new(
             move |ScalarFunctionInput {
                       arguments,
                       function_context: _,
-                  }| {
-                Ok(expr::Expr::ScalarFunction(expr::ScalarFunction {
-                    func: func.clone(),
-                    args: arguments,
-                }))
-            },
+                  }| { Ok(func.call(arguments)) },
         )
     }
 
@@ -164,12 +159,7 @@ impl ScalarFunctionBuilder {
             move |ScalarFunctionInput {
                       arguments,
                       function_context: _,
-                  }| {
-                Ok(expr::Expr::ScalarFunction(expr::ScalarFunction {
-                    func: f(),
-                    args: arguments,
-                }))
-            },
+                  }| { Ok(f().call(arguments)) },
         )
     }
 
@@ -336,13 +326,4 @@ pub(crate) fn get_null_treatment(ignore_nulls: Option<bool>) -> Option<NullTreat
         Some(false) => Some(NullTreatment::RespectNulls),
         None => None,
     }
-}
-
-pub(crate) fn udf_expr<UDFType: ScalarUDFImpl + Default + 'static>(
-    args: Vec<expr::Expr>,
-) -> expr::Expr {
-    expr::Expr::ScalarFunction(expr::ScalarFunction {
-        func: Arc::new(ScalarUDF::from(UDFType::default())),
-        args,
-    })
 }

--- a/crates/sail-plan/src/function/scalar/array.rs
+++ b/crates/sail-plan/src/function/scalar/array.rs
@@ -112,10 +112,9 @@ fn array_insert(
         )
         .end()?;
 
-    let zero_index_error =
-        ScalarUDF::from(RaiseError::new())
-            .call(vec![lit("array_insert: The index 0 is invalid. 
-        An index shall be either < 0 or > 0 (the first element has index 1)")]);
+    let zero_index_error = ScalarUDF::from(RaiseError::new()).call(vec![lit(
+        "array_insert: the index 0 is invalid. An index shall be either < 0 or > 0 (the first element has index 1)"
+    )]);
 
     Ok(when(array.clone().is_null(), array.clone())
         .when(pos_from_zero.clone().is_null(), zero_index_error)

--- a/crates/sail-plan/src/function/scalar/array.rs
+++ b/crates/sail-plan/src/function/scalar/array.rs
@@ -3,9 +3,7 @@ use datafusion::functions::expr_fn::{coalesce, nvl};
 use datafusion::functions_nested::expr_fn;
 use datafusion::functions_nested::position::array_position as datafusion_array_position;
 use datafusion_common::ScalarValue;
-use datafusion_expr::{
-    cast, expr, is_null, lit, not, or, when, BinaryExpr, ExprSchemable, Operator,
-};
+use datafusion_expr::{cast, expr, is_null, lit, not, or, when, ExprSchemable, ScalarUDF};
 use datafusion_functions_nested::make_array::make_array;
 use datafusion_functions_nested::string::ArrayToString;
 
@@ -19,11 +17,7 @@ use crate::function::common::{ScalarFunction, ScalarFunctionInput};
 use crate::utils::ItemTaker;
 
 fn array_repeat(element: expr::Expr, count: expr::Expr) -> expr::Expr {
-    let count = expr::Expr::Cast(expr::Cast {
-        expr: Box::new(count),
-        data_type: DataType::Int64,
-    });
-    expr_fn::array_repeat(element, count)
+    expr_fn::array_repeat(element, cast(count, DataType::Int64))
 }
 
 fn array_compact(array: expr::Expr) -> expr::Expr {
@@ -31,29 +25,13 @@ fn array_compact(array: expr::Expr) -> expr::Expr {
 }
 
 fn slice(array: expr::Expr, start: expr::Expr, length: expr::Expr) -> expr::Expr {
-    let start = expr::Expr::Cast(expr::Cast {
-        expr: Box::new(start),
-        data_type: DataType::Int64,
-    });
-    let length = expr::Expr::Cast(expr::Cast {
-        expr: Box::new(length),
-        data_type: DataType::Int64,
-    });
-    let end = expr::Expr::BinaryExpr(BinaryExpr {
-        left: Box::new(start.clone()),
-        op: Operator::Plus,
-        right: Box::new(expr::Expr::BinaryExpr(BinaryExpr {
-            left: Box::new(length),
-            op: Operator::Minus,
-            right: Box::new(lit(ScalarValue::Int64(Some(1)))),
-        })),
-    });
+    let start = cast(start, DataType::Int64);
+    let length = cast(length, DataType::Int64);
+    let end = start.clone() + length - lit(1_i64);
     expr_fn::array_slice(array, start, end, None)
 }
 
-fn sort_array(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
-    let ScalarFunctionInput { arguments, .. } = input;
-    let (array, asc) = arguments.two()?;
+fn sort_array(array: expr::Expr, asc: expr::Expr) -> PlanResult<expr::Expr> {
     let (sort, nulls) = match asc {
         expr::Expr::Literal(ScalarValue::Boolean(Some(true)), _metadata) => (
             lit(ScalarValue::Utf8(Some("ASC".to_string()))),
@@ -72,95 +50,60 @@ fn sort_array(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     Ok(expr_fn::array_sort(array, sort, nulls))
 }
 
-fn array_append(array: expr::Expr, element: expr::Expr) -> expr::Expr {
-    expr::Expr::Case(expr::Case {
-        expr: None,
-        when_then_expr: vec![(
-            Box::new(expr::Expr::IsNotNull(Box::new(array.clone()))),
-            Box::new(expr_fn::array_append(array, element)),
-        )],
-        else_expr: None,
-    })
+fn array_append(array: expr::Expr, element: expr::Expr) -> PlanResult<expr::Expr> {
+    Ok(when(
+        array.clone().is_not_null(),
+        expr_fn::array_append(array, element),
+    )
+    .end()?)
 }
 
-fn array_prepend(array: expr::Expr, element: expr::Expr) -> expr::Expr {
-    expr::Expr::Case(expr::Case {
-        expr: None,
-        when_then_expr: vec![(
-            Box::new(expr::Expr::IsNotNull(Box::new(array.clone()))),
-            Box::new(expr_fn::array_prepend(element, array)),
-        )],
-        else_expr: None,
-    })
+fn array_prepend(array: expr::Expr, element: expr::Expr) -> PlanResult<expr::Expr> {
+    Ok(when(
+        array.clone().is_not_null(),
+        expr_fn::array_prepend(element, array),
+    )
+    .end()?)
 }
 
 fn array_element(array: expr::Expr, element: expr::Expr) -> expr::Expr {
-    let element = expr::Expr::BinaryExpr(BinaryExpr {
-        left: Box::new(element),
-        op: Operator::Plus,
-        right: Box::new(lit(ScalarValue::Int64(Some(1)))),
-    });
-    expr_fn::array_element(array, element)
+    expr_fn::array_element(array, element + lit(1_i64))
 }
 
-fn array_contains(array: expr::Expr, element: expr::Expr) -> expr::Expr {
-    coalesce(vec![
+fn array_contains(array: expr::Expr, element: expr::Expr) -> PlanResult<expr::Expr> {
+    Ok(coalesce(vec![
         expr_fn::array_has(array.clone(), element),
-        expr::Expr::Case(expr::Case {
-            expr: None,
-            when_then_expr: vec![(
-                Box::new(expr::Expr::IsNotNull(Box::new(array))),
-                Box::new(lit(ScalarValue::Boolean(Some(false)))),
-            )],
-            else_expr: None,
-        }),
-    ])
+        when(array.is_not_null(), lit(false)).end()?,
+    ]))
 }
 
 fn array_contains_all(array: expr::Expr, element: expr::Expr) -> expr::Expr {
-    nvl(
-        expr_fn::array_has_all(array, element),
-        lit(ScalarValue::Boolean(Some(false))),
-    )
+    nvl(expr_fn::array_has_all(array, element), lit(false))
 }
 
-fn array_position(array: expr::Expr, element: expr::Expr) -> expr::Expr {
-    coalesce(vec![
+fn array_position(array: expr::Expr, element: expr::Expr) -> PlanResult<expr::Expr> {
+    Ok(coalesce(vec![
         datafusion_array_position(
-            expr::Expr::Case(expr::Case {
-                expr: None,
-                when_then_expr: vec![(
-                    Box::new(expr::Expr::BinaryExpr(BinaryExpr {
-                        left: Box::new(expr_fn::cardinality(array.clone())),
-                        op: Operator::Gt,
-                        right: Box::new(lit(ScalarValue::UInt64(Some(0)))),
-                    })),
-                    Box::new(array.clone()),
-                )],
-                else_expr: None, // datafusion panics if from_index > array_len
-            }), // So if the inner array_len == 0, search in NULL array instead
+            // datafusion panics if from_index > array_len
+            // So if the inner array_len == 0, search in NULL array instead
+            when(
+                expr_fn::cardinality(array.clone()).gt(lit(0)),
+                array.clone(),
+            )
+            .end()?,
             element,
-            lit(ScalarValue::Int32(Some(1))),
+            lit(1_i32),
         ),
-        expr::Expr::Case(expr::Case {
-            expr: None,
-            when_then_expr: vec![(
-                Box::new(expr::Expr::IsNotNull(Box::new(array.clone()))),
-                Box::new(lit(ScalarValue::Int32(Some(0)))),
-            )], // if Array is not NULL, but elem not found, need to return 0
-            else_expr: None, // On NULL array still return NULL
-        }),
-    ])
+        when(array.clone().is_not_null(), lit(0_i32)).end()?,
+    ]))
 }
 
-fn array_insert(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
-    use crate::function::common::ScalarFunctionBuilder as F;
-    let (array, position, value) = input.arguments.three()?;
-
-    let array_len = expr::Expr::Cast(expr::Cast {
-        expr: Box::new(expr_fn::array_length(array.clone())),
-        data_type: DataType::Int64,
-    });
+fn array_insert(
+    array: expr::Expr,
+    position: expr::Expr,
+    value: expr::Expr,
+) -> PlanResult<expr::Expr> {
+    let array_len = cast(expr_fn::array_length(array.clone()), DataType::Int64);
 
     let pos_from_zero = when(position.clone().gt(lit(0)), position.clone() - lit(1))
         .when(
@@ -169,11 +112,10 @@ fn array_insert(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
         )
         .end()?;
 
-    let zero_index_error = F::udf(RaiseError::new())(ScalarFunctionInput {
-        arguments: vec![lit("[INVALID_INDEX_OF_ZERO] The index 0 is invalid. 
-        An index shall be either < 0 or > 0 (the first element has index 1)")],
-        function_context: input.function_context,
-    })?;
+    let zero_index_error =
+        ScalarUDF::from(RaiseError::new())
+            .call(vec![lit("array_insert: The index 0 is invalid. 
+        An index shall be either < 0 or > 0 (the first element has index 1)")]);
 
     Ok(when(array.clone().is_null(), array.clone())
         .when(pos_from_zero.clone().is_null(), zero_index_error)
@@ -235,26 +177,19 @@ fn arrays_overlap(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     let left_has_null = expr_fn::array_has_any(left.clone(), same_type_null_only_array.clone());
     let right_has_null = expr_fn::array_has_any(left.clone(), same_type_null_only_array);
 
-    Ok(expr::Expr::Case(expr::Case {
-        expr: None,
-        when_then_expr: vec![
-            (
-                Box::new(or(is_null(left.clone()), is_null(right.clone()))),
-                Box::new(lit(ScalarValue::Null)),
-            ),
-            (
-                Box::new(or(left_has_null, right_has_null)),
-                Box::new(or(
-                    expr_fn::array_has_any(
-                        array_compact(left.clone()),
-                        array_compact(right.clone()),
-                    ),
-                    lit(ScalarValue::Null),
-                )),
-            ),
-        ],
-        else_expr: Some(Box::new(expr_fn::array_has_any(left, right))),
-    }))
+    Ok(when(
+        or(is_null(left.clone()), is_null(right.clone())),
+        lit(ScalarValue::Null),
+    )
+    .when(
+        or(left_has_null, right_has_null),
+        or(
+            expr_fn::array_has_any(array_compact(left.clone()), array_compact(right.clone())),
+            lit(ScalarValue::Null),
+        ),
+    )
+    .when(lit(true), expr_fn::array_has_any(left, right))
+    .end()?)
 }
 
 fn flatten(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
@@ -265,10 +200,10 @@ fn flatten(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
 
     let array = arguments.one()?;
 
-    let same_type_null_only_array = expr::Expr::Cast(expr::Cast {
-        expr: Box::new(make_array(vec![lit(ScalarValue::Null)])),
-        data_type: array.get_type(function_context.schema)?,
-    });
+    let same_type_null_only_array = cast(
+        make_array(vec![lit(ScalarValue::Null)]),
+        array.get_type(function_context.schema)?,
+    );
 
     let array_has_null = expr_fn::array_has_any(array.clone(), same_type_null_only_array);
 
@@ -293,7 +228,7 @@ pub(super) fn list_built_in_array_functions() -> Vec<(&'static str, ScalarFuncti
         ("array_contains_all", F::binary(array_contains_all)),
         ("array_distinct", F::unary(expr_fn::array_distinct)),
         ("array_except", F::binary(expr_fn::array_except)),
-        ("array_insert", F::custom(array_insert)),
+        ("array_insert", F::ternary(array_insert)),
         ("array_intersect", F::binary(expr_fn::array_intersect)),
         ("array_join", F::udf(ArrayToString::new())),
         ("array_max", F::udf(ArrayMax::new())),
@@ -314,7 +249,7 @@ pub(super) fn list_built_in_array_functions() -> Vec<(&'static str, ScalarFuncti
         ("sequence", F::udf(SparkSequence::new())),
         ("shuffle", F::unknown("shuffle")),
         ("slice", F::ternary(slice)),
-        ("sort_array", F::custom(sort_array)),
+        ("sort_array", F::binary(sort_array)),
     ]
 }
 


### PR DESCRIPTION
introduced `IntoPlanResult` trait and added logic to ScalarFunctionBuilder
now it is possible to use `unary`, `binary`, `ternary` etc. with functions that return PlanResult but not use function_context
this is most useful for using `when.when...end()` which returns Result instead of Expr
more clean than turning to `custom`
see `F::ternary(array_insert)` and `F::binary(sort_array)` for example

removed unnesessary boilerplate without logic change
replaced handwritten`udf_expr` to builtin `ScalarUDF::from(RaiseError::new()).call(args)` functionality