### PR TITLE
fix: ensure task completion upon closed sink

### DIFF
--- a/crates/sail-execution/src/driver/output.rs
+++ b/crates/sail-execution/src/driver/output.rs
@@ -101,6 +101,8 @@ pub fn build_job_output(
         // via prior task status updates.
         // Therefore, it is safe to clean up the job. The job can reach a terminal state and all
         // its streams can be removed.
+        // When `tx` is dropped at the end of this async block, the job output stream built around
+        // `rx` will also end, signaling to the consumer that the job has completed.
         // This is how we ensure the data plane event (output stream termination) is consistent
         // with the control plane event (job termination).
         let _ = handle.send(DriverEvent::CleanUpJob { job_id }).await;

--- a/crates/sail-execution/src/stream/writer.rs
+++ b/crates/sail-execution/src/stream/writer.rs
@@ -64,6 +64,8 @@ pub trait TaskStreamWriter: fmt::Debug + Send + Sync {
 pub trait TaskStreamSink: Send {
     /// Write a record batch or an error to the sink.
     async fn write(&mut self, batch: TaskStreamResult<RecordBatch>) -> TaskStreamSinkState;
+    // TODO: Are we required to call `close` when the user encounters an error and wants to
+    //   abort the sink? Should we have a separate `abort` method?
     /// Flush all data and close the sink.
     /// Since the operation may be async, the user must call this method before
     /// dropping the sink, unless the user has received [`TaskStreamSinkState::Error`] or

--- a/crates/sail-execution/src/stream_manager/local.rs
+++ b/crates/sail-execution/src/stream_manager/local.rs
@@ -1,6 +1,6 @@
 use datafusion::arrow::array::RecordBatch;
 use datafusion::common::Result;
-use log::warn;
+use log::debug;
 use tokio::sync::mpsc;
 use tonic::codegen::tokio_stream::wrappers::ReceiverStream;
 
@@ -81,7 +81,7 @@ impl TaskStreamSink for MemoryStreamReplicaSender {
                     Err(_) => {
                         // This can happen under normal operation when the receiver no longer needs
                         // more data (e.g., after a LIMIT operator has received enough rows).
-                        warn!("memory stream replica receiver has been dropped");
+                        debug!("memory stream replica receiver has been dropped");
                         *sender = None;
                     }
                 }


### PR DESCRIPTION
This pull request fixes the `test_rate_with_filtering` tests that hangs in cluster mode previously. The issue is that we need to stop the execution for streaming nodes when all the stream receivers have closed.