### PR TITLE
fix: session key without user ID

### DIFF
--- a/crates/sail-plan/src/config.rs
+++ b/crates/sail-plan/src/config.rs
@@ -54,7 +54,7 @@ impl Default for PlanConfig {
             pyspark_udf_config: Arc::new(PySparkUdfConfig::default()),
             default_table_file_format: "PARQUET".to_string(),
             default_warehouse_directory: "spark-warehouse".to_string(),
-            session_user_id: "sail".to_string(),
+            session_user_id: "".to_string(),
             ansi_mode: false,
         }
     }

--- a/crates/sail-spark-connect/src/proto/function.rs
+++ b/crates/sail-spark-connect/src/proto/function.rs
@@ -67,7 +67,7 @@ mod tests {
             .primary()
             .block_on(async { SessionManager::new(options) });
         let session_key = SessionKey {
-            user_id: None,
+            user_id: "".to_string(),
             session_id: "test".to_string(),
         };
         let context = handle

--- a/crates/sail-spark-connect/src/server.rs
+++ b/crates/sail-spark-connect/src/server.rs
@@ -60,7 +60,7 @@ impl SparkConnectService for SparkConnectServer {
         let request = request.into_inner();
         debug!("{request:?}");
         let session_key = SessionKey {
-            user_id: request.user_context.map(|u| u.user_id),
+            user_id: request.user_context.map(|u| u.user_id).unwrap_or_default(),
             session_id: request.session_id,
         };
         let metadata = ExecutorMetadata {
@@ -169,7 +169,7 @@ impl SparkConnectService for SparkConnectServer {
         let request = request.into_inner();
         debug!("{request:?}");
         let session_key = SessionKey {
-            user_id: request.user_context.map(|u| u.user_id),
+            user_id: request.user_context.map(|u| u.user_id).unwrap_or_default(),
             session_id: request.session_id.clone(),
         };
         let ctx = self
@@ -253,7 +253,7 @@ impl SparkConnectService for SparkConnectServer {
         let request = request.into_inner();
         debug!("{request:?}");
         let session_key = SessionKey {
-            user_id: request.user_context.map(|u| u.user_id),
+            user_id: request.user_context.map(|u| u.user_id).unwrap_or_default(),
             session_id: request.session_id.clone(),
         };
         let ctx = self
@@ -303,7 +303,7 @@ impl SparkConnectService for SparkConnectServer {
         };
         debug!("{first:?}");
         let session_key = SessionKey {
-            user_id: first.user_context.map(|u| u.user_id),
+            user_id: first.user_context.map(|u| u.user_id).unwrap_or_default(),
             session_id: first.session_id.clone(),
         };
         let ctx = self
@@ -344,7 +344,7 @@ impl SparkConnectService for SparkConnectServer {
         let request = request.into_inner();
         debug!("{request:?}");
         let session_key = SessionKey {
-            user_id: request.user_context.map(|u| u.user_id),
+            user_id: request.user_context.map(|u| u.user_id).unwrap_or_default(),
             session_id: request.session_id.clone(),
         };
         let ctx = self
@@ -368,7 +368,7 @@ impl SparkConnectService for SparkConnectServer {
         let request = request.into_inner();
         debug!("{request:?}");
         let session_key = SessionKey {
-            user_id: request.user_context.map(|u| u.user_id),
+            user_id: request.user_context.map(|u| u.user_id).unwrap_or_default(),
             session_id: request.session_id.clone(),
         };
         let ctx = self
@@ -413,7 +413,7 @@ impl SparkConnectService for SparkConnectServer {
         let request = request.into_inner();
         debug!("{request:?}");
         let session_key = SessionKey {
-            user_id: request.user_context.map(|u| u.user_id),
+            user_id: request.user_context.map(|u| u.user_id).unwrap_or_default(),
             session_id: request.session_id,
         };
         let ctx = self
@@ -433,7 +433,7 @@ impl SparkConnectService for SparkConnectServer {
         let request = request.into_inner();
         debug!("{request:?}");
         let session_key = SessionKey {
-            user_id: request.user_context.map(|u| u.user_id),
+            user_id: request.user_context.map(|u| u.user_id).unwrap_or_default(),
             session_id: request.session_id.clone(),
         };
         let ctx = self

--- a/crates/sail-spark-connect/src/session.rs
+++ b/crates/sail-spark-connect/src/session.rs
@@ -29,7 +29,7 @@ pub(crate) struct SparkSessionOptions {
 ///
 /// [`SessionContext`]: datafusion::prelude::SessionContext
 pub(crate) struct SparkSession {
-    user_id: Option<String>,
+    user_id: String,
     session_id: String,
     job_runner: Box<dyn JobRunner>,
     options: SparkSessionOptions,
@@ -54,7 +54,7 @@ impl SessionExtension for SparkSession {
 
 impl SparkSession {
     pub(crate) fn try_new(
-        user_id: Option<String>,
+        user_id: String,
         session_id: String,
         job_runner: Box<dyn JobRunner>,
         options: SparkSessionOptions,
@@ -77,9 +77,8 @@ impl SparkSession {
         &self.session_id
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn user_id(&self) -> Option<&str> {
-        self.user_id.as_deref()
+    pub(crate) fn user_id(&self) -> &str {
+        &self.user_id
     }
 
     pub(crate) fn options(&self) -> &SparkSessionOptions {
@@ -89,9 +88,7 @@ impl SparkSession {
     pub(crate) fn plan_config(&self) -> SparkResult<Arc<PlanConfig>> {
         let state = self.state.lock()?;
         let mut config = PlanConfig::try_from(&state.config)?;
-        if let Some(user_id) = self.user_id() {
-            config.session_user_id = user_id.to_string();
-        }
+        config.session_user_id = self.user_id().to_string();
         Ok(Arc::new(config))
     }
 

--- a/crates/sail-spark-connect/src/session_manager.rs
+++ b/crates/sail-spark-connect/src/session_manager.rs
@@ -36,17 +36,13 @@ use crate::session::{SparkSession, SparkSessionOptions};
 
 #[derive(Eq, PartialEq, Hash, Clone, Debug)]
 pub struct SessionKey {
-    pub user_id: Option<String>,
+    pub user_id: String,
     pub session_id: String,
 }
 
 impl Display for SessionKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(user_id) = &self.user_id {
-            write!(f, "{}@{}", user_id, self.session_id)
-        } else {
-            write!(f, "{}", self.session_id)
-        }
+        write!(f, "{}@{}", self.user_id, self.session_id)
     }
 }
 


### PR DESCRIPTION
Fixes #844.

If the `USER` or `SPARK_USER` environment variables are not set, the PySpark client does not consistently send the same user context to the server across gRPC calls. For some endpoints, the client sends `None`, while for other endpoints, the client sends `Some(UserContext { user_id: "", user_name: "", extensions: [] })`. Currently, the server generates different session keys for these two cases, so two sessions are created, resulting in the confusing "operation not found" error for some operations.

The "operation not found" error is observed on Windows since the `USER` environment variable is not set. I can also reproduce this on macOS after running `unset USER` in the shell.

This PR fixes the issue by handling missing or empty user ID in the same way.