### PR TITLE
feat: allow `EXPLAIN` for SQL statements

### DIFF
--- a/crates/sail-common/src/spec/plan.rs
+++ b/crates/sail-common/src/spec/plan.rs
@@ -413,7 +413,7 @@ pub enum CommandNode {
     Explain {
         // TODO: Support stringified_plans
         mode: ExplainMode,
-        input: Box<QueryPlan>,
+        input: Box<Plan>,
     },
     InsertInto {
         input: Box<QueryPlan>,

--- a/crates/sail-spark-connect/src/service/plan_analyzer.rs
+++ b/crates/sail-spark-connect/src/service/plan_analyzer.rs
@@ -69,7 +69,7 @@ pub(crate) async fn handle_analyze_explain(
     let explain_mode = ExplainMode::try_from(explain_mode)?;
     let explain = spec::Plan::Command(spec::CommandPlan::new(spec::CommandNode::Explain {
         mode: explain_mode.try_into()?,
-        input: Box::new(plan.try_into()?),
+        input: Box::new(spec::Plan::Query(plan.try_into()?)),
     }));
     let (plan, _) = resolve_and_execute_plan(ctx, spark.plan_config()?, explain).await?;
     let stream = spark.job_runner().execute(ctx, plan).await?;

--- a/crates/sail-spark-connect/tests/gold_data/plan/plan_explain.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/plan_explain.json
@@ -9,24 +9,26 @@
             "explain": {
               "mode": "formatted",
               "input": {
-                "project": {
-                  "input": {
-                    "empty": {
-                      "produceOneRow": true
+                "query": {
+                  "project": {
+                    "input": {
+                      "empty": {
+                        "produceOneRow": true
+                      },
+                      "planId": null
                     },
-                    "planId": null
-                  },
-                  "expressions": [
-                    {
-                      "literal": {
-                        "int32": {
-                          "value": 1
+                    "expressions": [
+                      {
+                        "literal": {
+                          "int32": {
+                            "value": 1
+                          }
                         }
                       }
-                    }
-                  ]
-                },
-                "planId": null
+                    ]
+                  },
+                  "planId": null
+                }
               }
             },
             "planId": null
@@ -38,7 +40,7 @@
       "input": "EXPLAIN logical SELECT 1",
       "exception": "\n[INVALID_SQL_SYNTAX.UNSUPPORTED_SQL_STATEMENT] Invalid SQL syntax: Unsupported SQL statement: EXPLAIN logical SELECT 1. SQLSTATE: 42000\n== SQL (line 1, position 1) ==\nEXPLAIN logical SELECT 1\n^^^^^^^^^^^^^^^^^^^^^^^^\n",
       "output": {
-        "failure": "invalid argument: found logical at 8:15 expected 'EXTENDED', 'CODEGEN', 'COST', 'FORMATTED', 'ANALYZE', 'VERBOSE', or query"
+        "failure": "invalid argument: found logical at 8:15 expected 'EXTENDED', 'CODEGEN', 'COST', 'FORMATTED', 'ANALYZE', 'VERBOSE', or statement"
       }
     }
   ]

--- a/crates/sail-sql-analyzer/src/statement.rs
+++ b/crates/sail-sql-analyzer/src/statement.rs
@@ -429,13 +429,13 @@ pub fn from_ast_statement(statement: Statement) -> SqlResult<spec::Plan> {
         Statement::Explain {
             explain: _,
             format,
-            query,
+            statement,
         } => {
             let mode = from_ast_explain_format(format)?;
-            let query = from_ast_query(query)?;
+            let statement = from_ast_statement(*statement)?;
             let node = spec::CommandNode::Explain {
                 mode,
-                input: Box::new(query),
+                input: Box::new(statement),
             };
             Ok(spec::Plan::Command(spec::CommandPlan::new(node)))
         }

--- a/crates/sail-sql-parser/src/ast/statement.rs
+++ b/crates/sail-sql-parser/src/ast/statement.rs
@@ -24,7 +24,7 @@ use crate::ast::operator::{
     Asterisk, Colon, Comma, Equals, ExclamationMark, LeftParenthesis, Minus, Plus, RightParenthesis,
 };
 use crate::ast::query::{AliasClause, IdentList, Query, WhereClause};
-use crate::combinator::{compose, sequence, unit};
+use crate::combinator::{boxed, compose, sequence, unit};
 use crate::common::Sequence;
 use crate::token::TokenLabel;
 
@@ -191,8 +191,8 @@ pub enum Statement {
     Explain {
         explain: Explain,
         format: Option<ExplainFormat>,
-        #[parser(function = |(_, q, _, _), _| q)]
-        query: Query,
+        #[parser(function = |(s, _, _, _), _| boxed(s))]
+        statement: Box<Statement>,
     },
     InsertOverwriteDirectory {
         insert: Insert,

--- a/crates/sail-sql-parser/tests/gold_data/syntax.json
+++ b/crates/sail-sql-parser/tests/gold_data/syntax.json
@@ -1149,6 +1149,12 @@
               }
             },
             {
+              "name": "Box(Statement)",
+              "node": {
+                "nonTerminal": "Statement"
+              }
+            },
+            {
               "name": "Box(TableWithJoins)",
               "node": {
                 "nonTerminal": "TableWithJoins"
@@ -9162,7 +9168,7 @@
                         "nonTerminal": "Option(ExplainFormat)"
                       },
                       {
-                        "nonTerminal": "Query"
+                        "nonTerminal": "Box(Statement)"
                       }
                     ]
                   },


### PR DESCRIPTION
Currently we only allow `EXPLAIN` for queries. This PR extends this behavior to support `EXPLAIN` for all SQL statements.

After this PR, it becomes obvious that the current approach for handling SQL commands via "logical plan execution" has its drawback. SQL statements such as `EXPLAIN SHOW TABLES` will display an error for the physical plan since the command is already "executed" before physical planning. A better approach would be requiring all side-effects (e.g. catalog operations) to happen in physical execution. This is how Spark supports SQL commands as well.