### PR TITLE
fix: robots meta tag for docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -131,7 +131,7 @@ class TransformPageData {
   static robots(pageData: PageData): void {
     const isDevGuide = pageData.relativePath.startsWith("development/");
     if (
-      (Site.version() === "latest" && !isDevGuide) ||
+      Site.version() === "latest" ||
       (Site.version() === "main" && isDevGuide)
     ) {
       return;


### PR DESCRIPTION
We would like search engines to index everything under `/latest`

Also, hoping to fix the fact that Claude will not visit `docs.lakesail.com`:
```
Unfortunately, I cannot access docs.lakesail.com because the site's robots.txt file blocks automated access.
```

