### PR TITLE
fix: support non-literal expressions in window RANGE frame boundaries

### DIFF
--- a/crates/sail-plan/src/resolver/expression/window.rs
+++ b/crates/sail-plan/src/resolver/expression/window.rs
@@ -238,25 +238,18 @@ impl PlanResolver<'_> {
         if let datafusion_expr::Expr::Literal(scalar, _) = resolved {
             return Ok(scalar);
         }
-        // Apply type coercion and constant folding before evaluating.
+        // Apply type coercion so that expressions like `CAST(0 AS INTERVAL SECOND)`
+        // have compatible types before physical evaluation.
         let props = ExecutionProps::new();
         let context = SimplifyContext::new(&props).with_schema(schema.clone());
-        let simplifier = ExprSimplifier::new(context).with_max_cycles(10);
+        let simplifier = ExprSimplifier::new(context);
         let coerced = simplifier.coerce(resolved, schema).map_err(|e| {
             PlanError::invalid(format!(
                 "window boundary must be a constant expression: {e}"
             ))
         })?;
-        let simplified = simplifier.simplify(coerced).map_err(|e| {
-            PlanError::invalid(format!(
-                "window boundary must be a constant expression: {e}"
-            ))
-        })?;
-        if let datafusion_expr::Expr::Literal(scalar, _) = simplified {
-            return Ok(scalar);
-        }
         let evaluator = LiteralEvaluator::new();
-        evaluator.evaluate(&simplified).map_err(|e| {
+        evaluator.evaluate(&coerced).map_err(|e| {
             PlanError::invalid(format!(
                 "window boundary must be a constant expression: {e}"
             ))

--- a/python/pysail/tests/spark/function/features/window_range_interval.feature
+++ b/python/pysail/tests/spark/function/features/window_range_interval.feature
@@ -72,3 +72,30 @@ Feature: Window RANGE frame with interval boundaries
         | 20  | 30    |
         | 30  | 60    |
         | 40  | 70    |
+
+  Rule: RANGE frame with integer boundary on numeric ORDER BY
+
+    Scenario: sum with integer range boundary
+      When query
+        """
+        SELECT
+          id,
+          SUM(val) OVER (ORDER BY id RANGE BETWEEN 2 PRECEDING AND CURRENT ROW) AS total
+        FROM (
+          SELECT * FROM VALUES
+            (1, 10),
+            (2, 20),
+            (3, 30),
+            (5, 50),
+            (8, 80)
+          AS t(id, val)
+        )
+        ORDER BY id
+        """
+      Then query result ordered
+        | id | total |
+        | 1  | 10    |
+        | 2  | 30    |
+        | 3  | 60    |
+        | 5  | 80    |
+        | 8  | 80    |


### PR DESCRIPTION
Ibis generates `CAST(0 AS INTERVAL SECOND)` for window RANGE boundaries,
which failed because `resolve_window_boundary` only accepted literals.
Now it resolves arbitrary constant expressions via type coercion +
constant folding + LiteralEvaluator.

part #501 