### PR TITLE
chore: skip PySpark parity test with segfault

### DIFF
--- a/scripts/spark-tests/plugins/spark.py
+++ b/scripts/spark-tests/plugins/spark.py
@@ -260,6 +260,10 @@ SKIPPED_SPARK_TESTS = [
         reason="Segmentation fault",
     ),
     TestMarker(
+        keywords=["test_data_source_segfault"],
+        reason="Segmentation fault",
+    ),
+    TestMarker(
         keywords=["test_reattach.py"],
         reason="Slow test not working yet",
     ),


### PR DESCRIPTION
This is needed before merging #1336.