### PR TITLE
feat: update runtime config and catalog config

### DIFF
--- a/crates/sail-cli/src/worker/entrypoint.rs
+++ b/crates/sail-cli/src/worker/entrypoint.rs
@@ -1,10 +1,12 @@
+use std::sync::Arc;
+
 use sail_common::config::AppConfig;
 use sail_common::runtime::RuntimeManager;
 use sail_session::session_factory::{SessionFactory, WorkerSessionFactory};
 use sail_telemetry::telemetry::{init_telemetry, shutdown_telemetry, ResourceOptions};
 
 pub fn run_worker() -> Result<(), Box<dyn std::error::Error>> {
-    let config = AppConfig::load()?;
+    let config = Arc::new(AppConfig::load()?);
     let runtime = RuntimeManager::try_new(&config.runtime)?;
 
     runtime.handle().primary().block_on(async {
@@ -12,7 +14,7 @@ pub fn run_worker() -> Result<(), Box<dyn std::error::Error>> {
         init_telemetry(&config.telemetry, resource)
     })?;
 
-    let session = WorkerSessionFactory::new(&runtime.handle()).create(())?;
+    let session = WorkerSessionFactory::new(config.clone(), runtime.handle()).create(())?;
     runtime
         .handle()
         .primary()

--- a/crates/sail-common/src/config/application.yaml
+++ b/crates/sail-common/src/config/application.yaml
@@ -22,6 +22,53 @@
     Use a secondary Tokio runtime to separate object storage I/O tasks from other operations.
   experimental: true
 
+- key: runtime.memory_pool.type
+  type: string
+  default: "unbounded"
+  description: |
+    The type of memory pool to use for managing memory allocations during query execution.
+    Valid values are `unbounded`, `greedy`, and `fair`.
+    If the value is `unbounded`, there is no limit on memory usage.
+    If the value is `greedy`, the memory pool will allocate memory up to a limit on a
+    first come, first served basis.
+    If the value is `fair`, the memory pool will allocate memory up to a limit and ensure
+    that a single operator does not use too much memory.
+  experimental: true
+
+- key: runtime.memory_pool.greedy.max_size
+  type: number
+  default: "68719476736"
+  description: |
+    The maximum size in bytes if the `greedy` memory pool is in use.
+  experimental: true
+
+- key: runtime.memory_pool.fair.max_size
+  type: number
+  default: "68719476736"
+  description: |
+    The maximum size in bytes if the `fair` memory pool is in use.
+  experimental: true
+
+- key: runtime.temporary_files.paths
+  type: array
+  default: "[]"
+  description: |
+    The list of local directories for storing temporary files.
+    If multiple directories are specified, temporary files are distributed
+    across the directories.
+    If no directory is specified, the operating system default temporary directory is used.
+  experimental: true
+
+- key: runtime.temporary_files.max_size
+  type: number
+  default: "68719476736"
+  description: |
+    The maximum total size in bytes for temporary files.
+    If the size of temporary files exceeds this limit, an error will be raised.
+    If the value is `0`, writing to temporary files is disabled and an error
+    will be raised if a query attempts to spill to disk.
+  experimental: true
+
 - key: cluster.enable_tls
   type: boolean
   default: "false"
@@ -644,9 +691,11 @@
 
 - key: catalog.default_catalog
   type: string
-  default: "sail"
+  default: ""
   description: |
     The name of the default catalog to use.
+    If this is not set and there is only one catalog, that only catalog is used as the default catalog.
+    If this is not set and there are multiple catalogs, an error will be raised when a session is created.
   experimental: true
 
 - key: catalog.default_database

--- a/crates/sail-session/src/lib.rs
+++ b/crates/sail-session/src/lib.rs
@@ -4,5 +4,6 @@ pub mod formats;
 pub mod observable;
 pub mod optimizer;
 pub mod planner;
+pub mod runtime;
 pub mod session_factory;
 pub mod session_manager;

--- a/crates/sail-session/src/runtime.rs
+++ b/crates/sail-session/src/runtime.rs
@@ -1,0 +1,157 @@
+use std::sync::Arc;
+
+use datafusion::execution::cache::cache_manager::{
+    CacheManagerConfig, FileMetadataCache, FileStatisticsCache, ListFilesCache,
+};
+use datafusion::execution::disk_manager::{DiskManagerBuilder, DiskManagerMode};
+use datafusion::execution::memory_pool::{
+    FairSpillPool, GreedyMemoryPool, MemoryPool, UnboundedMemoryPool,
+};
+use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
+use datafusion::execution::DiskManager;
+use datafusion_common::Result;
+use log::debug;
+use sail_cache::file_listing_cache::MokaFileListingCache;
+use sail_cache::file_metadata_cache::MokaFileMetadataCache;
+use sail_cache::file_statistics_cache::MokaFileStatisticsCache;
+use sail_common::config::{
+    AppConfig, CacheType, FairMemoryPoolConfig, GreedyMemoryPoolConfig, MemoryPoolConfig,
+};
+use sail_common::runtime::RuntimeHandle;
+use sail_object_store::DynamicObjectStoreRegistry;
+
+pub struct RuntimeEnvFactory {
+    config: Arc<AppConfig>,
+    runtime: RuntimeHandle,
+    global_file_listing_cache: Option<Arc<dyn ListFilesCache>>,
+    global_file_statistics_cache: Option<Arc<dyn FileStatisticsCache>>,
+    global_file_metadata_cache: Option<Arc<MokaFileMetadataCache>>,
+}
+
+impl RuntimeEnvFactory {
+    pub fn new(config: Arc<AppConfig>, runtime: RuntimeHandle) -> Self {
+        Self {
+            config,
+            runtime,
+            global_file_listing_cache: None,
+            global_file_statistics_cache: None,
+            global_file_metadata_cache: None,
+        }
+    }
+
+    pub fn create<M>(&mut self, mutator: M) -> Result<Arc<RuntimeEnv>>
+    where
+        M: FnOnce(RuntimeEnvBuilder) -> Result<RuntimeEnvBuilder>,
+    {
+        let registry = DynamicObjectStoreRegistry::new(self.runtime.clone());
+        let cache_config = CacheManagerConfig::default()
+            .with_files_statistics_cache(Some(self.create_file_statistics_cache()))
+            .with_list_files_cache(Some(self.create_file_listing_cache()))
+            .with_file_metadata_cache(Some(self.create_file_metadata_cache()));
+        let builder = RuntimeEnvBuilder::default()
+            .with_object_store_registry(Arc::new(registry))
+            .with_cache_manager(cache_config)
+            .with_memory_pool(self.create_memory_pool())
+            .with_disk_manager_builder(self.create_disk_manager_builder());
+        let builder = mutator(builder)?;
+        Ok(Arc::new(builder.build()?))
+    }
+
+    fn create_memory_pool(&self) -> Arc<dyn MemoryPool> {
+        match self.config.runtime.memory_pool {
+            MemoryPoolConfig::Unbounded => Arc::new(UnboundedMemoryPool::default()),
+            MemoryPoolConfig::Greedy(GreedyMemoryPoolConfig { max_size }) => {
+                Arc::new(GreedyMemoryPool::new(max_size))
+            }
+            MemoryPoolConfig::Fair(FairMemoryPoolConfig { max_size }) => {
+                Arc::new(FairSpillPool::new(max_size))
+            }
+        }
+    }
+
+    fn create_disk_manager_builder(&self) -> DiskManagerBuilder {
+        let max_size = self.config.runtime.temporary_files.max_size;
+        let paths = self.config.runtime.temporary_files.paths.as_slice();
+
+        let mut builder = DiskManager::builder();
+        builder.set_max_temp_directory_size(max_size as u64);
+        if max_size == 0 {
+            builder.set_mode(DiskManagerMode::Disabled);
+        } else if paths.is_empty() {
+            builder.set_mode(DiskManagerMode::OsTmpDirectory);
+        } else {
+            let paths = paths.iter().map(|x| x.into()).collect();
+            builder.set_mode(DiskManagerMode::Directories(paths));
+        }
+        builder
+    }
+
+    fn create_file_statistics_cache(&mut self) -> Arc<dyn FileStatisticsCache> {
+        let ttl = self.config.parquet.file_statistics_cache.ttl;
+        let max_entries = self.config.parquet.file_statistics_cache.max_entries;
+        match &self.config.parquet.file_statistics_cache.r#type {
+            CacheType::None => {
+                debug!("Not using file statistics cache");
+                Arc::new(MokaFileStatisticsCache::new(ttl, Some(0)))
+            }
+            CacheType::Global => {
+                debug!("Using global file statistics cache");
+                self.global_file_statistics_cache
+                    .get_or_insert_with(|| {
+                        Arc::new(MokaFileStatisticsCache::new(ttl, max_entries))
+                            as Arc<dyn FileStatisticsCache>
+                    })
+                    .clone()
+            }
+            CacheType::Session => {
+                debug!("Using session file statistics cache");
+                Arc::new(MokaFileStatisticsCache::new(ttl, max_entries))
+            }
+        }
+    }
+
+    fn create_file_listing_cache(&mut self) -> Arc<dyn ListFilesCache> {
+        let ttl = self.config.execution.file_listing_cache.ttl;
+        let max_entries = self.config.execution.file_listing_cache.max_entries;
+        match &self.config.execution.file_listing_cache.r#type {
+            CacheType::None => {
+                debug!("Not using file listing cache");
+                Arc::new(MokaFileListingCache::new(ttl, Some(0)))
+            }
+            CacheType::Global => {
+                debug!("Using global file listing cache");
+                self.global_file_listing_cache
+                    .get_or_insert_with(|| {
+                        Arc::new(MokaFileListingCache::new(ttl, max_entries))
+                            as Arc<dyn ListFilesCache>
+                    })
+                    .clone()
+            }
+            CacheType::Session => {
+                debug!("Using session file listing cache");
+                Arc::new(MokaFileListingCache::new(ttl, max_entries))
+            }
+        }
+    }
+
+    fn create_file_metadata_cache(&mut self) -> Arc<dyn FileMetadataCache> {
+        let ttl = self.config.parquet.file_metadata_cache.ttl;
+        let size_limit = self.config.parquet.file_metadata_cache.size_limit;
+        match self.config.parquet.file_metadata_cache.r#type {
+            CacheType::None => {
+                debug!("Not using file metadata cache");
+                Arc::new(MokaFileMetadataCache::new(ttl, Some(0)))
+            }
+            CacheType::Global => {
+                debug!("Using global file metadata cache");
+                self.global_file_metadata_cache
+                    .get_or_insert_with(|| Arc::new(MokaFileMetadataCache::new(ttl, size_limit)))
+                    .clone()
+            }
+            CacheType::Session => {
+                debug!("Using session file metadata cache");
+                Arc::new(MokaFileMetadataCache::new(ttl, size_limit))
+            }
+        }
+    }
+}

