### PR TITLE
feat: support dynamic expressions as map keys in element access

### DIFF
--- a/crates/sail-plan/src/resolver/expression/misc.rs
+++ b/crates/sail-plan/src/resolver/expression/misc.rs
@@ -112,22 +112,15 @@ impl PlanResolver<'_> {
 
         // For Maps, we support non-literal expressions as keys
         if matches!(data_type, DataType::Map(_, _)) {
-            // Check if extraction is a literal to generate appropriate column name
-            let result_name = if let spec::Expr::Literal(ref lit) = extraction {
-                let literal_value = self.resolve_literal(lit.clone(), state)?;
-                let service = self.ctx.extension::<PlanService>()?;
-                let literal_name = service
-                    .plan_formatter()
-                    .literal_to_string(&literal_value, &self.config.session_timezone)?;
-                format!("{}[{}]", name.one()?, literal_name)
-            } else {
-                format!("{}[<expr>]", name.one()?)
-            };
-
-            let extraction_expr = self
+            let NamedExpr {
+                name: extraction_name,
+                expr: extraction_expr,
+                ..
+            } = self
                 .resolve_named_expression(extraction, schema, state)
-                .await?
-                .expr;
+                .await?;
+
+            let result_name = format!("{}[{}]", name.one()?, extraction_name.one()?);
             // Use map_extract which supports dynamic keys, then extract first element
             let result_expr = array_element(map_extract(expr, extraction_expr), lit(1));
             return Ok(NamedExpr::new(vec![result_name], result_expr));


### PR DESCRIPTION
uses https://github.com/lakehq/sail/issues/501 to detect errors

This PR fixes map element access (`map[key]`) to support dynamic expressions as keys, not just literals. Previously, Sail required map keys to be compile-time literals, which was more restrictive than Spark's behavior and caused 64 Ibis tests to fail.

## Problem

Before this change:
- `map[literal_key]` ✅ worked
- `map[expression_key]` ❌ failed with "extraction must be a literal"