### PR TITLE
fix: only use rename table provider if necessary

### DIFF
--- a/crates/sail-plan/src/resolver/query/misc.rs
+++ b/crates/sail-plan/src/resolver/query/misc.rs
@@ -1,14 +1,11 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use datafusion::catalog::MemTable;
-use datafusion::datasource::{provider_as_source, TableProvider};
 use datafusion_common::{DFSchema, DFSchemaRef, ParamValues};
-use datafusion_expr::{EmptyRelation, Extension, LogicalPlan, TableScan, UNNAMED_TABLE};
+use datafusion_expr::{EmptyRelation, Extension, LogicalPlan, UNNAMED_TABLE};
 use sail_common::spec;
 use sail_common_datafusion::array::record_batch::{cast_record_batch, read_record_batches};
-use sail_common_datafusion::rename::logical_plan::rename_logical_plan;
-use sail_common_datafusion::rename::table_provider::RenameTableProvider;
 use sail_logical_plan::range::RangeNode;
 
 use crate::error::{PlanError, PlanResult};
@@ -121,32 +118,14 @@ impl PlanResolver<'_> {
             return Err(PlanError::invalid("missing schema for local relation"));
         };
         let table_provider = Arc::new(MemTable::try_new(schema, vec![batches])?);
-        let schema = table_provider.schema();
-        let has_duplicates = {
-            let mut seen = HashSet::new();
-            schema.fields().iter().any(|f| !seen.insert(f.name()))
-        };
-        if has_duplicates {
-            let names = state.register_fields(schema.fields());
-            let provider = Arc::new(RenameTableProvider::try_new(table_provider, names.clone())?);
-            Ok(LogicalPlan::TableScan(TableScan::try_new(
-                UNNAMED_TABLE,
-                provider_as_source(provider),
-                None,
-                vec![],
-                None,
-            )?))
-        } else {
-            let table_scan = LogicalPlan::TableScan(TableScan::try_new(
-                UNNAMED_TABLE,
-                provider_as_source(table_provider),
-                None,
-                vec![],
-                None,
-            )?);
-            let names = state.register_fields(table_scan.schema().fields());
-            Ok(rename_logical_plan(table_scan, &names)?)
-        }
+        self.resolve_table_provider_with_rename(
+            table_provider,
+            UNNAMED_TABLE,
+            None,
+            vec![],
+            None,
+            state,
+        )
     }
 
     pub(super) async fn resolve_query_hint(


### PR DESCRIPTION
Using `RenameTableProvider` causes predicate pushdown to be lost. As a temporary workaround, use `RenameTableProvider` only when duplicate field names are detected in the schema.

Future work should address the underlying issue in `RenameTableProvider`.