### PR TITLE
fix: plan optimization for show string

### DIFF
--- a/crates/sail-plan/src/extension/logical/show_string.rs
+++ b/crates/sail-plan/src/extension/logical/show_string.rs
@@ -306,4 +306,8 @@ impl UserDefinedLogicalNodeCore for ShowStringNode {
             schema: self.schema.clone(),
         })
     }
+
+    fn necessary_children_exprs(&self, _output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {
+        Some(vec![(0..self.input.schema().fields().len()).collect()])
+    }
 }


### PR DESCRIPTION
We need to implement the `UserDefinedLogicalNodeCore::necessary_children_exprs()` method for `ShowStringNode` so that the `optimize_projections` logical optimization rule can work properly.