### PR TITLE
refactor: remove redundant arg count checks in invoke_with_args

### DIFF
--- a/crates/sail-function/src/scalar/array/spark_array_item_with_position.rs
+++ b/crates/sail-function/src/scalar/array/spark_array_item_with_position.rs
@@ -11,7 +11,6 @@ use datafusion::arrow::datatypes::{
 use datafusion::common::cast::{as_large_list_array, as_list_array};
 use datafusion::common::{DataFusionError, Result};
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
-use datafusion_common::exec_err;
 use datafusion_expr::ScalarFunctionArgs;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -126,12 +125,7 @@ impl ScalarUDFImpl for ArrayItemWithPosition {
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
         let args = ColumnarValue::values_to_arrays(&args)?;
-        let [arg] = args.as_slice() else {
-            return exec_err!(
-                "{} should only be called with a single argument",
-                self.name()
-            );
-        };
+        let arg = &args[0];
         let out = match arg.data_type() {
             DataType::List(f) => {
                 let array = as_list_array(arg)?;

--- a/crates/sail-function/src/scalar/array/spark_sequence.rs
+++ b/crates/sail-function/src/scalar/array/spark_sequence.rs
@@ -124,13 +124,6 @@ impl ScalarUDFImpl for SparkSequence {
 }
 
 fn gen_sequence_timestamp(args: &[ArrayRef]) -> Result<ArrayRef> {
-    if args.len() != 3 {
-        return exec_err!(
-            "Spark `sequence` function requires 3 arguments for TIMESTAMP, got {}",
-            args.len()
-        );
-    }
-
     let (start_array, start_tz, stop_array, stop_tz) =
         match (&args[0].data_type(), &args[1].data_type()) {
             (
@@ -228,13 +221,6 @@ fn gen_sequence_timestamp(args: &[ArrayRef]) -> Result<ArrayRef> {
 }
 
 fn gen_sequence_date(args: &[ArrayRef]) -> Result<ArrayRef> {
-    if args.len() < 2 || args.len() > 3 {
-        return exec_err!(
-            "Spark `sequence` function requires 2 or 3 arguments for DATE, got {}",
-            args.len()
-        );
-    }
-
     let (start_array, stop_array, step_array) = match args.len() {
         2 => (
             Some(args[0].as_primitive::<Date32Type>()),

--- a/crates/sail-function/src/scalar/collection/spark_reverse.rs
+++ b/crates/sail-function/src/scalar/collection/spark_reverse.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 
 use datafusion::arrow::datatypes::DataType;
 use datafusion::functions::unicode::reverse::ReverseFunc;
-use datafusion_common::{exec_err, Result};
+use datafusion_common::Result;
 use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
 use datafusion_functions_nested::reverse::array_reverse_inner;
 
@@ -45,9 +45,6 @@ impl ScalarUDFImpl for SparkReverse {
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        if args.args.len() != 1 {
-            return exec_err!("array_reverse needs one argument");
-        }
         match args.args[0].data_type() {
             DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
                 ReverseFunc::new().invoke_with_args(args)

--- a/crates/sail-function/src/scalar/datetime/negate_duration.rs
+++ b/crates/sail-function/src/scalar/datetime/negate_duration.rs
@@ -47,12 +47,7 @@ impl ScalarUDFImpl for NegateDuration {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
-        let [arg] = args.as_slice() else {
-            return exec_err!(
-                "`negate_duration` function requires 1 argument, got {}",
-                args.len()
-            );
-        };
+        let arg = &args[0];
         match arg {
             ColumnarValue::Scalar(ScalarValue::DurationSecond(val)) => Ok(ColumnarValue::Scalar(
                 ScalarValue::DurationSecond(val.map(|x| -x)),

--- a/crates/sail-function/src/scalar/datetime/spark_last_day.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_last_day.rs
@@ -46,12 +46,7 @@ impl ScalarUDFImpl for SparkLastDay {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
-        let [arg] = args.as_slice() else {
-            return exec_err!(
-                "Spark `last_day` function requires 1 argument, got {}",
-                args.len()
-            );
-        };
+        let arg = &args[0];
         match arg {
             ColumnarValue::Scalar(ScalarValue::Date32(days)) => {
                 if let Some(days) = days {

--- a/crates/sail-function/src/scalar/datetime/spark_make_time.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_make_time.rs
@@ -62,13 +62,6 @@ impl ScalarUDFImpl for SparkMakeTime {
             args, number_rows, ..
         } = args;
 
-        if args.len() != 3 {
-            return exec_err!(
-                "Spark `make_time` function requires 3 arguments, got {}",
-                args.len()
-            );
-        }
-
         // Handle NULL propagation for scalar inputs
         let contains_scalar_null = args.iter().any(|arg| {
             matches!(

--- a/crates/sail-function/src/scalar/datetime/spark_make_ym_interval.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_make_ym_interval.rs
@@ -45,12 +45,8 @@ impl ScalarUDFImpl for SparkMakeYmInterval {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
-        let [year, month] = args.as_slice() else {
-            return exec_err!(
-                "Spark `make_ym_interval` function requires 2 arguments, got {}",
-                args.len()
-            );
-        };
+        let year = &args[0];
+        let month = &args[1];
         match (year, month) {
             (
                 ColumnarValue::Scalar(ScalarValue::Int32(years)),

--- a/crates/sail-function/src/scalar/datetime/spark_next_day.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_next_day.rs
@@ -46,12 +46,8 @@ impl ScalarUDFImpl for SparkNextDay {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
-        let [date, day_of_week] = args.as_slice() else {
-            return exec_err!(
-                "Spark `next_day` function requires 2 arguments, got {}",
-                args.len()
-            );
-        };
+        let date = &args[0];
+        let day_of_week = &args[1];
 
         match (date, day_of_week) {
             (ColumnarValue::Scalar(date), ColumnarValue::Scalar(day_of_week)) => {

--- a/crates/sail-function/src/scalar/datetime/spark_time_diff.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_time_diff.rs
@@ -65,12 +65,9 @@ impl ScalarUDFImpl for SparkTimeDiff {
             args, number_rows, ..
         } = args;
 
-        let [unit_arg, start_arg, end_arg] = args.as_slice() else {
-            return exec_err!(
-                "Spark `time_diff` function requires 3 arguments, got {}",
-                args.len()
-            );
-        };
+        let unit_arg = &args[0];
+        let start_arg = &args[1];
+        let end_arg = &args[2];
 
         // All-scalar fast path — return a scalar value directly.
         if let (

--- a/crates/sail-function/src/scalar/datetime/spark_time_trunc.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_time_trunc.rs
@@ -62,12 +62,8 @@ impl ScalarUDFImpl for SparkTimeTrunc {
             args, number_rows, ..
         } = args;
 
-        let [unit_arg, time_arg] = args.as_slice() else {
-            return exec_err!(
-                "Spark `time_trunc` function requires 2 arguments, got {}",
-                args.len()
-            );
-        };
+        let unit_arg = &args[0];
+        let time_arg = &args[1];
 
         match (unit_arg, time_arg) {
             // (Scalar unit, Scalar time) — return a scalar

--- a/crates/sail-function/src/scalar/drop_struct_field.rs
+++ b/crates/sail-function/src/scalar/drop_struct_field.rs
@@ -125,12 +125,7 @@ impl ScalarUDFImpl for DropStructField {
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
         let args = ColumnarValue::values_to_arrays(&args)?;
-        let [array] = args.as_slice() else {
-            return exec_err!(
-                "drop_struct_field function requires 1 argument, got {}",
-                args.len()
-            );
-        };
+        let array = &args[0];
         let new_array = Self::drop_nested_field_from_array(array, &self.field_names)?;
         Ok(ColumnarValue::Array(new_array))
     }

--- a/crates/sail-function/src/scalar/geo/st_asbinary.rs
+++ b/crates/sail-function/src/scalar/geo/st_asbinary.rs
@@ -55,13 +55,6 @@ impl ScalarUDFImpl for StAsBinary {
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let args = args.args;
 
-        if args.len() != 1 {
-            return exec_err!(
-                "st_asbinary requires exactly 1 argument, got {}",
-                args.len()
-            );
-        }
-
         match &args[0] {
             ColumnarValue::Scalar(ScalarValue::Binary(Some(b))) => {
                 Ok(ColumnarValue::Scalar(ScalarValue::Binary(Some(b.to_vec()))))

--- a/crates/sail-function/src/scalar/geo/st_geogfromwkb.rs
+++ b/crates/sail-function/src/scalar/geo/st_geogfromwkb.rs
@@ -69,13 +69,6 @@ impl ScalarUDFImpl for StGeogFromWKB {
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let args = args.args;
 
-        if args.len() != 1 {
-            return exec_err!(
-                "st_geogfromwkb requires exactly 1 argument, got {}",
-                args.len()
-            );
-        }
-
         match &args[0] {
             ColumnarValue::Scalar(ScalarValue::Binary(Some(b))) => {
                 if let Err(e) = validate_geography(b) {

--- a/crates/sail-function/src/scalar/geo/st_geomfromwkb.rs
+++ b/crates/sail-function/src/scalar/geo/st_geomfromwkb.rs
@@ -69,13 +69,6 @@ impl ScalarUDFImpl for StGeomFromWKB {
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let args = args.args;
 
-        if args.len() != 1 {
-            return exec_err!(
-                "st_geomfromwkb requires exactly 1 argument, got {}",
-                args.len()
-            );
-        }
-
         match &args[0] {
             ColumnarValue::Scalar(ScalarValue::Binary(Some(b))) => {
                 if let Err(e) = validate_geometry(b) {

--- a/crates/sail-function/src/scalar/math/rand_poisson.rs
+++ b/crates/sail-function/src/scalar/math/rand_poisson.rs
@@ -51,18 +51,6 @@ impl ScalarUDFImpl for RandPoisson {
         let ScalarFunctionArgs {
             args, number_rows, ..
         } = args;
-        if args.is_empty() {
-            return exec_err!(
-                "`random_poisson` must be called with either 1 or 2 arguments, got {}",
-                args.len()
-            );
-        }
-        if args.len() > 2 {
-            return exec_err!(
-                "`random_poisson` must be called with either 1 or 2 arguments, got {}",
-                args.len()
-            );
-        }
         let lambda = &args[0];
         let lambda = match lambda {
             ColumnarValue::Scalar(scalar) => match scalar {

--- a/crates/sail-function/src/scalar/math/randn.rs
+++ b/crates/sail-function/src/scalar/math/randn.rs
@@ -55,12 +55,7 @@ impl ScalarUDFImpl for Randn {
             return invoke_no_seed(number_rows);
         }
 
-        let [seed] = args.as_slice() else {
-            return exec_err!(
-                "randn should be called with at most 1 argument, got {}",
-                args.len()
-            );
-        };
+        let seed = &args[0];
         match seed {
             ColumnarValue::Scalar(scalar) => {
                 let seed = match scalar {

--- a/crates/sail-function/src/scalar/math/random.rs
+++ b/crates/sail-function/src/scalar/math/random.rs
@@ -54,12 +54,7 @@ impl ScalarUDFImpl for Random {
             return invoke_no_seed(number_rows);
         }
 
-        let [seed] = args.as_slice() else {
-            return exec_err!(
-                "random should be called with at most 1 argument, got {}",
-                args.len()
-            );
-        };
+        let seed = &args[0];
 
         match seed {
             ColumnarValue::Scalar(scalar) => {

--- a/crates/sail-function/src/scalar/math/spark_abs.rs
+++ b/crates/sail-function/src/scalar/math/spark_abs.rs
@@ -66,12 +66,7 @@ impl ScalarUDFImpl for SparkAbs {
     // TODO: ANSI mode
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
-        let [arg] = args.as_slice() else {
-            return exec_err!(
-                "Spark `abs` function requires 1 argument, got {}",
-                args.len()
-            );
-        };
+        let arg = &args[0];
         match arg {
             ColumnarValue::Scalar(ScalarValue::IntervalYearMonth(interval)) => {
                 Ok(ColumnarValue::Scalar(ScalarValue::IntervalYearMonth(

--- a/crates/sail-function/src/scalar/math/spark_bin.rs
+++ b/crates/sail-function/src/scalar/math/spark_bin.rs
@@ -45,9 +45,6 @@ impl ScalarUDFImpl for SparkBin {
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        if args.args.len() != 1 {
-            return Err(invalid_arg_count_exec_err("bin", (1, 1), args.args.len()));
-        }
         match &args.args[0] {
             ColumnarValue::Scalar(ScalarValue::Int64(value)) => {
                 Ok(ColumnarValue::Scalar(ScalarValue::Utf8(value.map(bin))))

--- a/crates/sail-function/src/scalar/math/spark_conv.rs
+++ b/crates/sail-function/src/scalar/math/spark_conv.rs
@@ -55,9 +55,9 @@ impl ScalarUDFImpl for SparkConv {
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
 
-        let [num, from_base, to_base] = args.as_slice() else {
-            return Err(invalid_arg_count_exec_err("spark_conv", (3, 3), args.len()));
-        };
+        let num = &args[0];
+        let from_base = &args[1];
+        let to_base = &args[2];
 
         if matches!(num, ColumnarValue::Array(_)) {
             return invoke_vectorized(num, from_base, to_base);

--- a/crates/sail-function/src/scalar/math/spark_div.rs
+++ b/crates/sail-function/src/scalar/math/spark_div.rs
@@ -67,14 +67,6 @@ impl ScalarUDFImpl for SparkIntervalDiv {
 }
 
 fn interval_div_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
-    if args.len() != 2 {
-        return Err(invalid_arg_count_exec_err(
-            "spark_interval_div",
-            (2, 2),
-            args.len(),
-        ));
-    }
-
     let dividend = &args[0];
     let divisor = &args[1];
 

--- a/crates/sail-function/src/scalar/math/spark_signum.rs
+++ b/crates/sail-function/src/scalar/math/spark_signum.rs
@@ -64,12 +64,7 @@ impl ScalarUDFImpl for SparkSignum {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
-        let [arg] = args.as_slice() else {
-            return exec_err!(
-                "Spark `signum` function requires 1 argument, got {}",
-                args.len()
-            );
-        };
+        let arg = &args[0];
         match arg {
             ColumnarValue::Scalar(ScalarValue::UInt8(val)) => {
                 Ok(ColumnarValue::Scalar(ScalarValue::Float64(val.map(|x| {

--- a/crates/sail-function/src/scalar/math/spark_try_add.rs
+++ b/crates/sail-function/src/scalar/math/spark_try_add.rs
@@ -81,13 +81,8 @@ impl ScalarUDFImpl for SparkTryAdd {
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
 
-        let [left, right] = args.as_slice() else {
-            return Err(invalid_arg_count_exec_err(
-                "spark_try_add",
-                (2, 2),
-                args.len(),
-            ));
-        };
+        let left = &args[0];
+        let right = &args[1];
 
         let len: usize = match (&left, &right) {
             (ColumnarValue::Array(arr), _) => arr.len(),

--- a/crates/sail-function/src/scalar/math/spark_try_div.rs
+++ b/crates/sail-function/src/scalar/math/spark_try_div.rs
@@ -70,9 +70,8 @@ impl ScalarUDFImpl for SparkTryDiv {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
-        let [left, right] = args.as_slice() else {
-            return Err(invalid_arg_count_exec_err("try_divide", (2, 2), args.len()));
-        };
+        let left = &args[0];
+        let right = &args[1];
 
         let len = match (&left, &right) {
             (ColumnarValue::Array(arr), _) => arr.len(),

--- a/crates/sail-function/src/scalar/math/spark_try_mod.rs
+++ b/crates/sail-function/src/scalar/math/spark_try_mod.rs
@@ -71,13 +71,8 @@ impl ScalarUDFImpl for SparkTryMod {
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
 
-        let [left, right] = args.as_slice() else {
-            return Err(invalid_arg_count_exec_err(
-                "spark_try_mod",
-                (2, 2),
-                args.len(),
-            ));
-        };
+        let left = &args[0];
+        let right = &args[1];
 
         let len = match (&left, &right) {
             (ColumnarValue::Array(arr), _) => arr.len(),

--- a/crates/sail-function/src/scalar/math/spark_try_subtract.rs
+++ b/crates/sail-function/src/scalar/math/spark_try_subtract.rs
@@ -80,13 +80,8 @@ impl ScalarUDFImpl for SparkTrySubtract {
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
 
-        let [left, right] = args.as_slice() else {
-            return Err(invalid_arg_count_exec_err(
-                "spark_try_subtract",
-                (2, 2),
-                args.len(),
-            ));
-        };
+        let left = &args[0];
+        let right = &args[1];
 
         let len = match (&left, &right) {
             (ColumnarValue::Array(arr), _) => arr.len(),

--- a/crates/sail-function/src/scalar/string/format_number.rs
+++ b/crates/sail-function/src/scalar/string/format_number.rs
@@ -49,9 +49,6 @@ impl ScalarUDFImpl for FormatNumber {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
-        if args.len() != 2 {
-            return exec_err!("`format_number` requires 2 arguments, got {}", args.len());
-        }
 
         match &args[1] {
             ColumnarValue::Scalar(s) => match s {

--- a/crates/sail-function/src/scalar/string/levenshtein.rs
+++ b/crates/sail-function/src/scalar/string/levenshtein.rs
@@ -82,13 +82,7 @@ impl ScalarUDFImpl for Levenshtein {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
-        let [first, _, ..] = args.as_slice() else {
-            return exec_err!(
-                "`levenshtein` function requires two or three arguments, got {}",
-                args.len()
-            );
-        };
-        match first.data_type() {
+        match args[0].data_type() {
             DataType::Utf8 | DataType::Utf8View => {
                 make_scalar_function(levenshtein::<i32>, vec![])(&args)
             }

--- a/crates/sail-function/src/scalar/string/randstr.rs
+++ b/crates/sail-function/src/scalar/string/randstr.rs
@@ -49,13 +49,6 @@ impl ScalarUDFImpl for Randstr {
             args, number_rows, ..
         } = args;
 
-        if args.is_empty() || args.len() > 2 {
-            return exec_err!(
-                "`randstr` requires 1 or 2 arguments (length, [seed]), got {}",
-                args.len()
-            );
-        }
-
         let length = match &args[0] {
             ColumnarValue::Scalar(ScalarValue::Int32(Some(v))) => *v as usize,
             ColumnarValue::Scalar(ScalarValue::Int64(Some(v))) => *v as usize,

--- a/crates/sail-function/src/scalar/string/soundex.rs
+++ b/crates/sail-function/src/scalar/string/soundex.rs
@@ -50,9 +50,6 @@ impl ScalarUDFImpl for Soundex {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
-        if args.len() != 1 {
-            return exec_err!("`soundex` function requires 1 argument, got {}", args.len());
-        }
         match args[0].data_type() {
             DataType::Utf8 => make_scalar_function(soundex::<i32>, vec![])(&args),
             DataType::Utf8View => make_scalar_function(soundex_view, vec![])(&args),

--- a/crates/sail-function/src/scalar/string/spark_encode_decode.rs
+++ b/crates/sail-function/src/scalar/string/spark_encode_decode.rs
@@ -59,12 +59,8 @@ impl ScalarUDFImpl for SparkEncode {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
-        let [first, second] = args.as_slice() else {
-            return exec_err!(
-                "Spark `encode` function requires 2 arguments, got {}",
-                args.len()
-            );
-        };
+        let first = &args[0];
+        let second = &args[1];
 
         if matches!(
             first,
@@ -299,12 +295,8 @@ impl ScalarUDFImpl for SparkDecode {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
-        let [first, second] = args.as_slice() else {
-            return exec_err!(
-                "Spark `decode` function requires 2 arguments, got {}",
-                args.len()
-            );
-        };
+        let first = &args[0];
+        let second = &args[1];
 
         if matches!(
             first,

--- a/crates/sail-function/src/scalar/update_struct_field.rs
+++ b/crates/sail-function/src/scalar/update_struct_field.rs
@@ -175,12 +175,8 @@ impl ScalarUDFImpl for UpdateStructField {
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs { args, .. } = args;
         let args = ColumnarValue::values_to_arrays(&args)?;
-        let [struct_array, new_field_array] = args.as_slice() else {
-            return exec_err!(
-                "update_struct_field function requires 2 arguments, got {}",
-                args.len()
-            );
-        };
+        let struct_array = &args[0];
+        let new_field_array = &args[1];
         if struct_array.data_type().is_null() {
             return Ok(ColumnarValue::Scalar(ScalarValue::Null));
         }


### PR DESCRIPTION
## Summary
- Remove redundant argument count validation from invoke_with_args in 32 UDF implementations
- These checks are already performed by coerce_types or the Signature (user_defined, one_of, exact, String(N)) before invoke_with_args is called


## Changes
- Replace let [a, b] = args.as_slice() else { return Err(...) } with direct indexing let a = &args[0]
- Remove if args.len() != N { return Err(...) } blocks
- Remove inner function arg checks in make_scalar_function delegates
- Clean up unused imports where applicable

## Test plan
- cargo clippy --all-targets --all-features -- -D warnings passes with zero warnings
- cargo nextest run passes all 515 tests
- No behavioral changes — only removal of unreachable code paths