### PR TITLE
fix: explicit Python initialization for Python data source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6483,6 +6483,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "pyo3",
  "quote",
  "regex",
  "sail-cache",

--- a/crates/sail-data-source/Cargo.toml
+++ b/crates/sail-data-source/Cargo.toml
@@ -27,7 +27,7 @@ bytes = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 chrono = { workspace = true }
-pyo3 = { workspace = true, features = ["auto-initialize"] }
+pyo3 = { workspace = true }
 arrow = { workspace = true }
 arrow-schema = { workspace = true }
 arrow-pyarrow = { workspace = true }

--- a/crates/sail-spark-connect/Cargo.toml
+++ b/crates/sail-spark-connect/Cargo.toml
@@ -39,6 +39,7 @@ phf = { workspace = true }
 log = { workspace = true }
 futures = { workspace = true }
 fastrace = { workspace = true }
+pyo3 = { workspace = true }
 
 [build-dependencies]
 prost-build = { workspace = true }

--- a/crates/sail-spark-connect/src/proto/function.rs
+++ b/crates/sail-spark-connect/src/proto/function.rs
@@ -6,6 +6,7 @@ mod tests {
     use datafusion::arrow::array::RecordBatch;
     use datafusion::arrow::error::ArrowError;
     use datafusion::arrow::util::display::{ArrayFormatter, FormatOptions};
+    use pyo3::Python;
     use sail_common::config::AppConfig;
     use sail_common::runtime::RuntimeManager;
     use sail_common::tests::test_gold_set;
@@ -54,6 +55,8 @@ mod tests {
 
     #[test]
     fn test_sql_function() -> Result<(), Box<dyn std::error::Error>> {
+        // Initialize Python for Python data source registration when creating sessions.
+        Python::initialize();
         let config = Arc::new(AppConfig::load()?);
         let runtime = RuntimeManager::try_new(&config.runtime)?;
         let handle = runtime.handle();


### PR DESCRIPTION
We cannot use the `auto-initialize` feature in PyO3 when building the `pysail` Python package.