### PR TITLE
chore: deny macros used for development

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ rust-version = "1.87.0"
 unwrap_used = "deny"
 expect_used = "deny"
 panic = "deny"
+dbg_macro = "deny"
+todo = "deny"
 
 [workspace.dependencies]
 thiserror = { version = "2.0.16" }


### PR DESCRIPTION
This PR adds a few Clippy lints to ensure that the `dbg!()` and `todo!()` macros used during development are not committed to the repo.