### PR TITLE
fix: map_from_entries error on lists with null entries

### DIFF
--- a/crates/sail-function/src/scalar/map/utils.rs
+++ b/crates/sail-function/src/scalar/map/utils.rs
@@ -137,8 +137,15 @@ fn map_deduplicate_keys(
     let offsets_len = keys_offsets.len();
     let mut new_offsets = Vec::with_capacity(offsets_len);
 
-    let mut cur_keys_offset = 0;
-    let mut cur_values_offset = 0;
+    let mut cur_keys_offset = keys_offsets
+        .first()
+        .map(|offset| *offset as usize)
+        .unwrap_or(0);
+    let mut cur_values_offset = values_offsets
+        .first()
+        .map(|offset| *offset as usize)
+        .unwrap_or(0);
+
     let mut new_last_offset = 0;
     new_offsets.push(new_last_offset);
 
@@ -156,33 +163,36 @@ fn map_deduplicate_keys(
         let mut keys_mask_one = [false].repeat(num_keys_entries);
         let mut values_mask_one = [false].repeat(num_values_entries);
 
-        if num_keys_entries != num_values_entries {
-            let key_is_valid = keys_nulls.is_none_or(|buf| buf.is_valid(row_idx));
-            let value_is_valid = values_nulls.is_none_or(|buf| buf.is_valid(row_idx));
-            if key_is_valid && value_is_valid {
-                return exec_err!("map_deduplicate_keys: keys and values lists in the same row must have equal lengths");
-            }
-            // else the result entry is NULL
-            // both current row offsets are skipped
-            // keys or values in the current row are marked false in the masks
-        } else if num_keys_entries != 0 {
-            let mut seen_keys = HashSet::new();
+        let key_is_valid = keys_nulls.is_none_or(|buf| buf.is_valid(row_idx));
+        let value_is_valid = values_nulls.is_none_or(|buf| buf.is_valid(row_idx));
 
-            for cur_entry_idx in (0..num_keys_entries).rev() {
-                let key = ScalarValue::try_from_array(&flat_keys, cur_keys_offset + cur_entry_idx)?
-                    .compacted();
-                if seen_keys.contains(&key) {
-                    // TODO: implement configuration and logic for spark.sql.mapKeyDedupPolicy=EXCEPTION (this is default spark-config)
-                    // exec_err!("invalid argument: duplicate keys in map")
-                    // https://github.com/apache/spark/blob/cf3a34e19dfcf70e2d679217ff1ba21302212472/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L4961
-                } else {
-                    // This code implements deduplication logic for spark.sql.mapKeyDedupPolicy=LAST_WIN (this is NOT default spark-config)
-                    keys_mask_one[cur_entry_idx] = true;
-                    values_mask_one[cur_entry_idx] = true;
-                    seen_keys.insert(key);
-                    new_last_offset += 1;
+        if key_is_valid && value_is_valid {
+            if num_keys_entries != num_values_entries {
+                return exec_err!("map_deduplicate_keys: keys and values lists in the same row must have equal lengths");
+            } else if num_keys_entries != 0 {
+                let mut seen_keys = HashSet::new();
+
+                for cur_entry_idx in (0..num_keys_entries).rev() {
+                    let key =
+                        ScalarValue::try_from_array(&flat_keys, cur_keys_offset + cur_entry_idx)?
+                            .compacted();
+                    if seen_keys.contains(&key) {
+                        // TODO: implement configuration and logic for spark.sql.mapKeyDedupPolicy=EXCEPTION (this is default spark-config)
+                        // exec_err!("invalid argument: duplicate keys in map")
+                        // https://github.com/apache/spark/blob/cf3a34e19dfcf70e2d679217ff1ba21302212472/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L4961
+                    } else {
+                        // This code implements deduplication logic for spark.sql.mapKeyDedupPolicy=LAST_WIN (this is NOT default spark-config)
+                        keys_mask_one[cur_entry_idx] = true;
+                        values_mask_one[cur_entry_idx] = true;
+                        seen_keys.insert(key);
+                        new_last_offset += 1;
+                    }
                 }
             }
+        } else {
+            // the result entry is NULL
+            // both current row offsets are skipped
+            // keys or values in the current row are marked false in the masks
         }
         keys_mask_builder.append_array(&keys_mask_one.into());
         values_mask_builder.append_array(&values_mask_one.into());

--- a/python/pysail/tests/spark/function/test_map_from_entries.txt
+++ b/python/pysail/tests/spark/function/test_map_from_entries.txt
@@ -9,7 +9,8 @@
 ...     ), 
 ...     (array()),
 ...     (cast(NULL as array<struct<a: int, b: string>>)) 
-... as tab(data)""").show(truncate=False)
+... as tab(data)
+""").show(truncate=False)
 +---------------------------+---------------+
 |result                     |type           |
 +---------------------------+---------------+
@@ -18,3 +19,33 @@
 |{}                         |map<int,string>|
 |NULL                       |map<int,string>|
 +---------------------------+---------------+
+
+>>> spark.sql("""
+... SELECT map_from_entries(data) as result, typeof(map_from_entries(data)) as type
+... from values
+...     (array(
+...         struct(1 as a, "a" as b), 
+...         cast(NULL as struct<a: int, b: string>), 
+...         cast(NULL as struct<a: int, b: string>)
+...     )),
+...     (NULL),
+...     (array(
+...         struct(2 as a, "b" as b), 
+...         struct(3 as a, "c" as b)
+...     )),
+...     (array(
+...         struct(4 as a, "d" as b),
+...         cast(NULL as struct<a: int, b: string>),
+...         struct(5 as a, "e" as b),
+...         struct(6 as a, "f" as b)
+...     ))
+... as tab(data);
+... """).show(truncate=False)
++----------------+---------------+
+|result          |type           |
++----------------+---------------+
+|NULL            |map<int,string>|
+|NULL            |map<int,string>|
+|{2 -> b, 3 -> c}|map<int,string>|
+|NULL            |map<int,string>|
++----------------+---------------+

--- a/python/pysail/tests/spark/function/test_map_from_entries.txt
+++ b/python/pysail/tests/spark/function/test_map_from_entries.txt
@@ -9,8 +9,8 @@
 ...     ), 
 ...     (array()),
 ...     (cast(NULL as array<struct<a: int, b: string>>)) 
-... as tab(data)
-""").show(truncate=False)
+... as tab(data);
+... """).show(truncate=False)
 +---------------------------+---------------+
 |result                     |type           |
 +---------------------------+---------------+


### PR DESCRIPTION
map_from_entries now returns NULL for the row if any entry in list is null:
(was failing)
```python
from pysail.spark import SparkConnectServer
from pyspark.sql import SparkSession
import pyspark.sql.functions as F

server = SparkConnectServer()
server.start()
_, port = server.listening_address

spark = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
#spark = SparkSession.builder.appName("test").master("local[4]").getOrCreate()

spark.sql("""
SELECT map_from_entries(data) as result, typeof(map_from_entries(data)) as type
from values
    (array(
        struct(1 as a, "a" as b), 
        cast(NULL as struct<a: int, b: string>), 
        cast(NULL as struct<a: int, b: string>)
    )),
    (NULL),
    (array(
        struct(2 as a, "b" as b), 
        struct(3 as a, "c" as b)
    )),
    (array(
        struct(4 as a, "d" as b),
        cast(NULL as struct<a: int, b: string>),
        struct(5 as a, "e" as b),
        struct(6 as a, "f" as b)
    ))
as tab(data);
""").show(truncate=False)
```
```
+----------------+---------------+
|result          |type           |
+----------------+---------------+
|NULL            |map<int,string>|
|NULL            |map<int,string>|
|{2 -> b, 3 -> c}|map<int,string>|
|NULL            |map<int,string>|
+----------------+---------------+
```
added a test for this

slightly tuned up the offsets logic
not sure if the first offset can be not 0, in list slices maybe
but now it will be correct if it can

closes #925 