### PR TITLE
feat: support inferschema option for csv dataframereader

### DIFF
--- a/crates/sail-data-source/src/formats/arrow/mod.rs
+++ b/crates/sail-data-source/src/formats/arrow/mod.rs
@@ -6,7 +6,7 @@ use datafusion::datasource::file_format::arrow::ArrowFormat;
 use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_datasource::file_format::FileFormat;
 
-use crate::formats::listing::{ListingFormat, ListingTableFormat};
+use crate::formats::listing::{DefaultSchemaInfer, ListingFormat, ListingTableFormat, SchemaInfer};
 
 pub type ArrowTableFormat = ListingTableFormat<ArrowListingFormat>;
 
@@ -33,5 +33,9 @@ impl ListingFormat for ArrowListingFormat {
         _options: Vec<HashMap<String, String>>,
     ) -> datafusion_common::Result<(Arc<dyn FileFormat>, Option<String>)> {
         Ok((Arc::new(ArrowFormat), None))
+    }
+
+    fn schema_inferrer(&self) -> Arc<dyn SchemaInfer> {
+        Arc::new(DefaultSchemaInfer)
     }
 }

--- a/crates/sail-data-source/src/formats/avro/mod.rs
+++ b/crates/sail-data-source/src/formats/avro/mod.rs
@@ -6,7 +6,7 @@ use datafusion::datasource::file_format::avro::AvroFormat;
 use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_datasource::file_format::FileFormat;
 
-use crate::formats::listing::{ListingFormat, ListingTableFormat};
+use crate::formats::listing::{DefaultSchemaInfer, ListingFormat, ListingTableFormat, SchemaInfer};
 
 pub type AvroTableFormat = ListingTableFormat<AvroListingFormat>;
 
@@ -33,5 +33,9 @@ impl ListingFormat for AvroListingFormat {
         _options: Vec<HashMap<String, String>>,
     ) -> datafusion_common::Result<(Arc<dyn FileFormat>, Option<String>)> {
         Ok((Arc::new(AvroFormat), None))
+    }
+
+    fn schema_inferrer(&self) -> Arc<dyn SchemaInfer> {
+        Arc::new(DefaultSchemaInfer)
     }
 }

--- a/crates/sail-data-source/src/formats/binary/mod.rs
+++ b/crates/sail-data-source/src/formats/binary/mod.rs
@@ -10,7 +10,7 @@ use datafusion_datasource::file_format::FileFormat;
 
 use crate::formats::binary::file_format::BinaryFileFormat;
 use crate::formats::binary::options::resolve_binary_read_options;
-use crate::formats::listing::{ListingFormat, ListingTableFormat};
+use crate::formats::listing::{DefaultSchemaInfer, ListingFormat, ListingTableFormat, SchemaInfer};
 
 pub mod file_format;
 pub mod options;
@@ -49,6 +49,10 @@ impl ListingFormat for BinaryListingFormat {
         _options: Vec<HashMap<String, String>>,
     ) -> Result<(Arc<dyn FileFormat>, Option<String>)> {
         not_impl_err!("Binary file format does not support writing")
+    }
+
+    fn schema_inferrer(&self) -> Arc<dyn SchemaInfer> {
+        Arc::new(DefaultSchemaInfer)
     }
 }
 

--- a/crates/sail-data-source/src/formats/csv/mod.rs
+++ b/crates/sail-data-source/src/formats/csv/mod.rs
@@ -1,17 +1,111 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use datafusion::arrow::datatypes::{DataType, Field, Schema};
 use datafusion::catalog::Session;
 use datafusion::datasource::file_format::csv::CsvFormat;
 use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_datasource::file_format::FileFormat;
 
 use crate::formats::csv::options::{resolve_csv_read_options, resolve_csv_write_options};
-use crate::formats::listing::{ListingFormat, ListingTableFormat};
+use crate::formats::listing::{ListingFormat, ListingTableFormat, SchemaInfer};
+use crate::options::{load_options, merge_options, CsvReadOptions};
 
 mod options;
 
 pub type CsvTableFormat = ListingTableFormat<CsvListingFormat>;
