### PR TITLE
feat: heartbeat for long-running execution

### DIFF
--- a/crates/sail-common/src/config/application.rs
+++ b/crates/sail-common/src/config/application.rs
@@ -269,6 +269,7 @@ pub enum CatalogType {
 #[serde(deny_unknown_fields)]
 pub struct SparkConfig {
     pub session_timeout_secs: u64,
+    pub execution_heartbeat_interval_secs: u64,
 }
 
 /// Environment variables for application cluster configuration.

--- a/crates/sail-common/src/config/application.yaml
+++ b/crates/sail-common/src/config/application.yaml
@@ -586,4 +586,16 @@
 - key: spark.session_timeout_secs
   type: number
   default: "900"
-  description: The Spark session timeout in seconds.
+  description: |
+    The duration in seconds allowed for the session to be idle.
+    If the server does not receive any requests from the client after this duration,
+    the session will be removed from the server.
+
+- key: spark.execution_heartbeat_interval_secs
+  type: number
+  default: "15"
+  description: |
+    The interval in seconds for the server to send empty response to the client
+    during long-running operations. The empty response serves as a heartbeat to keep
+    the session active.
+  experimental: true

--- a/crates/sail-spark-connect/src/service/plan_executor.rs
+++ b/crates/sail-spark-connect/src/service/plan_executor.rs
@@ -119,7 +119,11 @@ async fn handle_execute_plan(
     let stream = spark.job_runner().execute(ctx, plan).await?;
     let rx = match mode {
         ExecutePlanMode::Lazy => {
-            let executor = Executor::new(metadata, stream);
+            let executor = Executor::new(
+                metadata,
+                stream,
+                spark.options().execution_heartbeat_interval,
+            );
             let rx = executor.start()?;
             spark.add_executor(executor)?;
             rx

--- a/crates/sail-spark-connect/src/session_manager.rs
+++ b/crates/sail-spark-connect/src/session_manager.rs
@@ -31,7 +31,7 @@ use tokio::sync::oneshot;
 use tokio::time::Instant;
 
 use crate::error::{SparkError, SparkResult};
-use crate::session::SparkSession;
+use crate::session::{SparkSession, SparkSessionOptions};
 
 #[derive(Eq, PartialEq, Hash, Clone, Debug)]
 pub struct SessionKey {
@@ -112,6 +112,11 @@ impl SessionManagerActor {
                 key.user_id,
                 key.session_id,
                 job_runner,
+                SparkSessionOptions {
+                    execution_heartbeat_interval: Duration::from_secs(
+                        options.config.spark.execution_heartbeat_interval_secs,
+                    ),
+                },
             )?));
 
         // execution options


### PR DESCRIPTION
Closes #808.

This PR allows the server to send empty response periodically during long-running executions. Upon receiving the response, the PySpark client will send a `ReleaseExecuteRequest`, which has a side-effect of resetting the session idle time. This allows the session to remain active regardless of `spark.session_timeout_secs` as long as the client is not disconnected.

This can be manually tested using the following code. The code works as expected under different values of the `SAIL_SPARK__SESSION_TIMEOUT_SECS` and `SAIL_SPARK__EXECUTION_HEARTBEAT_INTERVAL_SECS` environment variables.

```python
import time
from pyspark.sql.functions import udf

@udf("integer")
def slow(x):
    time.sleep(10)
    return x + 1

spark.range(1).select(slow("id")).show()
```
