### PR TITLE
docs: add Clickbench benchmark link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Our mission is to **unify batch processing, stream processing, and compute-inten
 - **94% cheaper** on infrastructure costs.
 - **100% Rust-native** with no JVM overhead, delivering memory safety, instant startup, and predictable performance.
 
-**🚀 Sail outperforms Spark, popular Spark accelerators, Databricks, and Snowflake on [ClickBench](https://shm.to/clickbench).**
+**🚀 Sail outperforms Spark, popular Spark accelerators, Databricks, and Snowflake on [ClickBench](https://go.lakesail.com/clickbench).**
 
 ## Documentation
 


### PR DESCRIPTION
Adds Clickbench benchmark comparison link to README, highlighting performance vs Spark + Spark accelerators, Databricks, and Snowflake.