### PR TITLE
feat!: remove `job_output_buffer` config option

### DIFF
--- a/crates/sail-common/src/config/application.rs
+++ b/crates/sail-common/src/config/application.rs
@@ -170,7 +170,6 @@ pub struct ClusterConfig {
     pub task_stream_buffer: usize,
     pub task_stream_creation_timeout_secs: u64,
     pub task_max_attempts: usize,
-    pub job_output_buffer: usize,
     pub rpc_retry_strategy: RetryStrategy,
 }
 

--- a/crates/sail-common/src/config/application.yaml
+++ b/crates/sail-common/src/config/application.yaml
@@ -192,12 +192,6 @@
   default: "3"
   description: The maximum number of attempts for a task.
 
-- key: cluster.job_output_buffer
-  type: number
-  default: "16"
-  description: The number of batches to buffer in the job output stream.
-  experimental: true
-
 - key: cluster.rpc_retry_strategy.type
   type: string
   default: "fixed"

--- a/crates/sail-execution/src/driver/options.rs
+++ b/crates/sail-execution/src/driver/options.rs
@@ -25,7 +25,6 @@ pub struct DriverOptions {
     pub task_stream_buffer: usize,
     pub task_stream_creation_timeout: Duration,
     pub task_max_attempts: usize,
-    pub job_output_buffer: usize,
     pub rpc_retry_strategy: RetryStrategy,
     pub runtime: RuntimeHandle,
     pub worker_manager: Arc<dyn WorkerManager>,
@@ -61,7 +60,6 @@ impl DriverOptions {
                 config.cluster.task_stream_creation_timeout_secs,
             ),
             task_max_attempts: config.cluster.task_max_attempts,
-            job_output_buffer: config.cluster.job_output_buffer,
             runtime,
             worker_manager,
         }


### PR DESCRIPTION
This configuration option is no longer in use.