### PR TITLE
fix: JVM Spark Connect client compatibility

### DIFF
--- a/crates/sail-spark-connect/build.rs
+++ b/crates/sail-spark-connect/build.rs
@@ -98,10 +98,10 @@ fn build_spark_config() -> Result<(), Box<dyn std::error::Error>> {
         // Spark 4.1 changes the local relation cache threshold from 64 MB to 1 MB
         // which causes DataFrame creation more likely to fail since we do not support
         // caching local relations as artifacts yet.
-        // Here we override the default value to Int.MAX_VALUE to effectively turn off
-        // local relation caching. We use 2147483647 instead of 2147483648 because the
-        // JVM Spark Connect client parses this value with Integer.parseInt, which
-        // overflows at 2^31.
+        // Here we override the default value to 2^31-1 (2147483647, Integer.MAX_VALUE)
+        // to effectively turn off local relation caching. We use 2^31-1 instead of 2^31
+        // because the JVM Spark Connect client parses this value with Integer.parseInt,
+        // which overflows for values greater than 2^31-1.
         if entry.key == "spark.sql.session.localRelationCacheThreshold" {
             entry.default_value = Some("2147483647".to_string())
         }
@@ -117,16 +117,23 @@ fn build_spark_config() -> Result<(), Box<dyn std::error::Error>> {
     // to decide whether to compress plans before sending them to the server.
     // This key is not part of Spark's SQL config (spark_config.json) but the client
     // expects it to exist. Without it, the client logs a NoSuchElementException warning.
-    config.entries.push(SparkConfigEntry {
-        key: "spark.connect.session.planCompression.threshold".to_string(),
-        doc: "Minimum plan size in bytes before the client attempts to compress it.".to_string(),
-        default_value: Some("1048576".to_string()),
-        alternatives: Vec::new(),
-        fallback: None,
-        is_static: false,
-        deprecated: None,
-        removed: None,
-    });
+    if !config
+        .entries
+        .iter()
+        .any(|entry| entry.key == "spark.connect.session.planCompression.threshold")
+    {
+        config.entries.push(SparkConfigEntry {
+            key: "spark.connect.session.planCompression.threshold".to_string(),
+            doc: "Minimum plan size in bytes before the client attempts to compress it."
+                .to_string(),
+            default_value: Some("1048576".to_string()),
+            alternatives: Vec::new(),
+            fallback: None,
+            is_static: false,
+            deprecated: None,
+            removed: None,
+        });
+    }
 
     let keys = config
         .entries


### PR DESCRIPTION
- Change localRelationCacheThreshold default from 2147483648 to 2147483647 (Int.MAX_VALUE) to avoid NumberFormatException in theJVM client's Integer.parseInt
- Add spark.connect.session.planCompression.threshold config entry with default 1048576 to suppress NoSuchElementException warning
with these code in scala:

build.sbt
```scala
ThisBuild / version := "0.1.0-SNAPSHOT"
ThisBuild / scalaVersion := "2.13.12"

lazy val root = (project in file("."))
  .settings(
    name := "sail-spark-scala",

    libraryDependencies += "org.apache.spark" %% "spark-connect-client-jvm" % "4.0.0",

    Compile / run / fork := true,

    // Arrow + Java 17 (evita el crash de MemoryUtil)
    Compile / run / javaOptions ++= Seq(
      "--add-opens=java.base/java.nio=ALL-UNNAMED"
    )
  )
```


```scala
import org.apache.spark.sql.{Dataset, SparkSession, functions => F}
import org.apache.spark.sql.expressions.Window

import java.sql.Timestamp

object Main {
  case class Event(userId: Long, ts: Timestamp, eventType: String, amount: Double, tags: Seq[String])
  case class User(userId: Long, country: String, segment: String)
  case class User2(id: Long, country: String)

  def main(args: Array[String]): Unit = {
    val connectUrl = sys.env.getOrElse("SPARK_CONNECT_URL", "sc://localhost:50051")

    val spark = SparkSession
      .builder()
      .remote(connectUrl)
      .getOrCreate()

    spark.range(10).selectExpr("id", "id * 2 as value").show()

    import spark.implicits._

    // ----- Datos de ejemplo (cliente) -----
    val users = Seq(
      User(1, "ES", "pro"),
      User(2, "ES", "free"),
      User(3, "US", "pro"),
      User(4, "FR", "free")
    ).toDS()

    val events = Seq(
      Event(1, ts("2025-12-12 09:00:00"), "click",    0.0,  Seq("home", "cta")),
      Event(1, ts("2025-12-12 09:01:00"), "purchase", 9.99, Seq("checkout", "promo")),
      Event(1, ts("2025-12-12 09:03:00"), "purchase", 3.50, Seq("checkout")),
      Event(2, ts("2025-12-12 10:00:00"), "click",    0.0,  Seq("home")),
      Event(2, ts("2025-12-12 10:02:00"), "purchase", 1.25, Seq("checkout")),
      Event(3, ts("2025-12-12 11:00:00"), "click",    0.0,  Seq("pricing", "cta")),
      Event(3, ts("2025-12-12 11:04:00"), "purchase", 20.0, Seq("checkout", "vip")),
      Event(4, ts("2025-12-12 12:00:00"), "click",    0.0,  Seq("home", "seo"))
    ).toDS()

    // ----- 1) Join + features base -----
    val enriched = events
      .join(users, Seq("userId"), "left")
      .withColumn("isPurchase", F.col("eventType") === F.lit("purchase"))
      .withColumn("day", F.to_date(F.col("ts")))
      .withColumn("hour", F.hour(F.col("ts")))
      .withColumn("tag", F.explode_outer(F.col("tags")))

    val daily = enriched
      .groupBy("country", "segment", "day")
      .agg(
        F.count(F.lit(1)).as("events"),
        F.sum(F.when(F.col("isPurchase"), F.col("amount")).otherwise(F.lit(0.0))).as("revenue"),
        F.countDistinct("userId").as("active_users"),
        F.approx_count_distinct("tag").as("approx_distinct_tags")
      )
      .orderBy("day", "country", "segment")

    println("=== Daily metrics ===")
    daily.show(truncate = false)


    val wByUserTime = Window.partitionBy("userId").orderBy(F.col("ts").asc)
    val wByUser2Prev = wByUserTime.rowsBetween(-2, 0)

    val purchases = enriched
      .filter(F.col("isPurchase"))
      .select("userId", "country", "segment", "ts", "amount")
      .withColumn("purchase_rank", F.row_number().over(wByUserTime))
      .withColumn("running_revenue", F.sum("amount").over(wByUserTime))
      .withColumn("mov_avg_3", F.avg("amount").over(wByUser2Prev))
      .orderBy("userId", "ts")

    println("=== Purchases with window analytics ===")
    purchases.show(truncate = false)
    purchases.explain()
    enriched.createOrReplaceTempView("events_enriched")

    val top = spark.sql("""
      SELECT
        country,
        userId,
        segment,
        SUM(CASE WHEN eventType = 'purchase' THEN amount ELSE 0.0 END) AS revenue,
        COUNT(*) AS events
      FROM events_enriched
      WHERE segment IN ('pro', 'free')
      GROUP BY country, userId, segment
      ORDER BY revenue DESC, events DESC
      LIMIT 10
    """)

    println("=== Top users by revenue (SQL) ===")
    top.show(truncate = false)


    val ds: Dataset[User2] = Seq(
      User2(1, "ES"),
      User2(2, "US")
    ).toDS()
    ds.select($"id", $"country").show(false)

    val fixed = ds.select(ds.columns.map(F.col): _*)
    fixed.show(false)

    spark.stop()
  }

  private def ts(s: String): Timestamp = Timestamp.valueOf(s)
}
```

have these error:
```
[info] +---+-----+
[error] Exception in thread "main" java.lang.NumberFormatException: For input string: "2147483648"
[error]         at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
[error]         at java.base/java.lang.Integer.parseInt(Integer.java:672)
[error]         at java.base/java.lang.Integer.parseInt(Integer.java:786)
[error]         at scala.collection.StringOps$.toInt$extension(StringOps.scala:910)
[error]         at org.apache.spark.sql.connect.SparkSession.$anonfun$createDataset$1(SparkSession.scala:120)
[error]         at org.apache.spark.sql.connect.SparkSession.$anonfun$createDataset$1$adapted(SparkSession.scala:116)
[error]         at org.apache.spark.sql.connect.SparkSession.newDataset(SparkSession.scala:428)
[error]         at org.apache.spark.sql.connect.SparkSession.newDataset(SparkSession.scala:393)
[error]         at org.apache.spark.sql.connect.SparkSession.createDataset(SparkSession.scala:116)
[error]         at org.apache.spark.sql.connect.SparkSession.createDataset(SparkSession.scala:154)
[error]         at org.apache.spark.sql.connect.SQLImplicits.localSeqToDatasetHolder(SQLImplicits.scala:30)
[error]         at org.apache.spark.sql.connect.SQLImplicits.localSeqToDatasetHolder(SQLImplicits.scala:26)
[error]         at Main$.main(Main.scala:24)
[error]         at Main.main(Main.scala)
[error] Nonzero exit code returned from runner: 1
[error] (Compile / run) Nonzero exit code returned from runner: 1
[error] Total time: 3 s, completed 21 mar 2026 13:49:05
```

