### PR TITLE
feat: json_object_keys, fix: get_json_object with scalar

### DIFF
--- a/crates/sail-plan/src/function/scalar/json.rs
+++ b/crates/sail-plan/src/function/scalar/json.rs
@@ -1,55 +1,42 @@
 use datafusion::arrow::datatypes::DataType;
-use datafusion_common::ScalarValue;
-use datafusion_expr::{cast, expr};
+use datafusion_common::{DataFusionError, ScalarValue};
+use datafusion_expr::{cast, expr, lit, when};
+use datafusion_functions::unicode::expr_fn as unicode_fn;
 use datafusion_functions_json::udfs;
 
 use crate::error::PlanResult;
-use crate::function::common::{ScalarFunction, ScalarFunctionInput};
-use crate::utils::ItemTaker;
+use crate::function::common::ScalarFunction;
 
-fn get_json_object(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
-    // > 1 path means nested access e.g. json_as_text(json, p1, p2) => json.p1.p2
-    let ScalarFunctionInput { arguments, .. } = input;
-    let (expr, paths) = arguments.at_least_one()?;
-    let paths: Vec<expr::Expr> = paths
-        .into_iter()
-        .map(|path| match &path {
-            expr::Expr::Literal(ScalarValue::Utf8(Some(value)), metadata) => {
-                if value.starts_with("$") {
-                    let nth = if value.starts_with("$.") { 2 } else { 1 };
-                    let index = value
-                        .char_indices()
-                        .nth(nth)
-                        .map(|(idx, _)| idx)
-                        .unwrap_or(value.len());
-                    expr::Expr::Literal(
-                        ScalarValue::Utf8(Some(value[index..].to_string())),
-                        metadata.clone(),
-                    )
-                } else {
-                    path
-                }
-            }
-            _ => path,
-        })
-        .collect();
+fn get_json_object(expr: expr::Expr, path: expr::Expr) -> PlanResult<expr::Expr> {
+    let paths: Vec<expr::Expr> = match path {
+        expr::Expr::Literal(ScalarValue::Utf8(Some(value)), _metadata)
+            if value.starts_with("$.") =>
+        {
+            Ok::<_, DataFusionError>(value.replacen("$.", "", 1).split(".").map(lit).collect())
+        }
+        // FIXME: json_as_text_udf for array of paths with subpaths is not implemented, so only top level keys supported
+        _ => Ok(vec![when(
+            path.clone().like(lit("$.%")),
+            unicode_fn::substr(path, lit(3)),
+        )
+        .when(lit(true), lit(""))
+        .end()?]),
+    }?;
     let mut args = Vec::with_capacity(1 + paths.len());
     args.push(expr);
     args.extend(paths);
-    Ok(expr::Expr::ScalarFunction(expr::ScalarFunction {
-        func: udfs::json_as_text_udf(),
-        args,
-    }))
+    Ok(udfs::json_as_text_udf().call(args))
 }
 
 fn json_array_length(json_data: expr::Expr) -> expr::Expr {
     cast(
-        expr::Expr::ScalarFunction(expr::ScalarFunction {
-            func: udfs::json_length_udf(),
-            args: vec![json_data],
-        }),
+        udfs::json_length_udf().call(vec![json_data]),
         DataType::Int32,
     )
+}
+
+fn json_object_keys(json_data: expr::Expr) -> expr::Expr {
+    udfs::json_object_keys_udf().call(vec![json_data])
 }
 
 pub(super) fn list_built_in_json_functions() -> Vec<(&'static str, ScalarFunction)> {
@@ -57,9 +44,9 @@ pub(super) fn list_built_in_json_functions() -> Vec<(&'static str, ScalarFunctio
 
     vec![
         ("from_json", F::unknown("from_json")),
-        ("get_json_object", F::custom(get_json_object)),
+        ("get_json_object", F::binary(get_json_object)),
         ("json_array_length", F::unary(json_array_length)),
-        ("json_object_keys", F::unknown("json_object_keys")),
+        ("json_object_keys", F::unary(json_object_keys)),
         ("json_tuple", F::unknown("json_tuple")),
         ("schema_of_json", F::unknown("schema_of_json")),
         ("to_json", F::unknown("to_json")),

--- a/crates/sail-spark-connect/tests/gold_data/function/json.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/json.json
@@ -239,7 +239,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: json_object_keys"
+        "success": "ok"
       }
     },
     {
@@ -265,7 +265,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: json_object_keys"
+        "success": "ok"
       }
     },
     {
@@ -291,7 +291,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: json_object_keys"
+        "success": "ok"
       }
     },
     {


### PR DESCRIPTION
feat:
`json_object_keys function`
https://spark.apache.org/docs/latest/api/sql/index.html#json_object_keys

fix:
`get_json_object` now works more consistent with spark
https://spark.apache.org/docs/latest/api/sql/index.html#get_json_object
works the same when the input is scalar or column with top-level keys, which may be most cases of usage
closes #800, except p.4
for arrays with subpaths the large-scale code porting from contrib library is neeeded
FIXME added in the code

chore: small refactoring of json_array_length to unify the code patterns

part of #219 