### PR TITLE
fix: assertion message

### DIFF
--- a/crates/sail-delta-lake/src/operations/write/stats.rs
+++ b/crates/sail-delta-lake/src/operations/write/stats.rs
@@ -371,7 +371,7 @@ impl StatsScalar {
 
 /// Performs big endian sign extension
 pub fn sign_extend_be<const N: usize>(b: &[u8]) -> [u8; N] {
-    assert!(b.len() <= N, "Array too large, expected less than {N}");
+    assert!(b.len() <= N, "Array too large, expected at most {N}");
     let is_negative = (b[0] & 128u8) == 128u8;
     let mut result = if is_negative { [255u8; N] } else { [0u8; N] };
     for (d, s) in result.iter_mut().skip(N - b.len()).zip(b) {


### PR DESCRIPTION
In assertion `assert!(b.len() <= N, "Array too large, expected less than {N}");`, the predicate is b.len() <= N while the message requires b.len() < N, the message should be fixed into "expected at most {N}".