### PR TITLE
feat: str_to_map function

### DIFF
--- a/crates/sail-execution/src/codec.rs
+++ b/crates/sail-execution/src/codec.rs
@@ -75,6 +75,7 @@ use sail_plan::extension::function::drop_struct_field::DropStructField;
 use sail_plan::extension::function::explode::{explode_name_to_kind, Explode};
 use sail_plan::extension::function::kurtosis::KurtosisFunction;
 use sail_plan::extension::function::map::map_function::MapFunction;
+use sail_plan::extension::function::map::str_to_map::StrToMap;
 use sail_plan::extension::function::math::least_greatest::{Greatest, Least};
 use sail_plan::extension::function::math::rand_poisson::RandPoisson;
 use sail_plan::extension::function::math::randn::Randn;
@@ -1003,6 +1004,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             "spark_try_subtract" | "try_subtract" => {
                 Ok(Arc::new(ScalarUDF::from(SparkTrySubtract::new())))
             }
+            "str_to_map" => Ok(Arc::new(ScalarUDF::from(StrToMap::new()))),
             "parse_url" => Ok(Arc::new(ScalarUDF::from(ParseUrl::new()))),
             "url_decode" => Ok(Arc::new(ScalarUDF::from(UrlDecode::new()))),
             "url_encode" => Ok(Arc::new(ScalarUDF::from(UrlEncode::new()))),
@@ -1083,6 +1085,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node.inner().as_any().is::<SparkTryMod>()
             || node.inner().as_any().is::<SparkTryMult>()
             || node.inner().as_any().is::<SparkTrySubtract>()
+            || node.inner().as_any().is::<StrToMap>()
             || node.inner().as_any().is::<ParseUrl>()
             || node.inner().as_any().is::<UrlDecode>()
             || node.inner().as_any().is::<UrlEncode>()

--- a/crates/sail-plan/src/extension/function/map/map_function.rs
+++ b/crates/sail-plan/src/extension/function/map/map_function.rs
@@ -78,7 +78,7 @@ impl ScalarUDFImpl for MapFunction {
     }
 }
 
-fn map_from_arrays_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+pub fn map_from_arrays_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     let lists = args
         .iter()
         .map(|list_arc| as_list_array(list_arc.as_ref()))

--- a/crates/sail-plan/src/extension/function/map/mod.rs
+++ b/crates/sail-plan/src/extension/function/map/mod.rs
@@ -1,1 +1,2 @@
 pub mod map_function;
+pub mod str_to_map;

--- a/crates/sail-plan/src/extension/function/map/str_to_map.rs
+++ b/crates/sail-plan/src/extension/function/map/str_to_map.rs
@@ -1,0 +1,121 @@
+use std::any::Any;
+use std::sync::Arc;
+
+use arrow::array::{AsArray, ListArray};
+use datafusion::arrow::array::{Array, ArrayRef, StringArray};
+use datafusion::arrow::datatypes::{DataType, Field, Fields};
+use datafusion_common::utils::take_function_args;
+use datafusion_common::{internal_err, Result};
+use datafusion_expr::{ColumnarValue, ScalarUDFImpl, Signature, TypeSignature, Volatility};
+use datafusion_functions::utils::make_scalar_function;
+
+use crate::extension::function::map::map_function::map_from_arrays_inner;
+use crate::extension::function::string::spark_split::{spark_split_inner, split_to_array};
+
+#[derive(Debug)]
+pub struct StrToMap {
+    signature: Signature,
+}
+
+impl Default for StrToMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StrToMap {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::one_of(
+                vec![
+                    TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8, DataType::Utf8]),
+                    TypeSignature::Exact(vec![DataType::Utf8View, DataType::Utf8, DataType::Utf8]),
+                    TypeSignature::Exact(vec![DataType::LargeUtf8, DataType::Utf8, DataType::Utf8]),
+                ],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for StrToMap {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "map"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        let (key_type, value_type) = (DataType::Utf8, DataType::Utf8);
+
+        Ok(DataType::Map(
+            Arc::new(Field::new(
+                "entries",
+                DataType::Struct(Fields::from(vec![
+                    // the key must not be nullable
+                    Field::new("key", key_type.clone(), false),
+                    Field::new("value", value_type.clone(), true),
+                ])),
+                false, // the entry is not nullable
+            )),
+            false, // the keys are not sorted
+        ))
+    }
+
+    fn invoke_with_args(&self, args: datafusion_expr::ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(str_to_map_inner, vec![])(&args.args)
+    }
+}
+
+fn str_to_map_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let [strs, pair_delims, key_value_delims] = take_function_args("str_to_map", args)?;
+
+    let pair_array = spark_split_inner(&[strs.clone(), pair_delims.clone()])?;
+    let pair_lists = pair_array.as_list::<i32>();
+
+    match (
+        pair_lists.values().as_any().downcast_ref::<StringArray>(),
+        key_value_delims.as_any().downcast_ref::<StringArray>(),
+    ) {
+        (Some(pair_strs), Some(key_value_delim_strs)) => {
+            let pair_offsets = pair_lists.offsets().as_ref();
+            let result_row_cnt = pair_offsets.last().cloned().unwrap_or(0) as usize;
+            let mut keys = Vec::with_capacity(result_row_cnt);
+            let mut values = Vec::with_capacity(result_row_cnt);
+
+            for rn in 0..pair_offsets.len() - 1 {
+                if pair_lists.is_null(rn) {
+                    continue;
+                }
+                let key_value_delim = key_value_delim_strs.value(rn);
+
+                for pair_rn in pair_offsets[rn]..pair_offsets[rn + 1] {
+                    let pair = pair_strs.value(pair_rn as usize);
+                    let key_value = split_to_array(pair, key_value_delim, 2)?;
+                    keys.push(key_value.first().cloned().flatten());
+                    values.push(key_value.get(1).cloned().flatten());
+                }
+            }
+
+            let create_list_array = |values: Vec<Option<String>>, name: &str, nullable: bool| {
+                Arc::new(ListArray::new(
+                    Arc::new(Field::new(name, DataType::Utf8, nullable)),
+                    pair_lists.offsets().clone(),
+                    Arc::new(StringArray::from_iter(values)),
+                    pair_lists.nulls().cloned(),
+                ))
+            };
+
+            let keys = create_list_array(keys, "key", false);
+            let values = create_list_array(values, "value", true);
+            map_from_arrays_inner(&[keys, values])
+        }
+        _ => internal_err!("str_to_map: failed to downcast arguments to StringArrays"),
+    }
+}

