### PR TITLE
feat: implement UPDATE DML for Delta Lake

### DIFF
--- a/crates/sail-common-datafusion/src/datasource.rs
+++ b/crates/sail-common-datafusion/src/datasource.rs
@@ -255,6 +255,8 @@ pub struct RowLevelWriteInfo {
     pub target: RowLevelTargetInfo,
     /// Condition for DELETE/UPDATE. `None` for MERGE.
     pub condition: Option<ExprWithSource>,
+    /// Assignments for UPDATE (column name, value with source text). `None` for other commands.
+    pub assignments: Option<Vec<(String, ExprWithSource)>>,
     /// Pre-expanded physical plan for writing (MERGE, future UPDATE).
     pub expanded_input: Option<Arc<dyn ExecutionPlan>>,
     /// Physical plan that yields touched file paths (MERGE targeted rewrite).

--- a/crates/sail-common/src/spec/plan.rs
+++ b/crates/sail-common/src/spec/plan.rs
@@ -462,7 +462,7 @@ pub enum CommandNode {
         table: ObjectName,
         table_alias: Option<Identifier>,
         assignments: Vec<(ObjectName, Expr)>,
-        condition: Option<Expr>,
+        condition: Option<ExprWithSource>,
     },
     Delete {
         table: ObjectName,

--- a/crates/sail-delta-lake/src/physical_plan/planner/op_update.rs
+++ b/crates/sail-delta-lake/src/physical_plan/planner/op_update.rs
@@ -13,7 +13,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use datafusion::common::{DataFusionError, Result, ToDFSchema};
+use datafusion::arrow::datatypes::SchemaRef as ArrowSchemaRef;
+use datafusion::common::{DFSchema, DataFusionError, Result, ToDFSchema};
 use datafusion::physical_expr::expressions::{CaseExpr, CastExpr, Column};
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_expr_adapter::PhysicalExprAdapterFactory;
@@ -21,6 +22,7 @@ use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::{ExecutionPlan, Partitioning};
 use sail_common_datafusion::datasource::RowLevelWriteInfo;
+use sail_common_datafusion::logical_expr::ExprWithSource;
 
 use super::commit::assemble_commit_plan;
 use super::context::PlannerContext;
@@ -31,6 +33,7 @@ use crate::physical_plan::{
     DeltaDiscoveryExec, DeltaPhysicalExprAdapterFactory, DeltaScanByAddsExec,
     DeltaWriterExecOptions,
 };
+use crate::table::DeltaSnapshot;
 
 pub async fn build_update_plan(
     ctx: &PlannerContext<'_>,
@@ -62,46 +65,22 @@ pub async fn build_update_plan(
         None => None,
     };
 
-    let partition_only = match &condition {
-        Some(cond) => !predicate_requires_stats(&cond.expr, &partition_columns),
-        None => true,
-    };
-
-    let log_replay_options = LogReplayOptions {
-        include_stats_json: !partition_only,
-        ..Default::default()
-    };
-
-    let meta_scan: Arc<dyn ExecutionPlan> =
-        build_log_replay_pipeline_with_options(ctx, snapshot_state, log_replay_options).await?;
-
-    let meta_scan: Arc<dyn ExecutionPlan> = match &condition {
-        Some(cond) => {
-            build_metadata_filter(ctx.session(), meta_scan, snapshot_state, cond.expr.clone())?
-        }
-        None => meta_scan,
-    };
-
-    // UPDATE must always scan file content to produce updated rows, even when the predicate
-    // touches only partition columns. `partition_scan=true` is a DELETE optimization that emits
-    // empty batches and drops touched files — for UPDATE that would silently delete data.
-    let find_files_exec: Arc<dyn ExecutionPlan> = Arc::new(DeltaDiscoveryExec::with_input(
-        meta_scan,
-        ctx.table_url().clone(),
-        None,
-        None,
+    let find_files_exec = build_find_files_plan(
+        ctx,
+        snapshot_state,
         version,
-        partition_columns.clone(),
-        false,
-    )?);
+        condition.as_ref(),
+        &partition_columns,
+    )
+    .await?;
 
     let target_partitions = ctx.session().config().target_partitions().max(1);
     let find_files_exec: Arc<dyn ExecutionPlan> = Arc::new(RepartitionExec::try_new(
-        Arc::clone(&find_files_exec),
+        find_files_exec,
         Partitioning::RoundRobinBatch(target_partitions),
     )?);
 
-    let scan_exec = Arc::new(DeltaScanByAddsExec::new(
+    let scan_exec: Arc<dyn ExecutionPlan> = Arc::new(DeltaScanByAddsExec::new(
         Arc::clone(&find_files_exec),
         ctx.table_url().clone(),
         version,
@@ -113,9 +92,84 @@ pub async fn build_update_plan(
         None,
     ));
 
+    let projection_exec = build_update_projection(
+        ctx,
+        scan_exec,
+        &table_schema,
+        &table_df_schema,
+        physical_condition,
+        assignments,
+    )?;
+
+    let operation = Some(DeltaOperation::Update {
+        predicate: condition.and_then(|c| c.source),
+    });
+
+    assemble_commit_plan(
+        projection_exec,
+        Some(find_files_exec),
+        ctx.table_url().clone(),
+        DeltaWriterExecOptions::from(ctx.options().clone()),
+        ctx.metadata_configuration().clone(),
+        partition_columns,
+        ctx.table_exists(),
+        table_schema,
+        operation,
+    )
+}
+
+async fn build_find_files_plan(
+    ctx: &PlannerContext<'_>,
+    snapshot: &DeltaSnapshot,
+    version: i64,
+    condition: Option<&ExprWithSource>,
+    partition_columns: &[String],
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let partition_only = match condition {
+        Some(cond) => !predicate_requires_stats(&cond.expr, partition_columns),
+        None => true,
+    };
+
+    let log_replay_options = LogReplayOptions {
+        include_stats_json: !partition_only,
+        ..Default::default()
+    };
+
+    let meta_scan: Arc<dyn ExecutionPlan> =
+        build_log_replay_pipeline_with_options(ctx, snapshot, log_replay_options).await?;
+
+    let meta_scan: Arc<dyn ExecutionPlan> = match condition {
+        Some(cond) => build_metadata_filter(ctx.session(), meta_scan, snapshot, cond.expr.clone())?,
+        None => meta_scan,
+    };
+
+    // UPDATE must always scan file content to produce updated rows, even when the predicate
+    // touches only partition columns. `partition_scan=true` is a DELETE optimization that emits
+    // empty batches and drops touched files — for UPDATE that would silently delete data.
+    Ok(Arc::new(DeltaDiscoveryExec::with_input(
+        meta_scan,
+        ctx.table_url().clone(),
+        None,
+        None,
+        version,
+        partition_columns.to_vec(),
+        false,
+    )?))
+}
+
+fn build_update_projection(
+    ctx: &PlannerContext<'_>,
+    scan_exec: Arc<dyn ExecutionPlan>,
+    table_schema: &ArrowSchemaRef,
+    table_df_schema: &DFSchema,
+    physical_condition: Option<Arc<dyn PhysicalExpr>>,
+    assignments: Vec<(String, ExprWithSource)>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let scan_schema = scan_exec.schema();
+
     let adapter_factory = Arc::new(DeltaPhysicalExprAdapterFactory {});
     let adapter = adapter_factory
-        .create(table_schema.clone(), scan_exec.schema())
+        .create(table_schema.clone(), scan_schema.clone())
         .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
     let adapted_condition = match physical_condition {
@@ -127,16 +181,11 @@ pub async fn build_update_plan(
         None => None,
     };
 
-    let scan_schema = scan_exec.schema();
-
-    // Map assignment column name (lowercase) → adapted RHS physical expression cast to the target
-    // column's type. Casting is required because the RHS expression may not naturally carry the
-    // column's declared type (e.g. a literal NULL has type Null).
     let mut assignment_exprs: HashMap<String, Arc<dyn PhysicalExpr>> = HashMap::new();
     for (col_name, rhs) in assignments {
         let rhs_physical = ctx
             .session()
-            .create_physical_expr(rhs.expr.clone(), &table_df_schema)?;
+            .create_physical_expr(rhs.expr.clone(), table_df_schema)?;
         let adapted_rhs = adapter
             .rewrite(rhs_physical)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
@@ -176,22 +225,8 @@ pub async fn build_update_plan(
         projection_exprs.push((expr, name));
     }
 
-    let projection_exec: Arc<dyn ExecutionPlan> =
-        Arc::new(ProjectionExec::try_new(projection_exprs, scan_exec)?);
-
-    let operation = Some(DeltaOperation::Update {
-        predicate: condition.and_then(|c| c.source),
-    });
-
-    assemble_commit_plan(
-        projection_exec,
-        Some(find_files_exec),
-        ctx.table_url().clone(),
-        DeltaWriterExecOptions::from(ctx.options().clone()),
-        ctx.metadata_configuration().clone(),
-        partition_columns,
-        ctx.table_exists(),
-        table_schema,
-        operation,
-    )
+    Ok(Arc::new(ProjectionExec::try_new(
+        projection_exprs,
+        scan_exec,
+    )?))
 }

--- a/crates/sail-delta-lake/src/physical_plan/planner/op_update.rs
+++ b/crates/sail-delta-lake/src/physical_plan/planner/op_update.rs
@@ -10,18 +10,189 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
-use datafusion::common::{DataFusionError, Result};
-use datafusion::physical_plan::ExecutionPlan;
+use datafusion::common::{DataFusionError, Result, ToDFSchema};
+use datafusion::physical_expr::expressions::{CaseExpr, CastExpr, Column};
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr_adapter::PhysicalExprAdapterFactory;
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion::physical_plan::{ExecutionPlan, Partitioning};
+use sail_common_datafusion::datasource::RowLevelWriteInfo;
 
+use super::commit::assemble_commit_plan;
 use super::context::PlannerContext;
+use super::metadata_predicate::{build_metadata_filter, predicate_requires_stats};
+use super::utils::{build_log_replay_pipeline_with_options, LogReplayOptions};
+use crate::kernel::DeltaOperation;
+use crate::physical_plan::{
+    DeltaDiscoveryExec, DeltaPhysicalExprAdapterFactory, DeltaScanByAddsExec,
+    DeltaWriterExecOptions,
+};
 
 pub async fn build_update_plan(
-    _ctx: &PlannerContext<'_>,
-    _input: Arc<dyn ExecutionPlan>,
+    ctx: &PlannerContext<'_>,
+    info: RowLevelWriteInfo,
 ) -> Result<Arc<dyn ExecutionPlan>> {
-    Err(DataFusionError::NotImplemented(
-        "UPDATE planner not implemented".to_string(),
-    ))
+    let table = ctx.open_table().await?;
+    let snapshot_state = table
+        .snapshot()
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+    let version = snapshot_state.version();
+
+    let table_schema = snapshot_state
+        .input_schema()
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+    let partition_columns = snapshot_state.metadata().partition_columns().clone();
+    let table_df_schema = table_schema
+        .clone()
+        .to_dfschema()
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+    let condition = info.condition;
+    let assignments = info.assignments.unwrap_or_default();
+
+    let physical_condition = match &condition {
+        Some(cond) => Some(
+            ctx.session()
+                .create_physical_expr(cond.expr.clone(), &table_df_schema)?,
+        ),
+        None => None,
+    };
+
+    let partition_only = match &condition {
+        Some(cond) => !predicate_requires_stats(&cond.expr, &partition_columns),
+        None => true,
+    };
+
+    let log_replay_options = LogReplayOptions {
+        include_stats_json: !partition_only,
+        ..Default::default()
+    };
+
+    let meta_scan: Arc<dyn ExecutionPlan> =
+        build_log_replay_pipeline_with_options(ctx, snapshot_state, log_replay_options).await?;
+
+    let meta_scan: Arc<dyn ExecutionPlan> = match &condition {
+        Some(cond) => {
+            build_metadata_filter(ctx.session(), meta_scan, snapshot_state, cond.expr.clone())?
+        }
+        None => meta_scan,
+    };
+
+    // UPDATE must always scan file content to produce updated rows, even when the predicate
+    // touches only partition columns. `partition_scan=true` is a DELETE optimization that emits
+    // empty batches and drops touched files — for UPDATE that would silently delete data.
+    let find_files_exec: Arc<dyn ExecutionPlan> = Arc::new(DeltaDiscoveryExec::with_input(
+        meta_scan,
+        ctx.table_url().clone(),
+        None,
+        None,
+        version,
+        partition_columns.clone(),
+        false,
+    )?);
+
+    let target_partitions = ctx.session().config().target_partitions().max(1);
+    let find_files_exec: Arc<dyn ExecutionPlan> = Arc::new(RepartitionExec::try_new(
+        Arc::clone(&find_files_exec),
+        Partitioning::RoundRobinBatch(target_partitions),
+    )?);
+
+    let scan_exec = Arc::new(DeltaScanByAddsExec::new(
+        Arc::clone(&find_files_exec),
+        ctx.table_url().clone(),
+        version,
+        table_schema.clone(),
+        table_schema.clone(),
+        crate::datasource::DeltaScanConfig::default(),
+        None,
+        None,
+        None,
+    ));
+
+    let adapter_factory = Arc::new(DeltaPhysicalExprAdapterFactory {});
+    let adapter = adapter_factory
+        .create(table_schema.clone(), scan_exec.schema())
+        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+
+    let adapted_condition = match physical_condition {
+        Some(cond) => Some(
+            adapter
+                .rewrite(cond)
+                .map_err(|e| DataFusionError::External(Box::new(e)))?,
+        ),
+        None => None,
+    };
+
+    let scan_schema = scan_exec.schema();
+
+    // Map assignment column name (lowercase) → adapted RHS physical expression cast to the target
+    // column's type. Casting is required because the RHS expression may not naturally carry the
+    // column's declared type (e.g. a literal NULL has type Null).
+    let mut assignment_exprs: HashMap<String, Arc<dyn PhysicalExpr>> = HashMap::new();
+    for (col_name, rhs) in assignments {
+        let rhs_physical = ctx
+            .session()
+            .create_physical_expr(rhs.expr.clone(), &table_df_schema)?;
+        let adapted_rhs = adapter
+            .rewrite(rhs_physical)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let target_field = table_schema.field_with_name(&col_name)?;
+        let rhs_type = adapted_rhs.data_type(&scan_schema)?;
+        let final_rhs: Arc<dyn PhysicalExpr> = if &rhs_type == target_field.data_type() {
+            adapted_rhs
+        } else {
+            Arc::new(CastExpr::new(
+                adapted_rhs,
+                target_field.data_type().clone(),
+                None,
+            ))
+        };
+        assignment_exprs.insert(col_name.to_ascii_lowercase(), final_rhs);
+    }
+
+    let mut projection_exprs: Vec<(Arc<dyn PhysicalExpr>, String)> =
+        Vec::with_capacity(table_schema.fields().len());
+    for field in table_schema.fields() {
+        let name = field.name().clone();
+        let scan_index = scan_schema.index_of(&name)?;
+        let original_col: Arc<dyn PhysicalExpr> =
+            Arc::new(Column::new(&name, scan_index));
+
+        let expr: Arc<dyn PhysicalExpr> = match assignment_exprs.get(&name.to_ascii_lowercase()) {
+            Some(rhs) => match &adapted_condition {
+                Some(cond) => Arc::new(CaseExpr::try_new(
+                    None,
+                    vec![(Arc::clone(cond), Arc::clone(rhs))],
+                    Some(original_col),
+                )?),
+                None => Arc::clone(rhs),
+            },
+            None => original_col,
+        };
+
+        projection_exprs.push((expr, name));
+    }
+
+    let projection_exec: Arc<dyn ExecutionPlan> =
+        Arc::new(ProjectionExec::try_new(projection_exprs, scan_exec)?);
+
+    let operation = Some(DeltaOperation::Update {
+        predicate: condition.and_then(|c| c.source),
+    });
+
+    assemble_commit_plan(
+        projection_exec,
+        Some(find_files_exec),
+        ctx.table_url().clone(),
+        DeltaWriterExecOptions::from(ctx.options().clone()),
+        ctx.metadata_configuration().clone(),
+        partition_columns,
+        ctx.table_exists(),
+        table_schema,
+        operation,
+    )
 }

--- a/crates/sail-delta-lake/src/physical_plan/planner/op_update.rs
+++ b/crates/sail-delta-lake/src/physical_plan/planner/op_update.rs
@@ -159,8 +159,7 @@ pub async fn build_update_plan(
     for field in table_schema.fields() {
         let name = field.name().clone();
         let scan_index = scan_schema.index_of(&name)?;
-        let original_col: Arc<dyn PhysicalExpr> =
-            Arc::new(Column::new(&name, scan_index));
+        let original_col: Arc<dyn PhysicalExpr> = Arc::new(Column::new(&name, scan_index));
 
         let expr: Arc<dyn PhysicalExpr> = match assignment_exprs.get(&name.to_ascii_lowercase()) {
             Some(rhs) => match &adapted_condition {

--- a/crates/sail-delta-lake/src/physical_plan/planner/op_update.rs
+++ b/crates/sail-delta-lake/src/physical_plan/planner/op_update.rs
@@ -54,10 +54,9 @@ pub async fn build_update_plan(
         .to_dfschema()
         .map_err(|e| DataFusionError::External(Box::new(e)))?;
 
-    let condition = info.condition;
     let assignments = info.assignments.unwrap_or_default();
 
-    let physical_condition = match &condition {
+    let physical_condition = match &info.condition {
         Some(cond) => Some(
             ctx.session()
                 .create_physical_expr(cond.expr.clone(), &table_df_schema)?,
@@ -69,7 +68,7 @@ pub async fn build_update_plan(
         ctx,
         snapshot_state,
         version,
-        condition.as_ref(),
+        info.condition.as_ref(),
         &partition_columns,
     )
     .await?;
@@ -102,7 +101,7 @@ pub async fn build_update_plan(
     )?;
 
     let operation = Some(DeltaOperation::Update {
-        predicate: condition.and_then(|c| c.source),
+        predicate: info.condition.and_then(|c| c.source),
     });
 
     assemble_commit_plan(

--- a/crates/sail-delta-lake/src/spec/operation.rs
+++ b/crates/sail-delta-lake/src/spec/operation.rs
@@ -80,6 +80,10 @@ pub enum DeltaOperation {
         #[serde(skip_serializing_if = "Option::is_none")]
         predicate: Option<String>,
     },
+    Update {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        predicate: Option<String>,
+    },
     #[serde(rename_all = "camelCase")]
     Merge {
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -109,6 +113,7 @@ impl DeltaOperation {
             Self::Create { .. } => "CREATE TABLE",
             Self::Write { .. } => "WRITE",
             Self::Delete { .. } => "DELETE",
+            Self::Update { .. } => "UPDATE",
             Self::Merge { .. } => "MERGE",
             Self::FileSystemCheck { .. } => "FSCK",
             Self::Restore { .. } => "RESTORE",
@@ -159,6 +164,9 @@ impl DeltaOperation {
                 insert_opt(&mut parameters, "predicate", predicate.clone());
             }
             Self::Delete { predicate } => {
+                insert_opt(&mut parameters, "predicate", predicate.clone());
+            }
+            Self::Update { predicate } => {
                 insert_opt(&mut parameters, "predicate", predicate.clone());
             }
             Self::Merge {
@@ -228,6 +236,7 @@ impl DeltaOperation {
         match self {
             Self::Write { predicate, .. } => predicate.clone(),
             Self::Delete { predicate, .. } => predicate.clone(),
+            Self::Update { predicate, .. } => predicate.clone(),
             Self::Merge { predicate, .. } => predicate.clone(),
             _ => None,
         }

--- a/crates/sail-delta-lake/src/table_format.rs
+++ b/crates/sail-delta-lake/src/table_format.rs
@@ -8,8 +8,8 @@ use datafusion::datasource::listing::ListingTableUrl;
 use datafusion::logical_expr::TableSource;
 use datafusion::physical_plan::ExecutionPlan;
 use sail_common_datafusion::datasource::{
-    MergeStrategy, OptionLayer, PhysicalSinkMode, RowLevelCommand, RowLevelWriteInfo, SinkInfo,
-    SourceInfo, TableFormat, TableFormatRegistry,
+    MergeStrategy, OptionLayer, PhysicalSinkMode, RowLevelCommand, RowLevelTargetInfo,
+    RowLevelWriteInfo, SinkInfo, SourceInfo, TableFormat, TableFormatRegistry,
 };
 use sail_common_datafusion::streaming::event::schema::is_flow_event_schema;
 use sail_data_source::error::DataSourceResult;
@@ -265,48 +265,23 @@ impl TableFormat for DeltaTableFormat {
 
         match info.command {
             RowLevelCommand::Delete => {
-                let table_url = Self::parse_table_url(ctx, vec![info.target.path]).await?;
                 let condition = info.condition.ok_or_else(|| {
                     DataFusionError::Plan("DELETE operation requires a WHERE condition".to_string())
                 })?;
-                let delta_options = resolve_delta_write_options(info.target.options)?;
-                let delete_config = DeltaPlannerConfig::new(
-                    table_url,
-                    delta_options,
-                    HashMap::new(),
-                    Vec::new(),
-                    None,
-                    true,
-                );
-                let delete_ctx = PlannerContext::new(ctx, delete_config);
+                let delete_ctx =
+                    Self::build_row_level_planner_context(ctx, &info.target, Vec::new()).await?;
                 plan_delete(&delete_ctx, condition).await
             }
             RowLevelCommand::Merge => {
-                let table_url = Self::parse_table_url(ctx, vec![info.target.path.clone()]).await?;
-                let delta_options = resolve_delta_write_options(info.target.options.clone())?;
-                let merge_config = DeltaPlannerConfig::new(
-                    table_url,
-                    delta_options,
-                    HashMap::new(),
-                    info.target.partition_by.clone(),
-                    None,
-                    true,
-                );
-                let merge_ctx = PlannerContext::new(ctx, merge_config);
+                let partition_by = info.target.partition_by.clone();
+                let merge_ctx =
+                    Self::build_row_level_planner_context(ctx, &info.target, partition_by).await?;
                 plan_merge(&merge_ctx, info).await
             }
             RowLevelCommand::Update => {
-                let table_url = Self::parse_table_url(ctx, vec![info.target.path.clone()]).await?;
-                let delta_options = resolve_delta_write_options(info.target.options.clone())?;
-                let update_config = DeltaPlannerConfig::new(
-                    table_url,
-                    delta_options,
-                    HashMap::new(),
-                    info.target.partition_by.clone(),
-                    None,
-                    true,
-                );
-                let update_ctx = PlannerContext::new(ctx, update_config);
+                let partition_by = info.target.partition_by.clone();
+                let update_ctx =
+                    Self::build_row_level_planner_context(ctx, &info.target, partition_by).await?;
                 plan_update(&update_ctx, info).await
             }
         }
@@ -320,6 +295,24 @@ impl DeltaTableFormat {
             (Some(path), true) => Ok(<ListingTableUrl as AsRef<Url>>::as_ref(&path).clone()),
             _ => plan_err!("expected a single path for Delta table sink: {paths:?}"),
         }
+    }
+
+    async fn build_row_level_planner_context<'a>(
+        ctx: &'a dyn Session,
+        target: &RowLevelTargetInfo,
+        partition_by: Vec<String>,
+    ) -> Result<PlannerContext<'a>> {
+        let table_url = Self::parse_table_url(ctx, vec![target.path.clone()]).await?;
+        let delta_options = resolve_delta_write_options(target.options.clone())?;
+        let config = DeltaPlannerConfig::new(
+            table_url,
+            delta_options,
+            HashMap::new(),
+            partition_by,
+            None,
+            true,
+        );
+        Ok(PlannerContext::new(ctx, config))
     }
 }
 

--- a/crates/sail-delta-lake/src/table_format.rs
+++ b/crates/sail-delta-lake/src/table_format.rs
@@ -22,7 +22,7 @@ use url::Url;
 
 use crate::kernel::DeltaSnapshotConfig;
 use crate::physical_plan::planner::{
-    plan_delete, plan_merge, DeltaPhysicalPlanner, DeltaPlannerConfig, PlannerContext,
+    plan_delete, plan_merge, plan_update, DeltaPhysicalPlanner, DeltaPlannerConfig, PlannerContext,
 };
 use crate::spec::{canonicalize_and_validate_table_properties, route_table_property_key};
 use crate::table::open_table_with_object_store_and_table_config;
@@ -296,7 +296,18 @@ impl TableFormat for DeltaTableFormat {
                 plan_merge(&merge_ctx, info).await
             }
             RowLevelCommand::Update => {
-                not_impl_err!("UPDATE is not yet implemented for Delta Lake")
+                let table_url = Self::parse_table_url(ctx, vec![info.target.path.clone()]).await?;
+                let delta_options = resolve_delta_write_options(info.target.options.clone())?;
+                let update_config = DeltaPlannerConfig::new(
+                    table_url,
+                    delta_options,
+                    HashMap::new(),
+                    info.target.partition_by.clone(),
+                    None,
+                    true,
+                );
+                let update_ctx = PlannerContext::new(ctx, update_config);
+                plan_update(&update_ctx, info).await
             }
         }
     }

--- a/crates/sail-logical-plan/src/file_update.rs
+++ b/crates/sail-logical-plan/src/file_update.rs
@@ -1,0 +1,80 @@
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+use datafusion_common::{DFSchema, DFSchemaRef};
+use datafusion_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
+use educe::Educe;
+use sail_common_datafusion::logical_expr::ExprWithSource;
+use sail_common_datafusion::utils::items::ItemTaker;
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd)]
+pub struct FileUpdateOptions {
+    pub table_name: Vec<String>,
+    pub path: String,
+    pub format: String,
+    pub assignments: Vec<(String, ExprWithSource)>,
+    pub condition: Option<ExprWithSource>,
+    pub options: Vec<Vec<(String, String)>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Educe)]
+#[educe(PartialOrd)]
+pub struct FileUpdateNode {
+    options: FileUpdateOptions,
+    #[educe(PartialOrd(ignore))]
+    schema: DFSchemaRef,
+}
+
+impl FileUpdateNode {
+    pub fn new(options: FileUpdateOptions) -> Self {
+        Self {
+            options,
+            schema: Arc::new(DFSchema::empty()),
+        }
+    }
+
+    pub fn options(&self) -> &FileUpdateOptions {
+        &self.options
+    }
+}
+
+impl UserDefinedLogicalNodeCore for FileUpdateNode {
+    fn name(&self) -> &str {
+        "FileUpdate"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "FileUpdate: options={:?}", self.options)?;
+        Ok(())
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        exprs: Vec<Expr>,
+        inputs: Vec<LogicalPlan>,
+    ) -> datafusion_common::Result<Self> {
+        exprs.zero()?;
+        inputs.zero()?;
+
+        Ok(Self {
+            options: self.options.clone(),
+            schema: self.schema.clone(),
+        })
+    }
+
+    fn necessary_children_exprs(&self, _output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {
+        None
+    }
+}

--- a/crates/sail-logical-plan/src/lib.rs
+++ b/crates/sail-logical-plan/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod barrier;
 pub mod file_delete;
+pub mod file_update;
 pub mod file_write;
 pub mod map_partitions;
 pub mod merge;

--- a/crates/sail-logical-plan/src/merge.rs
+++ b/crates/sail-logical-plan/src/merge.rs
@@ -306,6 +306,9 @@ pub struct RowLevelWriteNode {
     /// Condition for DELETE/UPDATE (passed through to physical planner).
     #[educe(PartialOrd(ignore))]
     condition: Option<ExprWithSource>,
+    /// Assignments for UPDATE (column name, value with source text).
+    #[educe(PartialOrd(ignore))]
+    assignments: Option<Vec<(String, ExprWithSource)>>,
     #[educe(PartialOrd(ignore))]
     merge_options: Option<MergeIntoOptions>,
     target_format: String,
@@ -343,6 +346,7 @@ impl RowLevelWriteNode {
             write_plan: Some(write_plan),
             touched_files_plan: Some(touched_files_plan),
             condition: None,
+            assignments: None,
             merge_options: Some(options),
             schema,
         }
@@ -366,6 +370,38 @@ impl RowLevelWriteNode {
             write_plan: None,
             touched_files_plan: None,
             condition,
+            assignments: None,
+            merge_options: None,
+            target_format: format,
+            target_location: location,
+            target_table_name: table_name,
+            target_partition_by: Vec::new(),
+            target_options: options,
+            with_schema_evolution: false,
+            schema: Arc::new(DFSchema::empty()),
+        }
+    }
+
+    /// Create an UPDATE write node carrying the condition and assignments for the physical planner.
+    pub fn new_update(
+        raw_target: Arc<LogicalPlan>,
+        raw_input_schema: DFSchemaRef,
+        condition: Option<ExprWithSource>,
+        assignments: Vec<(String, ExprWithSource)>,
+        format: String,
+        location: String,
+        table_name: Vec<String>,
+        options: Vec<Vec<(String, String)>>,
+    ) -> Self {
+        Self {
+            command: RowLevelCommand::Update,
+            raw_target,
+            raw_source: None,
+            raw_input_schema,
+            write_plan: None,
+            touched_files_plan: None,
+            condition,
+            assignments: Some(assignments),
             merge_options: None,
             target_format: format,
             target_location: location,
@@ -407,6 +443,10 @@ impl RowLevelWriteNode {
 
     pub fn condition(&self) -> Option<&ExprWithSource> {
         self.condition.as_ref()
+    }
+
+    pub fn assignments(&self) -> Option<&[(String, ExprWithSource)]> {
+        self.assignments.as_deref()
     }
 
     pub fn target_format(&self) -> &str {
@@ -486,7 +526,14 @@ impl UserDefinedLogicalNodeCore for RowLevelWriteNode {
                     )?;
                 }
             }
-            RowLevelCommand::Update => {}
+            RowLevelCommand::Update => {
+                if let Some(cond) = self.condition.as_ref().and_then(|c| c.source.as_deref()) {
+                    write!(f, ", condition={}", cond.trim())?;
+                }
+                if let Some(assignments) = &self.assignments {
+                    write!(f, ", assignments={}", assignments.len())?;
+                }
+            }
         }
         Ok(())
     }
@@ -522,6 +569,7 @@ impl UserDefinedLogicalNodeCore for RowLevelWriteNode {
             write_plan,
             touched_files_plan,
             condition: self.condition.clone(),
+            assignments: self.assignments.clone(),
             merge_options: self.merge_options.clone(),
             target_format: self.target_format.clone(),
             target_location: self.target_location.clone(),

--- a/crates/sail-physical-plan/src/file_update.rs
+++ b/crates/sail-physical-plan/src/file_update.rs
@@ -8,26 +8,27 @@ use sail_common_datafusion::datasource::{
     OptionLayer, RowLevelCommand, RowLevelTargetInfo, RowLevelWriteInfo, TableFormatRegistry,
 };
 use sail_common_datafusion::extension::SessionExtensionAccessor;
-use sail_logical_plan::file_delete::FileDeleteOptions;
+use sail_logical_plan::file_update::FileUpdateOptions;
 
-/// Fallback physical planner for non-lakehouse DELETE (e.g. session planner).
-/// Lakehouse DELETEs are handled via `RowLevelWriteNode` → `create_row_level_write_physical_plan`.
-pub async fn create_file_delete_physical_plan(
+/// Fallback physical planner for non-lakehouse UPDATE (e.g. session planner).
+/// Lakehouse UPDATEs are handled via `RowLevelWriteNode` → `create_row_level_write_physical_plan`.
+pub async fn create_file_update_physical_plan(
     ctx: &SessionState,
     _planner: &dyn PhysicalPlanner,
     _schema: datafusion::common::DFSchemaRef,
-    options: FileDeleteOptions,
+    options: FileUpdateOptions,
 ) -> Result<Arc<dyn ExecutionPlan>> {
-    let FileDeleteOptions {
+    let FileUpdateOptions {
         table_name,
         path,
         format,
+        assignments,
         condition,
         options,
     } = options;
 
     let info = RowLevelWriteInfo {
-        command: RowLevelCommand::Delete,
+        command: RowLevelCommand::Update,
         target: RowLevelTargetInfo {
             table_name,
             path,
@@ -38,7 +39,7 @@ pub async fn create_file_delete_physical_plan(
                 .collect(),
         },
         condition,
-        assignments: None,
+        assignments: Some(assignments),
         expanded_input: None,
         touched_file_plan: None,
         with_schema_evolution: false,

--- a/crates/sail-physical-plan/src/lib.rs
+++ b/crates/sail-physical-plan/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod barrier;
 pub mod catalog_command;
 pub mod file_delete;
+pub mod file_update;
 pub mod file_write;
 pub mod map_partitions;
 pub mod merge_cardinality_check;

--- a/crates/sail-physical-plan/src/row_level_write.rs
+++ b/crates/sail-physical-plan/src/row_level_write.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use datafusion::execution::SessionState;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_planner::PhysicalPlanner;
-use datafusion_common::{internal_err, Result};
+use datafusion_common::Result;
 use sail_common_datafusion::datasource::{
     MergePredicateInfo, OperationOverride, OptionLayer, RowLevelCommand, RowLevelTargetInfo,
     RowLevelWriteInfo, TableFormatRegistry,
@@ -45,6 +45,7 @@ pub async fn create_row_level_write_physical_plan(
                 command: RowLevelCommand::Delete,
                 target,
                 condition: node.condition().cloned(),
+                assignments: None,
                 expanded_input: None,
                 touched_file_plan: None,
                 with_schema_evolution: false,
@@ -84,6 +85,7 @@ pub async fn create_row_level_write_physical_plan(
                 command: RowLevelCommand::Merge,
                 target,
                 condition: None,
+                assignments: None,
                 expanded_input: Some(physical_write),
                 touched_file_plan: if is_insert_only {
                     None
@@ -97,7 +99,18 @@ pub async fn create_row_level_write_physical_plan(
             table_format.create_row_level_writer(ctx, info).await
         }
         RowLevelCommand::Update => {
-            internal_err!("UPDATE is not yet implemented")
+            let info = RowLevelWriteInfo {
+                command: RowLevelCommand::Update,
+                target,
+                condition: node.condition().cloned(),
+                assignments: node.assignments().map(|a| a.to_vec()),
+                expanded_input: None,
+                touched_file_plan: None,
+                with_schema_evolution: false,
+                operation_override: None,
+                merge_strategy,
+            };
+            table_format.create_row_level_writer(ctx, info).await
         }
     }
 }

--- a/crates/sail-plan-lakehouse/src/lib.rs
+++ b/crates/sail-plan-lakehouse/src/lib.rs
@@ -11,9 +11,11 @@ use sail_data_source::resolve_listing_urls;
 use sail_delta_lake::table::open_table_with_object_store_and_table_config;
 use sail_delta_lake::DeltaSnapshotConfig;
 use sail_logical_plan::file_delete::FileDeleteNode;
+use sail_logical_plan::file_update::FileUpdateNode;
 use sail_logical_plan::file_write::FileWriteNode;
 use sail_logical_plan::merge::{MergeCardinalityCheckNode, RowLevelWriteNode};
 use sail_physical_plan::file_delete::create_file_delete_physical_plan;
+use sail_physical_plan::file_update::create_file_update_physical_plan;
 use sail_physical_plan::file_write::create_file_write_physical_plan;
 use sail_physical_plan::merge_cardinality_check::MergeCardinalityCheckExec;
 use sail_physical_plan::row_level_write::create_row_level_write_physical_plan;
@@ -107,6 +109,25 @@ impl ExtensionPlanner for DeltaExtensionPlanner {
 
             let schema = delta_table_schema(session_state, &node.options().path).await?;
             let plan = create_file_delete_physical_plan(
+                session_state,
+                planner,
+                schema,
+                node.options().clone(),
+            )
+            .await?;
+            return Ok(Some(plan));
+        }
+
+        if let Some(node) = node.as_any().downcast_ref::<FileUpdateNode>() {
+            if !is_lakehouse_format(node.options().format.as_str()) {
+                return Ok(None);
+            }
+            if !logical_inputs.is_empty() || !physical_inputs.is_empty() {
+                return internal_err!("FileUpdateNode should have no inputs");
+            }
+
+            let schema = delta_table_schema(session_state, &node.options().path).await?;
+            let plan = create_file_update_physical_plan(
                 session_state,
                 planner,
                 schema,

--- a/crates/sail-plan-lakehouse/src/optimizer.rs
+++ b/crates/sail-plan-lakehouse/src/optimizer.rs
@@ -13,6 +13,7 @@ use sail_common_datafusion::datasource::{
 };
 use sail_delta_lake::DeltaTableSource;
 use sail_logical_plan::file_delete::FileDeleteNode;
+use sail_logical_plan::file_update::FileUpdateNode;
 use sail_logical_plan::merge::{expand_merge, MergeIntoNode, RowLevelWriteNode};
 
 /// Optimizer rule that expands row-level operations (DELETE, UPDATE, MERGE)
@@ -48,6 +49,14 @@ impl OptimizerRule for ExpandRowLevelOp {
                         return Ok(Transformed::no(plan));
                     }
                     return expand_delete_node(node);
+                }
+
+                // UPDATE → RowLevelWriteNode (delegates physical plan to format)
+                if let Some(node) = ext.node.as_any().downcast_ref::<FileUpdateNode>() {
+                    if !is_lakehouse_format(node.options().format.as_str()) {
+                        return Ok(Transformed::no(plan));
+                    }
+                    return expand_update_node(node);
                 }
             }
             Ok(Transformed::no(plan))
@@ -139,6 +148,33 @@ fn expand_delete_node(node: &FileDeleteNode) -> Result<Transformed<LogicalPlan>>
         )),
         Arc::new(DFSchema::empty()),
         opts.condition.clone(),
+        opts.format.clone(),
+        opts.path.clone(),
+        opts.table_name.clone(),
+        opts.options.clone(),
+    );
+
+    Ok(Transformed::yes(LogicalPlan::Extension(Extension {
+        node: Arc::new(write_node),
+    })))
+}
+
+/// Convert `FileUpdateNode` → `RowLevelWriteNode(Update)`.
+///
+/// UPDATE's physical plan is built by the format's `create_row_level_writer`
+/// (e.g., Delta's `build_update_plan`), so we simply wrap the parameters.
+fn expand_update_node(node: &FileUpdateNode) -> Result<Transformed<LogicalPlan>> {
+    let opts = node.options();
+    let write_node = RowLevelWriteNode::new_update(
+        Arc::new(LogicalPlan::EmptyRelation(
+            datafusion_expr::logical_plan::EmptyRelation {
+                produce_one_row: false,
+                schema: Arc::new(DFSchema::empty()),
+            },
+        )),
+        Arc::new(DFSchema::empty()),
+        opts.condition.clone(),
+        opts.assignments.clone(),
         opts.format.clone(),
         opts.path.clone(),
         opts.table_name.clone(),

--- a/crates/sail-plan/src/resolver/command/delete.rs
+++ b/crates/sail-plan/src/resolver/command/delete.rs
@@ -1,11 +1,9 @@
 use std::sync::Arc;
 
-use datafusion_common::{DFSchemaRef, ToDFSchema};
+use datafusion_common::ToDFSchema;
 use datafusion_expr::{Extension, LogicalPlan};
 use sail_catalog::manager::CatalogManager;
 use sail_common::spec;
-use sail_common_datafusion::catalog::{TableKind, TableStatus};
-use sail_common_datafusion::datasource::{SourceInfo, TableFormatRegistry};
 use sail_common_datafusion::extension::SessionExtensionAccessor;
 use sail_common_datafusion::logical_expr::ExprWithSource;
 use sail_common_datafusion::rename::expression::expression_before_rename;
@@ -34,7 +32,9 @@ impl PlanResolver<'_> {
             .get_table_or_view(table.parts())
             .await
             .map_err(PlanError::from)?;
-        let (location, format, table_schema) = self.get_schema_for_delete(&table_status).await?;
+        let (location, format, table_schema) = self
+            .get_row_level_target_schema(&table_status, "DELETE")
+            .await?;
 
         let field_ids = state.register_fields(table_schema.fields());
 
@@ -71,53 +71,5 @@ impl PlanResolver<'_> {
         Ok(LogicalPlan::Extension(Extension {
             node: Arc::new(FileDeleteNode::new(file_delete_options)),
         }))
-    }
-
-    async fn get_schema_for_delete(
-        &self,
-        table_status: &TableStatus,
-    ) -> PlanResult<(String, String, DFSchemaRef)> {
-        let (location, format, columns) = match &table_status.kind {
-            TableKind::Table {
-                location,
-                format,
-                columns,
-                ..
-            } => (location.clone(), format.clone(), columns.clone()),
-            _ => {
-                return Err(PlanError::unsupported(
-                    "DELETE is only supported on tables, not views",
-                ));
-            }
-        };
-
-        let location =
-            location.ok_or_else(|| PlanError::unsupported("DELETE on tables without location"))?;
-
-        let schema = if columns.is_empty() && format.eq_ignore_ascii_case("DELTA") {
-            // Schema is not in catalog, try to infer from data source
-            let source_info = SourceInfo {
-                paths: vec![location.clone()],
-                schema: None,
-                constraints: Default::default(),
-                partition_by: vec![],
-                bucket_by: None,
-                sort_order: vec![],
-                options: vec![],
-            };
-            let registry = self.ctx.extension::<TableFormatRegistry>()?;
-            let table_format = registry.get(&format)?;
-            let source = table_format
-                .create_source(&self.ctx.state(), source_info)
-                .await?;
-            source.schema().to_dfschema_ref()?
-        } else {
-            let schema = datafusion::arrow::datatypes::Schema::new(
-                columns.iter().map(|c| c.field()).collect::<Vec<_>>(),
-            );
-            schema.to_dfschema_ref()?
-        };
-
-        Ok((location, format, schema))
     }
 }

--- a/crates/sail-plan/src/resolver/command/mod.rs
+++ b/crates/sail-plan/src/resolver/command/mod.rs
@@ -16,7 +16,9 @@ mod explain;
 mod function;
 mod insert;
 mod merge;
+mod row_level;
 mod show;
+mod update;
 mod variable;
 mod write;
 mod write_stream;
@@ -256,7 +258,15 @@ impl PlanResolver<'_> {
             CommandNode::SetVariable { variable, value } => {
                 self.resolve_command_set_variable(variable, value).await
             }
-            CommandNode::Update { .. } => Err(PlanError::todo("CommandNode::Update")),
+            CommandNode::Update {
+                table,
+                table_alias,
+                assignments,
+                condition,
+            } => {
+                self.resolve_command_update(table, table_alias, assignments, condition, state)
+                    .await
+            }
             CommandNode::Delete {
                 table,
                 table_alias,

--- a/crates/sail-plan/src/resolver/command/row_level.rs
+++ b/crates/sail-plan/src/resolver/command/row_level.rs
@@ -1,0 +1,60 @@
+use datafusion_common::{DFSchemaRef, ToDFSchema};
+use sail_common_datafusion::catalog::{TableKind, TableStatus};
+use sail_common_datafusion::datasource::{SourceInfo, TableFormatRegistry};
+use sail_common_datafusion::extension::SessionExtensionAccessor;
+
+use crate::error::{PlanError, PlanResult};
+use crate::resolver::PlanResolver;
+
+impl PlanResolver<'_> {
+    /// Shared helper that resolves `(location, format, schema)` for a row-level
+    /// operation (DELETE/UPDATE) target. `op_name` is used only for error messages.
+    pub(super) async fn get_row_level_target_schema(
+        &self,
+        table_status: &TableStatus,
+        op_name: &str,
+    ) -> PlanResult<(String, String, DFSchemaRef)> {
+        let (location, format, columns) = match &table_status.kind {
+            TableKind::Table {
+                location,
+                format,
+                columns,
+                ..
+            } => (location.clone(), format.clone(), columns.clone()),
+            _ => {
+                return Err(PlanError::unsupported(format!(
+                    "{op_name} is only supported on tables, not views"
+                )));
+            }
+        };
+
+        let location = location.ok_or_else(|| {
+            PlanError::unsupported(format!("{op_name} on tables without location"))
+        })?;
+
+        let schema = if columns.is_empty() && format.eq_ignore_ascii_case("DELTA") {
+            let source_info = SourceInfo {
+                paths: vec![location.clone()],
+                schema: None,
+                constraints: Default::default(),
+                partition_by: vec![],
+                bucket_by: None,
+                sort_order: vec![],
+                options: vec![],
+            };
+            let registry = self.ctx.extension::<TableFormatRegistry>()?;
+            let table_format = registry.get(&format)?;
+            let source = table_format
+                .create_source(&self.ctx.state(), source_info)
+                .await?;
+            source.schema().to_dfschema_ref()?
+        } else {
+            let schema = datafusion::arrow::datatypes::Schema::new(
+                columns.iter().map(|c| c.field()).collect::<Vec<_>>(),
+            );
+            schema.to_dfschema_ref()?
+        };
+
+        Ok((location, format, schema))
+    }
+}

--- a/crates/sail-plan/src/resolver/command/update.rs
+++ b/crates/sail-plan/src/resolver/command/update.rs
@@ -55,27 +55,25 @@ impl PlanResolver<'_> {
         let mut resolved_assignments: Vec<(String, ExprWithSource)> = Vec::new();
 
         for (target, value) in assignments {
-            let mut parts: Vec<String> = target.into();
-            let column_name = match parts.len() {
-                1 => parts.pop().unwrap(),
-                2 => {
-                    let column = parts.pop().unwrap();
-                    let qualifier = parts.pop().unwrap();
+            let parts: Vec<String> = target.into();
+            let column_name = match parts.as_slice() {
+                [column] => column.clone(),
+                [qualifier, column] => {
                     let matches_alias = alias_str
                         .as_deref()
-                        .map(|a| a.eq_ignore_ascii_case(&qualifier))
+                        .map(|a| a.eq_ignore_ascii_case(qualifier))
                         .unwrap_or(false);
                     let matches_table = table
                         .parts()
                         .last()
-                        .map(|id| id.as_ref().eq_ignore_ascii_case(&qualifier))
+                        .map(|id| id.as_ref().eq_ignore_ascii_case(qualifier))
                         .unwrap_or(false);
                     if !matches_alias && !matches_table {
                         return Err(PlanError::invalid(format!(
                             "UPDATE assignment qualifier `{qualifier}` does not match target table"
                         )));
                     }
-                    column
+                    column.clone()
                 }
                 _ => {
                     return Err(PlanError::invalid(
@@ -109,7 +107,8 @@ impl PlanResolver<'_> {
                 &original_arrow_schema,
                 true,
             )?;
-            resolved_assignments.push((canonical, ExprWithSource::new(rewritten_value, source_text)));
+            resolved_assignments
+                .push((canonical, ExprWithSource::new(rewritten_value, source_text)));
         }
 
         let file_update_options = FileUpdateOptions {

--- a/crates/sail-plan/src/resolver/command/update.rs
+++ b/crates/sail-plan/src/resolver/command/update.rs
@@ -1,0 +1,135 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use datafusion_common::ToDFSchema;
+use datafusion_expr::{Extension, LogicalPlan};
+use sail_catalog::manager::CatalogManager;
+use sail_common::spec;
+use sail_common_datafusion::extension::SessionExtensionAccessor;
+use sail_common_datafusion::logical_expr::ExprWithSource;
+use sail_common_datafusion::rename::expression::expression_before_rename;
+use sail_common_datafusion::rename::schema::rename_schema;
+use sail_logical_plan::file_update::{FileUpdateNode, FileUpdateOptions};
+
+use crate::error::{PlanError, PlanResult};
+use crate::resolver::state::PlanResolverState;
+use crate::resolver::PlanResolver;
+
+impl PlanResolver<'_> {
+    /// Resolves the UPDATE command.
+    pub(super) async fn resolve_command_update(
+        &self,
+        table: spec::ObjectName,
+        table_alias: Option<spec::Identifier>,
+        assignments: Vec<(spec::ObjectName, spec::Expr)>,
+        condition: Option<spec::ExprWithSource>,
+        state: &mut PlanResolverState,
+    ) -> PlanResult<LogicalPlan> {
+        let catalog_manager = self.ctx.extension::<CatalogManager>()?;
+        let table_status = catalog_manager
+            .get_table_or_view(table.parts())
+            .await
+            .map_err(PlanError::from)?;
+        let (location, format, table_schema) = self
+            .get_row_level_target_schema(&table_status, "UPDATE")
+            .await?;
+
+        let field_ids = state.register_fields(table_schema.fields());
+        let original_arrow_schema = Arc::new(table_schema.as_arrow().clone());
+        let schema_for_resolution = rename_schema(&original_arrow_schema, &field_ids)?;
+        let df_schema_for_resolution = schema_for_resolution.to_dfschema_ref()?;
+
+        let resolved_condition = if let Some(condition) = condition {
+            let expr = self
+                .resolve_expression(condition.expr, &df_schema_for_resolution, state)
+                .await?;
+            let rewritten =
+                expression_before_rename(&expr, &field_ids, &original_arrow_schema, true)?;
+            Some(ExprWithSource::new(rewritten, condition.source))
+        } else {
+            None
+        };
+
+        let alias_str = table_alias.as_ref().map(|id| id.as_ref().to_string());
+        let mut seen_columns: HashSet<String> = HashSet::new();
+        let mut resolved_assignments: Vec<(String, ExprWithSource)> = Vec::new();
+
+        for (target, value) in assignments {
+            let mut parts: Vec<String> = target.into();
+            let column_name = match parts.len() {
+                1 => parts.pop().unwrap(),
+                2 => {
+                    let column = parts.pop().unwrap();
+                    let qualifier = parts.pop().unwrap();
+                    let matches_alias = alias_str
+                        .as_deref()
+                        .map(|a| a.eq_ignore_ascii_case(&qualifier))
+                        .unwrap_or(false);
+                    let matches_table = table
+                        .parts()
+                        .last()
+                        .map(|id| id.as_ref().eq_ignore_ascii_case(&qualifier))
+                        .unwrap_or(false);
+                    if !matches_alias && !matches_table {
+                        return Err(PlanError::invalid(format!(
+                            "UPDATE assignment qualifier `{qualifier}` does not match target table"
+                        )));
+                    }
+                    column
+                }
+                _ => {
+                    return Err(PlanError::invalid(
+                        "UPDATE assignment target must be an unqualified or table-qualified column",
+                    ));
+                }
+            };
+
+            let canonical = table_schema
+                .fields()
+                .iter()
+                .find(|f| f.name().eq_ignore_ascii_case(&column_name))
+                .map(|f| f.name().clone())
+                .ok_or_else(|| {
+                    PlanError::invalid(format!("unknown column `{column_name}` in UPDATE target"))
+                })?;
+
+            if !seen_columns.insert(canonical.to_ascii_lowercase()) {
+                return Err(PlanError::invalid(format!(
+                    "column `{canonical}` assigned multiple times in UPDATE"
+                )));
+            }
+
+            let source_text = spec_expr_source(&value);
+            let resolved_value = self
+                .resolve_expression(value, &df_schema_for_resolution, state)
+                .await?;
+            let rewritten_value = expression_before_rename(
+                &resolved_value,
+                &field_ids,
+                &original_arrow_schema,
+                true,
+            )?;
+            resolved_assignments.push((canonical, ExprWithSource::new(rewritten_value, source_text)));
+        }
+
+        let file_update_options = FileUpdateOptions {
+            table_name: table.into(),
+            path: location,
+            format,
+            assignments: resolved_assignments,
+            condition: resolved_condition,
+            options: vec![],
+        };
+
+        Ok(LogicalPlan::Extension(Extension {
+            node: Arc::new(FileUpdateNode::new(file_update_options)),
+        }))
+    }
+}
+
+fn spec_expr_source(_expr: &spec::Expr) -> Option<String> {
+    // Spec expressions do not carry source text for assignment RHS today.
+    // We leave this None to preserve parity with DELETE; any source capture
+    // would require changing the parser to emit `ExprWithSource` here too.
+    None
+}

--- a/crates/sail-session/src/planner.rs
+++ b/crates/sail-session/src/planner.rs
@@ -24,6 +24,7 @@ use sail_common_datafusion::streaming::event::schema::{
 use sail_delta_lake::logical::RewriteDeltaTableSource;
 use sail_logical_plan::barrier::BarrierNode;
 use sail_logical_plan::file_delete::FileDeleteNode;
+use sail_logical_plan::file_update::FileUpdateNode;
 use sail_logical_plan::file_write::FileWriteNode;
 use sail_logical_plan::map_partitions::MapPartitionsNode;
 use sail_logical_plan::merge::MergeIntoNode;
@@ -41,6 +42,7 @@ use sail_logical_plan::streaming::source_wrapper::StreamSourceWrapperNode;
 use sail_physical_plan::barrier::BarrierExec;
 use sail_physical_plan::catalog_command::CatalogCommandExec;
 use sail_physical_plan::file_delete::create_file_delete_physical_plan;
+use sail_physical_plan::file_update::create_file_update_physical_plan;
 use sail_physical_plan::file_write::create_file_write_physical_plan;
 use sail_physical_plan::map_partitions::MapPartitionsExec;
 use sail_physical_plan::monotonic_id::MonotonicIdExec;
@@ -225,6 +227,55 @@ impl ExtensionPlanner for ExtensionPhysicalPlanner {
                 _ => internal_err!("Expected a table for DELETE"),
             }?;
             create_file_delete_physical_plan(session_state, planner, schema, node.options().clone())
+                .await?
+        } else if let Some(node) = node.as_any().downcast_ref::<FileUpdateNode>() {
+            if !logical_inputs.is_empty() || !physical_inputs.is_empty() {
+                return internal_err!("FileUpdateNode should have no inputs");
+            }
+            let catalog_manager = session_state
+                .config()
+                .get_extension::<CatalogManager>()
+                .ok_or_else(|| internal_datafusion_err!("CatalogManager extension not found"))?;
+            let table_status = catalog_manager
+                .get_table_or_view(&node.options().table_name)
+                .await
+                .map_err(|e| internal_datafusion_err!("Failed to get table: {e}"))?;
+
+            let schema = match &table_status.kind {
+                TableKind::Table {
+                    columns,
+                    format,
+                    location,
+                    ..
+                } if columns.is_empty() && format.eq_ignore_ascii_case("DELTA") => {
+                    let Some(location) = location.as_ref() else {
+                        return internal_err!("Table for update has no location");
+                    };
+                    let source_info = SourceInfo {
+                        paths: vec![location.clone()],
+                        schema: None,
+                        constraints: Default::default(),
+                        partition_by: vec![],
+                        bucket_by: None,
+                        sort_order: vec![],
+                        options: vec![],
+                    };
+                    let registry = session_state.extension::<TableFormatRegistry>()?;
+                    let source = registry
+                        .get(format)?
+                        .create_source(session_state, source_info)
+                        .await?;
+                    Ok(source.schema().to_dfschema_ref()?)
+                }
+                TableKind::Table { columns, .. } => {
+                    let schema = datafusion::arrow::datatypes::Schema::new(
+                        columns.iter().map(|c| c.field()).collect::<Vec<_>>(),
+                    );
+                    Ok(schema.to_dfschema_ref()?)
+                }
+                _ => internal_err!("Expected a table for UPDATE"),
+            }?;
+            create_file_update_physical_plan(session_state, planner, schema, node.options().clone())
                 .await?
         } else if let Some(node) = node.as_any().downcast_ref::<MergeIntoNode>() {
             let _ = (

--- a/crates/sail-spark-connect/tests/gold_data/plan/ddl_update.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/ddl_update.json
@@ -88,37 +88,40 @@
                 ]
               ],
               "condition": {
-                "unresolvedFunction": {
-                  "functionName": [
-                    "=="
-                  ],
-                  "arguments": [
-                    {
-                      "unresolvedAttribute": {
-                        "name": [
-                          "t",
-                          "c"
-                        ],
-                        "planId": null,
-                        "isMetadataColumn": false
-                      }
-                    },
-                    {
-                      "literal": {
-                        "int32": {
-                          "value": 2
+                "expr": {
+                  "unresolvedFunction": {
+                    "functionName": [
+                      "=="
+                    ],
+                    "arguments": [
+                      {
+                        "unresolvedAttribute": {
+                          "name": [
+                            "t",
+                            "c"
+                          ],
+                          "planId": null,
+                          "isMetadataColumn": false
+                        }
+                      },
+                      {
+                        "literal": {
+                          "int32": {
+                            "value": 2
+                          }
                         }
                       }
-                    }
-                  ],
-                  "namedArguments": [],
-                  "isDistinct": false,
-                  "isUserDefinedFunction": false,
-                  "isInternal": null,
-                  "ignoreNulls": null,
-                  "filter": null,
-                  "orderBy": null
-                }
+                    ],
+                    "namedArguments": [],
+                    "isDistinct": false,
+                    "isUserDefinedFunction": false,
+                    "isInternal": null,
+                    "ignoreNulls": null,
+                    "filter": null,
+                    "orderBy": null
+                  }
+                },
+                "source": "t . c = 2 "
               }
             },
             "planId": null

--- a/crates/sail-sql-analyzer/src/statement.rs
+++ b/crates/sail-sql-analyzer/src/statement.rs
@@ -820,7 +820,11 @@ pub fn from_ast_statement(statement: Statement) -> SqlResult<spec::Plan> {
                         r#where: _,
                         condition,
                     } = x;
-                    from_ast_expression(condition)
+                    let source = condition.text();
+                    Ok::<_, SqlError>(spec::ExprWithSource {
+                        expr: from_ast_expression(condition)?,
+                        source: Some(source),
+                    })
                 })
                 .transpose()?;
             let node = spec::CommandNode::Update {

--- a/python/pysail/tests/spark/delta/features/update.feature
+++ b/python/pysail/tests/spark/delta/features/update.feature
@@ -1,0 +1,246 @@
+Feature: Delta Lake Update
+
+  Rule: Basic operations
+    Background:
+      Given variable location for temporary directory x
+      Given final statement
+        """
+        DROP TABLE IF EXISTS delta_update_basic
+        """
+      Given statement template
+        """
+        CREATE TABLE delta_update_basic (
+          id INT,
+          name STRING,
+          age INT,
+          department STRING,
+          salary INT,
+          active BOOLEAN
+        )
+        USING DELTA LOCATION {{ location.sql }}
+        """
+      Given statement
+        """
+        INSERT INTO delta_update_basic
+        SELECT * FROM VALUES
+          (1, 'Alice', 25, 'Engineering', 75000, true),
+          (2, 'Bob', 30, 'Marketing', 65000, true),
+          (3, 'Charlie', 35, 'Engineering', 85000, false),
+          (4, 'Diana', 28, 'Sales', 55000, true),
+          (5, 'Eve', 32, 'Marketing', 70000, true),
+          (6, 'Frank', 40, 'Engineering', 95000, false),
+          (7, 'Grace', 27, 'Sales', 50000, true),
+          (8, 'Henry', 33, 'HR', 60000, true)
+        """
+
+    Scenario: Simple WHERE condition
+      Given statement
+        """
+        UPDATE delta_update_basic SET salary = 100000 WHERE department = 'Engineering'
+        """
+      Then delta log latest commit info contains
+        | path                          | value                           |
+        | operation                     | "UPDATE"                        |
+        | operationParameters.predicate | "department = 'Engineering' " |
+      When query
+        """
+        SELECT id, name, salary FROM delta_update_basic ORDER BY id
+        """
+      Then query result ordered
+        | id | name    | salary |
+        | 1  | Alice   | 100000 |
+        | 2  | Bob     | 65000  |
+        | 3  | Charlie | 100000 |
+        | 4  | Diana   | 55000  |
+        | 5  | Eve     | 70000  |
+        | 6  | Frank   | 100000 |
+        | 7  | Grace   | 50000  |
+        | 8  | Henry   | 60000  |
+
+    Scenario: Multi-predicate WHERE
+      Given statement
+        """
+        UPDATE delta_update_basic
+        SET active = false
+        WHERE (department = 'Marketing' AND age > 30)
+          OR (department = 'Sales' AND salary < 60000)
+        """
+      When query
+        """
+        SELECT id, name, active FROM delta_update_basic ORDER BY id
+        """
+      Then query result ordered
+        | id | name    | active |
+        | 1  | Alice   | true   |
+        | 2  | Bob     | true   |
+        | 3  | Charlie | false  |
+        | 4  | Diana   | false  |
+        | 5  | Eve     | false  |
+        | 6  | Frank   | false  |
+        | 7  | Grace   | false  |
+        | 8  | Henry   | true   |
+
+    Scenario: Condition that matches no rows
+      Given statement
+        """
+        UPDATE delta_update_basic SET salary = 0 WHERE age > 100
+        """
+      When query
+        """
+        SELECT COUNT(*) as count FROM delta_update_basic WHERE salary = 0
+        """
+      Then query result
+        | count |
+        | 0     |
+
+    Scenario: No WHERE updates all rows
+      Given statement
+        """
+        UPDATE delta_update_basic SET active = false
+        """
+      When query
+        """
+        SELECT COUNT(*) as count FROM delta_update_basic WHERE active = true
+        """
+      Then query result
+        | count |
+        | 0     |
+
+    Scenario: Multi-column SET
+      Given statement
+        """
+        UPDATE delta_update_basic
+        SET salary = 99000, active = false
+        WHERE id = 1
+        """
+      When query
+        """
+        SELECT id, salary, active FROM delta_update_basic WHERE id = 1
+        """
+      Then query result
+        | id | salary | active |
+        | 1  | 99000  | false  |
+
+    Scenario: Self-referential RHS
+      Given statement
+        """
+        UPDATE delta_update_basic SET salary = salary + 1000 WHERE department = 'Sales'
+        """
+      When query
+        """
+        SELECT id, name, salary FROM delta_update_basic WHERE department = 'Sales' ORDER BY id
+        """
+      Then query result ordered
+        | id | name  | salary |
+        | 4  | Diana | 56000  |
+        | 7  | Grace | 51000  |
+
+    Scenario: Set to NULL
+      Given statement
+        """
+        UPDATE delta_update_basic SET department = NULL WHERE id = 2
+        """
+      When query
+        """
+        SELECT id, department FROM delta_update_basic WHERE id = 2
+        """
+      Then query result
+        | id | department |
+        | 2  | NULL       |
+
+  Rule: Operations on partitioned tables
+    Background:
+      Given variable location for temporary directory x
+      Given final statement
+        """
+        DROP TABLE IF EXISTS delta_update_partitioned
+        """
+      Given statement template
+        """
+        CREATE TABLE delta_update_partitioned (
+          id INT,
+          name STRING,
+          year INT,
+          month INT,
+          value INT
+        )
+        USING DELTA LOCATION {{ location.sql }}
+        PARTITIONED BY (year, month)
+        """
+      Given statement
+        """
+        INSERT INTO delta_update_partitioned
+        SELECT * FROM VALUES
+          (1, 'Alice', 2023, 1, 100),
+          (2, 'Bob', 2023, 1, 200),
+          (3, 'Charlie', 2023, 2, 300),
+          (4, 'Diana', 2023, 2, 400),
+          (5, 'Eve', 2024, 1, 500),
+          (6, 'Frank', 2024, 1, 600),
+          (7, 'Grace', 2024, 2, 700),
+          (8, 'Henry', 2024, 2, 800)
+        """
+
+    Scenario: Partition-only predicate
+      Given statement
+        """
+        UPDATE delta_update_partitioned SET value = 0 WHERE year = 2023
+        """
+      When query
+        """
+        SELECT id, name, year, month, value FROM delta_update_partitioned ORDER BY id
+        """
+      Then query result ordered
+        | id | name    | year | month | value |
+        | 1  | Alice   | 2023 | 1     | 0     |
+        | 2  | Bob     | 2023 | 1     | 0     |
+        | 3  | Charlie | 2023 | 2     | 0     |
+        | 4  | Diana   | 2023 | 2     | 0     |
+        | 5  | Eve     | 2024 | 1     | 500   |
+        | 6  | Frank   | 2024 | 1     | 600   |
+        | 7  | Grace   | 2024 | 2     | 700   |
+        | 8  | Henry   | 2024 | 2     | 800   |
+
+  Rule: Null handling
+    Background:
+      Given variable location for temporary directory x
+      Given final statement
+        """
+        DROP TABLE IF EXISTS delta_update_null
+        """
+      Given statement template
+        """
+        CREATE TABLE delta_update_null (
+          id INT,
+          name STRING,
+          department STRING
+        )
+        USING DELTA LOCATION {{ location.sql }}
+        """
+      Given statement
+        """
+        INSERT INTO delta_update_null
+        SELECT * FROM VALUES
+          (1, 'Alice', 'Engineering'),
+          (2, 'Bob', NULL),
+          (3, NULL, 'Marketing'),
+          (4, 'Diana', 'Sales'),
+          (5, NULL, NULL)
+        """
+
+    Scenario: WHERE col IS NULL
+      Given statement
+        """
+        UPDATE delta_update_null SET department = 'Unknown' WHERE department IS NULL
+        """
+      When query
+        """
+        SELECT id, department FROM delta_update_null ORDER BY id
+        """
+      Then query result ordered
+        | id | department  |
+        | 1  | Engineering |
+        | 2  | Unknown     |
+        | 3  | Marketing   |
+        | 4  | Sales       |
+        | 5  | Unknown     |


### PR DESCRIPTION
## Summary

Implements UPDATE DML end-to-end for Delta Lake by plumbing UPDATE through the existing `RowLevelWriteNode` / `create_row_level_writer` pipeline, mirroring DELETE layer-for-layer. Unblocks dbt-sail adapter snapshot tests (`TestSnapshotCheckColsSpark::test_snapshot_check_cols`, `TestSnapshotTimestampSpark::test_snapshot_timestamp`) that were failing with `UnsupportedOperationException: CommandNode::Update`.

## Implementation layers

1. **Parser + spec** — `CommandNode::Update.condition` gains `ExprWithSource` so the original WHERE source text can be written to the Delta commit log's `operationParameters.predicate`, matching DELETE's behavior.
2. **Delta spec** — adds `DeltaOperation::Update { predicate }` variant; `name()` returns `"UPDATE"` and the parameter is serialized to the commit log.
3. **Logical `FileUpdateNode`** — new extension mirroring `FileDeleteNode`; carries `table_name, path, format, assignments, condition, options`.
4. **`RowLevelWriteNode::new_update`** — adds a new constructor, an `assignments: Option<Vec<(String, ExprWithSource)>>` field (educe-ignored), and an accessor. `new_delete` / `new_merge` initialize it to `None`.
5. **Shared row-level schema helper** — extracts `get_row_level_target_schema(&self, table_status, op_name)` from `delete.rs` into `resolver/command/row_level.rs` so DELETE and UPDATE share target-schema resolution.
6. **Resolver** — `resolve_command_update` looks up the table, registers fields, resolves condition/assignments against the renamed schema, rewrites back via `expression_before_rename`, validates LHS (1-part or alias-qualified, case-insensitive, canonicalized), rejects duplicate assignments.
7. **Optimizer** — `expand_update_node` wraps `FileUpdateNode` into `RowLevelWriteNode::new_update` for lakehouse formats; non-Delta formats fall through to `not_impl_err!` (same as DELETE).
8. **`RowLevelWriteInfo.assignments`** — new field propagated through Delete/Merge/Update construction sites.
9. **Physical dispatch** — `row_level_write.rs` UPDATE arm replaces the old `internal_err!` stub; `sail-physical-plan/src/file_update.rs` + session planner `FileUpdateNode` branch for fallback (EXPLAIN on unexpanded node).
10. **Delta `create_row_level_writer` UPDATE arm** — replaces the `not_impl_err!` with config setup + `plan_update(&update_ctx, info).await`.
11. **Delta `build_update_plan` (COW)** — opens table; log-replay + metadata filter; `DeltaDiscoveryExec` + `DeltaScanByAddsExec`; `DeltaPhysicalExprAdapterFactory` rewrites condition and each assignment RHS to scan-schema column indices; per-column projection wraps each assignment in `CaseExpr(cond, rhs, else=original_col)` (or uses `rhs` directly when there's no WHERE); casts RHS to the target column's declared type to handle `NULL` literal → typed NULL and implicit promotions; `assemble_commit_plan` produces Remove + Add actions with `DeltaOperation::Update`.
12. **Tests** — `python/pysail/tests/spark/delta/features/update.feature` mirrors `delete.feature` with scenarios for simple WHERE, multi-predicate WHERE, no-match, no-WHERE (update all), multi-column SET, self-referential RHS, set-to-NULL, partition-only predicate, and `WHERE IS NULL`. Gold data under `crates/sail-spark-connect/tests/gold_data/plan/ddl_update.json` refreshed for the new `ExprWithSource` shape.

## Subtle correctness notes

- **UPDATE must scan file content even for partition-only predicates.** `DeltaDiscoveryExec`'s `partition_scan=true` short-circuit is a DELETE optimization (it emits empty batches because files will be fully removed). For UPDATE we always pass `partition_scan=false` so the touched rows survive the rewrite.
- **RHS type cast is required.** A literal `NULL` in `SET col = NULL` has type `Null`, not the column's declared type; the writer expects a matching Arrow type. The planner inserts a `CastExpr` when `rhs_type != target.data_type()`.

## Scope

Delta-only, same as DELETE today. Non-Delta formats continue to return `not_impl_err!`. Merge-on-Read strategy for UPDATE is not implemented (the enum slot exists but Delta doesn't use it for any row-level op today). Row-count metrics in operation metadata (`numTargetRowsUpdated`, etc.) remain a pre-existing gap shared with DELETE. UPDATE on partition columns is permissive for MVP — COW handles it correctly.
