### PR TITLE
chore: prepare v0.3.6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
           - runner: ubuntu-24.04-x64-8-core
             target: aarch64
             os: linux
-          - runner: macos-13
+          - runner: macos-15-intel
             target: x86_64
             os: macos
           - runner: macos-14
@@ -243,7 +243,7 @@ jobs:
         platform:
           - runner: ubuntu-24.04-x64-8-core
           - runner: ubuntu-24.04-arm-8-core
-          - runner: macos-13
+          - runner: macos-15-intel
           - runner: macos-14
           - runner: windows-2022
     needs:
@@ -303,7 +303,7 @@ jobs:
         platform:
           - runner: ubuntu-24.04
           - runner: ubuntu-24.04-arm
-          - runner: macos-13
+          - runner: macos-15-intel
           - runner: macos-14
           - runner: windows-2022
     needs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,26 +585,26 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.3"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
+checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
 dependencies = [
  "aws-lc-sys",
- "untrusted 0.7.1",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.30.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
+checksum = "1ba2e2516bdf37af57fc6ff047855f54abad0066e5c4fdaaeb76dabb2e05bcf5"
 dependencies = [
  "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "libloading",
 ]
 
 [[package]]
@@ -997,25 +997,22 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn",
- "which",
 ]
 
 [[package]]
@@ -2555,7 +2552,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2644,7 +2641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3617,15 +3614,6 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -3804,12 +3792,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "lexical-core"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,12 +3862,12 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
-version = "0.8.9"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.0",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -5090,7 +5072,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "socket2 0.6.0",
  "thiserror 2.0.16",