+
+fn convert_string_columns(schema: Schema) -> Schema {
+    let string_fields = schema
+        .fields()
+        .iter()
+        .map(|field| Field::new(field.name(), DataType::Utf8, field.is_nullable()))
+        .collect::<Vec<_>>();
+
+    Schema::new_with_metadata(string_fields, schema.metadata().clone())
+}
+
+fn rename_default_csv_columns(schema: Schema) -> Schema {
+    use std::collections::HashSet;
+
+    let mut failed_parsing = false;
+    let mut seen_names = HashSet::new();
+    let mut new_fields = schema
+        .fields()
+        .iter()
+        .map(|field| {
+            // Order may not be guaranteed, so we try to parse the index from the column name
+            let new_name = if field.name().starts_with("column_") {
+                if let Some(index_str) = field.name().strip_prefix("column_") {
+                    if let Ok(index) = index_str.trim().parse::<usize>() {
+                        format!("_c{}", index.saturating_sub(1))
+                    } else {
+                        failed_parsing = true;
+                        field.name().to_string()
+                    }
+                } else {
+                    field.name().to_string()
+                }
+            } else {
+                field.name().to_string()
+            };
+            if !seen_names.insert(new_name.clone()) {
+                failed_parsing = true;
+            }
+            Field::new(new_name, field.data_type().clone(), field.is_nullable())
+        })
+        .collect::<Vec<_>>();
+
+    if failed_parsing {
+        new_fields = schema
+            .fields()
+            .iter()
+            .enumerate()
+            .map(|(i, field)| {
+                Field::new(
+                    format!("_c{i}"),
+                    field.data_type().clone(),
+                    field.is_nullable(),
+                )
+            })
+            .collect::<Vec<_>>();
+    }
+
+    Schema::new_with_metadata(new_fields, schema.metadata().clone())
+}
+
+/// Schema inferrer for CSV format
+#[derive(Debug)]
+pub struct CsvSchemaInfer;
+
+#[async_trait::async_trait]
+impl SchemaInfer for CsvSchemaInfer {
+    async fn get_schema(
+        &self,
+        ctx: &dyn Session,
+        store: &Arc<dyn object_store::ObjectStore>,
+        files: &[object_store::ObjectMeta],
+        list_options: &datafusion::datasource::listing::ListingOptions,
+        options: &[HashMap<String, String>],
+    ) -> datafusion_common::Result<Schema> {
+        let mut schema = list_options
+            .format
+            .infer_schema(ctx, store, files)
+            .await?
+            .as_ref()
+            .clone();
+        let merged_options = merge_options(options.to_vec());
+        if let Ok(csv_options) = load_options::<CsvReadOptions>(merged_options) {
+            if csv_options.infer_schema == Some(false) {
+                schema = convert_string_columns(schema);
+            }
+        }
+        // Rename default CSV columns (column_1 -> _c0, etc.)
+        schema = rename_default_csv_columns(schema);
+
+        Ok(schema)
+    }
+}
 
 #[derive(Debug, Default)]
 pub struct CsvListingFormat;
@@ -41,5 +135,59 @@ impl ListingFormat for CsvListingFormat {
     ) -> datafusion_common::Result<(Arc<dyn FileFormat>, Option<String>)> {
         let options = resolve_csv_write_options(ctx, options)?;
         Ok((Arc::new(CsvFormat::default().with_options(options)), None))
+    }
+
+    fn schema_inferrer(&self) -> Arc<dyn SchemaInfer> {
+        Arc::new(CsvSchemaInfer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn test_convert_string_columns() {
+        // Create schema with mixed types
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int64, true),
+            Field::new("name", DataType::Utf8, true),
+            Field::new("birthday", DataType::Date32, true),
+        ]);
+        let converted = convert_string_columns(schema);
+        // Verify all fields are now strings
+        assert_eq!(converted.fields()[0].data_type(), &DataType::Utf8);
+        assert_eq!(converted.fields()[1].data_type(), &DataType::Utf8);
+        assert_eq!(converted.fields()[2].data_type(), &DataType::Utf8);
+    }
+
+    #[test]
+    fn test_rename_default_csv_columns() {
+        // Create schema with default column names
+        let schema = Schema::new(vec![
+            Field::new("column_1", DataType::Utf8, true),
+            Field::new("column_2", DataType::Int64, true),
+            Field::new("column_3", DataType::Utf8, true),
+        ]);
+        let renamed = rename_default_csv_columns(schema);
+        // Check renamed columns
+        assert_eq!(renamed.fields()[0].name(), "_c0");
+        assert_eq!(renamed.fields()[1].name(), "_c1");
+        assert_eq!(renamed.fields()[2].name(), "_c2");
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn test_csv_read_options_parsing() {
+        use crate::options::{load_options, CsvReadOptions};
+        // Test infer_schema option parsing
+        let options = HashMap::from([("infer_schema".to_string(), "false".to_string())]);
+        let csv_options = load_options::<CsvReadOptions>(options).unwrap();
+        assert_eq!(csv_options.infer_schema, Some(false));
+        let options = HashMap::from([("inferSchema".to_string(), "true".to_string())]);
+        let csv_options = load_options::<CsvReadOptions>(options).unwrap();
+        assert_eq!(csv_options.infer_schema, Some(true));
     }
 }

