### PR TITLE
feat: collect_list(cols) over (window_frame)

### DIFF
--- a/crates/sail-plan/src/function/window.rs
+++ b/crates/sail-plan/src/function/window.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use datafusion::functions_aggregate::{average, count, min_max, sum};
+use datafusion::functions_aggregate::{array_agg, average, count, min_max, sum};
 use datafusion::functions_window::cume_dist::cume_dist_udwf;
 use datafusion::functions_window::lead_lag::{lag_udwf, lead_udwf};
 use datafusion::functions_window::nth_value::{first_value_udwf, last_value_udwf, nth_value_udwf};
@@ -83,6 +83,7 @@ fn list_built_in_window_functions() -> Vec<(&'static str, WinFunction)> {
     use crate::function::common::WinFunctionBuilder as F;
     vec![
         ("avg", F::aggregate(average::avg_udaf)),
+        ("collect_list", F::aggregate(array_agg::array_agg_udaf)),
         ("min", F::aggregate(min_max::min_udaf)),
         ("max", F::aggregate(min_max::max_udaf)),
         ("sum", F::aggregate(sum::sum_udaf)),


### PR DESCRIPTION
collect_list over window should work now:

```python
from pysail.spark import SparkConnectServer
from pyspark.sql import SparkSession
import pyspark.sql.functions as F

server = SparkConnectServer()
server.start()
_, port = server.listening_address

print(port)
spark = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
#spark = SparkSession.builder.appName("test").master("local[4]").getOrCreate()

spark.sql(
"""
    select distinct 
        part,  
        collect_list(array(f1, f2)) over(
			partition by part 
			order by ord 
			rows between unbounded preceding and unbounded following
		) as sorted_features
    from values (2, 3, 3, 3), (2, 2, 2, 2), (1, 0, 0, 0), (1, 1, 1, 1) as tab(part, ord, f1, f2)
""").toPandas()
```

```
	part	sorted_features
0	1		[[0, 0], [1, 1]]
1	2		[[2, 2], [3, 3]]
```

closes #804 