### PR TITLE
feat: get SQL text from AST

### DIFF
--- a/crates/sail-sql-analyzer/src/value.rs
+++ b/crates/sail-sql-analyzer/src/value.rs
@@ -50,7 +50,11 @@ enum StringLiteralList {
 
 impl StringLiteralList {
     fn try_new(value: StringLiteral) -> SqlResult<Self> {
-        let StringLiteral { span: _, value } = value;
+        let StringLiteral {
+            span: _,
+            tokens: _,
+            value,
+        } = value;
         match value {
             StringValue::Valid {
                 value,
@@ -116,7 +120,11 @@ pub(crate) fn from_ast_boolean_literal(value: BooleanLiteral) -> SqlResult<spec:
 }
 
 pub(crate) fn from_ast_string(s: StringLiteral) -> SqlResult<String> {
-    let StringLiteral { span: _, value } = s;
+    let StringLiteral {
+        span: _,
+        tokens: _,
+        value,
+    } = s;
     match value {
         StringValue::Valid { value, prefix: _ } => Ok(value),
         StringValue::Invalid { reason } => Err(SqlError::invalid(reason)),

--- a/crates/sail-sql-macro/src/lib.rs
+++ b/crates/sail-sql-macro/src/lib.rs
@@ -89,3 +89,18 @@ pub fn derive_tree_syntax(input: TokenStream) -> TokenStream {
         .unwrap_or_else(syn::Error::into_compile_error)
         .into()
 }
+
+/// Derives the `TreeText` trait.
+///
+/// The type can be an enum with struct or tuple variants, or a struct with named or unnamed fields.
+/// For enums, the variants represent a choice of texts.
+/// For structs, the fields represent a sequence of texts.
+///
+/// The text cannot be derived for enums with unit variants, or structs with no fields.
+#[proc_macro_derive(TreeText)]
+pub fn derive_tree_text(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    tree::text::derive_tree_text(input)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
+}

--- a/crates/sail-sql-macro/src/tree/mod.rs
+++ b/crates/sail-sql-macro/src/tree/mod.rs
@@ -1,2 +1,3 @@
 pub mod parser;
 pub mod syntax;
+pub mod text;

--- a/crates/sail-sql-macro/src/tree/text.rs
+++ b/crates/sail-sql-macro/src/tree/text.rs
@@ -1,0 +1,114 @@
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+use syn::spanned::Spanned;
+use syn::{Data, DeriveInput, Field, Fields};
+
+/// The trait to derive for tree text.
+const TRAIT: &str = "TreeText";
+
+struct TextFields {
+    pattern: TokenStream,
+    statements: TokenStream,
+}
+
+fn derive_fields_inner<'a>(
+    fields: impl IntoIterator<Item = &'a Field>,
+) -> (TokenStream, Vec<Ident>) {
+    let mut initializer = quote! {};
+    let mut variables = vec![];
+    for (i, field) in fields.into_iter().enumerate() {
+        let v = format_ident!("v{}", i);
+        if let Some(name) = &field.ident {
+            initializer.extend(quote! { #name: #v, });
+        } else {
+            initializer.extend(quote! { #v, });
+        }
+        variables.push(v);
+    }
+    (initializer, variables)
+}
+
+fn derive_fields(spanned: impl Spanned, fields: &Fields) -> syn::Result<TextFields> {
+    let (pattern, variables) = match fields {
+        Fields::Named(named) => {
+            let (initializer, variables) = derive_fields_inner(&named.named);
+            (quote! { { #initializer } }, variables)
+        }
+        Fields::Unnamed(unnamed) => {
+            let (initializer, variables) = derive_fields_inner(&unnamed.unnamed);
+            (quote! { ( #initializer ) }, variables)
+        }
+        Fields::Unit => {
+            return Err(syn::Error::new(
+                spanned.span(),
+                format!("cannot derive `{TRAIT}` for unit fields"),
+            ))
+        }
+    };
+    Ok(TextFields {
+        pattern,
+        statements: quote! { #( result.push_str(&#variables.text()); )* },
+    })
+}
+
+pub(crate) fn derive_tree_text(input: DeriveInput) -> syn::Result<TokenStream> {
+    let name = &input.ident;
+
+    let statements = match &input.data {
+        Data::Enum(data) => {
+            if data.variants.is_empty() {
+                return Err(syn::Error::new(
+                    data.variants.span(),
+                    format!("cannot derive `{TRAIT}` for empty enums"),
+                ));
+            }
+            let arms = data
+                .variants
+                .iter()
+                .map(|variant| {
+                    let variant_name = &variant.ident;
+                    let TextFields {
+                        pattern,
+                        statements,
+                    } = derive_fields(variant, &variant.fields)?;
+                    Ok(quote! {
+                        Self::#variant_name #pattern => {
+                            #statements
+                        }
+                    })
+                })
+                .collect::<syn::Result<Vec<_>>>()?;
+            quote! {
+                match self {
+                    #(#arms)*
+                }
+            }
+        }
+        Data::Struct(data) => {
+            let TextFields {
+                pattern,
+                statements,
+            } = derive_fields(&input, &data.fields)?;
+            quote! {
+                let Self #pattern = self;
+                #statements
+            }
+        }
+        _ => {
+            return Err(syn::Error::new(
+                input.span(),
+                format!("`{TRAIT}` can only be derived for enums or structs"),
+            ));
+        }
+    };
+
+    Ok(quote! {
+        impl crate::tree::TreeText for #name {
+            fn text(&self) -> std::string::String {
+                let mut result = std::string::String::new();
+                #statements
+                result
+            }
+        }
+    })
+}

--- a/crates/sail-sql-parser/src/ast/data_type.rs
+++ b/crates/sail-sql-parser/src/ast/data_type.rs
@@ -1,4 +1,4 @@
-use sail_sql_macro::{TreeParser, TreeSyntax};
+use sail_sql_macro::{TreeParser, TreeSyntax, TreeText};
 
 use crate::ast::identifier::Ident;
 use crate::ast::keywords::{
@@ -16,7 +16,7 @@ use crate::combinator::{boxed, compose, sequence, unit};
 use crate::common::Sequence;
 use crate::token::TokenLabel;
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "DataType", label = TokenLabel::DataType)]
 pub enum DataType {
     Null(Null),
@@ -107,14 +107,14 @@ pub enum DataType {
     ),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum DecimalType {
     Decimal(Decimal),
     Dec(Dec),
     Numeric(Numeric),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum IntervalType {
     YearMonth(
         Interval,
@@ -129,13 +129,13 @@ pub enum IntervalType {
     Default(Interval),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum IntervalYearMonthUnit {
     Year(Year),
     Month(Month),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum IntervalDayTimeUnit {
     Day(Day),
     Hour(Hour),
@@ -144,14 +144,14 @@ pub enum IntervalDayTimeUnit {
 }
 
 #[allow(clippy::enum_variant_names)]
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum TimezoneType {
     WithTimeZone(With, Time, Zone),
     WithoutTimeZone(Without, Time, Zone),
     WithLocalTimeZone(With, Local, Time, Zone),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "DataType")]
 pub struct StructField {
     pub identifier: Ident,

--- a/crates/sail-sql-parser/src/ast/expression.rs
+++ b/crates/sail-sql-parser/src/ast/expression.rs
@@ -5,7 +5,7 @@ use chumsky::pratt::{infix, left, postfix, prefix, Operator};
 use chumsky::prelude::{any, choice};
 use chumsky::Parser;
 use either::Either;
-use sail_sql_macro::{TreeParser, TreeSyntax};
+use sail_sql_macro::{TreeParser, TreeSyntax, TreeText};
 
 use crate::ast::data_type::{DataType, IntervalDayTimeUnit, IntervalYearMonthUnit};
 use crate::ast::identifier::{Ident, ObjectName, Variable};
@@ -36,7 +36,7 @@ use crate::span::TokenSpan;
 use crate::token::{Token, TokenLabel};
 use crate::tree::TreeParser;
 
-#[derive(Debug, Clone, TreeSyntax)]
+#[derive(Debug, Clone, TreeSyntax, TreeText)]
 #[syntax(name = "Expression")]
 pub enum Expr {
     Atom(AtomExpr),
@@ -96,7 +96,7 @@ pub enum Expr {
     ),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Expr, Query, DataType)")]
 #[syntax(name = "AtomExpression")]
 pub enum AtomExpr {
@@ -227,7 +227,7 @@ pub enum AtomExpr {
     Identifier(Ident),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Query")]
 pub enum TableExpr {
     Name(ObjectName),
@@ -239,13 +239,13 @@ pub enum TableExpr {
     ),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum BooleanLiteral {
     True(True),
     False(False),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct IntervalLiteral {
     pub interval: Option<Interval>,
@@ -253,7 +253,7 @@ pub struct IntervalLiteral {
     pub value: IntervalExpr,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum IntervalExpr {
     // The multi-unit pattern must be defined before the standard pattern,
@@ -278,7 +278,7 @@ pub enum IntervalExpr {
     Literal(StringLiteral),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct IntervalValueWithUnit {
     #[parser(function = |e, _| e)]
@@ -286,7 +286,7 @@ pub struct IntervalValueWithUnit {
     pub unit: IntervalUnit,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum IntervalUnit {
     Year(Year),
     Years(Years),
@@ -308,13 +308,13 @@ pub enum IntervalUnit {
     Microseconds(Microseconds),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum IntervalQualifier {
     YearMonth(IntervalYearMonthUnit, Option<(To, IntervalYearMonthUnit)>),
     DayTime(IntervalDayTimeUnit, Option<(To, IntervalDayTimeUnit)>),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum TrimExpr {
     LeadingSpace(Leading, From, #[parser(function = |e, _| e)] Expr),
@@ -340,7 +340,7 @@ pub enum TrimExpr {
     ),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct FunctionExpr {
     pub name: ObjectName,
@@ -357,7 +357,7 @@ pub struct FunctionExpr {
     pub over_clause: Option<OverClause>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct FunctionArgumentList {
     pub left: LeftParenthesis,
@@ -368,7 +368,7 @@ pub struct FunctionArgumentList {
     pub right: RightParenthesis,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum FunctionArgument {
     Named(
@@ -379,19 +379,19 @@ pub enum FunctionArgument {
     Unnamed(#[parser(function = |e, _| e)] Expr),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum DuplicateTreatment {
     All(All),
     Distinct(Distinct),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum NullTreatment {
     RespectNulls(Respect, Nulls),
     IgnoreNulls(Ignore, Nulls),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct WithinGroupClause {
     pub within_group: (Within, Group),
@@ -402,7 +402,7 @@ pub struct WithinGroupClause {
     pub right: RightParenthesis,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct FilterClause {
     pub filter: Filter,
@@ -413,7 +413,7 @@ pub struct FilterClause {
     pub right: RightParenthesis,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct OverClause {
     pub over: Over,
@@ -421,7 +421,7 @@ pub struct OverClause {
     pub window: WindowSpec,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 #[allow(clippy::large_enum_variant)]
 pub enum WindowSpec {
@@ -438,7 +438,7 @@ pub enum WindowSpec {
 }
 
 #[allow(clippy::enum_variant_names)]
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum WindowModifier {
     ClusterBy(#[parser(function = |e, o| compose(e, o))] ClusterByClause),
@@ -448,7 +448,7 @@ pub enum WindowModifier {
     SortBy(#[parser(function = |e, o| compose(e, o))] SortByClause),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct OrderByExpr {
     #[parser(function = |e, _| e)]
@@ -457,19 +457,19 @@ pub struct OrderByExpr {
     pub nulls: Option<OrderNulls>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum OrderDirection {
     Asc(Asc),
     Desc(Desc),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum OrderNulls {
     First(Nulls, First),
     Last(Nulls, Last),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum WindowFrame {
     RangeBetween(
@@ -496,7 +496,7 @@ pub enum WindowFrame {
     ),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum WindowFrameBound {
     UnboundedPreceding(Unbounded, Preceding),
@@ -506,7 +506,7 @@ pub enum WindowFrameBound {
     Following(#[parser(function = |e, _| e)] Expr, Following),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum UnaryOperator {
     Plus(operator::Plus),
     Minus(operator::Minus),
@@ -515,7 +515,7 @@ pub enum UnaryOperator {
     LogicalNot(operator::ExclamationMark),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum BinaryOperator {
     Plus(operator::Plus),
     Minus(operator::Minus),
@@ -545,7 +545,7 @@ pub enum BinaryOperator {
     BitwiseOr(operator::VerticalBar),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct CaseWhen {
     pub when: When,
@@ -556,7 +556,7 @@ pub struct CaseWhen {
     pub result: Expr,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct CaseElse {
     pub r#else: Else,
@@ -564,26 +564,26 @@ pub struct CaseElse {
     pub result: Expr,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum LambdaFunctionParameters {
     Single(Ident),
     Multiple(LeftParenthesis, Sequence<Ident, Comma>, RightParenthesis),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum PatternQuantifier {
     All(All),
     Any(Any),
     Some(crate::ast::keywords::Some),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub struct PatternEscape {
     pub escape: Escape,
     pub value: StringLiteral,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum GroupingExpr {
     GroupingSets(
@@ -602,7 +602,7 @@ pub enum GroupingExpr {
 }
 
 // TODO: support nested grouping sets
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct GroupingSet {
     pub left: LeftParenthesis,
@@ -614,7 +614,7 @@ pub struct GroupingSet {
 // All private `struct`s or `enum`s are "internal" AST nodes used to parse expressions.
 // They are not part of the final AST.
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Expr, DataType)")]
 enum ExprModifier {
     Wildcard(Period, operator::Asterisk),
@@ -627,7 +627,7 @@ enum ExprModifier {
     Cast(DoubleColon, #[parser(function = |(_, d), _| d)] DataType),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Expr, Query)")]
 enum ExprPostfixPredicate {
     IsFalse(Is, Option<Not>, False),
@@ -650,7 +650,7 @@ enum ExprPostfixPredicate {
     ),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 enum ExprInfixPredicate {
     IsDistinctFrom(Is, Option<Not>, Distinct, From),
     Between(Option<Not>, Between),

--- a/crates/sail-sql-parser/src/ast/identifier.rs
+++ b/crates/sail-sql-parser/src/ast/identifier.rs
@@ -3,7 +3,7 @@ use chumsky::input::{Input, InputRef, ValueInput};
 use chumsky::label::LabelError;
 use chumsky::prelude::custom;
 use chumsky::Parser;
-use sail_sql_macro::{TreeParser, TreeSyntax};
+use sail_sql_macro::{TreeParser, TreeSyntax, TreeText};
 
 use crate::ast::operator::{Asterisk, Period};
 use crate::combinator::sequence;
@@ -12,7 +12,7 @@ use crate::options::ParserOptions;
 use crate::span::TokenSpan;
 use crate::string::StringValue;
 use crate::token::{Keyword, Punctuation, StringStyle, Token, TokenLabel};
-use crate::tree::{SyntaxDescriptor, SyntaxNode, TerminalKind, TreeParser, TreeSyntax};
+use crate::tree::{SyntaxDescriptor, SyntaxNode, TerminalKind, TreeParser, TreeSyntax, TreeText};
 use crate::utils::skip_whitespace;
 
 fn parse_identifier<'a, F, I, E>(
@@ -89,6 +89,12 @@ impl TreeSyntax for Ident {
     }
 }
 
+impl TreeText for Ident {
+    fn text(&self) -> String {
+        format!("{} ", self.value.clone())
+    }
+}
+
 /// A restricted identifier parser for column names.
 pub(crate) fn column_ident<'a, I, E>(
     options: &'a ParserOptions,
@@ -123,7 +129,7 @@ where
     custom(move |input| parse_identifier(input, matcher, options))
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub struct ObjectName(pub Sequence<Ident, Period>);
 
 /// A restricted object name parser.
@@ -141,7 +147,7 @@ where
     sequence(ident, Period::parser((), options)).map(ObjectName)
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub struct QualifiedWildcard(pub Sequence<Ident, Period>, pub Period, pub Asterisk);
 
 /// A named variable `$name` or `:name`, or an unnamed variable `?`.
@@ -235,6 +241,12 @@ impl TreeSyntax for Variable {
             node: SyntaxNode::Terminal(TerminalKind::Variable),
             children: vec![],
         }
+    }
+}
+
+impl TreeText for Variable {
+    fn text(&self) -> String {
+        format!("{} ", self.value)
     }
 }
 

--- a/crates/sail-sql-parser/src/ast/keywords.rs
+++ b/crates/sail-sql-parser/src/ast/keywords.rs
@@ -7,7 +7,7 @@ use chumsky::Parser;
 use crate::options::ParserOptions;
 use crate::span::TokenSpan;
 use crate::token::{Keyword, Token, TokenLabel};
-use crate::tree::{SyntaxDescriptor, SyntaxNode, TerminalKind, TreeParser, TreeSyntax};
+use crate::tree::{SyntaxDescriptor, SyntaxNode, TerminalKind, TreeParser, TreeSyntax, TreeText};
 use crate::utils::skip_whitespace;
 
 fn parse_keyword<'a, I, E>(
@@ -89,6 +89,12 @@ macro_rules! keyword_types {
                         node: SyntaxNode::Terminal(TerminalKind::Keyword(keyword)),
                         children: vec![],
                     }
+                }
+            }
+
+            impl TreeText for $name {
+                fn text(&self) -> std::string::String {
+                    format!("{} ", Self::keyword().as_str())
                 }
             }
         )*

--- a/crates/sail-sql-parser/src/ast/operator.rs
+++ b/crates/sail-sql-parser/src/ast/operator.rs
@@ -7,7 +7,7 @@ use chumsky::Parser;
 use crate::options::ParserOptions;
 use crate::span::TokenSpan;
 use crate::token::{Punctuation, Token, TokenLabel};
-use crate::tree::{SyntaxDescriptor, SyntaxNode, TerminalKind, TreeParser, TreeSyntax};
+use crate::tree::{SyntaxDescriptor, SyntaxNode, TerminalKind, TreeParser, TreeSyntax, TreeText};
 use crate::utils::skip_whitespace;
 
 fn parse_operator<'a, I, E>(
@@ -80,6 +80,13 @@ macro_rules! define_operator {
                     node: SyntaxNode::Terminal(TerminalKind::Operator(operator)),
                     children: vec![],
                 }
+            }
+        }
+
+        impl TreeText for $name {
+            fn text(&self) -> String {
+                let operator: String = Self::punctuations().iter().map(|p| p.to_char()).collect();
+                format!("{operator} ")
             }
         }
     };

--- a/crates/sail-sql-parser/src/ast/query.rs
+++ b/crates/sail-sql-parser/src/ast/query.rs
@@ -5,7 +5,7 @@ use chumsky::pratt::{infix, left};
 use chumsky::prelude::choice;
 use chumsky::Parser;
 use either::Either;
-use sail_sql_macro::{TreeParser, TreeSyntax};
+use sail_sql_macro::{TreeParser, TreeSyntax, TreeText};
 
 use crate::ast::expression::{
     DuplicateTreatment, Expr, FunctionArgument, GroupingExpr, OrderByExpr, WindowSpec,
@@ -27,7 +27,7 @@ use crate::span::TokenSpan;
 use crate::token::{Token, TokenLabel};
 use crate::tree::TreeParser;
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Query, Expr, TableWithJoins)", label = TokenLabel::Query)]
 pub struct Query {
     #[parser(function = |(q, _, _), o| compose(q, o))]
@@ -38,7 +38,7 @@ pub struct Query {
     pub modifiers: Vec<QueryModifier>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum QueryModifier {
     Window(#[parser(function = |e, o| compose(e, o))] WindowClause),
@@ -50,7 +50,7 @@ pub enum QueryModifier {
     Offset(#[parser(function = |e, o| compose(e, o))] OffsetClause),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Query")]
 pub struct WithClause {
     pub with: With,
@@ -59,7 +59,7 @@ pub struct WithClause {
     pub ctes: Sequence<NamedQuery, Comma>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Query")]
 pub struct NamedQuery {
     pub name: Ident,
@@ -71,14 +71,14 @@ pub struct NamedQuery {
     pub right: RightParenthesis,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub struct IdentList {
     pub left: LeftParenthesis,
     pub names: Sequence<Ident, Comma>,
     pub right: RightParenthesis,
 }
 
-#[derive(Debug, Clone, TreeSyntax)]
+#[derive(Debug, Clone, TreeSyntax, TreeText)]
 #[allow(clippy::large_enum_variant)]
 pub enum QueryBody {
     // FIXME: Rust 1.87 triggers `clippy::large_enum_variant` warning
@@ -139,7 +139,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum SetOperator {
     Union(Union),
     Except(Except),
@@ -147,7 +147,7 @@ pub enum SetOperator {
     Intersect(Intersect),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum SetQuantifier {
     Distinct(Distinct),
     DistinctByName(Distinct, By, Name),
@@ -156,7 +156,7 @@ pub enum SetQuantifier {
     ByName(By, Name),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Query, Expr, TableWithJoins)")]
 #[allow(clippy::large_enum_variant)]
 pub enum QueryTerm {
@@ -171,7 +171,7 @@ pub enum QueryTerm {
     ),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Query, Expr, TableWithJoins)")]
 pub struct QuerySelect {
     #[parser(function = |(_, e, _), o| compose(e, o))]
@@ -188,7 +188,7 @@ pub struct QuerySelect {
     pub having: Option<HavingClause>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct ValuesClause {
     pub values: Values,
@@ -197,7 +197,7 @@ pub struct ValuesClause {
     pub alias: Option<AliasClause>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub struct AliasClause {
     pub r#as: Option<As>,
     #[parser(function = |(), o| table_ident(o))]
@@ -205,7 +205,7 @@ pub struct AliasClause {
     pub columns: Option<IdentList>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct SelectClause {
     pub select: Select,
@@ -214,7 +214,7 @@ pub struct SelectClause {
     pub projection: Sequence<NamedExpr, Comma>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Expr, Ident)")]
 pub struct NamedExpr {
     #[parser(function = |(e, _), _| e)]
@@ -226,7 +226,7 @@ pub struct NamedExpr {
     pub alias: Option<(Option<As>, Either<Ident, IdentList>)>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct NamedExprList {
     pub left: LeftParenthesis,
@@ -237,7 +237,7 @@ pub struct NamedExprList {
     pub right: RightParenthesis,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "TableWithJoins")]
 pub struct FromClause {
     pub from: From,
@@ -245,7 +245,7 @@ pub struct FromClause {
     pub tables: Sequence<TableWithJoins, Comma>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Query, Expr, TableWithJoins)")]
 pub struct TableWithJoins {
     pub lateral: Option<Lateral>,
@@ -255,7 +255,7 @@ pub struct TableWithJoins {
     pub joins: Vec<TableJoin>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Query, Expr, TableWithJoins)")]
 #[allow(clippy::large_enum_variant)]
 pub enum TableFactor {
@@ -300,7 +300,7 @@ pub enum TableFactor {
     },
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum TemporalClause {
     Version {
@@ -319,7 +319,7 @@ pub enum TemporalClause {
     },
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct TableSampleClause {
     pub sample: Tablesample,
@@ -330,7 +330,7 @@ pub struct TableSampleClause {
     pub repeatable: Option<TableSampleRepeatable>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum TableSampleMethod {
     Percent {
@@ -351,7 +351,7 @@ pub enum TableSampleMethod {
     },
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub struct TableSampleRepeatable {
     pub repeatable: Repeatable,
     pub left: LeftParenthesis,
@@ -360,14 +360,14 @@ pub struct TableSampleRepeatable {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum TableModifier {
     Pivot(#[parser(function = |e, o| compose(e, o))] PivotClause),
     Unpivot(UnpivotClause),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct PivotClause {
     pub pivot: Pivot,
@@ -382,7 +382,7 @@ pub struct PivotClause {
     pub right: RightParenthesis,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub struct UnpivotClause {
     pub unpivot: Unpivot,
     pub nulls: Option<UnpivotNulls>,
@@ -391,13 +391,13 @@ pub struct UnpivotClause {
     pub right: RightParenthesis,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum UnpivotNulls {
     IncludeNulls(Include, Nulls),
     ExcludeNulls(Exclude, Nulls),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum UnpivotColumns {
     SingleValue {
         values: Ident,
@@ -421,7 +421,7 @@ pub enum UnpivotColumns {
     },
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct TableFunction {
     pub name: ObjectName,
@@ -431,7 +431,7 @@ pub struct TableFunction {
     pub right: RightParenthesis,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Query, Expr, TableWithJoins)")]
 pub struct TableJoin {
     // The join criteria must be absent for natural joins.
@@ -446,7 +446,7 @@ pub struct TableJoin {
     pub criteria: Option<JoinCriteria>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum JoinOperator {
     Inner(Inner),
     Cross(Cross),
@@ -465,14 +465,14 @@ pub enum JoinOperator {
     Full(Full),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum JoinCriteria {
     On(On, #[parser(function = |e, _| e)] Expr),
     Using(Using, IdentList),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct LateralViewClause {
     pub lateral_view: (Lateral, View),
@@ -490,7 +490,7 @@ pub struct LateralViewClause {
     pub columns: Option<(Option<As>, Sequence<Ident, Comma>)>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct WhereClause {
     pub r#where: Where,
@@ -498,7 +498,7 @@ pub struct WhereClause {
     pub condition: Expr,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct GroupByClause {
     pub group_by: (Group, By),
@@ -507,13 +507,13 @@ pub struct GroupByClause {
     pub modifier: Option<GroupByModifier>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum GroupByModifier {
     WithRollup(With, Rollup),
     WithCube(With, Cube),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct HavingClause {
     pub having: Having,
@@ -521,7 +521,7 @@ pub struct HavingClause {
     pub condition: Expr,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct WindowClause {
     pub window: Window,
@@ -529,7 +529,7 @@ pub struct WindowClause {
     pub items: Sequence<NamedWindow, Comma>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct NamedWindow {
     pub name: Ident,
@@ -538,7 +538,7 @@ pub struct NamedWindow {
     pub window: WindowSpec,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct OrderByClause {
     pub order_by: (Order, By),
@@ -546,7 +546,7 @@ pub struct OrderByClause {
     pub items: Sequence<OrderByExpr, Comma>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct SortByClause {
     pub sort_by: (Sort, By),
@@ -554,7 +554,7 @@ pub struct SortByClause {
     pub items: Sequence<OrderByExpr, Comma>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct ClusterByClause {
     pub cluster_by: (Cluster, By),
@@ -562,7 +562,7 @@ pub struct ClusterByClause {
     pub items: Sequence<Expr, Comma>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct PartitionByClause {
     pub partition_by: (Partition, By),
@@ -570,7 +570,7 @@ pub struct PartitionByClause {
     pub items: Sequence<Expr, Comma>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct DistributeByClause {
     pub distribute_by: (Distribute, By),
@@ -578,7 +578,7 @@ pub struct DistributeByClause {
     pub items: Sequence<Expr, Comma>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct LimitClause {
     pub limit: Limit,
@@ -586,7 +586,7 @@ pub struct LimitClause {
     pub value: LimitValue,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 #[allow(clippy::large_enum_variant)]
 pub enum LimitValue {
@@ -595,7 +595,7 @@ pub enum LimitValue {
     Value(#[parser(function = |e, _| e)] Expr),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct OffsetClause {
     pub offset: Offset,

--- a/crates/sail-sql-parser/src/ast/statement.rs
+++ b/crates/sail-sql-parser/src/ast/statement.rs
@@ -1,5 +1,5 @@
 use either::Either;
-use sail_sql_macro::{TreeParser, TreeSyntax};
+use sail_sql_macro::{TreeParser, TreeSyntax, TreeText};
 
 use crate::ast;
 use crate::ast::data_type::DataType;
@@ -28,7 +28,7 @@ use crate::combinator::{compose, sequence, unit};
 use crate::common::Sequence;
 use crate::token::TokenLabel;
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Statement, Query, Expr, DataType)", label = TokenLabel::Statement)]
 #[allow(clippy::large_enum_variant)]
 pub enum Statement {
@@ -339,7 +339,7 @@ pub enum Statement {
     },
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum ExplainFormat {
     Extended(Extended),
     Codegen(Codegen),
@@ -349,46 +349,46 @@ pub enum ExplainFormat {
     Verbose(Verbose),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub struct PropertyList {
     pub left: LeftParenthesis,
     pub properties: Sequence<PropertyKeyValue, Comma>,
     pub right: RightParenthesis,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub struct PropertyKeyList {
     pub left: LeftParenthesis,
     pub properties: Sequence<PropertyKey, Comma>,
     pub right: RightParenthesis,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub struct PropertyKeyValue {
     pub key: PropertyKey,
     pub value: Option<(Option<Equals>, PropertyValue)>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum PropertyKey {
     Name(ObjectName),
     Literal(StringLiteral),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum PropertyValue {
     String(StringLiteral),
     Number(Option<Either<Plus, Minus>>, NumberLiteral),
     Boolean(BooleanLiteral),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum AlterDatabaseOperation {
     SetProperties(Set, Either<Dbproperties, Properties>, PropertyList),
     SetLocation(Set, Location, StringLiteral),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Query")]
 pub struct AsQueryClause {
     pub r#as: Option<As>,
@@ -396,7 +396,7 @@ pub struct AsQueryClause {
     pub query: Query,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Expr, DataType)")]
 pub struct ColumnDefinitionList {
     pub left: LeftParenthesis,
@@ -405,7 +405,7 @@ pub struct ColumnDefinitionList {
     pub right: RightParenthesis,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Expr, DataType)")]
 pub struct ColumnDefinition {
     pub name: Ident,
@@ -415,7 +415,7 @@ pub struct ColumnDefinition {
     pub options: Vec<ColumnDefinitionOption>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum ColumnDefinitionOption {
     NotNull(Not, Null),
@@ -431,7 +431,7 @@ pub enum ColumnDefinitionOption {
     Comment(Comment, StringLiteral),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "DataType")]
 pub struct ColumnTypeDefinition {
     pub name: Ident,
@@ -442,7 +442,7 @@ pub struct ColumnTypeDefinition {
     pub comment: Option<(Comment, StringLiteral)>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "DataType")]
 #[allow(clippy::large_enum_variant)]
 pub enum PartitionColumn {
@@ -451,7 +451,7 @@ pub enum PartitionColumn {
     Name(Ident),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "DataType")]
 pub struct PartitionColumnList {
     pub left: LeftParenthesis,
@@ -460,7 +460,7 @@ pub struct PartitionColumnList {
     pub right: RightParenthesis,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct PartitionClause {
     pub partition: Partition,
@@ -468,7 +468,7 @@ pub struct PartitionClause {
     pub values: PartitionValueList,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct PartitionValue {
     pub column: Ident,
@@ -476,7 +476,7 @@ pub struct PartitionValue {
     pub value: Option<(Equals, Expr)>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct PartitionValueList {
     pub left: LeftParenthesis,
@@ -485,14 +485,14 @@ pub struct PartitionValueList {
     pub right: RightParenthesis,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum CreateDatabaseClause {
     Comment(Comment, StringLiteral),
     Location(Location, StringLiteral),
     Properties(With, Either<Dbproperties, Properties>, PropertyList),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "DataType")]
 pub enum CreateTableClause {
     /// The `PARTITIONED BY` clause for table.
@@ -528,20 +528,20 @@ pub enum CreateTableClause {
     Properties(Tblproperties, PropertyList),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub struct SortColumnList {
     pub left: LeftParenthesis,
     pub columns: Sequence<SortColumn, Comma>,
     pub right: RightParenthesis,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub struct SortColumn {
     pub column: Ident,
     pub direction: Option<OrderDirection>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum RowFormat {
     Serde {
         serde: Serde,
@@ -554,7 +554,7 @@ pub enum RowFormat {
     },
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum RowFormatDelimitedClause {
     Fields(
         Fields,
@@ -569,25 +569,25 @@ pub enum RowFormatDelimitedClause {
     Null(Null, Defined, As, StringLiteral),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum FileFormat {
     Table(Inputformat, StringLiteral, Outputformat, StringLiteral),
     General(Ident),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum CreateViewClause {
     Comment(Comment, StringLiteral),
     Properties(Tblproperties, PropertyList),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub struct ViewColumn {
     pub name: Ident,
     pub comment: Option<(Comment, StringLiteral)>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Expr, DataType)")]
 pub enum AlterTableOperation {
     RenameTable {
@@ -678,7 +678,7 @@ pub enum AlterTableOperation {
     },
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Query, Expr)")]
 pub enum AlterViewOperation {
     RenameView {
@@ -700,7 +700,7 @@ pub enum AlterViewOperation {
     Query(#[parser(function = |(q, _), o| compose(q, o))] AsQueryClause),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Expr, DataType)")]
 pub enum AlterColumnOperation {
     Type(Type, #[parser(function = |(_, d), _| d)] DataType),
@@ -712,7 +712,7 @@ pub enum AlterColumnOperation {
     DropDefault(Drop, Default),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Expr, DataType)")]
 pub enum ColumnAlterationList {
     Delimited {
@@ -727,7 +727,7 @@ pub enum ColumnAlterationList {
     },
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Expr, DataType)")]
 pub struct ColumnAlteration {
     pub name: ObjectName,
@@ -737,7 +737,7 @@ pub struct ColumnAlteration {
     pub options: Vec<ColumnAlterationOption>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum ColumnAlterationOption {
     NotNull(Not, Null),
@@ -746,13 +746,13 @@ pub enum ColumnAlterationOption {
     Position(ColumnPosition),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum ColumnPosition {
     First(First),
     After(After, ObjectName),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum ColumnDropList {
     Delimited {
         left: LeftParenthesis,
@@ -765,7 +765,7 @@ pub enum ColumnDropList {
 }
 
 #[allow(clippy::large_enum_variant)]
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum InsertDirectoryDestination {
     Spark {
         path: Option<StringLiteral>,
@@ -779,7 +779,7 @@ pub enum InsertDirectoryDestination {
     },
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Query")]
 pub enum MergeSource {
     Table {
@@ -795,7 +795,7 @@ pub enum MergeSource {
     },
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum MergeMatchClause {
     Matched {
@@ -831,7 +831,7 @@ pub enum MergeMatchClause {
     },
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum MergeMatchedAction {
     Delete(Delete),
@@ -843,7 +843,7 @@ pub enum MergeMatchedAction {
     ),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum MergeNotMatchedBySourceAction {
     Delete(Delete),
@@ -854,7 +854,7 @@ pub enum MergeNotMatchedBySourceAction {
     ),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum MergeNotMatchedByTargetAction {
     InsertAll(Insert, Asterisk),
@@ -869,7 +869,7 @@ pub enum MergeNotMatchedByTargetAction {
     },
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub struct UpdateTableAlias {
     pub r#as: Option<As>,
     #[parser(function = |(), o| table_ident(o))]
@@ -877,7 +877,7 @@ pub struct UpdateTableAlias {
     pub columns: Option<IdentList>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct SetClause {
     pub set: Set,
@@ -885,7 +885,7 @@ pub struct SetClause {
     pub assignments: AssignmentList,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub enum AssignmentList {
     Delimited {
@@ -900,7 +900,7 @@ pub enum AssignmentList {
     },
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "Expr")]
 pub struct Assignment {
     pub target: ObjectName,
@@ -909,7 +909,7 @@ pub struct Assignment {
     pub value: Expr,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub struct DeleteTableAlias {
     pub r#as: Option<As>,
     #[parser(function = |(), o| table_ident(o))]
@@ -917,14 +917,14 @@ pub struct DeleteTableAlias {
     pub columns: Option<IdentList>,
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum AnalyzeTableModifier {
     NoScan(Noscan),
     ForAllColumns(For, All, Columns),
     ForColumns(For, Columns, Sequence<ObjectName, Comma>),
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 #[parser(dependency = "(Query, Expr)")]
 pub enum DescribeItem {
     // We need to try `DESCRIBE QUERY` first since the `QUERY` keyword
@@ -960,7 +960,7 @@ pub enum DescribeItem {
     },
 }
 
-#[derive(Debug, Clone, TreeParser, TreeSyntax)]
+#[derive(Debug, Clone, TreeParser, TreeSyntax, TreeText)]
 pub enum CommentValue {
     NotNull(StringLiteral),
     Null(Null),

--- a/crates/sail-sql-parser/src/container/box.rs
+++ b/crates/sail-sql-parser/src/container/box.rs
@@ -1,6 +1,6 @@
 use std::any::TypeId;
 
-use crate::tree::{SyntaxDescriptor, SyntaxNode, TreeSyntax};
+use crate::tree::{SyntaxDescriptor, SyntaxNode, TreeSyntax, TreeText};
 
 impl<T> TreeSyntax for Box<T>
 where
@@ -12,5 +12,14 @@ where
             node: SyntaxNode::NonTerminal(TypeId::of::<T>()),
             children: vec![(TypeId::of::<T>(), Box::new(T::syntax))],
         }
+    }
+}
+
+impl<T> TreeText for Box<T>
+where
+    T: TreeText,
+{
+    fn text(&self) -> String {
+        self.as_ref().text()
     }
 }

--- a/crates/sail-sql-parser/src/container/either.rs
+++ b/crates/sail-sql-parser/src/container/either.rs
@@ -7,7 +7,7 @@ use either::Either;
 
 use crate::combinator::either_or;
 use crate::options::ParserOptions;
-use crate::tree::{SyntaxDescriptor, SyntaxNode, TreeParser, TreeSyntax};
+use crate::tree::{SyntaxDescriptor, SyntaxNode, TreeParser, TreeSyntax, TreeText};
 
 impl<'a, L, R, I, E, A> TreeParser<'a, I, E, A> for Either<L, R>
 where
@@ -38,6 +38,19 @@ where
                 (TypeId::of::<L>(), Box::new(L::syntax)),
                 (TypeId::of::<R>(), Box::new(R::syntax)),
             ],
+        }
+    }
+}
+
+impl<L, R> TreeText for Either<L, R>
+where
+    L: TreeText,
+    R: TreeText,
+{
+    fn text(&self) -> String {
+        match self {
+            Either::Left(l) => l.text(),
+            Either::Right(r) => r.text(),
         }
     }
 }

--- a/crates/sail-sql-parser/src/container/option.rs
+++ b/crates/sail-sql-parser/src/container/option.rs
@@ -5,7 +5,7 @@ use chumsky::prelude::Input;
 use chumsky::Parser;
 
 use crate::options::ParserOptions;
-use crate::tree::{SyntaxDescriptor, SyntaxNode, TreeParser, TreeSyntax};
+use crate::tree::{SyntaxDescriptor, SyntaxNode, TreeParser, TreeSyntax, TreeText};
 
 impl<'a, T, I, E, A> TreeParser<'a, I, E, A> for Option<T>
 where
@@ -28,6 +28,18 @@ where
             name: format!("Option({})", child.name),
             node: SyntaxNode::Optional(Box::new(SyntaxNode::NonTerminal(TypeId::of::<T>()))),
             children: vec![(TypeId::of::<T>(), Box::new(T::syntax))],
+        }
+    }
+}
+
+impl<T> TreeText for Option<T>
+where
+    T: TreeText,
+{
+    fn text(&self) -> String {
+        match self {
+            Some(t) => t.text(),
+            None => String::new(),
         }
     }
 }

--- a/crates/sail-sql-parser/src/container/sequence.rs
+++ b/crates/sail-sql-parser/src/container/sequence.rs
@@ -7,7 +7,7 @@ use chumsky::Parser;
 use crate::combinator::sequence;
 use crate::common::Sequence;
 use crate::options::ParserOptions;
-use crate::tree::{SyntaxDescriptor, SyntaxNode, TreeParser, TreeSyntax};
+use crate::tree::{SyntaxDescriptor, SyntaxNode, TreeParser, TreeSyntax, TreeText};
 
 impl<'a, T, S, I, E, A> TreeParser<'a, I, E, A> for Sequence<T, S>
 where
@@ -42,5 +42,21 @@ where
                 (TypeId::of::<S>(), Box::new(S::syntax)),
             ],
         }
+    }
+}
+
+impl<T, S> TreeText for Sequence<T, S>
+where
+    T: TreeText,
+    S: TreeText,
+{
+    fn text(&self) -> String {
+        let mut result = String::new();
+        result.push_str(&self.head.text());
+        for (sep, item) in &self.tail {
+            result.push_str(&sep.text());
+            result.push_str(&item.text());
+        }
+        result
     }
 }

--- a/crates/sail-sql-parser/src/container/tuple.rs
+++ b/crates/sail-sql-parser/src/container/tuple.rs
@@ -6,7 +6,7 @@ use chumsky::Parser;
 use paste::paste;
 
 use crate::options::ParserOptions;
-use crate::tree::{SyntaxDescriptor, SyntaxNode, TreeParser, TreeSyntax};
+use crate::tree::{SyntaxDescriptor, SyntaxNode, TreeParser, TreeSyntax, TreeText};
 
 macro_rules! nested {
     (@fold $acc:tt) => { $acc };
@@ -54,6 +54,24 @@ macro_rules! impl_tree_parser_for_tuple {
                         $(,(TypeId::of::<$Ts>(), Box::new($Ts::syntax)))*
                     ],
                 }
+            }
+        }
+
+        impl<$T $(,$Ts)*> TreeText for ($T, $($Ts,)*)
+        where
+            $T: TreeText
+            $(,$Ts: TreeText)*
+        {
+            fn text(&self) -> String {
+                let mut result = String::new();
+                paste! {
+                    let ([<$T:lower>], $([<$Ts:lower>],)*) = self;
+                    result.push_str(&[<$T:lower>].text());
+                    $(
+                        result.push_str(&[<$Ts:lower>].text());
+                    )*
+                }
+                result
             }
         }
     };

--- a/crates/sail-sql-parser/src/container/vec.rs
+++ b/crates/sail-sql-parser/src/container/vec.rs
@@ -5,7 +5,7 @@ use chumsky::prelude::Input;
 use chumsky::{IterParser, Parser};
 
 use crate::options::ParserOptions;
-use crate::tree::{SyntaxDescriptor, SyntaxNode, TreeParser, TreeSyntax};
+use crate::tree::{SyntaxDescriptor, SyntaxNode, TreeParser, TreeSyntax, TreeText};
 
 impl<'a, T, I, E, A> TreeParser<'a, I, E, A> for Vec<T>
 where
@@ -29,5 +29,18 @@ where
             node: SyntaxNode::ZeroOrMore(Box::new(SyntaxNode::NonTerminal(TypeId::of::<T>()))),
             children: vec![(TypeId::of::<T>(), Box::new(T::syntax))],
         }
+    }
+}
+
+impl<T> TreeText for Vec<T>
+where
+    T: TreeText,
+{
+    fn text(&self) -> String {
+        let mut result = String::new();
+        for item in self {
+            result.push_str(&item.text());
+        }
+        result
     }
 }

--- a/crates/sail-sql-parser/src/tree/mod.rs
+++ b/crates/sail-sql-parser/src/tree/mod.rs
@@ -1,5 +1,7 @@
 mod parser;
 mod syntax;
+mod text;
 
 pub use parser::*;
 pub use syntax::*;
+pub use text::*;

--- a/crates/sail-sql-parser/src/tree/text.rs
+++ b/crates/sail-sql-parser/src/tree/text.rs
@@ -1,0 +1,8 @@
+/// A trait for converting AST nodes to their text representation.
+pub trait TreeText {
+    /// Returns the corresponding text of the AST node.
+    /// The text must form a valid input that can be parsed to the same AST node.
+    /// If the text is non-empty, it must end with a whitespace character
+    /// so that the texts of multiple AST nodes can be concatenated easily.
+    fn text(&self) -> String;
+}


### PR DESCRIPTION
This PR implements a trait and a corresponding procedural macro to "unparse" SQL AST as SQL text. This will be used to support the `CREATE VIEW` statement since we need to store the SQL text in the catalog.