--- a/crates/sail-session/src/session_manager/actor/handler.rs
+++ b/crates/sail-session/src/session_manager/actor/handler.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::time::Duration;
 
 use chrono::Utc;
 use datafusion::prelude::SessionContext;
@@ -77,7 +76,7 @@ impl SessionManagerActor {
                         session_id,
                         instant: active_at,
                     },
-                    Duration::from_secs(self.options.config.spark.session_timeout_secs),
+                    self.options.session_timeout,
                 );
             }
         }

--- a/crates/sail-session/src/session_manager/options.rs
+++ b/crates/sail-session/src/session_manager/options.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
-use sail_common::config::AppConfig;
 use sail_common::runtime::RuntimeHandle;
 use sail_server::actor::ActorSystem;
 
@@ -8,7 +8,7 @@ use crate::session_factory::{ServerSessionInfo, SessionFactory};
 
 #[readonly::make]
 pub struct SessionManagerOptions {
-    pub config: Arc<AppConfig>,
+    pub session_timeout: Duration,
     pub runtime: RuntimeHandle,
     pub system: Arc<Mutex<ActorSystem>>,
     pub factory: Box<dyn Fn() -> Box<dyn SessionFactory<ServerSessionInfo>> + Send>,
@@ -16,16 +16,20 @@ pub struct SessionManagerOptions {
 
 impl SessionManagerOptions {
     pub fn new(
-        config: Arc<AppConfig>,
         runtime: RuntimeHandle,
         system: Arc<Mutex<ActorSystem>>,
         factory: Box<dyn Fn() -> Box<dyn SessionFactory<ServerSessionInfo>> + Send>,
     ) -> Self {
         Self {
-            config,
+            session_timeout: Duration::MAX,
             runtime,
             system,
             factory,
         }
+    }
+
+    pub fn with_session_timeout(mut self, timeout: Duration) -> Self {
+        self.session_timeout = timeout;
+        self
     }
 }

--- a/crates/sail-spark-connect/src/session_manager.rs
+++ b/crates/sail-spark-connect/src/session_manager.rs
@@ -90,6 +90,7 @@ pub fn create_spark_session_manager(
             create_spark_session_factory(config.clone(), runtime.clone(), system.clone())
         })
     };
