### PR TITLE
fix: add remote codec support for relaxed tz cast

### DIFF
--- a/crates/sail-delta-lake/src/physical_plan/relaxed_tz_exec.rs
+++ b/crates/sail-delta-lake/src/physical_plan/relaxed_tz_exec.rs
@@ -38,6 +38,10 @@ impl RelaxedTzCastExec {
         }
     }
 
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
     fn aligned_timestamp_columns(&self) -> Vec<String> {
         let input_schema = self.input.schema();
         self.schema

--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -54,6 +54,7 @@ message ExtendedPhysicalPlanNode {
     PythonDataSourceWriteCommitExecNode python_data_source_write_commit = 39;
     CatalogCommandExecNode catalog_command = 40;
     BarrierExecNode barrier = 41;
+    RelaxedTzCastExecNode relaxed_tz_cast = 42;
   }
 }
 
@@ -566,6 +567,11 @@ message MonotonicIdExecNode {
   bytes input = 1;
   string column_name = 2;
   bytes schema = 3;
+}
+
+message RelaxedTzCastExecNode {
+  bytes input = 1;
+  bytes schema = 2;
 }
 
 message JoinOn {

--- a/crates/sail-execution/src/codec.rs
+++ b/crates/sail-execution/src/codec.rs
@@ -92,6 +92,7 @@ use sail_data_source::options::gen::RateReadOptions;
 use sail_delta_lake::physical_plan::{
     DeltaCastColumnExpr, DeltaCommitExec, DeltaDiscoveryExec, DeltaLogReplayExec,
     DeltaMetadataStatsExec, DeltaRemoveActionsExec, DeltaScanByAddsExec, DeltaWriterExec,
+    RelaxedTzCastExec,
 };
 use sail_delta_lake::spec::DeltaOperation;
 use sail_function::aggregate::bitmap_construct_agg::BitmapConstructAggFunction;
@@ -982,6 +983,11 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                     Arc::new(schema),
                 )?))
             }
+            NodeKind::RelaxedTzCast(gen::RelaxedTzCastExecNode { input, schema }) => {
+                let input = self.try_decode_plan(&input, ctx)?;
+                let schema = Arc::new(self.try_decode_schema(&schema)?);
+                Ok(Arc::new(RelaxedTzCastExec::new(input, schema)))
+            }
             NodeKind::IcebergWriter(gen::IcebergWriterExecNode {
                 input,
                 table_url,
@@ -1621,6 +1627,10 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 column_name: monotonic_id.column_name().to_string(),
                 schema,
             })
+        } else if let Some(relaxed_tz_cast) = node.as_any().downcast_ref::<RelaxedTzCastExec>() {
+            let input = self.try_encode_plan(relaxed_tz_cast.input().clone())?;
+            let schema = self.try_encode_schema(relaxed_tz_cast.schema().as_ref())?;
+            NodeKind::RelaxedTzCast(gen::RelaxedTzCastExecNode { input, schema })
         } else if let Some(iceberg_writer_exec) = node.as_any().downcast_ref::<IcebergWriterExec>()
         {
             let input = self.try_encode_plan(iceberg_writer_exec.input().clone())?;


### PR DESCRIPTION
## Summary
- register `RelaxedTzCastExec` in the remote physical plan proto
- add encode and decode support in `RemoteExecutionCodec`
- align the execution node API with the surrounding codec access pattern via `input()`