### PR TITLE
fix: remove the `auto-initialize` feature for PyO3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,8 +145,7 @@ datafusion-spark = { version = "50.3.0" }
 datafusion-functions-json = { git = "https://github.com/lakehq/datafusion-functions-json.git", rev = "db8e357" }
 # The `pyo3` version must match the one used in `arrow-pyarrow` (replace `RELEASE` with the release we are using):
 #   https://github.com/apache/arrow-rs/blob/RELEASE/arrow-pyarrow/Cargo.toml
-# auto-initialize: Changes [`Python::with_gil`] to automatically initialize the Python interpreter if needed.
-pyo3 = { version = "0.25.1", features = ["auto-initialize", "serde"] }
+pyo3 = { version = "0.25.1", features = ["serde"] }
 arrow = { version = "56.2.0", features = ["chrono-tz"] }
 arrow-buffer = { version = "56.2.0" }
 arrow-schema = { version = "56.2.0", features = ["serde"] }

--- a/crates/sail-cli/src/main.rs
+++ b/crates/sail-cli/src/main.rs
@@ -31,6 +31,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         // the Python interpreter. When the Sail CLI runs as a standalone binary, the
         // Python interpreter is embedded and `sys.executable` points to the Sail binary.
         std::env::set_var(CliConfigEnv::RUN_PYTHON, "true");
+        // Initialize the Python interpreter.
+        pyo3::prepare_freethreaded_python();
         let args = std::env::args().collect();
         match sail_cli::runner::main(args) {
             Ok(()) => {}


### PR DESCRIPTION
The `auto-initialize` feature in PyO3 requires the Python shared library to be available. But Python extension modules are not expected to build against the shared library.

We enable `auto-initialize` since our very earliest integration with PyO3 (#14) but we never realized this issue. This finally breaks this week, possibly due to changes in the `quay.io/pypa/manylinux2014_x86_64` image used by `PyO3/maturin-action` (although the actual root cause remains unknown).

So the fix in this PR contains two aspects:
1. Remove the `auto-initialize` feature since it's not needed for the Python wheel anyway. And the wheel cannot built in our release workflow with this feature on.
2. Add the logic to explicitly initialize the Python interpreter when running Sail as a standalone binary.

I guess we didn't do this when we first integrated with PyO3 because the story for our entrypoints was not clear at that time. But now we have the separation of the `sail-cli` and `sail-python` crate, the initialization logic is pretty straightforward to reason about.

See also: <https://github.com/PyO3/maturin-action/issues/383>