### PR TITLE
fix: truncate gRPC error messages to prevent RESOURCE_EXHAUSTED

### DIFF
--- a/crates/sail-spark-connect/src/error.rs
+++ b/crates/sail-spark-connect/src/error.rs
@@ -295,16 +295,22 @@ impl From<SparkThrowable> for Status {
         // Reference: org.apache.spark.sql.connect.utils.ErrorUtils#buildStatusFromThrowable
         //
         // Truncate the message to avoid exceeding the gRPC trailing metadata size limit (~8KB).
-        // The message appears both in `grpc-message` and `grpc-status-details-bin`,
-        // so the effective budget per message is roughly half the limit.
-        const MAX_ERROR_MESSAGE_LEN: usize = 2048;
+        // The message appears both in `grpc-message` (percent-encoded) and
+        // `grpc-status-details-bin` (base64-encoded), so the effective budget per message
+        // is roughly a quarter of the limit after encoding overhead.
+        const TRUNCATION_SUFFIX: &str = " (truncated)";
+        const MAX_ERROR_MESSAGE_LEN: usize = 1024;
         let message = throwable.message();
         let message = if message.len() > MAX_ERROR_MESSAGE_LEN {
-            &message[..message.floor_char_boundary(MAX_ERROR_MESSAGE_LEN)]
+            let available = MAX_ERROR_MESSAGE_LEN.saturating_sub(TRUNCATION_SUFFIX.len());
+            let end = message.floor_char_boundary(available);
+            let mut truncated = String::from(&message[..end]);
+            truncated.push_str(TRUNCATION_SUFFIX);
+            truncated
         } else {
-            message
+            message.to_string()
         };
-        Status::with_error_details(Code::Internal, message, details)
+        Status::with_error_details(Code::Internal, &message, details)
     }
 }
 


### PR DESCRIPTION
Truncate gRPC error messages to prevent RESOURCE_EXHAUSTED

Error messages containing full physical plans can exceed the gRPC trailing metadata size limit (~8KB), causing RESOURCE_EXHAUSTED instead of the actual error. This made debugging impossible since the real exception type and message were lost.

Truncate throwable.message() to 1KB before passing to Status::with_error_details(). The message appears in both grpc-message (percent-encoded) and grpc-status-details-bin (base64-encoded), so the effective budget is roughly a quarter of the limit after encoding overhead. A (truncated) suffix is appended so clients can distinguish truncation from the original message.

Before: StatusCode.RESOURCE_EXHAUSTED — no useful error info
After: SparkRuntimeException — real error with truncated plan (root cause visible)

Fixes ~4 Ibis tests that previously failed with RESOURCE_EXHAUSTED, now showing their real underlying errors (mostly CollectLeft planning failures).


part #501 