### PR TITLE
docs: add documentation to execution module and rename TaskSchedule to ScheduledTask

### DIFF
--- a/crates/sail-catalog-unity/src/provider.rs
+++ b/crates/sail-catalog-unity/src/provider.rs
@@ -660,6 +660,8 @@ impl CatalogProvider for UnityCatalogProvider {
         }
     }
 
+    /// Probably the most important method for the sail-unity-catalog. Actually gets the table
+    /// location from the Unity Catalog.
     async fn get_table(&self, database: &Namespace, table: &str) -> CatalogResult<TableStatus> {
         let client = self
             .get_client()

--- a/crates/sail-common-datafusion/src/session/job.rs
+++ b/crates/sail-common-datafusion/src/session/job.rs
@@ -7,6 +7,7 @@ use datafusion::prelude::SessionContext;
 
 use crate::extension::SessionExtension;
 
+/// Executes a physical execution plan and streams back the results.
 #[tonic::async_trait]
 pub trait JobRunner: Send + Sync + 'static {
     /// Executes a plan

--- a/crates/sail-execution/src/driver/actor/handler.rs
+++ b/crates/sail-execution/src/driver/actor/handler.rs
@@ -131,6 +131,8 @@ impl DriverActor {
         ActorAction::Continue
     }
 
+    /// This is where the driver takes in an execution plan
+    /// Does not complete it directly in here but schedules it instead.
     pub(super) fn handle_execute_job(
         &mut self,
         ctx: &mut ActorContext<Self>,
@@ -204,6 +206,7 @@ impl DriverActor {
         ActorAction::Continue
     }
 
+    /// Spins up more workes if needed.
     fn scale_up_workers(&mut self, ctx: &mut ActorContext<Self>) {
         let max_workers = self.options.worker_max_count;
         let slots_per_worker = self.options.worker_task_slots;
@@ -282,6 +285,9 @@ impl DriverActor {
         ActorAction::Continue
     }
 
+    /// Takes a look at the idle task slots and if there are
+    /// finds out the what tasks should be assigned to them
+    /// and then runs them.
     fn schedule_tasks(&mut self, ctx: &mut ActorContext<Self>) {
         let slots = self.worker_pool.find_idle_task_slots();
         for schedule in self.job_scheduler.schedule_tasks(ctx, slots) {

--- a/crates/sail-execution/src/driver/event.rs
+++ b/crates/sail-execution/src/driver/event.rs
@@ -14,6 +14,7 @@ use crate::driver::gen;
 use crate::error::ExecutionResult;
 use crate::id::{JobId, TaskInstance, WorkerId};
 
+/// Events that the driver can recieve and react to.
 pub enum DriverEvent {
     ServerReady {
         /// The local port that the driver server listens on.
@@ -45,6 +46,7 @@ pub enum DriverEvent {
         worker_id: WorkerId,
         instant: Instant,
     },
+    /// Exactly what you think - executes a plan. Contains a sender so we can send back the result too.
     ExecuteJob {
         plan: Arc<dyn ExecutionPlan>,
         result: oneshot::Sender<ExecutionResult<SendableRecordBatchStream>>,

--- a/crates/sail-execution/src/driver/job_scheduler/core.rs
+++ b/crates/sail-execution/src/driver/job_scheduler/core.rs
@@ -11,7 +11,7 @@ use sail_server::actor::ActorContext;
 
 use crate::driver::job_scheduler::state::{JobDescriptor, TaskDescriptor, TaskState};
 use crate::driver::job_scheduler::{
-    JobOutputChannel, JobOutputMetadata, JobScheduler, TaskSchedule, TaskSchedulePlan, TaskTimeout,
+    JobOutputChannel, JobOutputMetadata, JobScheduler, ScheduledTask, TaskSchedulePlan, TaskTimeout,
 };
 use crate::driver::planner::JobGraph;
 use crate::driver::{DriverActor, DriverEvent};
@@ -133,11 +133,13 @@ impl JobScheduler {
         task.messages.extend(message);
     }
 
+    /// Iterates through the task queue and finds tasks that are eligible
+    /// for scheduling and returns a vector of scheduled tasks.
     pub fn schedule_tasks(
         &mut self,
         ctx: &mut ActorContext<DriverActor>,
         slots: Vec<(WorkerId, usize)>,
-    ) -> Vec<TaskSchedule> {
+    ) -> Vec<ScheduledTask> {
         let mut assigner = TaskSlotAssigner::new(slots);
         let mut skipped_tasks = vec![];
         let mut scheduled_tasks = vec![];
@@ -204,7 +206,7 @@ impl JobScheduler {
                     }
                 }
             };
-            scheduled_tasks.push(TaskSchedule {
+            scheduled_tasks.push(ScheduledTask {
                 instance,
                 worker_id,
                 plan,

--- a/crates/sail-execution/src/driver/job_scheduler/mod.rs
+++ b/crates/sail-execution/src/driver/job_scheduler/mod.rs
@@ -39,7 +39,7 @@ pub enum TaskTimeout {
     No,
 }
 
-pub struct TaskSchedule {
+pub struct ScheduledTask {
     pub instance: TaskInstance,
     pub worker_id: WorkerId,
     pub plan: TaskSchedulePlan,

--- a/crates/sail-execution/src/driver/worker_pool/core.rs
+++ b/crates/sail-execution/src/driver/worker_pool/core.rs
@@ -20,7 +20,7 @@ use sail_server::actor::ActorContext;
 use sail_telemetry::common::SpanAttribute;
 use tokio::time::Instant;
 
-use crate::driver::job_scheduler::{JobOutputMetadata, TaskSchedule, TaskSchedulePlan};
+use crate::driver::job_scheduler::{JobOutputMetadata, ScheduledTask, TaskSchedulePlan};
 use crate::driver::worker_pool::state::WorkerState;
 use crate::driver::worker_pool::{
     WorkerDescriptor, WorkerIdle, WorkerLost, WorkerPool, WorkerPoolOptions, WorkerTimeout,
@@ -314,7 +314,7 @@ impl WorkerPool {
         }
     }
 
-    pub fn run_task(&mut self, ctx: &mut ActorContext<DriverActor>, schedule: TaskSchedule) {
+    pub fn run_task(&mut self, ctx: &mut ActorContext<DriverActor>, schedule: ScheduledTask) {
         let running_worker_locations = self.list_running_workers();
         let plan = match schedule.plan {
             TaskSchedulePlan::Valid(plan) => plan,

--- a/crates/sail-execution/src/runner.rs
+++ b/crates/sail-execution/src/runner.rs
@@ -60,6 +60,8 @@ impl JobRunner for LocalJobRunner {
     }
 }
 
+/// Runs the jobs on the cluster but is more or less a wrapper around the
+/// ActorHandle that we use to send messages to the driver.
 pub struct ClusterJobRunner {
     driver: ActorHandle<DriverActor>,
 }

--- a/crates/sail-server/src/actor.rs
+++ b/crates/sail-server/src/actor.rs
@@ -144,6 +144,7 @@ impl ActorSystem {
     }
 }
 
+/// Wrapper around the Sender to Actors.
 pub struct ActorHandle<T: Actor> {
     sender: mpsc::Sender<MessageEnvelop<T::Message>>,
 }


### PR DESCRIPTION
## Summary

Adds documentation comments to key components in the execution module and renames `TaskSchedule` to `ScheduledTask` for clarity. A TaskSchedule sounds like a list of Tasks in a Vec or something else, not something more atomic. 

## Changes

### Documentation
- `DriverEvent` enum and `ExecuteJob` variant
- `JobRunner` trait
- `ClusterJobRunner` struct
- `ActorHandle` struct
- `handle_execute_job`, `scale_up_workers`, `schedule_tasks` methods in driver actor
- `get_table` method in Unity Catalog provider

### Refactor
- Renamed `TaskSchedule` → `ScheduledTask` for better readability