### PR TITLE
feat: applyInArrow

### DIFF
--- a/crates/sail-common/src/spec/expression.rs
+++ b/crates/sail-common/src/spec/expression.rs
@@ -358,6 +358,7 @@ pub enum PySparkUdfType {
     CogroupedMapPandas = 206,
     MapArrowIter = 207,
     GroupedMapPandasWithState = 208,
+    GroupedMapArrow = 209,
     Table = 300,
     ArrowTable = 301,
 }

--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -144,7 +144,8 @@ message PySparkGroupMapUdaf {
   repeated string input_names = 4;
   repeated bytes input_types = 5;
   bytes output_type = 6;
-  PySparkUdfConfig config = 7;
+  bool is_pandas = 7;
+  PySparkUdfConfig config = 8;
 }
 
 message PySparkBatchCollectorUdaf {

--- a/crates/sail-execution/src/codec.rs
+++ b/crates/sail-execution/src/codec.rs
@@ -1506,6 +1506,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 input_names,
                 input_types,
                 output_type,
+                is_pandas,
                 config,
             })) => {
                 let input_types = input_types
@@ -1524,6 +1525,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                     input_names,
                     input_types,
                     output_type,
+                    is_pandas,
                     Arc::new(config),
                 );
                 Ok(Arc::new(AggregateUDF::from(udaf)))
@@ -1587,6 +1589,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 input_names: func.input_names().to_vec(),
                 input_types,
                 output_type,
+                is_pandas: func.is_pandas(),
                 config: Some(config),
             })
         } else if let Some(func) = node

