### PR TITLE
fix: coerce view types at query output for Arrow compatibility

### DIFF
--- a/crates/sail-common/src/config/application.rs
+++ b/crates/sail-common/src/config/application.rs
@@ -429,6 +429,7 @@ pub struct CatalogConfig {
 #[serde(deny_unknown_fields)]
 pub struct OptimizerConfig {
     pub enable_join_reorder: bool,
+    pub expand_views_at_output: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/sail-common/src/config/application.yaml
+++ b/crates/sail-common/src/config/application.yaml
@@ -710,6 +710,16 @@
     Whether to enable cost-based join reorder in the query optimizer.
   experimental: true
 
+- key: optimizer.expand_views_at_output
+  type: boolean
+  default: "true"
+  description: |
+    Whether the optimizer should coerce view types to non-view types at query output.
+    If the value is `true`, `Utf8View` is coerced to `LargeUtf8` and `BinaryView` is coerced
+    to `LargeBinary` before results leave the query boundary. If the value is `false`, view
+    types pass through to the client.
+  experimental: true
+
 - key: spark.session_timeout_secs
   type: number
   default: "900"

--- a/crates/sail-session/src/session_factory/server.rs
+++ b/crates/sail-session/src/session_factory/server.rs
@@ -121,6 +121,7 @@ impl ServerSessionFactory {
             .with_extension(Arc::new(DeltaTableCache::default()));
         self.apply_execution_config(&mut config);
         self.apply_execution_parquet_config(&mut config);
+        self.apply_optimizer_config(&mut config);
         let config = self.mutator.mutate_config(config, info)?;
         Ok(config)
     }
@@ -208,6 +209,11 @@ impl ServerSessionFactory {
             .execution
             .use_row_number_estimates_to_optimize_partitioning;
         execution.listing_table_ignore_subdirectory = false;
+    }
+
+    fn apply_optimizer_config(&mut self, config: &mut SessionConfig) {
+        let optimizer = &mut config.options_mut().optimizer;
+        optimizer.expand_views_at_output = self.config.optimizer.expand_views_at_output;
     }
 
     fn apply_execution_parquet_config(&mut self, config: &mut SessionConfig) {


### PR DESCRIPTION
## Before

```
pyspark.errors.exceptions.base.PySparkTypeError: [UNSUPPORTED_DATA_TYPE_FOR_ARROW_CONVERSION] string_view is not supported in conversion to Arrow.
```

PySpark's `from_arrow_type` has no case for `string_view`, so any query result containing a `Utf8View` column fails at the client.

## After

Same query returns `LargeUtf8` columns, which PySpark maps to `StringType`. No more `string_view` error.

## Change

Wires DataFusion's `optimizer.expand_views_at_output` into Sail's config (struct field, yaml entry, `apply_optimizer_config` in the server session factory) and defaults it to `true`. Coerces `Utf8View` → `LargeUtf8` and `BinaryView` → `LargeBinary` at query output regardless of where the view type originated (planner, Parquet reader, string kernels, literals).