### PR TITLE
fix: work around dependabot regression

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
     target-branch: main
     groups:
       all:
-        patterns:
-          - "*"
         update-types:
           - "minor"
           - "patch"
@@ -36,8 +34,6 @@ updates:
     target-branch: main
     groups:
       all:
-        patterns:
-          - "*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
The dependabot bug has caused individual PRs to be created for each package upgrade in the past few weeks. This PR tries to mitigate the issue since the root cause is not fixed upstream yet.

Reference: <https://github.com/dependabot/dependabot-core/issues/13154>