@@ -5110,7 +5092,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -5357,7 +5339,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -5388,12 +5370,6 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -5433,14 +5409,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5498,14 +5474,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -5563,7 +5539,6 @@ dependencies = [
 name = "sail-cli"
 version = "0.3.6"
 dependencies = [
- "aws-lc-rs",
  "clap",
  "fastrace",
  "log",
@@ -6507,7 +6482,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7057,12 +7032,6 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -7325,18 +7294,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7369,7 +7326,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -585,19 +585,20 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.14.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b8ff6c09cd57b16da53641caa860168b88c172a5ee163b0288d3d6eea12786"
+checksum = "5c953fe1ba023e6b7730c0d4b031d06f267f23a46167dcbd40316644b10a17ba"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.31.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e44d16778acaf6a9ec9899b92cebd65580b83f685446bf2e1f5d3d732f99dcd"
+checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
 dependencies = [
  "bindgen",
  "cc",
@@ -996,22 +997,25 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.72.1"
+version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
  "log",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn",
+ "which",
 ]
 
 [[package]]
@@ -3613,6 +3617,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -3789,6 +3802,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lexical-core"
@@ -5071,7 +5090,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2 0.6.0",
  "thiserror 2.0.16",
@@ -5091,7 +5110,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -5338,7 +5357,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -5369,6 +5388,12 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -5413,9 +5438,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.32"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5473,14 +5498,14 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.6"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5538,6 +5563,7 @@ dependencies = [
 name = "sail-cli"
 version = "0.3.6"
 dependencies = [
+ "aws-lc-rs",
  "clap",
  "fastrace",
  "log",
@@ -7031,6 +7057,12 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -7290,6 +7322,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5497,7 +5497,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "sail-cache"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "chrono",
  "datafusion",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "sail-catalog"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -5527,7 +5527,7 @@ dependencies = [
 
 [[package]]
 name = "sail-catalog-memory"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "dashmap",
@@ -5536,7 +5536,7 @@ dependencies = [
 
 [[package]]
 name = "sail-cli"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "clap",
  "fastrace",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "sail-common"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -5573,7 +5573,7 @@ dependencies = [
 
 [[package]]
 name = "sail-common-datafusion"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5596,7 +5596,7 @@ dependencies = [
 
 [[package]]
 name = "sail-data-source"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "sail-delta-lake"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -5657,7 +5657,7 @@ dependencies = [
 
 [[package]]
 name = "sail-execution"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "arrow-flight",
  "datafusion",
@@ -5692,7 +5692,7 @@ dependencies = [
 
 [[package]]
 name = "sail-function"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -5726,7 +5726,7 @@ dependencies = [
 
 [[package]]
 name = "sail-gold-test"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "clap",
  "lazy_static",
@@ -5738,14 +5738,14 @@ dependencies = [
 
 [[package]]
 name = "sail-logical-optimizer"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "datafusion",
 ]
 
 [[package]]
 name = "sail-logical-plan"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "comfy-table",
  "datafusion",
@@ -5759,7 +5759,7 @@ dependencies = [
 
 [[package]]
 name = "sail-object-store"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5790,7 +5790,7 @@ dependencies = [
 
 [[package]]
 name = "sail-physical-optimizer"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "datafusion",
  "datafusion-physical-expr",
@@ -5801,7 +5801,7 @@ dependencies = [
 
 [[package]]
 name = "sail-physical-plan"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "datafusion",
  "datafusion-common",
@@ -5815,7 +5815,7 @@ dependencies = [
 
 [[package]]
 name = "sail-plan"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "arrow",
  "async-recursion",
@@ -5854,7 +5854,7 @@ dependencies = [
 
 [[package]]
 name = "sail-python"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "fastrace",
  "log",
@@ -5868,7 +5868,7 @@ dependencies = [
 
 [[package]]
 name = "sail-python-udf"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "arrow-pyarrow",
  "datafusion",
@@ -5887,7 +5887,7 @@ dependencies = [
 
 [[package]]
 name = "sail-server"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "axum",
  "log",
@@ -5902,7 +5902,7 @@ dependencies = [
 
 [[package]]
 name = "sail-session"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "datafusion",
  "sail-catalog",
@@ -5912,7 +5912,7 @@ dependencies = [
 
 [[package]]
 name = "sail-spark-connect"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-stream",
  "datafusion",
@@ -5954,7 +5954,7 @@ dependencies = [
 
 [[package]]
 name = "sail-sql-analyzer"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "chrono",
  "chumsky",
@@ -5968,7 +5968,7 @@ dependencies = [
 
 [[package]]
 name = "sail-sql-macro"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5977,7 +5977,7 @@ dependencies = [
 
 [[package]]
 name = "sail-sql-parser"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "chumsky",
  "either",
@@ -5991,7 +5991,7 @@ dependencies = [
 
 [[package]]
 name = "sail-telemetry"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "env_logger",
  "fastrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ hf-hub = { version = "0.4.3", default-features = false, features = ["tokio"] }
 reqwest = "0.12.23"
 percent-encoding = "2.3.2"
 rustls = "0.23.31"
+aws-lc-rs = "~1.13.3"
 dashmap = "6.1.0"
 itertools = "0.14.0"
 moka = { version = "0.12.10", features = ["sync"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 authors = ["LakeSail <hello@lakesail.com>"]
 edition = "2021"
 homepage = "https://lakesail.com"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,6 @@ hf-hub = { version = "0.4.3", default-features = false, features = ["tokio"] }
 reqwest = "0.12.23"
 percent-encoding = "2.3.2"
 rustls = "0.23.31"
-aws-lc-rs = "~1.13.3"
 dashmap = "6.1.0"
 itertools = "0.14.0"
 moka = { version = "0.12.10", features = ["sync"] }

--- a/crates/sail-cli/Cargo.toml
+++ b/crates/sail-cli/Cargo.toml
@@ -27,4 +27,3 @@ log = { workspace = true }
 fastrace = { workspace = true }
 pyo3 = { workspace = true }
 rustls = { workspace = true }
-aws-lc-rs = { workspace = true }

--- a/crates/sail-cli/Cargo.toml
+++ b/crates/sail-cli/Cargo.toml
@@ -27,3 +27,4 @@ log = { workspace = true }
 fastrace = { workspace = true }
 pyo3 = { workspace = true }
 rustls = { workspace = true }
+aws-lc-rs = { workspace = true }

--- a/docs/reference/changelog/index.md
+++ b/docs/reference/changelog/index.md
@@ -9,6 +9,45 @@ next: false
 
 _September 30, 2025_
 
+- Added support for the binary file format ([#853](https://github.com/lakehq/sail/pull/853)).
+- Implemented an experimental join reorder physical optimizer using the DPhyp algorithm ([#810](https://github.com/lakehq/sail/pull/810) and [#917](https://github.com/lakehq/sail/pull/917)). This optimizer is not enabled by default but can be enabled via configuration options.
+- Added support for the PySpark UDF `applyInArrow()` method in the Spark DataFrame API for grouped and cogrouped data ([#886](https://github.com/lakehq/sail/pull/886) and [#887](https://github.com/lakehq/sail/pull/887)).
+- Added support for the following SQL functions ([#820](https://github.com/lakehq/sail/pull/820), [#841](https://github.com/lakehq/sail/pull/841), [#824](https://github.com/lakehq/sail/pull/824), [#843](https://github.com/lakehq/sail/pull/843), [#835](https://github.com/lakehq/sail/pull/835), [#855](https://github.com/lakehq/sail/pull/855), [#859](https://github.com/lakehq/sail/pull/859), and [#860](https://github.com/lakehq/sail/pull/860)):
+  - `elt`
+  - `inline`
+  - `inline_outer`
+  - `try_parse_url`
+  - `stack`
+  - `make_dt_interval`
+  - `version`
+  - `months_between`
+  - `user`
+  - `session_user`
+- Improved the following SQL functions ([#841](https://github.com/lakehq/sail/pull/841), [#847](https://github.com/lakehq/sail/pull/847), [#878](https://github.com/lakehq/sail/pull/878), [#920](https://github.com/lakehq/sail/pull/920), [#926](https://github.com/lakehq/sail/pull/926), and [#914](https://github.com/lakehq/sail/pull/914)):
+  - `array`
+  - `try_multiply`
+  - `map_from_arrays`
+  - `map_from_entries`
+  - `approx_count_distinct`
+- Added support for using all aggregate functions in window expressions ([#861](https://github.com/lakehq/sail/pull/861)).
+- Fixed issues with sorting by aggregate expressions ([#915](https://github.com/lakehq/sail/pull/915)).
+- Added an example of using Kustomize with pod templates for Sail workers ([#833](https://github.com/lakehq/sail/pull/833)).
+- Fixed issues with session key generation when the user ID is missing on the Windows platform ([#849](https://github.com/lakehq/sail/pull/849)).
+- Supported time travel for Delta Lake ([#854](https://github.com/lakehq/sail/pull/854)).
+- Supported the delete operation for Delta Lake ([#856](https://github.com/lakehq/sail/pull/856)).
+- Improved Delta Lake integration ([#848](https://github.com/lakehq/sail/pull/848) and [#916](https://github.com/lakehq/sail/pull/916)).
+- Continued the work for data streaming support ([#832](https://github.com/lakehq/sail/pull/832)).
+- Added batch view creation endpoints in the MCP server ([#875](https://github.com/lakehq/sail/pull/875)).
+- Fixed input repartitioning issues for PySpark UDTFs ([#662](https://github.com/lakehq/sail/pull/662)).
+- Fixed issues with the `DataFrame.replace()` method in the Spark DataFrame API ([#891](https://github.com/lakehq/sail/pull/891)).
+- Supported the `REAL` data type in the SQL parser ([#892](https://github.com/lakehq/sail/pull/892)).
+- Fixed various literal parsing issues in the SQL parser ([#868](https://github.com/lakehq/sail/pull/868), [#872](https://github.com/lakehq/sail/pull/872), and [#873](https://github.com/lakehq/sail/pull/873)).
+- Fixed issues with PySpark UDFs with no arguments ([#895](https://github.com/lakehq/sail/pull/895)).
+
+### Contributors
+
+Huge thanks to [@SparkApplicationMaster](https://github.com/SparkApplicationMaster), [@davidlghellin](https://github.com/davidlghellin), and [@rafafrdz](https://github.com/rafafrdz) for the continued contributions!
+
 ## 0.3.5
 
 _September 5, 2025_

--- a/docs/reference/changelog/index.md
+++ b/docs/reference/changelog/index.md
@@ -5,6 +5,10 @@ next: false
 
 # Changelog
 
+## 0.3.6
+
+_September 30, 2025_
+
 ## 0.3.5
 
 _September 5, 2025_

--- a/docs/reference/changelog/index.md
+++ b/docs/reference/changelog/index.md
@@ -11,6 +11,7 @@ _September 30, 2025_
 
 - Added support for the binary file format ([#853](https://github.com/lakehq/sail/pull/853)).
 - Implemented an experimental join reorder physical optimizer using the DPhyp algorithm ([#810](https://github.com/lakehq/sail/pull/810) and [#917](https://github.com/lakehq/sail/pull/917)). This optimizer is not enabled by default but can be enabled via configuration options.
+- Added support for file metadata caching to improve read performance for the Parquet data source ([#928](https://github.com/lakehq/sail/pull/928)).
 - Added support for the PySpark UDF `applyInArrow()` method in the Spark DataFrame API for grouped and cogrouped data ([#886](https://github.com/lakehq/sail/pull/886) and [#887](https://github.com/lakehq/sail/pull/887)).
 - Added support for the following SQL functions ([#820](https://github.com/lakehq/sail/pull/820), [#841](https://github.com/lakehq/sail/pull/841), [#824](https://github.com/lakehq/sail/pull/824), [#843](https://github.com/lakehq/sail/pull/843), [#835](https://github.com/lakehq/sail/pull/835), [#855](https://github.com/lakehq/sail/pull/855), [#859](https://github.com/lakehq/sail/pull/859), and [#860](https://github.com/lakehq/sail/pull/860)):
   - `elt`

--- a/docs/reference/changelog/index.md
+++ b/docs/reference/changelog/index.md
@@ -9,10 +9,13 @@ next: false
 
 _September 30, 2025_
 
-- Added support for the binary file format ([#853](https://github.com/lakehq/sail/pull/853)).
+- Supported the binary file format ([#853](https://github.com/lakehq/sail/pull/853)).
 - Implemented an experimental join reorder physical optimizer using the DPhyp algorithm ([#810](https://github.com/lakehq/sail/pull/810) and [#917](https://github.com/lakehq/sail/pull/917)). This optimizer is not enabled by default but can be enabled via configuration options.
-- Added support for file metadata caching to improve read performance for the Parquet data source ([#928](https://github.com/lakehq/sail/pull/928)).
-- Added support for the PySpark UDF `applyInArrow()` method in the Spark DataFrame API for grouped and cogrouped data ([#886](https://github.com/lakehq/sail/pull/886) and [#887](https://github.com/lakehq/sail/pull/887)).
+- Supported file metadata caching to improve read performance for the Parquet data source ([#928](https://github.com/lakehq/sail/pull/928)).
+- Supported the PySpark UDF `applyInArrow()` method in the Spark DataFrame API for grouped and cogrouped data ([#886](https://github.com/lakehq/sail/pull/886) and [#887](https://github.com/lakehq/sail/pull/887)).
+- Supported time travel for Delta Lake ([#854](https://github.com/lakehq/sail/pull/854)).
+- Supported the delete operation for Delta Lake ([#856](https://github.com/lakehq/sail/pull/856)).
+- Improved Delta Lake integration ([#848](https://github.com/lakehq/sail/pull/848) and [#916](https://github.com/lakehq/sail/pull/916)).
 - Added support for the following SQL functions ([#820](https://github.com/lakehq/sail/pull/820), [#841](https://github.com/lakehq/sail/pull/841), [#824](https://github.com/lakehq/sail/pull/824), [#843](https://github.com/lakehq/sail/pull/843), [#835](https://github.com/lakehq/sail/pull/835), [#855](https://github.com/lakehq/sail/pull/855), [#859](https://github.com/lakehq/sail/pull/859), and [#860](https://github.com/lakehq/sail/pull/860)):
   - `elt`
   - `inline`
@@ -32,13 +35,10 @@ _September 30, 2025_
   - `approx_count_distinct`
 - Added support for using all aggregate functions in window expressions ([#861](https://github.com/lakehq/sail/pull/861)).
 - Fixed issues with sorting by aggregate expressions ([#915](https://github.com/lakehq/sail/pull/915)).
-- Added an example of using Kustomize with pod templates for Sail workers ([#833](https://github.com/lakehq/sail/pull/833)).
 - Fixed issues with session key generation when the user ID is missing on the Windows platform ([#849](https://github.com/lakehq/sail/pull/849)).
-- Supported time travel for Delta Lake ([#854](https://github.com/lakehq/sail/pull/854)).
-- Supported the delete operation for Delta Lake ([#856](https://github.com/lakehq/sail/pull/856)).
-- Improved Delta Lake integration ([#848](https://github.com/lakehq/sail/pull/848) and [#916](https://github.com/lakehq/sail/pull/916)).
 - Continued the work for data streaming support ([#832](https://github.com/lakehq/sail/pull/832)).
 - Added batch view creation endpoints in the MCP server ([#875](https://github.com/lakehq/sail/pull/875)).
+- Added an example of using Kustomize with pod templates for Sail workers ([#833](https://github.com/lakehq/sail/pull/833)).
 - Fixed input repartitioning issues for PySpark UDTFs ([#662](https://github.com/lakehq/sail/pull/662)).
 - Fixed issues with the `DataFrame.replace()` method in the Spark DataFrame API ([#891](https://github.com/lakehq/sail/pull/891)).
 - Supported the `REAL` data type in the SQL parser ([#892](https://github.com/lakehq/sail/pull/892)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pysail"
-version = "0.3.5"
+version = "0.3.6"
 description = "Sail Python library"
 authors = [
     { name = "LakeSail", email = "hello@lakesail.com" },

--- a/python/pysail/__init__.py
+++ b/python/pysail/__init__.py
@@ -2,6 +2,6 @@
 # We have a CI step that verifies this.
 # We cannot use the Hatch dynamic version feature since the project
 # may be built with Maturin outside of Hatch.
-__version__: str = "0.3.5"
+__version__: str = "0.3.6"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
* Upgrade `aws-lc-rs` to 1.14.1 since 1.14.0 has a bug for cross-compilation.
* Use `macos-15-intel` for macOS x86 build since `macos-13` will be discontinued soon.