### PR TITLE
fix: position and locate funcs with startpos arg

### DIFF
--- a/crates/sail-plan/src/formatter.rs
+++ b/crates/sail-plan/src/formatter.rs
@@ -583,11 +583,8 @@ impl PlanFormatter for SparkPlanFormatter {
                 let arguments = arguments.join(", ");
                 Ok(format!("{}({arguments})", name.to_lowercase()))
             }
-            "regexp_replace" => {
-                let default_arg = if arguments.len() == 3 { ", 1" } else { "" };
-                let arguments = arguments.join(", ");
-                Ok(format!("{name}({arguments}{default_arg})"))
-            }
+            "position" | "locate" => Ok(append_start_pos_if_arglen_eq(2, name, arguments)),
+            "regexp_replace" => Ok(append_start_pos_if_arglen_eq(3, name, arguments)),
             // When the data type being exploded is `ExplodeDataType::List`, use "col" as the column name.
             "explode" | "explode_outer" => Ok("col".to_string()),
             "current_database" => Ok("current_schema()".to_string()),
@@ -631,6 +628,12 @@ impl Display for BinaryDisplay<'_> {
         }
         write!(f, "'")
     }
+}
+
+fn append_start_pos_if_arglen_eq(arglen: usize, name: &str, args: Vec<&str>) -> String {
+    let start_pos_str = if args.len() == arglen { ", 1" } else { "" };
+    let args = args.join(", ");
+    format!("{name}({args}{start_pos_str})")
 }
 
 fn format_decimal(value: &str, scale: i8) -> String {

--- a/crates/sail-spark-connect/tests/gold_data/function/string.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/string.json
@@ -1491,7 +1491,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: position with 3 arguments is not supported yet"
+        "success": "ok"
       }
     },
     {
@@ -2305,7 +2305,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: position with 3 arguments is not supported yet"
+        "success": "ok"
       }
     },
     {


### PR DESCRIPTION
`position` and `locate` functions now support third argument 
which is start 1-based position to search substring:
```
> SELECT position('bar', 'foobarbar', 5);
 7
```

https://spark.apache.org/docs/latest/api/sql/index.html#position
https://spark.apache.org/docs/latest/api/sql/index.html#locate

part of #508