### PR TITLE
fix: arrays_zip NULL and zero-arg handling

### DIFF
--- a/crates/sail-function/src/scalar/array/arrays_zip.rs
+++ b/crates/sail-function/src/scalar/array/arrays_zip.rs
@@ -3,14 +3,16 @@ use std::ops::BitAnd;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{
-    new_empty_array, Array, ArrayRef, AsArray, FixedSizeListArray, GenericListArray, NullArray,
-    OffsetSizeTrait, StructArray,
+    new_empty_array, new_null_array, Array, ArrayRef, AsArray, FixedSizeListArray,
+    GenericListArray, NullArray, OffsetSizeTrait, StructArray,
 };
 use datafusion::arrow::buffer::{NullBuffer, OffsetBuffer};
 use datafusion::arrow::compute::{cast, concat};
 use datafusion::arrow::datatypes::{DataType, Field, Fields};
 use datafusion_common::{arrow_err, exec_err, plan_err, DataFusionError, Result};
-use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+use datafusion_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
+};
 use datafusion_functions::utils::make_scalar_function;
 use sail_common::spec::SAIL_LIST_FIELD_NAME;
 
@@ -30,7 +32,10 @@ impl Default for ArraysZip {
 impl ArraysZip {
     pub fn new() -> Self {
         Self {
-            signature: Signature::variadic_any(Volatility::Immutable),
+            signature: Signature::one_of(
+                vec![TypeSignature::Nullary, TypeSignature::VariadicAny],
+                Volatility::Immutable,
+            ),
         }
     }
 }
@@ -82,6 +87,25 @@ impl ScalarUDFImpl for ArraysZip {
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        // Spark: arrays_zip() with no args returns an empty List<Struct<>> per row.
+        if args.args.is_empty() {
+            return Ok(ColumnarValue::Array(build_empty_zip_result(
+                args.number_rows,
+            )?));
+        }
+        // Untyped NULL (Spark: array<void>) makes every output row NULL.
+        // Short-circuit to a single typed-null allocation instead of building
+        // intermediate all-NULL ListArrays and running the row loop.
+        if args
+            .args
+            .iter()
+            .any(|a| matches!(a.data_type(), DataType::Null))
+        {
+            return Ok(ColumnarValue::Array(new_null_array(
+                args.return_field.data_type(),
+                args.number_rows,
+            )));
+        }
         match args.return_field.data_type() {
             DataType::LargeList(_) => {
                 make_scalar_function(arrays_zip_generic::<i64>, vec![])(&args.args)
@@ -92,6 +116,19 @@ impl ScalarUDFImpl for ArraysZip {
             _ => make_scalar_function(arrays_zip_generic::<i32>, vec![])(&args.args),
         }
     }
+}
+
+fn build_empty_zip_result(num_rows: usize) -> Result<ArrayRef> {
+    let struct_field = struct_result_field(&[]);
+    // StructArray with zero fields needs explicit length, not inferred from columns.
+    let empty_struct = StructArray::new_empty_fields(0, None);
+    let offsets = OffsetBuffer::<i32>::new_zeroed(num_rows);
+    Ok(Arc::new(GenericListArray::<i32>::try_new(
+        struct_field,
+        offsets,
+        Arc::new(empty_struct),
+        None,
+    )?))
 }
 
 struct ListParams {
@@ -121,6 +158,12 @@ fn get_list_params(data_type: &DataType) -> Result<ListParams> {
         DataType::LargeList(field) | DataType::LargeListView(field) => {
             Ok(ListParams::new(field.clone(), true, None))
         }
+        // Spark coerces bare untyped NULL to `array<void>`.
+        DataType::Null => Ok(ListParams::new(
+            Arc::new(Field::new_list_field(DataType::Null, true)),
+            false,
+            None,
+        )),
         _ => plan_err!("`arrays_zip` can only accept List, LargeList or FixedSizeList."),
     }
 }
@@ -220,7 +263,6 @@ fn arrays_zip_fixed_size(args: &[ArrayRef], fixed_size: &i32) -> Result<ArrayRef
 
 fn arrays_zip_generic<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
     let (num_rows, inner_fields, field_names) = num_rows_inner_fields_and_names(args)?;
-    let validity_mask_opt = combine_validity_masks(args);
 
     // Create fields with nullable=true, preserving metadata from inner fields
     let arg_fields: Vec<Arc<Field>> = inner_fields
@@ -252,6 +294,11 @@ fn arrays_zip_generic<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef>
             _ => exec_err!("`arrays_zip` can only accept List, LargeList or FixedSizeList."),
         })
         .collect::<Result<Vec<_>>>()?;
