### PR TITLE
chore: add doc comments and refactor task execution internals

### DIFF
--- a/crates/sail-execution/src/driver/actor/handler.rs
+++ b/crates/sail-execution/src/driver/actor/handler.rs
@@ -509,6 +509,11 @@ impl DriverActor {
         }
     }
 
+    /// Assigns pending tasks to available workers and dispatches them for execution.
+    ///
+    /// Gets task assignments from the task assigner, builds task definitions from the job
+    /// scheduler, and dispatches each task to either the driver or a remote worker via gRPC.
+    /// Tasks that fail to build a definition are reported as failed.
     fn run_tasks(&mut self, ctx: &mut ActorContext<Self>) {
         let assignments = self.task_assigner.assign_tasks();
         self.task_assigner.track_streams(&assignments);

--- a/crates/sail-execution/src/driver/job_scheduler/core.rs
+++ b/crates/sail-execution/src/driver/job_scheduler/core.rs
@@ -62,6 +62,7 @@ impl JobScheduler {
         Ok((job_id, stream))
     }
 
+    /// Updates the state of a task attempt, triggering any downstream job progress transitions.
     pub fn update_task(
         &mut self,
         key: &TaskKey,
@@ -503,6 +504,7 @@ impl JobScheduler {
         actions
     }
 
+    /// Builds the serialized task definition and context for the given task key.
     pub fn get_task_definition(
         &self,
         key: &TaskKey,
@@ -575,6 +577,7 @@ impl JobScheduler {
         }
     }
 
+    /// Computes the correct input locations (driver, worker, or remote) to resolve a given stage input dependency.
     fn get_task_input(
         &self,
         job: &JobDescriptor,
@@ -704,6 +707,7 @@ impl JobScheduler {
         Ok(TaskInput { locator })
     }
 
+    /// Determines the output distribution and storage location (local or remote) for a given stage.
     fn get_task_output(
         &self,
         job: &JobDescriptor,

--- a/crates/sail-execution/src/driver/task_assigner/mod.rs
+++ b/crates/sail-execution/src/driver/task_assigner/mod.rs
@@ -11,6 +11,7 @@ use crate::driver::task_assigner::state::{DriverResource, WorkerResource};
 use crate::id::{TaskKey, WorkerId};
 use crate::task::scheduling::{TaskAssignment, TaskRegion};
 
+/// Manages task queuing and assignment across the driver and worker slots.
 pub struct TaskAssigner {
     options: TaskAssignerOptions,
     driver: DriverResource,
@@ -18,11 +19,14 @@ pub struct TaskAssigner {
     requested_worker_count: usize,
     /// A lookup table from task attempts to the place they are assigned to.
     /// This is more convenient than finding the task attempt in the task slots.
+    ///
     /// Each task attempt can only be assigned once throughout its lifetime.
+    ///
     /// This lookup table is updated when the task attempt is assigned,
     /// but there is no need to remove the task attempt when it is completed, as
     /// the mapping is still valid for historical purposes.
     task_assignments: IndexMap<TaskKey, TaskAssignment>,
+    /// Pending task regions waiting to be assigned to available driver or worker slots.
     task_queue: VecDeque<TaskRegion>,
 }
 

--- a/crates/sail-execution/src/driver/worker_pool/core.rs
+++ b/crates/sail-execution/src/driver/worker_pool/core.rs
@@ -173,6 +173,7 @@ impl WorkerPool {
         }
     }
 
+    /// Returns the network locations of all currently running workers.
     fn list_running_workers(&self) -> Vec<WorkerLocation> {
         self.workers
             .iter()
@@ -255,6 +256,7 @@ impl WorkerPool {
         }
     }
 
+    /// Dispatches a task to a specific worker by sending the task definition over gRPC.
     pub fn run_task(
         &mut self,
         ctx: &mut ActorContext<DriverActor>,
@@ -406,6 +408,7 @@ impl WorkerPool {
         Self::clean_up_job_for_worker(ctx, job_id, stage, worker_id, worker, &self.options);
     }
 
+    /// Returns or initializes the gRPC client set for the given worker.
     fn get_client_set(
         worker_id: WorkerId,
         worker: &mut WorkerDescriptor,
@@ -491,6 +494,7 @@ impl WorkerPool {
         );
     }
 
+    /// Schedules probes to monitor the worker for idle timeout and heartbeat loss.
     fn track_worker_activity(
         ctx: &mut ActorContext<DriverActor>,
         worker_id: WorkerId,

--- a/crates/sail-execution/src/id.rs
+++ b/crates/sail-execution/src/id.rs
@@ -90,6 +90,7 @@ where
     }
 }
 
+/// Uniquely identifies a task attempt within a job by stage, partition, and attempt number.
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub struct TaskKey {
     pub job_id: JobId,

--- a/crates/sail-execution/src/job_graph/mod.rs
+++ b/crates/sail-execution/src/job_graph/mod.rs
@@ -96,6 +96,7 @@ pub struct Stage {
     pub placement: TaskPlacement,
 }
 
+/// Specifies whether a task must run on the driver or on any available worker node.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub enum TaskPlacement {
     Driver,

--- a/crates/sail-execution/src/job_graph/planner.rs
+++ b/crates/sail-execution/src/job_graph/planner.rs
@@ -164,6 +164,7 @@ enum PartitionUsage {
     Shared,
 }
 
+/// Recursively splits an execution plan into stages at shuffle boundaries and adds them to the job graph.
 fn build_job_graph(
     plan: Arc<dyn ExecutionPlan>,
     usage: PartitionUsage,

--- a/crates/sail-execution/src/task/scheduling.rs
+++ b/crates/sail-execution/src/task/scheduling.rs
@@ -30,12 +30,14 @@ pub struct TaskSet {
     pub entries: Vec<TaskSetEntry>,
 }
 
+/// A single task within a task set, pairing a task key with its output stream kind.
 #[derive(Debug, Clone)]
 pub struct TaskSetEntry {
     pub key: TaskKey,
     pub output: TaskOutputKind,
 }
 
+/// Whether a task's output stream is stored locally on the executing node or written to a remote location.
 #[derive(Debug, Clone)]
 pub enum TaskOutputKind {
     Local,
@@ -43,16 +45,19 @@ pub enum TaskOutputKind {
 }
 
 impl TaskRegion {
+    /// Returns true if any task set in this region contains the specified task key.
     pub fn contains(&self, key: &TaskKey) -> bool {
         self.tasks.iter().any(|(_, set)| set.contains(key))
     }
 }
 
 impl TaskSet {
+    /// Returns an iterator over all task keys within this set.
     pub fn tasks(&self) -> impl Iterator<Item = &TaskKey> {
         self.entries.iter().map(|entry| &entry.key)
     }
 
+    /// Returns an iterator over all task keys in this set whose outputs are streamed locally.
     pub fn local_streams(&self) -> impl Iterator<Item = &TaskKey> {
         self.entries
             .iter()
@@ -60,6 +65,7 @@ impl TaskSet {
             .map(|entry| &entry.key)
     }
 
+    /// Returns an iterator over all task keys in this set whose outputs are streamed remotely.
     pub fn remote_streams(&self) -> impl Iterator<Item = &TaskKey> {
         self.entries
             .iter()
@@ -67,11 +73,13 @@ impl TaskSet {
             .map(|entry| &entry.key)
     }
 
+    /// Returns true if the specified task key is included in this set.
     pub fn contains(&self, key: &TaskKey) -> bool {
         self.entries.iter().any(|entry| &entry.key == key)
     }
 }
 
+/// Pairs a TaskSet with an execution location.
 #[derive(Debug, Clone)]
 pub struct TaskSetAssignment {
     pub set: TaskSet,
@@ -79,12 +87,14 @@ pub struct TaskSetAssignment {
 }
 
 #[derive(Debug, Clone)]
+/// The resolved execution location for a task, either the driver or a specific worker slot.
 pub enum TaskAssignment {
     Driver,
     Worker { worker_id: WorkerId, slot: usize },
 }
 
 pub trait TaskAssignmentGetter {
+    /// Retrieves the assigned execution location for a specific task attempt, if it exists.
     fn get(&self, key: &TaskKey) -> Option<&TaskAssignment>;
 }
 

--- a/crates/sail-execution/src/worker/client.rs
+++ b/crates/sail-execution/src/worker/client.rs
@@ -41,6 +41,7 @@ impl WorkerClient {
 }
 
 impl WorkerClient {
+    /// Sends a task execution request to the remote worker via gRPC.
     pub async fn run_task(
         &self,
         key: TaskKey,

--- a/crates/sail-plan/src/lib.rs
+++ b/crates/sail-plan/src/lib.rs
@@ -51,7 +51,7 @@ pub async fn execute_logical_plan(ctx: &SessionContext, plan: LogicalPlan) -> Re
     Ok(df)
 }
 
-pub async fn resolve_and_execute_plan(
+pub async fn resolve_to_execution_plan(
     ctx: &SessionContext,
     config: Arc<PlanConfig>,
     plan: spec::Plan,

--- a/crates/sail-plan/src/resolver/command/mod.rs
+++ b/crates/sail-plan/src/resolver/command/mod.rs
@@ -24,6 +24,7 @@ mod write_v1;
 mod write_v2;
 
 impl PlanResolver<'_> {
+    /// Routes a command plan to the specific handler for its variant and returns the resolved plan.
     pub(super) async fn resolve_command_plan(
         &self,
         plan: spec::CommandPlan,

--- a/crates/sail-plan/src/resolver/plan.rs
+++ b/crates/sail-plan/src/resolver/plan.rs
@@ -14,6 +14,7 @@ pub struct NamedPlan {
 }
 
 impl PlanResolver<'_> {
+    /// Resolves a Spark plan spec into a DataFusion logical plan with optional output field names.
     pub async fn resolve_named_plan(&self, plan: spec::Plan) -> PlanResult<NamedPlan> {
         let mut state = PlanResolverState::new();
         match plan {

--- a/crates/sail-spark-connect/src/proto/function.rs
+++ b/crates/sail-spark-connect/src/proto/function.rs
@@ -12,7 +12,7 @@ mod tests {
     use sail_common::tests::test_gold_set;
     use sail_common_datafusion::extension::SessionExtensionAccessor;
     use sail_common_datafusion::session::job::JobService;
-    use sail_plan::resolve_and_execute_plan;
+    use sail_plan::resolve_to_execution_plan;
     use serde::{Deserialize, Serialize};
 
     use crate::error::{SparkError, SparkResult};
@@ -88,7 +88,7 @@ mod tests {
                     let spark = context.extension::<SparkSession>()?;
                     let service = context.extension::<JobService>()?;
                     let (plan, _) =
-                        resolve_and_execute_plan(&context, spark.plan_config()?, plan).await?;
+                        resolve_to_execution_plan(&context, spark.plan_config()?, plan).await?;
                     let stream = service.runner().execute(&context, plan).await?;
                     read_stream(stream).await
                 });

--- a/crates/sail-telemetry/src/execution/physical_plan.rs
+++ b/crates/sail-telemetry/src/execution/physical_plan.rs
@@ -50,6 +50,7 @@ impl TracingExecOptions {
     }
 }
 
+/// Wraps an execution plan with distributed tracing instrumentation, collecting spans and metrics per operator.
 pub fn trace_execution_plan(
     plan: Arc<dyn ExecutionPlan>,
     options: TracingExecOptions,


### PR DESCRIPTION
Non-function changes made when creating caching. Separating this out into it's own PR so it's easier to review.

## Summary

- Add doc comments to task scheduling, assignment, worker pool, telemetry, and plan resolver types and methods
- Extract `assign_all_possible` helper on `TaskSlotAssigner` to deduplicate region assignment logic in `TaskAssigner::assign_tasks`
- Extract `rewrite_stage_inputs` from `TaskRunner::rewrite_shuffle` to separate stage input replacement from shuffle write wrapping
- Extract `build_partitioner` from `ShuffleWriteExec::execute` to isolate partitioner construction
- Rename `resolve_and_execute_plan` → `resolve_to_execution_plan` to more accurately reflect that the function resolves to a physical plan without executing it