### PR TITLE
fix: get optional Spark config

### DIFF
--- a/crates/sail-spark-connect/src/config.rs
+++ b/crates/sail-spark-connect/src/config.rs
@@ -93,19 +93,30 @@ impl SparkRuntimeConfig {
         )))
     }
 
+    pub(crate) fn get_option(&self, key: &str) -> Option<&str> {
+        if let Some(value) = self.get_by_key(key) {
+            return Some(value);
+        }
+        let entry = SPARK_CONFIG.get(key);
+        if let Some(fallback) = entry.and_then(|x| x.fallback) {
+            return self.get_option(fallback);
+        }
+        entry.and_then(|x| x.default_value)
+    }
+
     pub(crate) fn get_with_default<'a>(
         &'a self,
         key: &'a str,
         default: Option<&'a str>,
-    ) -> SparkResult<Option<&'a str>> {
+    ) -> Option<&'a str> {
         if let Some(value) = self.get_by_key(key) {
-            return Ok(Some(value));
+            return Some(value);
         }
         let entry = SPARK_CONFIG.get(key);
         if let Some(fallback) = entry.and_then(|x| x.fallback) {
             return self.get_with_default(fallback, default);
         }
-        Ok(default)
+        default
     }
 
     pub(crate) fn set(&mut self, key: String, value: String) -> SparkResult<()> {

--- a/crates/sail-spark-connect/src/service/config_manager.rs
+++ b/crates/sail-spark-connect/src/service/config_manager.rs
@@ -61,11 +61,7 @@ pub(crate) fn handle_config_get_option(
 ) -> SparkResult<ConfigResponse> {
     let spark = ctx.extension::<SparkSession>()?;
     let warnings = SparkRuntimeConfig::get_warnings_by_keys(&keys);
-    let kv = keys
-        .into_iter()
-        .map(|key| ConfigKeyValue { key, value: None })
-        .collect::<Vec<_>>();
-    let pairs = spark.get_config_with_default(kv)?;
+    let pairs = spark.get_config_option(keys)?;
     let pairs = pairs.into_iter().map(Into::into).collect();
     Ok(ConfigResponse {
         session_id: spark.session_id().to_string(),


### PR DESCRIPTION
Fixes #1122.

I did a quick search in the Spark codebase, and it seems that the `GetOption` operation is not used by PySpark, so existing PySpark tests do not surface the issue. However, the JVM Spark Connect client relies on this operation when creating data frames.