+
+    // Combine validity masks on the CAST arrays: NullArray has implicit nulls
+    // (.nulls() returns None) but the cast path above produces an explicit
+    // all-NULL buffer on the resulting ListArray.
+    let validity_mask_opt = combine_validity_masks(&casted_lists);
 
     let lists = casted_lists
         .iter()

--- a/crates/sail-function/src/scalar/array/arrays_zip.rs
+++ b/crates/sail-function/src/scalar/array/arrays_zip.rs
@@ -262,8 +262,9 @@ fn arrays_zip_generic<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef>
         DataFusionError::Execution("`arrays_zip`: zero offset should always exist".to_string())
     })?;
 
-    let mut struct_arrays = vec![];
-    let mut offsets = vec![zero_offset];
+    let mut struct_arrays = Vec::with_capacity(num_rows);
+    let mut offsets = Vec::with_capacity(num_rows + 1);
+    offsets.push(zero_offset);
     let mut last_offset = zero_offset;
 
     for row_idx in 0..num_rows {
@@ -275,31 +276,40 @@ fn arrays_zip_generic<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef>
             continue;
         }
 
-        let arrays_one_row = lists
-            .iter()
-            .map(|arg| arg.value(row_idx))
-            .collect::<Vec<_>>();
+        let mut arrays_one_row: Vec<ArrayRef> = Vec::with_capacity(lists.len());
+        let mut lens_one_row: Vec<O> = Vec::with_capacity(lists.len());
+        let mut max_len_one_row = zero_offset;
+        let mut all_uniform = true;
+        for arg in &lists {
+            let arr = arg.value(row_idx);
+            let len = arg.value_length(row_idx);
+            if !lens_one_row.is_empty() && len != lens_one_row[0] {
+                all_uniform = false;
+            }
+            if len > max_len_one_row {
+                max_len_one_row = len;
+            }
+            arrays_one_row.push(arr);
+            lens_one_row.push(len);
+        }
 
-        let lens_one_row = lists
-            .iter()
-            .map(|arg| arg.value_length(row_idx))
-            .collect::<Vec<_>>();
-
-        let max_len_one_row = lens_one_row.iter().max().cloned().unwrap_or(zero_offset);
-
-        let arrays_padded = arrays_one_row
-            .iter()
-            .zip(lens_one_row.iter())
-            .map(|(arr, len)| {
-                Ok(match (max_len_one_row - *len).as_usize() {
-                    0 => arr.clone(),
-                    len_diff => Arc::new(concat(&[
-                        arr,
-                        &cast(&NullArray::new(len_diff), arr.data_type())?,
-                    ])?),
+        let arrays_padded = if all_uniform {
+            arrays_one_row
+        } else {
+            arrays_one_row
+                .iter()
+                .zip(lens_one_row.iter())
+                .map(|(arr, len)| {
+                    Ok(match (max_len_one_row - *len).as_usize() {
+                        0 => arr.clone(),
+                        len_diff => Arc::new(concat(&[
+                            arr,
+                            &cast(&NullArray::new(len_diff), arr.data_type())?,
+                        ])?),
+                    })
                 })
-            })
-            .collect::<Result<Vec<_>>>()?;
+                .collect::<Result<Vec<_>>>()?
+        };
 
         let struct_array = to_struct_array(
             arrays_padded.as_slice(),

--- a/crates/sail-function/src/scalar/array/arrays_zip.rs
+++ b/crates/sail-function/src/scalar/array/arrays_zip.rs
@@ -106,6 +106,17 @@ impl ScalarUDFImpl for ArraysZip {
                 args.number_rows,
             )));
         }
