### PR TITLE
feat: add `noop` write format

### DIFF
--- a/crates/sail-data-source/src/formats/mod.rs
+++ b/crates/sail-data-source/src/formats/mod.rs
@@ -5,6 +5,7 @@ pub mod console;
 pub mod csv;
 pub mod json;
 pub mod listing;
+pub mod noop;
 pub mod parquet;
 pub mod python;
 pub mod rate;

--- a/crates/sail-data-source/src/formats/noop/mod.rs
+++ b/crates/sail-data-source/src/formats/noop/mod.rs
@@ -1,0 +1,41 @@
+mod writer;
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use datafusion::catalog::{Session, TableProvider};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_common::{not_impl_err, Result};
+use sail_common_datafusion::datasource::{SinkInfo, SourceInfo, TableFormat};
+
+use crate::formats::noop::writer::NoopSinkExec;
+
+/// No-operation write format that consumes input without persisting data.
+///
+/// This is useful for benchmarking, profiling, dry-runs, and materializing
+/// caches without the I/O overhead of writing to storage.
+#[derive(Debug)]
+pub struct NoopTableFormat;
+
+#[async_trait]
+impl TableFormat for NoopTableFormat {
+    fn name(&self) -> &str {
+        "noop"
+    }
+
+    async fn create_provider(
+        &self,
+        _ctx: &dyn Session,
+        _info: SourceInfo,
+    ) -> Result<Arc<dyn TableProvider>> {
+        not_impl_err!("noop table format does not support reading")
+    }
+
+    async fn create_writer(
+        &self,
+        _ctx: &dyn Session,
+        info: SinkInfo,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(NoopSinkExec::new(info.input)))
+    }
+}

--- a/crates/sail-data-source/src/formats/noop/writer.rs
+++ b/crates/sail-data-source/src/formats/noop/writer.rs
@@ -1,0 +1,87 @@
+use std::any::Any;
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::Schema;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use datafusion::physical_plan::{DisplayAs, ExecutionPlan, PlanProperties};
+use datafusion_common::{plan_err, Result};
+use futures::StreamExt;
+
+#[derive(Debug)]
+pub struct NoopSinkExec {
+    input: Arc<dyn ExecutionPlan>,
+    properties: Arc<PlanProperties>,
+}
+
+impl NoopSinkExec {
+    pub fn new(input: Arc<dyn ExecutionPlan>) -> Self {
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(Arc::new(Schema::empty())),
+            Partitioning::UnknownPartitioning(
+                input.properties().output_partitioning().partition_count(),
+            ),
+            EmissionType::Final,
+            Boundedness::Bounded,
+        ));
+        Self { input, properties }
+    }
+}
+
+impl DisplayAs for NoopSinkExec {
+    fn fmt_as(
+        &self,
+        _t: datafusion::physical_plan::DisplayFormatType,
+        f: &mut std::fmt::Formatter,
+    ) -> std::fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl ExecutionPlan for NoopSinkExec {
+    fn name(&self) -> &str {
+        Self::static_name()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        match (children.pop(), children.is_empty()) {
+            (Some(child), true) => Ok(Arc::new(NoopSinkExec::new(child))),
+            _ => plan_err!("{} should have exactly one child", self.name()),
+        }
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let stream = self.input.execute(partition, context)?;
+        let output = futures::stream::once(async move {
+            // Consume all batches without doing anything.
+            stream.for_each(|_| async {}).await;
+            futures::stream::empty()
+        })
+        .flatten();
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema(),
+            output,
+        )))
+    }
+}

--- a/crates/sail-session/src/formats.rs
+++ b/crates/sail-session/src/formats.rs
@@ -6,6 +6,7 @@ use sail_data_source::formats::arrow::ArrowTableFormat;
 use sail_data_source::formats::avro::AvroTableFormat;
 use sail_data_source::formats::binary::BinaryTableFormat;
 use sail_data_source::formats::console::ConsoleTableFormat;
+use sail_data_source::formats::noop::NoopTableFormat;
 use sail_data_source::formats::csv::CsvTableFormat;
 use sail_data_source::formats::json::JsonTableFormat;
 use sail_data_source::formats::parquet::ParquetTableFormat;
@@ -34,6 +35,7 @@ fn register_builtin_formats(registry: &Arc<TableFormatRegistry>) -> Result<()> {
     registry.register(Arc::new(SocketTableFormat))?;
     registry.register(Arc::new(RateTableFormat))?;
     registry.register(Arc::new(ConsoleTableFormat))?;
+    registry.register(Arc::new(NoopTableFormat))?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Add a no-operation (`noop`) write format that consumes DataFrame input without persisting data to storage
- Enables benchmarking transformations in isolation from I/O, dry-run validation, and reliable cache materialization
- Follows the same `TableFormat` trait pattern as the existing `console` format

Closes #1385

## Usage

```python
df.write.format("noop").mode("overwrite").save()
```

## Test plan

- [x] `cargo check` passes
- [ ] Integration test with PySpark client

🤖 Generated with [Claude Code](https://claude.com/claude-code)