### PR TITLE
fix: emit spark-style missing database errors

### DIFF
--- a/crates/sail-catalog-glue/src/provider.rs
+++ b/crates/sail-catalog-glue/src/provider.rs
@@ -395,7 +395,7 @@ impl CatalogProvider for GlueCatalogProvider {
             Err(sdk_err) => {
                 let service_err = sdk_err.into_service_error();
                 if service_err.is_entity_not_found_exception() {
-                    Err(CatalogError::NotFound("database", database_name))
+                    Err(CatalogError::NotFound("Database", database_name))
                 } else {
                     Err(CatalogError::External(format!(
                         "Failed to get database: {service_err}"
@@ -459,7 +459,7 @@ impl CatalogProvider for GlueCatalogProvider {
                     if if_exists {
                         Ok(())
                     } else {
-                        Err(CatalogError::NotFound("database", database_name))
+                        Err(CatalogError::NotFound("Database", database_name))
                     }
                 } else {
                     Err(CatalogError::External(format!(

--- a/crates/sail-catalog-memory/src/provider.rs
+++ b/crates/sail-catalog-memory/src/provider.rs
@@ -175,7 +175,7 @@ impl CatalogProvider for MemoryCatalogProvider {
             ));
         }
         let mut db = self.databases.get_mut(database).ok_or_else(|| {
-            CatalogError::NotFound("database", quote_namespace_if_needed(database))
+            CatalogError::NotFound("Database", quote_namespace_if_needed(database))
         })?;
         if let Some(status) = db.tables.get(table) {
             if if_not_exists {
@@ -251,7 +251,7 @@ impl CatalogProvider for MemoryCatalogProvider {
             Ok(db.tables.values().cloned().collect())
         } else {
             Err(CatalogError::NotFound(
-                "database",
+                "Database",
                 quote_namespace_if_needed(database),
             ))
         }
@@ -280,7 +280,7 @@ impl CatalogProvider for MemoryCatalogProvider {
             Ok(())
         } else {
             Err(CatalogError::NotFound(
-                "database",
+                "Database",
                 quote_namespace_if_needed(database),
             ))
         }
@@ -301,7 +301,7 @@ impl CatalogProvider for MemoryCatalogProvider {
             properties,
         } = options;
         let mut db = self.databases.get_mut(database).ok_or_else(|| {
-            CatalogError::NotFound("database", quote_namespace_if_needed(database))
+            CatalogError::NotFound("Database", quote_namespace_if_needed(database))
         })?;
         if let Some(status) = db.views.get(view) {
             if if_not_exists {


### PR DESCRIPTION
## dbt integration test
- Test: `dbt-sail/tests/functional/adapter/test_basic.py::TestBaseAdapterMethod::test_adapter_methods`
- Command: `hatch run integration-tests -- tests/functional/adapter/test_basic.py::TestBaseAdapterMethod::test_adapter_methods -vv -s`
- The failure happens during `dbt compile`, inside `tests/get_columns_in_relation.sql`.

## Text that needed to change
```text
Before: database not found: <schema>
After:  Database not found: <schema>
```
- This is the text dbt cares about here.
- `dbt-spark` recognizes the Spark-style `Database not found` form as a missing-schema case it should continue past.
- Sail was emitting the lowercase `database not found` form instead.

## Source-side fix
- `crates/sail-catalog-memory/src/provider.rs`
- `crates/sail-catalog-glue/src/provider.rs`

```rust
Before: CatalogError::NotFound("database", ...)
After:  CatalogError::NotFound("Database", ...)
```

## After rerunning the same dbt integration test
```text
Runtime Error
  Runtime Error in test get_columns_in_relation (tests/get_columns_in_relation.sql)
    Runtime Error
      Runtime Error
        view not found: model
```
- After this change, the compile path gets past the missing-database blocker and reaches the next real failure.