### PR TITLE
fix: refine shuffle consumption planning

### DIFF
--- a/crates/sail-execution/src/driver/planner.rs
+++ b/crates/sail-execution/src/driver/planner.rs
@@ -73,14 +73,14 @@ fn build_job_graph(
         match join.mode {
             PartitionMode::Partitioned => {
                 vec![
-                    build_job_graph(left.clone(), PartitionUsage::Once, graph)?,
-                    build_job_graph(right.clone(), PartitionUsage::Once, graph)?,
+                    build_job_graph(left.clone(), usage, graph)?,
+                    build_job_graph(right.clone(), usage, graph)?,
                 ]
             }
             PartitionMode::CollectLeft => {
                 vec![
                     build_job_graph(left.clone(), PartitionUsage::Shared, graph)?,
-                    build_job_graph(right.clone(), PartitionUsage::Once, graph)?,
+                    build_job_graph(right.clone(), usage, graph)?,
                 ]
             }
             PartitionMode::Auto => {
@@ -96,7 +96,7 @@ fn build_job_graph(
         let (left, right) = plan.children().two()?;
         vec![
             build_job_graph(left.clone(), PartitionUsage::Shared, graph)?,
-            build_job_graph(right.clone(), PartitionUsage::Once, graph)?,
+            build_job_graph(right.clone(), usage, graph)?,
         ]
     } else if plan.as_any().is::<RepartitionExec>() || plan.as_any().is::<CoalescePartitionsExec>()
     {


### PR DESCRIPTION
In #316 we supported consuming shuffle data multiple times via memory streams, but we didn't look into why the shuffle data can be consumed multiple times. When revisiting our distributed execution code and studying DataFusion source code, I realized that this happens not because of `CoalescePartitionsExec` but is due to build-side data (which happens to be a `CoalescePartitionsExec` in many cases) for join operations. This PR refines the shuffle planning logic to take this into account.

This PR has two additional fixes for shuffle planning:
1. Support all partitioning modes for `RepartitionExec`.
2. Fix incorrect shuffle partitioning for `CoalescePartitionsExec`.

The changes are covered by running TPC-H and TPC-DS queries in cluster mode locally. 