+        // Any arg that is a fully-null ListArray column propagates NULL to
+        // every output row. Short-circuit: skip combine_validity_masks and
+        // the row loop entirely, return a typed-null array directly.
+        if args.args.iter().any(|a| {
+            matches!(a, ColumnarValue::Array(arr) if !arr.is_empty() && arr.null_count() == arr.len())
+        }) {
+            return Ok(ColumnarValue::Array(new_null_array(
+                args.return_field.data_type(),
+                args.number_rows,
+            )));
+        }
         match args.return_field.data_type() {
             DataType::LargeList(_) => {
                 make_scalar_function(arrays_zip_generic::<i64>, vec![])(&args.args)

--- a/python/pysail/tests/spark/function/features/arrays_zip.feature
+++ b/python/pysail/tests/spark/function/features/arrays_zip.feature
@@ -30,6 +30,24 @@ Feature: arrays_zip comprehensive tests
         | result          |
         | [{1}, {2}, {3}] |
 
+    Scenario: arrays_zip four args asymmetric
+      When query
+        """
+        SELECT arrays_zip(array(1), array('a','b'), array(true, false, NULL), array(1.0)) AS result
+        """
+      Then query result
+        | result                                                              |
+        | [{1, a, true, 1.0}, {NULL, b, false, NULL}, {NULL, NULL, NULL, NULL}] |
+
+    Scenario: arrays_zip self-zip same column
+      When query
+        """
+        SELECT arrays_zip(a, a) AS result FROM VALUES (array(1,2,3)) AS t(a)
+        """
+      Then query result
+        | result                   |
+        | [{1, 1}, {2, 2}, {3, 3}] |
+
     @sail-bug
     # Sail rejects 0 args but Spark returns empty array
     Scenario: arrays_zip zero args returns empty array
@@ -79,6 +97,29 @@ Feature: arrays_zip comprehensive tests
         | result |
         | []     |
 
+    Scenario: arrays_zip four args all empty returns empty
+      When query
+        """
+        SELECT arrays_zip(
+          CAST(array() AS ARRAY<INT>),
+          CAST(array() AS ARRAY<INT>),
+          CAST(array() AS ARRAY<INT>),
+          CAST(array() AS ARRAY<INT>)
+        ) AS result
+        """
+      Then query result
+        | result |
+        | []     |
+
+    Scenario: arrays_zip very asymmetric 1 vs 5
+      When query
+        """
+        SELECT arrays_zip(array(1), array('a','b','c','d','e')) AS result
+        """
+      Then query result
+        | result                                               |
+        | [{1, a}, {NULL, b}, {NULL, c}, {NULL, d}, {NULL, e}] |
+
   Rule: NULL handling
 
     @sail-bug
@@ -119,6 +160,47 @@ Feature: arrays_zip comprehensive tests
         | result                       |
         | [{NULL, NULL}, {NULL, NULL}] |
 
+    Scenario: arrays_zip both args NULL returns NULL
+      When query
+        """
+        SELECT arrays_zip(CAST(NULL AS ARRAY<INT>), CAST(NULL AS ARRAY<STRING>)) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: arrays_zip four NULL args returns NULL
+      When query
+        """
+        SELECT arrays_zip(
+          CAST(NULL AS ARRAY<INT>),
+          CAST(NULL AS ARRAY<STRING>),
+          CAST(NULL AS ARRAY<BOOLEAN>),
+          CAST(NULL AS ARRAY<DOUBLE>)
+        ) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: arrays_zip NULL and empty returns NULL
+      When query
+        """
+        SELECT arrays_zip(CAST(NULL AS ARRAY<INT>), CAST(array() AS ARRAY<STRING>)) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: arrays_zip untyped empty array() pads first as NULL
+      When query
+        """
+        SELECT arrays_zip(array(), array(1,2)) AS result
+        """
+      Then query result
+        | result                 |
+        | [{NULL, 1}, {NULL, 2}] |
+
   Rule: Type variety
 
     Scenario: arrays_zip int and double
@@ -127,7 +209,7 @@ Feature: arrays_zip comprehensive tests
         SELECT arrays_zip(array(1,2), array(1.5,2.5)) AS result
         """
       Then query result
-        | result                 |
+        | result                |
         | [{1, 1.5}, {2, 2.5}]  |
 
     Scenario: arrays_zip nested arrays
@@ -148,6 +230,143 @@ Feature: arrays_zip comprehensive tests
         | result                  |
         | [{true, 1}, {false, 2}] |
 
+    Scenario: arrays_zip struct elements
+      When query
+        """
+        SELECT arrays_zip(array(struct(1 AS a)), array(struct('x' AS b))) AS result
+        """
+      Then query result
+        | result       |
+        | [{{1}, {x}}] |
+
+    Scenario: arrays_zip map elements
+      When query
+        """
+        SELECT arrays_zip(array(map(1,'a')), array(map(2,'b'))) AS result
+        """
+      Then query result
+        | result                 |
+        | [{{1 -> a}, {2 -> b}}] |
+
+    Scenario: arrays_zip binary elements
+      When query
+        """
+        SELECT arrays_zip(array(X'01', X'02'), array(X'0A', X'0B')) AS result
+        """
+      Then query result
+        | result                       |
+        | [{[01], [0A]}, {[02], [0B]}] |
+
+    Scenario: arrays_zip date elements
+      When query
+        """
+        SELECT arrays_zip(array(DATE'2024-01-01'), array(DATE'2024-12-31')) AS result
+        """
+      Then query result
+        | result                     |
+        | [{2024-01-01, 2024-12-31}] |
+
+    Scenario: arrays_zip timestamp elements
+      When query
+        """
+        SELECT arrays_zip(array(TIMESTAMP'2024-01-01 00:00:00'), array(TIMESTAMP'2024-12-31 23:59:59')) AS result
+        """
+      Then query result
+        | result                                       |
+        | [{2024-01-01 00:00:00, 2024-12-31 23:59:59}] |
+
+    Scenario: arrays_zip decimal elements
+      When query
+        """
+        SELECT arrays_zip(
+          array(CAST(1.5 AS DECIMAL(10,2)), CAST(2.5 AS DECIMAL(10,2))),
+          array(1, 2)
+        ) AS result
+        """
+      Then query result
+        | result                 |
+        | [{1.50, 1}, {2.50, 2}] |
+
+    Scenario: arrays_zip float32 elements
+      When query
+        """
+        SELECT arrays_zip(
+          array(CAST(1.5 AS FLOAT)),
+          array(CAST(2.5 AS FLOAT))
+        ) AS result
+        """
+      Then query result
+        | result       |
+        | [{1.5, 2.5}] |
+
+    Scenario: arrays_zip deeply nested arrays
+      When query
+        """
+        SELECT arrays_zip(array(array(1,2)), array(array(3,4))) AS result
+        """
+      Then query result
+        | result             |
+        | [{[1, 2], [3, 4]}] |
+
+    Scenario: arrays_zip sequence results
+      When query
+        """
+        SELECT arrays_zip(sequence(1, 3), sequence(10, 12)) AS result
+        """
+      Then query result
+        | result                      |
+        | [{1, 10}, {2, 11}, {3, 12}] |
+
+  Rule: Composition
+
+    Scenario: arrays_zip nested in arrays_zip
+      When query
+        """
+        SELECT arrays_zip(arrays_zip(array(1,2), array('a','b')), array(true, false)) AS result
+        """
+      Then query result
+        | result                            |
+        | [{{1, a}, true}, {{2, b}, false}] |
+
+    Scenario: arrays_zip element field access by index-name
+      When query
+        """
+        SELECT arrays_zip(array(1,2,3), array('x','y','z'))[1].`0` AS result
+        """
+      Then query result
+        | result |
+        | 2      |
+
+    Scenario: arrays_zip element field access second position
+      When query
+        """
+        SELECT arrays_zip(array(1,2,3), array('x','y','z'))[1].`1` AS result
+        """
+      Then query result
+        | result |
+        | y      |
+
+    Scenario: arrays_zip to_json roundtrip
+      When query
+        """
+        SELECT to_json(arrays_zip(array(1,2), array('a','b'))) AS result
+        """
+      Then query result
+        | result                            |
+        | [{"0":1,"1":"a"},{"0":2,"1":"b"}] |
+
+    Scenario: arrays_zip LATERAL VIEW explode flatten
+      When query
+        """
+        SELECT e.`0` AS x, e.`1` AS y FROM
+          (SELECT arrays_zip(array(1,2,3), array('a','b','c')) AS z) LATERAL VIEW explode(z) AS e
+        """
+      Then query result ordered
+        | x | y |
+        | 1 | a |
+        | 2 | b |
+        | 3 | c |
+
   Rule: Multi-row
 
     Scenario: arrays_zip multi-row
@@ -160,6 +379,36 @@ Feature: arrays_zip comprehensive tests
         | [{1, x}, {2, y}]   |
         | [{3, z}, {NULL, w}] |
         | NULL                |
+
+    Scenario: arrays_zip multi-row uneven lengths per row
+      When query
+        """
+        SELECT arrays_zip(a, b) AS result FROM VALUES
+          (array(1,2,3), array('x','y')),
+          (array(1), array('a','b','c','d','e')),
+          (array(), array('z'))
+        AS t(a, b)
+        """
+      Then query result
+        | result                                                |
+        | [{1, x}, {2, y}, {3, NULL}]                          |
+        | [{1, a}, {NULL, b}, {NULL, c}, {NULL, d}, {NULL, e}] |
+        | [{NULL, z}]                                           |
+
+    Scenario: arrays_zip multi-row empty row mixed with NULL
+      When query
+        """
+        SELECT arrays_zip(a, b) AS result FROM VALUES
+          (array(), CAST(array() AS ARRAY<STRING>)),
+          (array(1), array('x')),
+          (CAST(NULL AS ARRAY<INT>), CAST(NULL AS ARRAY<STRING>))
+        AS t(a, b)
+        """
+      Then query result
+        | result   |
+        | []       |
+        | [{1, x}] |
+        | NULL     |
 
   Rule: Error conditions
 

--- a/python/pysail/tests/spark/function/features/arrays_zip.feature
+++ b/python/pysail/tests/spark/function/features/arrays_zip.feature
@@ -1,0 +1,178 @@
+@arrays_zip
+Feature: arrays_zip comprehensive tests
+
+  Rule: Basic usage
+
+    Scenario: arrays_zip two arrays same length
+      When query
+        """
+        SELECT arrays_zip(array(1,2,3), array('a','b','c')) AS result
+        """
+      Then query result
+        | result                   |
+        | [{1, a}, {2, b}, {3, c}] |
+
+    Scenario: arrays_zip three arrays
+      When query
+        """
+        SELECT arrays_zip(array(1,2), array('a','b'), array(true,false)) AS result
+        """
+      Then query result
+        | result                        |
+        | [{1, a, true}, {2, b, false}] |
+
+    Scenario: arrays_zip single array
+      When query
+        """
+        SELECT arrays_zip(array(1,2,3)) AS result
+        """
+      Then query result
+        | result          |
+        | [{1}, {2}, {3}] |
+
+    @sail-bug
+    # Sail rejects 0 args but Spark returns empty array
+    Scenario: arrays_zip zero args returns empty array
+      When query
+        """
+        SELECT arrays_zip() AS result
+        """
+      Then query result
+        | result |
+        | []     |
+
+  Rule: Different array lengths
+
+    Scenario: arrays_zip first longer pads NULL
+      When query
+        """
+        SELECT arrays_zip(array(1,2,3), array('a','b')) AS result
+        """
+      Then query result
+        | result                      |
+        | [{1, a}, {2, b}, {3, NULL}] |
+
+    Scenario: arrays_zip second longer pads NULL
+      When query
+        """
+        SELECT arrays_zip(array(1,2), array('a','b','c')) AS result
+        """
+      Then query result
+        | result                      |
+        | [{1, a}, {2, b}, {NULL, c}] |
+
+    Scenario: arrays_zip one empty array
+      When query
+        """
+        SELECT arrays_zip(array(1,2), array()) AS result
+        """
+      Then query result
+        | result                 |
+        | [{1, NULL}, {2, NULL}] |
+
+    Scenario: arrays_zip both empty arrays
+      When query
+        """
+        SELECT arrays_zip(array(), array()) AS result
+        """
+      Then query result
+        | result |
+        | []     |
+
+  Rule: NULL handling
+
+    @sail-bug
+    # Sail errors on untyped NULL but Spark returns NULL
+    Scenario: arrays_zip untyped NULL array returns NULL
+      When query
+        """
+        SELECT arrays_zip(NULL, array(1,2)) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: arrays_zip typed NULL array returns NULL
+      When query
+        """
+        SELECT arrays_zip(CAST(NULL AS ARRAY<INT>), array(1,2)) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: arrays_zip with NULL elements
+      When query
+        """
+        SELECT arrays_zip(array(1,NULL,3), array('a','b','c')) AS result
+        """
+      Then query result
+        | result                      |
+        | [{1, a}, {NULL, b}, {3, c}] |
+
+    Scenario: arrays_zip all NULL elements
+      When query
+        """
+        SELECT arrays_zip(array(NULL,NULL), array(NULL,NULL)) AS result
+        """
+      Then query result
+        | result                       |
+        | [{NULL, NULL}, {NULL, NULL}] |
+
+  Rule: Type variety
+
+    Scenario: arrays_zip int and double
+      When query
+        """
+        SELECT arrays_zip(array(1,2), array(1.5,2.5)) AS result
+        """
+      Then query result
+        | result                 |
+        | [{1, 1.5}, {2, 2.5}]  |
+
+    Scenario: arrays_zip nested arrays
+      When query
+        """
+        SELECT arrays_zip(array(array(1,2),array(3,4)), array('a','b')) AS result
+        """
+      Then query result
+        | result                     |
+        | [{[1, 2], a}, {[3, 4], b}] |
+
+    Scenario: arrays_zip boolean and int
+      When query
+        """
+        SELECT arrays_zip(array(true,false), array(1,2)) AS result
+        """
+      Then query result
+        | result                  |
+        | [{true, 1}, {false, 2}] |
+
+  Rule: Multi-row
+
+    Scenario: arrays_zip multi-row
+      When query
+        """
+        SELECT arrays_zip(a, b) AS result FROM VALUES (array(1,2), array('x','y')), (array(3), array('z','w')), (CAST(NULL AS ARRAY<INT>), array('a')) AS t(a, b)
+        """
+      Then query result
+        | result              |
+        | [{1, x}, {2, y}]   |
+        | [{3, z}, {NULL, w}] |
+        | NULL                |
+
+  Rule: Error conditions
+
+    Scenario: arrays_zip non-array input errors
+      When query
+        """
+        SELECT arrays_zip(1, 2) AS result
+        """
+      Then query error .*
+
+    Scenario: arrays_zip mixed array and non-array errors
+      When query
+        """
+        SELECT arrays_zip(array(1,2), 'hello') AS result
+        """
+      Then query error .*

--- a/python/pysail/tests/spark/function/features/arrays_zip.feature
+++ b/python/pysail/tests/spark/function/features/arrays_zip.feature
@@ -48,8 +48,6 @@ Feature: arrays_zip comprehensive tests
         | result                   |
         | [{1, 1}, {2, 2}, {3, 3}] |
 
-    @sail-bug
-    # Sail rejects 0 args but Spark returns empty array
     Scenario: arrays_zip zero args returns empty array
       When query
         """
@@ -122,8 +120,6 @@ Feature: arrays_zip comprehensive tests
 
   Rule: NULL handling
 
-    @sail-bug
-    # Sail errors on untyped NULL but Spark returns NULL
     Scenario: arrays_zip untyped NULL array returns NULL
       When query
         """

--- a/python/pysail/tests/spark/function/features/arrays_zip.feature
+++ b/python/pysail/tests/spark/function/features/arrays_zip.feature
@@ -406,6 +406,21 @@ Feature: arrays_zip comprehensive tests
         | [{1, x}] |
         | NULL     |
 
+    Scenario: arrays_zip multi-row all-null column returns all NULL
+      When query
+        """
+        SELECT arrays_zip(a, b) AS result FROM VALUES
+          (CAST(NULL AS ARRAY<INT>), array(1, 2)),
+          (CAST(NULL AS ARRAY<INT>), array(3, 4)),
+          (CAST(NULL AS ARRAY<INT>), array(5, 6))
+        AS t(a, b)
+        """
+      Then query result
+        | result |
+        | NULL   |
+        | NULL   |
+        | NULL   |
+
   Rule: Error conditions
 
     Scenario: arrays_zip non-array input errors


### PR DESCRIPTION
Fixes two correctness bugs in `arrays_zip` to match Spark's `ArraysZip` contract,
expands test coverage from 18 to 42 scenarios, and applies local arrow-check
hygiene (with_capacity + uniform-length fast-path)