### PR TITLE
feat: support `array_sort` without lambda

### DIFF
--- a/crates/sail-plan/src/function/scalar/array.rs
+++ b/crates/sail-plan/src/function/scalar/array.rs
@@ -32,7 +32,7 @@ fn slice(array: expr::Expr, start: expr::Expr, length: expr::Expr) -> expr::Expr
     expr_fn::array_slice(array, start, end, None)
 }
 
-pub(super) fn sort_array(array: expr::Expr, asc: expr::Expr) -> PlanResult<expr::Expr> {
+fn sort_array(array: expr::Expr, asc: expr::Expr) -> PlanResult<expr::Expr> {
     let (sort, nulls) = match asc {
         expr::Expr::Literal(ScalarValue::Boolean(Some(true)), _metadata) => (
             lit(ScalarValue::Utf8(Some("ASC".to_string()))),


### PR DESCRIPTION
part https://github.com/lakehq/sail/issues/229
I remembered https://github.com/lakehq/sail/pull/825