--- a/crates/sail-plan/src/function/scalar/map.rs
+++ b/crates/sail-plan/src/function/scalar/map.rs
@@ -1,9 +1,11 @@
 use datafusion::functions_nested::expr_fn;
-use datafusion_expr::expr;
+use datafusion_expr::{expr, lit};
 
 use crate::error::{PlanError, PlanResult};
 use crate::extension::function::map::map_function::MapFunction;
+use crate::extension::function::map::str_to_map::StrToMap;
 use crate::function::common::{ScalarFunction, ScalarFunctionInput};
+use crate::utils::ItemTaker;
 
 fn map(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     use crate::function::common::ScalarFunctionBuilder as F;
@@ -55,6 +57,20 @@ fn map_contains_key(map: expr::Expr, key: expr::Expr) -> expr::Expr {
     expr_fn::array_has(expr_fn::map_keys(map), key)
 }
 
+fn str_to_map(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
+    use crate::function::common::ScalarFunctionBuilder as F;
+
+    let (strs, delims) = input.arguments.at_least_one()?;
+
+    let pair_delims = delims.first().cloned().unwrap_or(lit(","));
+    let key_value_delims = delims.get(1).cloned().unwrap_or(lit(":"));
+
+    F::udf(StrToMap::new())(ScalarFunctionInput {
+        arguments: vec![strs, pair_delims, key_value_delims],
+        function_context: input.function_context,
+    })
+}
+
 pub(super) fn list_built_in_map_functions() -> Vec<(&'static str, ScalarFunction)> {
     use crate::function::common::ScalarFunctionBuilder as F;
 
@@ -67,6 +83,6 @@ pub(super) fn list_built_in_map_functions() -> Vec<(&'static str, ScalarFunction
         ("map_from_entries", F::udf(MapFunction::new())),
         ("map_keys", F::unary(expr_fn::map_keys)),
         ("map_values", F::unary(expr_fn::map_values)),
-        ("str_to_map", F::unknown("str_to_map")),
+        ("str_to_map", F::custom(str_to_map)),
     ]
 }

--- a/crates/sail-spark-connect/tests/gold_data/function/map.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/map.json
@@ -270,7 +270,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: str_to_map"
+        "success": "ok"
       }
     },
     {
@@ -297,7 +297,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: str_to_map"
+        "success": "ok"
       }
     }
   ]


### PR DESCRIPTION
implements `str_to_map`:
https://spark.apache.org/docs/latest/api/sql/index.html#str_to_map

reuse existing low-level functions:
- `spark_split_inner` (split input to pairs)
- `split_to_array` (split pairs to key-value elements)
- `map_from_arrays_inner` (create result Map)

closes #307