### PR TITLE
feat: inline and inline_outer funcs, fix: emty and all-null array datatype

### DIFF
--- a/crates/sail-plan/src/extension/function/explode.rs
+++ b/crates/sail-plan/src/extension/function/explode.rs
@@ -30,6 +30,8 @@ pub enum ExplodeKind {
     ExplodeOuter,
     PosExplode,
     PosExplodeOuter,
+    Inline,
+    InlineOuter,
 }
 
 impl Explode {
@@ -56,6 +58,8 @@ impl ScalarUDFImpl for Explode {
             ExplodeKind::ExplodeOuter => "explode_outer",
             ExplodeKind::PosExplode => "posexplode",
             ExplodeKind::PosExplodeOuter => "posexplode_outer",
+            ExplodeKind::Inline => "inline",
+            ExplodeKind::InlineOuter => "inline_outer",
         }
     }
 

--- a/crates/sail-plan/src/function/generator.rs
+++ b/crates/sail-plan/src/function/generator.rs
@@ -10,8 +10,11 @@ pub(super) fn list_built_in_generator_functions() -> Vec<(&'static str, ScalarFu
             "explode_outer",
             F::udf(Explode::new(ExplodeKind::ExplodeOuter)),
         ),
-        ("inline", F::unknown("inline")),
-        ("inline_outer", F::unknown("inline_outer")),
+        ("inline", F::udf(Explode::new(ExplodeKind::Inline))),
+        (
+            "inline_outer",
+            F::udf(Explode::new(ExplodeKind::InlineOuter)),
+        ),
         ("posexplode", F::udf(Explode::new(ExplodeKind::PosExplode))),
         (
             "posexplode_outer",

--- a/crates/sail-spark-connect/tests/gold_data/function/generator.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/generator.json
@@ -118,7 +118,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: inline"
+        "success": "ok"
       }
     },
     {
@@ -176,7 +176,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: inline_outer"
+        "success": "ok"
       }
     },
     {


### PR DESCRIPTION
implement `inline` and `inline_outer` functions:
https://spark.apache.org/docs/latest/api/sql/index.html#inline
https://spark.apache.org/docs/latest/api/sql/index.html#inline_outer
reusing explode functions code
part of #308

fix return type of array() function: 
should be Null for empty arrray and all-null array
closes #840

`inline_outer` doesn't pass spark-tests due to lack of `from values` type nullability inference
but this is not in scope of this PR