--- a/crates/sail-data-source/src/formats/csv/options.rs
+++ b/crates/sail-data-source/src/formats/csv/options.rs
@@ -26,6 +26,7 @@ fn apply_csv_read_options(
         multi_line,
         compression,
         allow_truncated_rows,
+        infer_schema: _,
     } = from;
     let null_regex = match (null_value, null_regex) {
         (Some(null_value), Some(null_regex))

--- a/crates/sail-data-source/src/formats/json/mod.rs
+++ b/crates/sail-data-source/src/formats/json/mod.rs
@@ -7,7 +7,7 @@ use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_datasource::file_format::FileFormat;
 
 use crate::formats::json::options::{resolve_json_read_options, resolve_json_write_options};
-use crate::formats::listing::{ListingFormat, ListingTableFormat};
+use crate::formats::listing::{DefaultSchemaInfer, ListingFormat, ListingTableFormat, SchemaInfer};
 
 mod options;
 
@@ -41,5 +41,9 @@ impl ListingFormat for JsonListingFormat {
     ) -> datafusion_common::Result<(Arc<dyn FileFormat>, Option<String>)> {
         let options = resolve_json_write_options(ctx, options)?;
         Ok((Arc::new(JsonFormat::default().with_options(options)), None))
+    }
+
+    fn schema_inferrer(&self) -> Arc<dyn SchemaInfer> {
+        Arc::new(DefaultSchemaInfer)
     }
 }

--- a/crates/sail-data-source/src/formats/parquet/mod.rs
+++ b/crates/sail-data-source/src/formats/parquet/mod.rs
@@ -7,7 +7,7 @@ use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_common::Result;
 use datafusion_datasource::file_format::FileFormat;
 
-use crate::formats::listing::{ListingFormat, ListingTableFormat};
+use crate::formats::listing::{DefaultSchemaInfer, ListingFormat, ListingTableFormat, SchemaInfer};
 use crate::formats::parquet::options::{
     resolve_parquet_read_options, resolve_parquet_write_options,
 };
@@ -45,5 +45,9 @@ impl ListingFormat for ParquetListingFormat {
             Arc::new(ParquetFormat::default().with_options(options)),
             compression,
         ))
+    }
+
+    fn schema_inferrer(&self) -> Arc<dyn SchemaInfer> {
+        Arc::new(DefaultSchemaInfer)
     }
 }

--- a/crates/sail-data-source/src/formats/text/mod.rs
+++ b/crates/sail-data-source/src/formats/text/mod.rs
@@ -5,7 +5,7 @@ use datafusion::catalog::Session;
 use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_datasource::file_format::FileFormat;
 
-use crate::formats::listing::{ListingFormat, ListingTableFormat};
+use crate::formats::listing::{DefaultSchemaInfer, ListingFormat, ListingTableFormat, SchemaInfer};
 use crate::formats::text::file_format::TextFileFormat;
 use crate::formats::text::options::{resolve_text_read_options, resolve_text_write_options};
 
@@ -64,5 +64,9 @@ impl ListingFormat for TextListingFormat {
     ) -> datafusion_common::Result<(Arc<dyn FileFormat>, Option<String>)> {
         let options = resolve_text_write_options(options)?;
         Ok((Arc::new(TextFileFormat::new(options)), None))
+    }
+
+    fn schema_inferrer(&self) -> Arc<dyn SchemaInfer> {
+        Arc::new(DefaultSchemaInfer)
     }
 }

