### PR TITLE
feat: make it possible to pass customised k8s labels to sail workers

### DIFF
--- a/k8s/test-volume-patch.yaml
+++ b/k8s/test-volume-patch.yaml
@@ -25,6 +25,13 @@ spec:
             - name: SAIL_KUBERNETES__WORKER_POD_TEMPLATE
               value: |
                 {
+                  "metadata": {
+                    "labels": {
+                      "custom-label": "sail-worker",
+                      "environment": "development",
+                      "component": "spark-worker"
+                    }
+                  },
                   "spec": {
                     "volumes": [
                       {


### PR DESCRIPTION
Make it possible to pass customised k8s labels to sail workers

Previously the pod labels for sail workers are limited to:

```
app.kubernetes.io/name
app.kubernetes.io/component
app.kubernetes.io/name
```

Defined at `crates/sail-execution/src/worker_manager/kubernetes.rs:92::build_pod_labels`

After this change, it is possible to specify k8s labels in the sail worker pod template, and labels got eventually rendered at the k8s pod yaml. 

Verified on a local docker kind cluster:

```
❯ k describe pod sail-worker-otz7h441ap-1 -n sail
Name:             sail-worker-otz7h441ap-1
Namespace:        sail
Priority:         0
Service Account:  sail-user
Node:             sail-control-plane/172.18.0.2
Start Time:       Mon, 01 Dec 2025 21:05:05 +0100
Labels:           app.kubernetes.io/component=worker
                  app.kubernetes.io/instance=otz7h441ap-1
                  app.kubernetes.io/name=sail
                  component=spark-worker
                  custom-label=sail-worker
                  environment=development
```

With sail worker pod template with additional labels:

```
                  "metadata": {
                    "labels": {
                      "custom-label": "sail-worker",
                      "environment": "development",
                      "component": "spark-worker"
                    }
                  },
```