### PR TITLE
chore: patch PySpark client for cleanup issue

### DIFF
--- a/scripts/spark-tests/plugins/spark.py
+++ b/scripts/spark-tests/plugins/spark.py
@@ -20,6 +20,30 @@ def _is_spark_testing():
 
 
 @pytest.fixture(scope="session", autouse=_is_spark_testing())
+def spark_cached_remote_relation_patch():
+    from pyspark.sql.connect import plan
+
+    _del = getattr(plan.CachedRemoteRelation, "__del__", None)
+
+    if _del is None:
+        yield
+        return
+
+    def _noop_del(self) -> None:  # noqa: ARG001
+        # Spark Connect client can hang when a CachedRemoteRelation finalizer issues
+        # a blocking gRPC cleanup call during GC while another gRPC request is started
+        # by another thread.
+        return None
+
+    plan.CachedRemoteRelation.__del__ = _noop_del
+
+    try:
+        yield
+    finally:
+        plan.CachedRemoteRelation.__del__ = _del
+
+
+@pytest.fixture(scope="session", autouse=_is_spark_testing())
 def spark_working_dir(tmp_path_factory):
     import pyspark
 
@@ -71,8 +95,10 @@ def spark_doctest_session(doctest_namespace, request):
 
         spark = SparkSession.builder.appName("doctest").remote("local").getOrCreate()
         doctest_namespace["spark"] = spark
-        yield
-        spark.stop()
+        try:
+            yield
+        finally:
+            spark.stop()
     else:
         yield
 


### PR DESCRIPTION
This PR fixes an issue that occasionally causes Spark parity tests to hang.

The `CachedRemoteRelation.__del__` method starts a gRPC request during cleanup in PySpark 4. The main thread, when issuing a gRPC request, locks the channel state and starts a new thread for the request. During the thread initialization, the thread may by occupied for GC to delete certain `CachedRemoteRelation` objects in previous tests, which starts another gRPC request in `__del__` and causes a deadlock since the gRPC channel state is already locked by another thread.

Both Claude Sonnet 4.6 and GPT 5.4 (high) identify the same root cause by analyzing the stack trace.

This is the same phenomenon as the issue we observed before (#86), but in this case, it is due to a different cleanup logic.