### PR TITLE
refactor: remove hard PyO3 dependency for error cause

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5585,7 +5585,6 @@ dependencies = [
  "lexical-core",
  "pin-project-lite",
  "prost",
- "pyo3",
  "ryu",
  "sail-common",
  "serde",

--- a/crates/sail-common-datafusion/Cargo.toml
+++ b/crates/sail-common-datafusion/Cargo.toml
@@ -18,7 +18,6 @@ thiserror = { workspace = true }
 lexical-core = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
-pyo3 = { workspace = true }
 async-trait = { workspace = true }
 prost = { workspace = true }
 tonic = { workspace = true }

--- a/crates/sail-execution/src/driver/actor/handler.rs
+++ b/crates/sail-execution/src/driver/actor/handler.rs
@@ -16,6 +16,7 @@ use log::{debug, error, info, warn};
 use prost::bytes::BytesMut;
 use prost::Message;
 use sail_common_datafusion::error::CommonErrorCause;
+use sail_python_udf::error::PyErrExtractor;
 use sail_server::actor::{ActorAction, ActorContext};
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::Instant;
@@ -616,7 +617,7 @@ impl DriverActor {
             Ok(x) => x,
             Err(e) => {
                 let message = format!("failed to rewrite shuffle: {e}");
-                let cause = CommonErrorCause::new(&e);
+                let cause = CommonErrorCause::new::<PyErrExtractor>(&e);
                 self.update_task(
                     ctx,
                     task_id,
@@ -647,7 +648,7 @@ impl DriverActor {
             Ok(client) => client.clone(),
             Err(e) => {
                 let message = format!("failed to get worker {worker_id} client: {e}");
-                let cause = CommonErrorCause::new(&e);
+                let cause = CommonErrorCause::new::<PyErrExtractor>(&e);
                 self.update_task(
                     ctx,
                     task_id,
@@ -780,7 +781,7 @@ impl DriverActor {
                     let stream = match stream {
                         Ok(x) => x,
                         Err(e) => {
-                            let cause = CommonErrorCause::new(&e);
+                            let cause = CommonErrorCause::new::<PyErrExtractor>(&e);
                             let _ = result.send(Err(e));
                             self.cancel_job(ctx, job_id, cause);
                             return;

--- a/crates/sail-execution/src/stream/error.rs
+++ b/crates/sail-execution/src/stream/error.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use arrow_flight::error::FlightError;
 use sail_common_datafusion::error::{CommonErrorCause, RemotePythonError};
+use sail_python_udf::error::PyErrExtractor;
 use tonic::{Code, Status};
 use tonic_types::{ErrorDetails, StatusExt};
 
@@ -109,8 +110,8 @@ impl From<CommonErrorCause> for TaskStreamError {
             | CommonErrorCause::Configuration(x)
             | CommonErrorCause::Execution(x)
             | CommonErrorCause::DeltaTable(x) => Self::Unknown(x),
-            CommonErrorCause::Python { summary, traceback } => {
-                Self::External(Arc::new(RemotePythonError { summary, traceback }))
+            CommonErrorCause::Python(cause) => {
+                Self::External(Arc::new(RemotePythonError::from(cause)))
             }
         }
     }
@@ -120,7 +121,7 @@ impl From<TaskStreamError> for CommonErrorCause {
     fn from(value: TaskStreamError) -> Self {
         match value {
             TaskStreamError::Unknown(x) => CommonErrorCause::Unknown(x),
-            TaskStreamError::External(e) => CommonErrorCause::new(&e),
+            TaskStreamError::External(e) => CommonErrorCause::new::<PyErrExtractor>(&e),
         }
     }
 }

--- a/crates/sail-execution/src/worker/actor/handler.rs
+++ b/crates/sail-execution/src/worker/actor/handler.rs
@@ -11,6 +11,7 @@ use datafusion_proto::protobuf::PhysicalPlanNode;
 use log::{debug, error, info, warn};
 use prost::Message;
 use sail_common_datafusion::error::CommonErrorCause;
+use sail_python_udf::error::PyErrExtractor;
 use sail_server::actor::{ActorAction, ActorContext};
 use tokio::sync::oneshot;
 
@@ -104,7 +105,7 @@ impl WorkerActor {
                     attempt,
                     status: TaskStatus::Failed,
                     message: Some(format!("failed to execute plan: {e}")),
-                    cause: Some(CommonErrorCause::new(&e)),
+                    cause: Some(CommonErrorCause::new::<PyErrExtractor>(&e)),
                 };
                 ctx.send(event);
                 return ActorAction::Continue;

--- a/crates/sail-execution/src/worker/actor/stream_monitor.rs
+++ b/crates/sail-execution/src/worker/actor/stream_monitor.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use datafusion::execution::SendableRecordBatchStream;
 use futures::StreamExt;
 use sail_common_datafusion::error::CommonErrorCause;
+use sail_python_udf::error::PyErrExtractor;
 use sail_server::actor::ActorHandle;
 use tokio::sync::oneshot;
 
@@ -99,7 +100,7 @@ impl TaskStreamMonitor {
                 Ok(_) => None,
                 Err(e) => Some((
                     format!("failed to read batch: {e}"),
-                    CommonErrorCause::new(e),
+                    CommonErrorCause::new::<PyErrExtractor>(e),
                 )),
             };
             if let Some(ref mut sink) = sink {

--- a/crates/sail-spark-connect/src/error.rs
+++ b/crates/sail-spark-connect/src/error.rs
@@ -9,9 +9,10 @@ use log::error;
 use prost::{DecodeError, UnknownEnumValue};
 use sail_cache::error::CacheError;
 use sail_common::error::CommonError;
-use sail_common_datafusion::error::CommonErrorCause;
+use sail_common_datafusion::error::{CommonErrorCause, PythonErrorCause};
 use sail_execution::error::ExecutionError;
 use sail_plan::error::PlanError;
+use sail_python_udf::error::PyErrExtractor;
 use sail_sql_analyzer::error::SqlError;
 use thiserror::Error;
 use tokio::sync::mpsc::error::SendError;
@@ -314,7 +315,7 @@ impl From<CommonErrorCause> for SparkThrowable {
                 SparkThrowable::ArithmeticException(x)
             }
             CommonErrorCause::ArrowParse(x) => SparkThrowable::ParseException(x),
-            CommonErrorCause::Python { summary, traceback } => {
+            CommonErrorCause::Python(PythonErrorCause { summary, traceback }) => {
                 // The message must end with a newline character
                 // since the PySpark unit tests expect it.
                 let message = if let Some(traceback) = traceback {
@@ -341,9 +342,11 @@ impl From<CommonErrorCause> for SparkThrowable {
 impl From<SparkError> for Status {
     fn from(error: SparkError) -> Self {
         match error {
-            SparkError::ArrowError(e) => SparkThrowable::from(CommonErrorCause::new(&e)).into(),
+            SparkError::ArrowError(e) => {
+                SparkThrowable::from(CommonErrorCause::new::<PyErrExtractor>(&e)).into()
+            }
             SparkError::DataFusionError(e) => {
-                SparkThrowable::from(CommonErrorCause::new(&e)).into()
+                SparkThrowable::from(CommonErrorCause::new::<PyErrExtractor>(&e)).into()
             }
             e @ SparkError::MissingArgument(_) | e @ SparkError::InvalidArgument(_) => {
                 SparkThrowable::IllegalArgumentException(e.to_string()).into()

--- a/crates/sail-spark-connect/src/streaming.rs
+++ b/crates/sail-spark-connect/src/streaming.rs
@@ -5,6 +5,7 @@ use datafusion::execution::SendableRecordBatchStream;
 use datafusion::logical_expr::{PlanType, StringifiedPlan};
 use futures::StreamExt;
 use sail_common_datafusion::error::CommonErrorCause;
+use sail_python_udf::error::PyErrExtractor;
 use tokio::sync::{oneshot, watch};
 
 use crate::error::{SparkError, SparkResult, SparkThrowable};
@@ -71,7 +72,7 @@ impl StreamingQuery {
                 match x {
                     Ok(_) => {}
                     Err(e) => {
-                        let cause = CommonErrorCause::new(&e);
+                        let cause = CommonErrorCause::new::<PyErrExtractor>(&e);
                         let _ = error.send(Some(cause.into()));
                     }
                 }


### PR DESCRIPTION
This PR ensures that `sail-common-datafusion` does not depend on `pyo3`, so that build time can be reduced when switching Python environments.