### PR TITLE
feat!: lazy config loading

### DIFF
--- a/crates/sail-python/src/lib.rs
+++ b/crates/sail-python/src/lib.rs
@@ -15,25 +15,6 @@ use pyo3::prelude::*;
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     spark::register_module(m)?;
     m.add_function(wrap_pyfunction!(cli::main, m)?)?;
-    m.add_function(wrap_pyfunction!(initialize, m)?)?;
     m.add("_SAIL_VERSION", env!("CARGO_PKG_VERSION"))?;
-    Ok(())
-}
-
-/// Initializes the native module global state eagerly.
-///
-/// The native module can still function properly if this function is not called,
-/// since the global state supports lazy initialization on first access.
-/// But calling this function makes it easier to reason about the environment variables
-/// used to load the configuration.
-///
-/// This function is idempotent on success and can be called multiple times.
-///
-/// This function should not be called when using `cli::main`, since the CLI
-/// entrypoint initializes telemetry on its own and conflicts with the global state
-/// that is supposed to be used only when using the library programmatically.
-#[pyfunction]
-fn initialize(py: Python<'_>) -> PyResult<()> {
-    let _ = globals::GlobalState::instance(py)?;
     Ok(())
 }

--- a/crates/sail-python/src/spark/server.rs
+++ b/crates/sail-python/src/spark/server.rs
@@ -56,13 +56,15 @@ impl SparkConnectServer {
     #[new]
     #[pyo3(signature = (ip, port, /))]
     fn new(py: Python<'_>, ip: &str, port: u16) -> PyResult<Self> {
+        let config = AppConfig::load().map_err(|e| {
+            PyErr::new::<PyRuntimeError, _>(format!("failed to load the application config: {e}"))
+        })?;
         let globals = GlobalState::instance(py)?;
-        let config = globals.config.clone();
         let runtime = globals.runtime.handle();
         Ok(Self {
             ip: ip.to_string(),
             port,
-            config,
+            config: Arc::new(config),
             runtime,
             state: None,
         })

--- a/python/pysail/spark/__init__.py
+++ b/python/pysail/spark/__init__.py
@@ -6,8 +6,6 @@ __all__ = [
     "SparkConnectServer",
 ]
 
-_native.initialize()
-
 
 class SparkConnectServer:
     """The Spark Connect server that uses Sail as the computation engine."""

--- a/python/pysail/tests/conftest.py
+++ b/python/pysail/tests/conftest.py
@@ -43,6 +43,8 @@ def configure_sail_environment():
     # number of CPU cores to ensure deterministic test results, especially for
     # snapshot tests involving execution plans.
     os.environ["SAIL_EXECUTION__DEFAULT_PARALLELISM"] = "4"
+    # Set the stack size explicitly to assist the configuration removal test.
+    os.environ["SAIL_RUNTIME__STACK_SIZE"] = "8388608"
 
     # Ensure the native module can be imported successfully.
     # This allows this function to be future-proof in case we ever change the native module name.

--- a/python/pysail/tests/spark/test_config.py
+++ b/python/pysail/tests/spark/test_config.py
@@ -5,27 +5,23 @@ import pytest
 from pysail.spark import SparkConnectServer
 
 
-def test_warning_on_config_addition(monkeypatch):
-    # The application configuration will refuse to load if there are unknown
-    # environment variables. But since the application configuration is already
-    # loaded globally, the configuration loader would not run inside this test,
-    # so this unknown environment variable is good enough for testing purposes here.
-    key = "SAIL_UNKNOWN_KEY"
+def test_warning_on_static_config_addition(monkeypatch):
+    key = "SAIL_TELEMETRY__OTLP_ENDPOINT"
     assert key not in os.environ
-    monkeypatch.setenv(key, "42")
+    monkeypatch.setenv(key, "http://localhost:4317")
     with pytest.warns(RuntimeWarning, match=f"ignored.*{key}"):
         _ = SparkConnectServer()
 
 
-def test_warning_on_config_deletion(monkeypatch):
-    key = "SAIL_EXECUTION__DEFAULT_PARALLELISM"
+def test_warning_on_static_config_deletion(monkeypatch):
+    key = "SAIL_RUNTIME__STACK_SIZE"
     monkeypatch.delenv(key, raising=True)
     with pytest.warns(RuntimeWarning, match=f"ignored.*{key}"):
         _ = SparkConnectServer()
 
 
-def test_warning_on_config_modification(monkeypatch):
-    key = "SAIL_EXECUTION__DEFAULT_PARALLELISM"
+def test_warning_on_static_config_modification(monkeypatch):
+    key = "SAIL_RUNTIME__STACK_SIZE"
     monkeypatch.setenv(key, str(int(os.environ[key]) * 2))
     with pytest.warns(RuntimeWarning, match=f"ignored.*{key}"):
         _ = SparkConnectServer()


### PR DESCRIPTION
#1302 introduces a breaking change that ignores Sail environment variable changes once the PySail module is imported. This was meant to make the server behavior predictable and consistent with telemetry initialization that is done globally. However, I now realize that such a way of configuring the Sail server may result in confusing user behavior, even if we have emitted a warning when we ignore environment variable changes.

For example, in benchmark scripts, we have this common pattern:

```python
import os
from pysail.spark import SparkConnectServer

# This is ignored after #1302.
os.environ["SAIL_OPTIMIZER__ENABLE_JOIN_REORDER"] = "true"

server = SparkConnectServer()
```

Since such scripts run automatically, we have no way to observe the warning and know that the server was initialized improperly.

This PR reverts the breaking change around configuration. Each `SparkConnectServer` instance now loads the configuration again from the environment variables (the same way before #1302). We only ignore the few configuration options related to telemetry and the runtime stack.

This should also revert the ~3% coverage decrease since #1302 (although we've already been thinking about fixing it).