--- a/crates/sail-data-source/src/options/data/csv_read.yaml
+++ b/crates/sail-data-source/src/options/data/csv_read.yaml
@@ -85,7 +85,9 @@
     Infers the input schema automatically from data. It requires one extra pass over the data.
     Ignored if the schema is specified explicitly. If False, the schema must be specified explicitly.
     CSV built-in functions ignore this option.
-  supported: false
+  supported: true
+  rust_type: bool
+  rust_deserialize_with: crate::options::serde::deserialize_bool
 
 - key: schema_infer_max_records
   aliases:

--- a/crates/sail-data-source/src/options/loader.rs
+++ b/crates/sail-data-source/src/options/loader.rs
@@ -26,10 +26,72 @@ pub fn load_default_options<T: DataSourceOptions>() -> Result<T> {
     load_options(options)
 }
 
+/// Merge multiple option layers into a single HashMap.
+/// Later options override earlier ones.
+pub fn merge_options(options: Vec<HashMap<String, String>>) -> HashMap<String, String> {
+    let mut merged = HashMap::new();
+    for layer in options {
+        merged.extend(layer);
+    }
+    merged
+}
+
 #[cfg(test)]
 pub fn build_options(options: &[(&str, &str)]) -> HashMap<String, String> {
     options
         .iter()
         .map(|(k, v)| (k.to_string(), v.to_string()))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_merge_options_empty() {
+        let result = merge_options(vec![]);
+        assert_eq!(result, HashMap::new());
+    }
+
+    #[test]
+    fn test_merge_options_single_layer() {
+        let options = vec![HashMap::from([
+            ("key1".to_string(), "value1".to_string()),
+            ("key2".to_string(), "value2".to_string()),
+        ])];
+        let result = merge_options(options);
+        assert_eq!(result.get("key1"), Some(&"value1".to_string()));
+        assert_eq!(result.get("key2"), Some(&"value2".to_string()));
+    }
+
+    #[test]
+    fn test_merge_options_override() {
+        let options = vec![
+            HashMap::from([
+                ("key1".to_string(), "value1".to_string()),
+                ("key2".to_string(), "value2".to_string()),
+            ]),
+            HashMap::from([
+                ("key2".to_string(), "overridden".to_string()),
+                ("key3".to_string(), "value3".to_string()),
+            ]),
+        ];
+        let result = merge_options(options);
+        assert_eq!(result.get("key1"), Some(&"value1".to_string()));
+        assert_eq!(result.get("key2"), Some(&"overridden".to_string()));
+        assert_eq!(result.get("key3"), Some(&"value3".to_string()));
+    }
+
+    #[test]
+    fn test_merge_options_multiple_layers() {
+        let options = vec![
+            HashMap::from([("a".to_string(), "1".to_string())]),
+            HashMap::from([("b".to_string(), "2".to_string())]),
+            HashMap::from([("a".to_string(), "3".to_string())]), // Override first layer
+        ];
+        let result = merge_options(options);
+        assert_eq!(result.get("a"), Some(&"3".to_string()));
+        assert_eq!(result.get("b"), Some(&"2".to_string()));
+    }
 }

--- a/crates/sail-data-source/src/options/mod.rs
+++ b/crates/sail-data-source/src/options/mod.rs
@@ -8,7 +8,7 @@ pub use internal::{
 };
 #[cfg(test)]
 pub use loader::build_options;
-pub use loader::{load_default_options, load_options};
+pub use loader::{load_default_options, load_options, merge_options};
 
 pub(crate) mod internal {
     include!(concat!(env!("OUT_DIR"), "/options/binary_read.rs"));


### PR DESCRIPTION
Fix Issue: https://github.com/lakehq/sail/issues/1191
Support inferSchema CsvReadOptions.

I'm a Rust beginner and new to its ecosystem. It seems to me that DataFusion doesn't directly support this inferSchema options, so I implement the logic in Sail's CsvListingFormat code. Feel free to correct me.

Did a little refactoring of the resolve_listing_schema fn in listing.rs
* Add SchemaInfer trait with a DefaultSchemaInferer that uses DataFusion's built-in inference. 
* CsvSchemaInfer as an overwritten implementation.
* Implement inferSchema handling in CsvSchemaInferer by replacing datatypes as nullable_string
* Move rename_default_csv_columns fn into CsvSchemaInferer
