### PR TITLE
fix: add --ignore-whitespace to git apply for Windows compatibility

### DIFF
--- a/scripts/shell-tools/git-patch.sh
+++ b/scripts/shell-tools/git-patch.sh
@@ -22,7 +22,7 @@ function apply_git_patch() {
   export __GIT_PATCH_FILE="${file}"
 
   echo "Applying the patch..."
-  git -C "${__GIT_PATCH_DIRECTORY}" apply "${file}"
+  git -C "${__GIT_PATCH_DIRECTORY}" apply --ignore-whitespace "${file}"
 
   trap 'revert_git_patch' EXIT
 }


### PR DESCRIPTION
## Summary
- Adds `--ignore-whitespace` flag to `git apply` in `git-patch.sh`
- Fixes patch application failure on Windows where Git converts line endings from LF to CRLF

## Problem
On Windows, Git may convert line endings when cloning repositories (due to `core.autocrlf` setting). This causes `git apply` to fail with errors like:
error: patch failed: python/packaging/classic/setup.py:206
error: python/packaging/classic/setup.py: patch does not apply

## Solution
Adding `--ignore-whitespace` makes patch application more lenient about whitespace differences, fixing the issue on Windows without affecting behavior on Linux/macOS.

## Test plan
- Tested manually on Windows with Git Bash: patch applies successfully with the flag

