### PR TITLE
fix: handle schemeless URLs in `parse_url` for PATH and FILE components

### DIFF
--- a/crates/sail-function/src/scalar/url/parse_url.rs
+++ b/crates/sail-function/src/scalar/url/parse_url.rs
@@ -95,11 +95,35 @@ impl ParseUrl {
                 _ => None,
             }),
             Err(url::ParseError::RelativeUrlWithoutBase) => {
-                // Spark's java.net.URI treats schemeless strings as relative URIs
-                // where the string itself becomes the path component.
+                // Spark's java.net.URI treats schemeless strings as relative URIs.
+                // Parse the components manually: path?query#fragment
+                let (without_fragment, fragment) = match value.find('#') {
+                    Some(i) => (&value[..i], Some(&value[i + 1..])),
+                    None => (value, None),
+                };
+                let (path, query) = match without_fragment.find('?') {
+                    Some(i) => (&without_fragment[..i], Some(&without_fragment[i + 1..])),
+                    None => (without_fragment, None),
+                };
                 Ok(match part {
-                    "PATH" => Some(value.to_string()),
-                    "FILE" => Some(value.to_string()),
+                    "PATH" => Some(path.to_string()),
+                    "QUERY" => match key {
+                        None => query.map(String::from),
+                        Some(key) => query.and_then(|q| {
+                            q.split('&')
+                                .filter_map(|pair| pair.split_once('='))
+                                .find(|(k, _)| *k == key)
+                                .map(|(_, v)| v.to_string())
+                        }),
+                    },
+                    "REF" => fragment.map(String::from),
+                    "FILE" => {
+                        let file = match query {
+                            Some(q) => format!("{path}?{q}"),
+                            None => path.to_string(),
+                        };
+                        Some(file)
+                    }
                     _ => None,
                 })
             }

--- a/python/pysail/tests/spark/function/features/parse_url.feature
+++ b/python/pysail/tests/spark/function/features/parse_url.feature
@@ -114,6 +114,119 @@ Feature: parse_url() extracts URL component
         | result  |
         | notaurl |
 
+    Scenario: parse_url schemeless URL with query extracts PATH without query
+      When query
+        """
+        SELECT parse_url('notaurl?key=value', 'PATH') AS result
+        """
+      Then query result
+        | result  |
+        | notaurl |
+
+    Scenario: parse_url schemeless URL with query extracts FILE with query
+      When query
+        """
+        SELECT parse_url('notaurl?key=value', 'FILE') AS result
+        """
+      Then query result
+        | result             |
+        | notaurl?key=value  |
+
+    Scenario: parse_url schemeless URL extracts QUERY
+      When query
+        """
+        SELECT parse_url('notaurl?key=value', 'QUERY') AS result
+        """
+      Then query result
+        | result    |
+        | key=value |
+
+    Scenario: parse_url schemeless URL extracts QUERY with key
+      When query
+        """
+        SELECT parse_url('notaurl?a=1&b=2', 'QUERY', 'b') AS result
+        """
+      Then query result
+        | result |
+        | 2      |
+
+    Scenario: parse_url schemeless URL extracts REF
+      When query
+        """
+        SELECT parse_url('notaurl#reference', 'REF') AS result
+        """
+      Then query result
+        | result    |
+        | reference |
+
+    Scenario: parse_url schemeless URL with query and fragment
+      When query
+        """
+        SELECT parse_url('page?q=1#frag', 'PATH') AS r1,
+               parse_url('page?q=1#frag', 'QUERY') AS r2,
+               parse_url('page?q=1#frag', 'REF') AS r3,
+               parse_url('page?q=1#frag', 'FILE') AS r4
+        """
+      Then query result
+        | r1   | r2  | r3   | r4       |
+        | page | q=1 | frag | page?q=1 |
+
+    Scenario: parse_url schemeless URL with path segments
+      When query
+        """
+        SELECT parse_url('a/b/c?q=1', 'PATH') AS r1,
+               parse_url('a/b/c?q=1', 'QUERY') AS r2,
+               parse_url('a/b/c?q=1', 'FILE') AS r3
+        """
+      Then query result
+        | r1    | r2  | r3        |
+        | a/b/c | q=1 | a/b/c?q=1 |
+
+    Scenario: parse_url schemeless URL HOST AUTHORITY USERINFO are NULL
+      When query
+        """
+        SELECT parse_url('notaurl?q=1', 'HOST') AS r1,
+               parse_url('notaurl?q=1', 'AUTHORITY') AS r2,
+               parse_url('notaurl?q=1', 'USERINFO') AS r3,
+               parse_url('notaurl?q=1', 'PROTOCOL') AS r4
+        """
+      Then query result
+        | r1   | r2   | r3   | r4   |
+        | NULL | NULL | NULL | NULL |
+
+    Scenario: parse_url schemeless URL with only query
+      When query
+        """
+        SELECT parse_url('?key=value', 'QUERY') AS r1,
+               parse_url('?key=value', 'QUERY', 'key') AS r2,
+               parse_url('?key=value', 'PATH') AS r3
+        """
+      Then query result
+        | r1        | r2    | r3 |
+        | key=value | value |    |
+
+    Scenario: parse_url schemeless URL with only fragment
+      When query
+        """
+        SELECT parse_url('#frag', 'REF') AS r1,
+               parse_url('#frag', 'PATH') AS r2
+        """
+      Then query result
+        | r1   | r2 |
+        | frag |    |
+
+    Scenario: parse_url schemeless URL multiple query params
+      When query
+        """
+        SELECT parse_url('page?a=1&b=2&c=3', 'QUERY') AS r1,
+               parse_url('page?a=1&b=2&c=3', 'QUERY', 'a') AS r2,
+               parse_url('page?a=1&b=2&c=3', 'QUERY', 'c') AS r3,
+               parse_url('page?a=1&b=2&c=3', 'QUERY', 'missing') AS r4
+        """
+      Then query result
+        | r1          | r2 | r3 | r4   |
+        | a=1&b=2&c=3 | 1  | 3  | NULL |
+
     Scenario: parse_url with URL without scheme PROTOCOL returns NULL
       When query
         """


### PR DESCRIPTION
Spark's `java.net.URI` treats schemeless strings (e.g. `'notaurl'`) as relative URIs where the entire input becomes the path component. The Rust `url` crate rejects these with `RelativeUrlWithoutBase`, and the current implementation maps all such errors to `NULL` — but Spark returns the input string for `PATH` and `FILE`.
