### PR TITLE
chore: execution configs

### DIFF
--- a/crates/sail-common/src/config/application.rs
+++ b/crates/sail-common/src/config/application.rs
@@ -166,6 +166,7 @@ mod retry_strategy {
 pub struct ExecutionConfig {
     pub batch_size: usize,
     pub collect_statistics: bool,
+    pub use_row_number_estimates_to_optimize_partitioning: bool,
     pub file_listing_cache: FileListingCacheConfig,
 }
 

--- a/crates/sail-common/src/config/application.yaml
+++ b/crates/sail-common/src/config/application.yaml
@@ -195,7 +195,7 @@
 
 - key: execution.batch_size
   type: number
-  default: "16384"
+  default: "8192"
   description: The batch size for physical plan execution.
   experimental: true
 
@@ -206,6 +206,14 @@
     Should statistics be collected when first creating a table.
     This can slow down the initial DataFrame creation while greatly accelerating queries with certain filters.
     Has no effect after the table is created.
+  experimental: true
+
+- key: execution.use_row_number_estimates_to_optimize_partitioning
+  type: boolean
+  default: "false"
+  description: |
+    Should Sail use row number estimates at the input to decide whether increasing parallelism is beneficial or not.
+    By default, only exact row numbers (not estimates) are used for this decision.
   experimental: true
 
 - key: execution.file_listing_cache.type
@@ -474,7 +482,7 @@
 
 - key: parquet.maximum_buffered_record_batches_per_stream
   type: number
-  default: "32"
+  default: "16"
   description: |
     (Writing) The maximum number of buffered record batches per stream for the Parquet writer.
     This may improve performance when writing large Parquet files,

--- a/crates/sail-spark-connect/src/session_manager.rs
+++ b/crates/sail-spark-connect/src/session_manager.rs
@@ -122,6 +122,10 @@ impl SessionManagerActor {
 
             execution.batch_size = options.config.execution.batch_size;
             execution.collect_statistics = options.config.execution.collect_statistics;
+            execution.use_row_number_estimates_to_optimize_partitioning = options
+                .config
+                .execution
+                .use_row_number_estimates_to_optimize_partitioning;
             execution.listing_table_ignore_subdirectory = false;
         }
 


### PR DESCRIPTION
- `execution.use_row_number_estimates_to_optimize_partitioning` now exposed
- `execution.batch_size` has a high default and could be contributing to OOMs
- `parquet.maximum_buffered_record_batches_per_stream` has a high default and could be contributing to OOMs