--- a/crates/sail-plan/src/resolver/expression/udf.rs
+++ b/crates/sail-plan/src/resolver/expression/udf.rs
@@ -90,6 +90,7 @@ impl PlanResolver<'_> {
         match function.eval_type {
             PySparkUdfType::None
             | PySparkUdfType::GroupedMapPandas
+            | PySparkUdfType::GroupedMapArrow
             | PySparkUdfType::WindowAggPandas
             | PySparkUdfType::MapPandasIter
             | PySparkUdfType::CogroupedMapPandas

--- a/crates/sail-python-udf/src/cereal/mod.rs
+++ b/crates/sail-python-udf/src/cereal/mod.rs
@@ -47,6 +47,7 @@ fn supports_kwargs(eval_type: spec::PySparkUdfType) -> bool {
     match eval_type {
         PySparkUdfType::None
         | PySparkUdfType::GroupedMapPandas
+        | PySparkUdfType::GroupedMapArrow
         | PySparkUdfType::WindowAggPandas
         | PySparkUdfType::MapPandasIter
         | PySparkUdfType::CogroupedMapPandas
@@ -70,6 +71,7 @@ fn should_write_config(eval_type: spec::PySparkUdfType) -> bool {
         PySparkUdfType::ArrowBatched
         | PySparkUdfType::ScalarPandas
         | PySparkUdfType::GroupedMapPandas
+        | PySparkUdfType::GroupedMapArrow
         | PySparkUdfType::GroupedAggPandas
         | PySparkUdfType::WindowAggPandas
         | PySparkUdfType::ScalarPandasIter

--- a/crates/sail-python-udf/src/python/spark.py
+++ b/crates/sail-python-udf/src/python/spark.py
@@ -373,6 +373,40 @@ def _pandas_to_arrow_array(data, data_type: pa.DataType, serializer: ArrowStream
     return serializer._create_array(data, data_type, arrow_cast=serializer._arrow_cast)  # noqa: SLF001
 
 
+def _arrow_array_to_output_type(data, data_type: pa.DataType) -> pa.Array:
+    if len(data) == 0:
+        return pa.array([], type=data_type)
+
+    struct_arrays = []
+
+    for batch in data:
+        if len(data_type.fields) != batch.num_columns:
+            raise ValueError("schema mismatch:", batch.schema, data_type)
+        
+        arrays = []
+        names = []
+        
+        for i, target_field in enumerate(data_type.fields):
+            target_name = target_field.name
+            target_type = target_field.type
+            
+            if target_name in batch.schema.names:
+                source_array = batch[target_name]
+            else:
+                source_array = batch.column(i)
+
+            if source_array.type != target_type:
+                source_array = source_array.cast(target_type)
+
+            arrays.append(source_array)
+            names.append(target_name)
+        
+        struct_arrays.append(pa.StructArray.from_arrays(arrays, names=names))
+
+    return pa.concat_arrays(struct_arrays)
+        
+
+
 def _named_arrays_to_pandas(
     data: Sequence[pa.Array], names: Sequence[str], serializer: ArrowStreamPandasUDFSerializer
 ) -> Sequence[pd.Series]:
@@ -492,10 +526,12 @@ class PySparkGroupMapUdf:
         self,
         udf: Callable[..., Any],
         input_names: Sequence[str],
+        is_pandas: bool,
         config,
     ):
         self._udf = udf
         self._input_names = input_names
+        self.is_pandas = is_pandas
         self._serializer = ArrowStreamPandasUDFSerializer(
             timezone=config.session_timezone,
             safecheck=config.arrow_convert_safely,
@@ -507,9 +543,25 @@ class PySparkGroupMapUdf:
         )
 
     def __call__(self, args: list[pa.Array]) -> pa.Array:
-        inputs = _named_arrays_to_pandas(args, self._input_names, self._serializer)
-        [[(output, output_type)]] = list(self._udf(None, (inputs,)))
-        return _pandas_to_arrow_array(output, output_type, self._serializer)
+        if self.is_pandas:
+            inputs = _named_arrays_to_pandas(args, self._input_names, self._serializer)
+            [[(output, output_type)]] = list(self._udf(None, (inputs,)))
+            return _pandas_to_arrow_array(output, output_type, self._serializer)
+        else:
+            inputs = [pa.RecordBatch.from_arrays(args, self._input_names)]
+            [(output, output_type)] = list(self._udf(None, (inputs,)))
+            return _arrow_array_to_output_type(output, output_type)
+            
+        
+
+#[([pyarrow.RecordBatch
+#    id: int64
+#    value: int64
+#    ----
+#    id: [0,1,2,3]
+#    value: [0,10,20,30]], 
+#    StructType(struct<id: int64, value: int64>)
+#)]
 
 
 class PySparkCoGroupMapUdf:

--- a/crates/sail-python-udf/src/python/spark.py
+++ b/crates/sail-python-udf/src/python/spark.py
@@ -404,7 +404,6 @@ def _arrow_array_to_output_type(data, data_type: pa.DataType) -> pa.Array:
         struct_arrays.append(pa.StructArray.from_arrays(arrays, names=names))
 
     return pa.concat_arrays(struct_arrays)
-        
 
 
 def _named_arrays_to_pandas(
@@ -551,17 +550,6 @@ class PySparkGroupMapUdf:
             inputs = [pa.RecordBatch.from_arrays(args, self._input_names)]
             [(output, output_type)] = list(self._udf(None, (inputs,)))
             return _arrow_array_to_output_type(output, output_type)
-            
-        
-
-#[([pyarrow.RecordBatch
-#    id: int64
-#    value: int64
-#    ----
-#    id: [0,1,2,3]
-#    value: [0,10,20,30]], 
-#    StructType(struct<id: int64, value: int64>)
-#)]
 
 
 class PySparkCoGroupMapUdf:

--- a/crates/sail-python-udf/src/python/spark.rs
+++ b/crates/sail-python-udf/src/python/spark.rs
@@ -100,12 +100,13 @@ impl PySpark {
         py: Python<'py>,
         udf: Bound<'py, PyAny>,
         input_names: Vec<String>,
+        is_pandas: bool,
         config: &PySparkUdfConfig,
     ) -> PyResult<Bound<'py, PyAny>> {
         py_init_object(
             Self::module(py)?,
             intern!(py, "PySparkGroupMapUdf"),
-            (udf, input_names, config.clone()),
+            (udf, input_names, is_pandas, config.clone()),
         )
     }
 


### PR DESCRIPTION
implement `groupBy(cols).applyInArrow(func, return_type)`:
https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.GroupedData.applyInArrow.html

reusing the code that implements applyInPandas 
and changing only input and output conversion