-    let options = SessionManagerOptions::new(config.clone(), runtime.clone(), system, factory);
+    let options = SessionManagerOptions::new(runtime.clone(), system, factory)
+        .with_session_timeout(Duration::from_secs(config.spark.session_timeout_secs));
     Ok(SessionManager::try_new(options)?)
 }


### PR DESCRIPTION
## Changes

1. Support inferring the default catalog if there is only one catalog (closes #1219).
2. Add memory pool runtime config.
3. Add disk manager runtime config (for temporary files used for spilling data).
4. Ensure that the runtime environment is created in the same way for the driver and worker sessions.
5. Adjust the way to specify session timeout for session manager.

## Testing

It's not yet easy to write tests for memory and disk config, so I tested the code change manually.

**Test 1: Memory error for a memory pool of insufficient size**

```python
spark.sql("SELECT id, count(id) FROM range(1024) GROUP BY id").show()
```

```bash
env \
  SAIL_MODE=local \
  SAIL_RUNTIME__MEMORY_POOL__TYPE="greedy" \
  SAIL_RUNTIME__MEMORY_POOL__GREEDY__MAX_SIZE=128 \
  hatch run scripts/spark-tests/run-server.sh
```

```bash
env \
  SAIL_MODE=local \
  SAIL_RUNTIME__MEMORY_POOL__TYPE="fair" \
  SAIL_RUNTIME__MEMORY_POOL__FAIR__MAX_SIZE=128 \
  hatch run scripts/spark-tests/run-server.sh
```

```
Failed to allocate additional XXX KB for GroupedHashAggregateStream[2] (count(range.#0)) with 0.0 B already allocated for this reservation - XXX B remain available for the total pool
```

**Test 2: Spill error when the disk manager is disabled**

```python
spark.sql("SELECT id FROM range(2048) ORDER BY id").collect()[:10]
```

```bash
env \
  SAIL_MODE=local \
  SAIL_RUNTIME__MEMORY_POOL__TYPE="greedy" \
  SAIL_RUNTIME__MEMORY_POOL__GREEDY__MAX_SIZE=16384 \
  SAIL_RUNTIME__TEMPORARY_FILES__MAX_SIZE=0 \
  hatch run scripts/spark-tests/run-server.sh
```

```
Memory Exhausted while Sorting (DiskManager is disabled)
```

**Test 3: Spill error when the disk manager allows only limited size**

```python
spark.sql("SELECT id FROM range(1048576) ORDER BY id").collect()[:10]
```

```bash
env \
  SAIL_MODE=local \
  SAIL_RUNTIME__MEMORY_POOL__TYPE="greedy" \
  SAIL_RUNTIME__MEMORY_POOL__GREEDY__MAX_SIZE=20971520 \
  SAIL_RUNTIME__TEMPORARY_FILES__MAX_SIZE=1024 \
  hatch run scripts/spark-tests/run-server.sh
```

```
The used disk space during the spilling process has exceeded the allowable limit of XXX B. Try increasing the `max_temp_directory_size` in the disk manager configuration.
```

**Test 4: Spill error when the file path cannot be written to**

```python
spark.sql("SELECT id FROM range(2048) ORDER BY id").collect()[:10]
```

```bash
env \
  SAIL_MODE=local \
  SAIL_RUNTIME__MEMORY_POOL__TYPE="unbounded" \
  SAIL_RUNTIME__TEMPORARY_FILES__PATHS='["/"]' \
  hatch run scripts/spark-tests/run-server.sh
```

```
Read-only file system (os error 30) at path "/datafusion-XXXXXX"
```