### PR TITLE
feat: add --experimental_allow_proto3_optional when building proto

### DIFF
--- a/crates/sail-execution/build.rs
+++ b/crates/sail-execution/build.rs
@@ -55,6 +55,7 @@ impl<'a> ProtoBuilder<'a> {
         }
 
         builder
+            .protoc_arg("--experimental_allow_proto3_optional")
             .compile_well_known_types(true)
             .compile_protos_with_config(config, &protos, &["proto"])?;
 

--- a/crates/sail-spark-connect/build.rs
+++ b/crates/sail-spark-connect/build.rs
@@ -13,6 +13,7 @@ fn build_proto() -> Result<(), Box<dyn std::error::Error>> {
         "spark.connect.ExecutePlanResponse.ArrowBatch",
     ]);
     tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional")
         .file_descriptor_set_path(&descriptor_path)
         .compile_well_known_types(true)
         .extern_path(".google.protobuf", "::pbjson_types")


### PR DESCRIPTION
## Context

For protobuf-compiler version between 3.12.0 and 3.14.x, it requires `experimental_allow_proto3_optional` flag in order to build protobuf to rust code. Given `sail-spark-connect` and `sail-execution` have multiple proto files specifying `optional` on fields, for these versions protobuf-compiler, build will fail. 

https://protobuf.dev/programming-guides/field_presence/

## Solution

Add `experimental_allow_proto3_optional` flag to the protobuf compilation process. 