### PR TITLE
feat: cogrouped applyInArrow

### DIFF
--- a/crates/sail-common/src/spec/expression.rs
+++ b/crates/sail-common/src/spec/expression.rs
@@ -359,6 +359,7 @@ pub enum PySparkUdfType {
     MapArrowIter = 207,
     GroupedMapPandasWithState = 208,
     GroupedMapArrow = 209,
+    CogroupedMapArrow = 210,
     Table = 300,
     ArrowTable = 301,
 }

--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -93,7 +93,8 @@ message PySparkCoGroupMapUdf {
   repeated bytes right_types = 6;
   repeated string right_names = 7;
   bytes output_type = 8;
-  PySparkUdfConfig config = 9;
+  bool is_pandas = 9;
+  PySparkUdfConfig config = 10;
 }
 
 message DropStructFieldUdf {

--- a/crates/sail-execution/src/codec.rs
+++ b/crates/sail-execution/src/codec.rs
@@ -1102,6 +1102,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 right_types,
                 right_names,
                 output_type,
+                is_pandas,
                 config,
             }) => {
                 let left_types = left_types
@@ -1126,6 +1127,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                     right_types,
                     right_names,
                     output_type,
+                    is_pandas,
                     Arc::new(config),
                 )?;
                 return Ok(Arc::new(ScalarUDF::from(udf)));
@@ -1419,6 +1421,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 right_types,
                 right_names: func.right_names().to_vec(),
                 output_type,
+                is_pandas: func.is_pandas(),
                 config: Some(config),
             })
         } else if let Some(func) = node.inner().as_any().downcast_ref::<DropStructField>() {

--- a/crates/sail-plan/src/resolver/expression/udf.rs
+++ b/crates/sail-plan/src/resolver/expression/udf.rs
@@ -94,6 +94,7 @@ impl PlanResolver<'_> {
             | PySparkUdfType::WindowAggPandas
             | PySparkUdfType::MapPandasIter
             | PySparkUdfType::CogroupedMapPandas
+            | PySparkUdfType::CogroupedMapArrow
             | PySparkUdfType::MapArrowIter
             | PySparkUdfType::GroupedMapPandasWithState
             | PySparkUdfType::Table

--- a/crates/sail-python-udf/src/cereal/mod.rs
+++ b/crates/sail-python-udf/src/cereal/mod.rs
@@ -51,6 +51,7 @@ fn supports_kwargs(eval_type: spec::PySparkUdfType) -> bool {
         | PySparkUdfType::WindowAggPandas
         | PySparkUdfType::MapPandasIter
         | PySparkUdfType::CogroupedMapPandas
+        | PySparkUdfType::CogroupedMapArrow
         | PySparkUdfType::MapArrowIter
         | PySparkUdfType::GroupedMapPandasWithState
         | PySparkUdfType::Table
@@ -77,6 +78,7 @@ fn should_write_config(eval_type: spec::PySparkUdfType) -> bool {
         | PySparkUdfType::ScalarPandasIter
         | PySparkUdfType::MapPandasIter
         | PySparkUdfType::CogroupedMapPandas
+        | PySparkUdfType::CogroupedMapArrow
         | PySparkUdfType::MapArrowIter
         | PySparkUdfType::GroupedMapPandasWithState
         | PySparkUdfType::ArrowTable => true,

--- a/crates/sail-python-udf/src/python/spark.py
+++ b/crates/sail-python-udf/src/python/spark.py
@@ -556,11 +556,13 @@ class PySparkCoGroupMapUdf:
         udf: Callable[..., Any],
         left_names: Sequence[str],
         right_names: Sequence[str],
+        is_pandas: bool,  # noqa: FBT001
         config,
     ):
         self._udf = udf
         self._left_names = left_names
         self._right_names = right_names
+        self.is_pandas = is_pandas
         self._serializer = ArrowStreamPandasUDFSerializer(
             timezone=config.session_timezone,
             safecheck=config.arrow_convert_safely,
@@ -572,12 +574,20 @@ class PySparkCoGroupMapUdf:
         )
 
     def __call__(self, left: list[pa.Array], right: list[pa.Array]) -> pa.Array:
-        args = [
-            _named_arrays_to_pandas(left, self._left_names, self._serializer),
-            _named_arrays_to_pandas(right, self._right_names, self._serializer),
+        if self.is_pandas:
+            inputs = [
+                _named_arrays_to_pandas(left, self._left_names, self._serializer),
+                _named_arrays_to_pandas(right, self._right_names, self._serializer),
+            ]
+            [[(output, output_type)]] = list(self._udf(None, (inputs,)))
+            return _pandas_to_arrow_array(output, output_type, self._serializer)
+
+        inputs = [
+            [pa.RecordBatch.from_arrays(left, self._left_names)],
+            [pa.RecordBatch.from_arrays(right, self._right_names)],
         ]
-        [[(output, output_type)]] = list(self._udf(None, (args,)))
-        return _pandas_to_arrow_array(output, output_type, self._serializer)
+        [(output, output_type)] = list(self._udf(None, (inputs,)))
+        return _arrow_array_to_output_type(output, output_type)
 
 
 class PySparkMapPandasIterUdf:

--- a/crates/sail-python-udf/src/python/spark.rs
+++ b/crates/sail-python-udf/src/python/spark.rs
@@ -115,12 +115,13 @@ impl PySpark {
         udf: Bound<'py, PyAny>,
         left_names: Vec<String>,
         right_names: Vec<String>,
+        is_pandas: bool,
         config: &PySparkUdfConfig,
     ) -> PyResult<Bound<'py, PyAny>> {
         py_init_object(
             Self::module(py)?,
             intern!(py, "PySparkCoGroupMapUdf"),
-            (udf, left_names, right_names, config.clone()),
+            (udf, left_names, right_names, is_pandas, config.clone()),
         )
     }
 

--- a/crates/sail-python-udf/src/udf/pyspark_cogroup_map_udf.rs
+++ b/crates/sail-python-udf/src/udf/pyspark_cogroup_map_udf.rs
@@ -30,6 +30,7 @@ pub struct PySparkCoGroupMapUDF {
     right_types: Vec<DataType>,
     right_names: Vec<String>,
     output_type: DataType,
+    is_pandas: bool,
     config: Arc<PySparkUdfConfig>,
     udf: LazyPyObject,
 }
@@ -45,6 +46,7 @@ impl PySparkCoGroupMapUDF {
         right_types: Vec<DataType>,
         right_names: Vec<String>,
         output_type: DataType,
+        is_pandas: bool,
         config: Arc<PySparkUdfConfig>,
     ) -> Result<Self> {
         let input_types = vec![
@@ -68,6 +70,7 @@ impl PySparkCoGroupMapUDF {
             right_names,
             output_type,
             config,
+            is_pandas,
             udf: LazyPyObject::new(),
         })
     }
@@ -100,6 +103,10 @@ impl PySparkCoGroupMapUDF {
         &self.output_type
     }
 
+    pub fn is_pandas(&self) -> bool {
+        self.is_pandas
+    }
+
     pub fn config(&self) -> &Arc<PySparkUdfConfig> {
         &self.config
     }
@@ -112,6 +119,7 @@ impl PySparkCoGroupMapUDF {
                 udf,
                 self.left_names.clone(),
                 self.right_names.clone(),
+                self.is_pandas,
                 &self.config,
             )?
             .unbind())


### PR DESCRIPTION
implement `left.cogroup(right).applyInArrow(func, return_type)`:
https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.PandasCogroupedOps.applyInArrow.html

reusing the code that implements cogrouped `applyInPandas`
and changing only input and output conversion