### PR TITLE
feat: add `luhn_check` function

### DIFF
--- a/crates/sail-plan/src/extension/function/string/mod.rs
+++ b/crates/sail-plan/src/extension/function/string/mod.rs
@@ -7,3 +7,4 @@ pub mod spark_split;
 pub mod spark_to_binary;
 pub mod spark_to_number;
 pub mod spark_try_to_number;
+pub mod spark_luhn_check;

--- a/crates/sail-plan/src/extension/function/string/spark_luhn_check.rs
+++ b/crates/sail-plan/src/extension/function/string/spark_luhn_check.rs
@@ -1,0 +1,6 @@
+use datafusion_expr_common::signature::Signature;
+
+#[derive(Debug)]
+pub struct SparkLuhnCheck {
+    signature: Signature,
+}


### PR DESCRIPTION
Part of #508 

This PR introduces the implementation of the `luhn_check` functionality, closely replicating Spark's `luhn_check` capabilities. If the num value contains any character that is not a digit, the result is `false`. If the input's last digit matches the algorithm, the result is `true`.

Spark Ref: [`luhn_check` doc](https://docs.databricks.com/gcp/en/sql/language-manual/functions/luhn_check)

- [ ] Add support for the `luhn_check` Spark SQL function