### PR TITLE
ci: add python path test

### DIFF
--- a/scripts/spark-tests/run-server.sh
+++ b/scripts/spark-tests/run-server.sh
@@ -34,5 +34,6 @@ if [ -z "${CI:-}" ]; then
 
   cargo run -p sail-cli -- spark server -C "${work_dir}"
 else
+  export PYTHONPATH="${VIRTUAL_ENV}/lib/python${python_version}/site-packages"
   sail spark server -C "${work_dir}"
 fi


### PR DESCRIPTION
Try to solve 
if run server like:
```sh
hatch run scripts/spark-tests/run-server.sh
```
test
```sh
export SPARK_REMOTE="sc://localhost:50051"
hatch run test-spark.spark-4.1.1:bash scripts/spark-tests/run-tests.sh --doctest-modules --pyargs pyspark.sql.dataframe -k "foreach" --tb=short -q
```
<img width="1206" height="144" alt="image" src="https://github.com/user-attachments/assets/6cd7b7e4-958e-46c2-a412-d2d29570a2f0" />


After seeing #478 implemented, I remembered these functions were failing.