### PR TITLE
fix: align datetime functions with Spark semantics

### DIFF
--- a/crates/sail-function/src/scalar/datetime/spark_next_day.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_next_day.rs
@@ -145,8 +145,14 @@ impl ScalarUDFImpl for SparkNextDay {
             if matches!(&arg_types[1], DataType::Utf8)
                 || matches!(&arg_types[1], DataType::LargeUtf8)
                 || matches!(&arg_types[1], DataType::Utf8View)
+                || matches!(&arg_types[1], DataType::Null)
             {
-                Ok(vec![DataType::Date32, arg_types[1].clone()])
+                let second_type = if matches!(&arg_types[1], DataType::Null) {
+                    DataType::Utf8
+                } else {
+                    arg_types[1].clone()
+                };
+                Ok(vec![DataType::Date32, second_type])
             } else {
                 plan_err!(
                     "The second argument of the Spark `next_day` function must be a string, but got {}",

--- a/crates/sail-plan/src/function/scalar/datetime.rs
+++ b/crates/sail-plan/src/function/scalar/datetime.rs
@@ -26,10 +26,13 @@ use crate::error::{PlanError, PlanResult};
 use crate::function::common::{ScalarFunction, ScalarFunctionInput};
 
 fn integer_part(expr: Expr, part: &str) -> Expr {
-    cast(
-        expr_fn::date_part(lit(part.to_uppercase()), expr),
-        DataType::Int32,
-    )
+    // Guard against Null type input — DataFusion's date_part rejects Null.
+    when(expr.clone().is_null(), lit(ScalarValue::Int32(None)))
+        .otherwise(cast(
+            expr_fn::date_part(lit(part.to_uppercase()), expr),
+            DataType::Int32,
+        ))
+        .unwrap_or_else(|_| lit(ScalarValue::Int32(None)))
 }
 
 fn trunc_part_conversion(part: Expr) -> Expr {
@@ -787,7 +790,16 @@ pub(super) fn list_built_in_datetime_functions() -> Vec<(&'static str, ScalarFun
             F::custom(|input| unix_time_unit(input, TimeUnit::Second)),
         ),
         ("unix_timestamp", F::custom(unix_timestamp)),
-        ("weekday", F::unary(|arg| integer_part(arg, "DOW") - lit(1))),
+        (
+            "weekday",
+            F::unary(|arg| {
+                Expr::BinaryExpr(BinaryExpr {
+                    left: Box::new(integer_part(arg, "DOW") + lit(6)),
+                    op: Operator::Modulo,
+                    right: Box::new(lit(7)),
+                })
+            }),
+        ),
         (
             "weekofyear",
             F::unary(|arg| cast(expr_fn::to_char(arg, lit("%V")), DataType::Int32)),

--- a/python/pysail/tests/spark/function/features/datetime.feature
+++ b/python/pysail/tests/spark/function/features/datetime.feature
@@ -1,0 +1,61 @@
+Feature: Datetime functions
+
+  Rule: weekday
+
+    Scenario: weekday sunday is 6
+      When query
+        """
+        SELECT weekday(DATE '2024-03-17') AS result
+        """
+      Then query result
+        | result |
+        | 6      |
+
+  Rule: null handling
+
+    Scenario: year of null
+      When query
+        """
+        SELECT year(NULL) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: month of null
+      When query
+        """
+        SELECT month(NULL) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: datediff with null
+      When query
+        """
+        SELECT datediff(NULL, DATE '2024-03-15') AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: last_day of null
+      When query
+        """
+        SELECT last_day(NULL) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+  Rule: next_day null handling
+
+    Scenario: next_day with null day of week
+      When query
+        """
+        SELECT next_day(DATE '2024-03-15', NULL) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |


### PR DESCRIPTION
- weekday: (DOW + 6) % 7 instead of DOW - 1 (Sunday returned -1 instead of 6)
- integer_part: null guard for year/month/day/etc with NULL input
- next_day: handle Null type for second argument in coerce_types