### PR TITLE
fix: map_from_entries wrong result on null input

### DIFF
--- a/crates/sail-function/src/scalar/map/map_from_entries.rs
+++ b/crates/sail-function/src/scalar/map/map_from_entries.rs
@@ -84,7 +84,7 @@ fn map_from_entries_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
         flat_values,
         &entries_offsets,
         &entries_offsets,
-        entries_values.nulls(),
-        entries_values.nulls(),
+        entries.nulls(),
+        entries.nulls(),
     )
 }

--- a/python/pysail/tests/spark/function/test_map_from_entries.txt
+++ b/python/pysail/tests/spark/function/test_map_from_entries.txt
@@ -1,0 +1,20 @@
+>>> spark.sql("""
+... SELECT map_from_entries(data) as result, typeof(map_from_entries(data)) as type
+... from VALUES
+...     (NULL), 
+...     (
+...         array(struct(1 as a, 'b' as b), 
+...         struct(2 as a, NULL as b), 
+...         struct(3 as a, 'd' as b))
+...     ), 
+...     (array()),
+...     (cast(NULL as array<struct<a: int, b: string>>)) 
+... as tab(data)""").show(truncate=False)
++---------------------------+---------------+
+|result                     |type           |
++---------------------------+---------------+
+|NULL                       |map<int,string>|
+|{1 -> b, 2 -> NULL, 3 -> d}|map<int,string>|
+|{}                         |map<int,string>|
+|NULL                       |map<int,string>|
++---------------------------+---------------+


### PR DESCRIPTION
fix sending wrong null masks as the input for the common map creation function 
now `map_from_entries(NULL)` returns NULL as expected
add a test with multiple rows with null and empty entries to ensure correct behaviour
closes #919