### PR TITLE
fix: fetch DuckDB arrow data in tests

### DIFF
--- a/python/pysail/tests/spark/test_tpcds.py
+++ b/python/pysail/tests/spark/test_tpcds.py
@@ -17,7 +17,7 @@ def duck():
 def data(spark, duck):
     tables = list(duck.sql("SHOW TABLES").df()["name"])
     for table in tables:
-        df = duck.sql(f"SELECT * FROM {table}").arrow().to_pandas()  # noqa: S608
+        df = duck.sql(f"SELECT * FROM {table}").fetch_arrow_table().to_pandas()  # noqa: S608
         spark.createDataFrame(df).createOrReplaceTempView(table)
     yield
     for table in tables:

--- a/python/pysail/tests/spark/test_tpch.py
+++ b/python/pysail/tests/spark/test_tpch.py
@@ -17,7 +17,7 @@ def duck():
 def data(spark, duck):
     tables = list(duck.sql("SHOW TABLES").df()["name"])
     for table in tables:
-        df = duck.sql(f"SELECT * FROM {table}").arrow().to_pandas()  # noqa: S608
+        df = duck.sql(f"SELECT * FROM {table}").fetch_arrow_table().to_pandas()  # noqa: S608
         spark.createDataFrame(df).createOrReplaceTempView(table)
     yield
     for table in tables:


### PR DESCRIPTION
DuckDB 1.4 introduces a breaking change that affects the return value for the `.arrow()` method (<https://github.com/duckdb/duckdb/pull/18642>). So we need to switch to `.fetch_arrow_table()` which is available in the earlier versions as well.