### PR TITLE
feat: implement coalesce function with Spark-compatible coercion for mixed string and temporal arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7191,6 +7191,7 @@ version = "0.6.0"
 dependencies = [
  "datafusion",
  "datafusion-common",
+ "datafusion-common-runtime",
  "datafusion-expr",
  "futures",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,7 @@ datafusion = { version = "53.1.0", default-features = false, features = [
     "recursive_protection",
 ] }
 datafusion-common = { version = "53.1.0", features = ["object_store", "avro"] }
+datafusion-common-runtime = { version = "53.1.0" }
 datafusion-datasource = { version = "53.1.0" }
 datafusion-expr = { version = "53.1.0", default-features = false }
 datafusion-expr-common = { version = "53.1.0" }

--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -57,6 +57,7 @@ message ExtendedPhysicalPlanNode {
     RelaxedTzCastExecNode relaxed_tz_cast = 42;
     SparkPartitionIdExecNode spark_partition_id = 43;
     DeletionVectorWriterExecNode deletion_vector_writer = 44;
+    NarrowCoalesceExecNode narrow_coalesce = 45;
   }
 }
 
@@ -594,6 +595,11 @@ message SparkPartitionIdExecNode {
   bytes input = 1;
   string column_name = 2;
   bytes schema = 3;
+}
+
+message NarrowCoalesceExecNode {
+  bytes input = 1;
+  uint64 target_partitions = 2;
 }
 
 message RelaxedTzCastExecNode {

--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -58,6 +58,7 @@ message ExtendedPhysicalPlanNode {
     SparkPartitionIdExecNode spark_partition_id = 43;
     DeletionVectorWriterExecNode deletion_vector_writer = 44;
     NarrowCoalesceExecNode narrow_coalesce = 45;
+    RoundRobinRepartitionExecNode round_robin_repartition = 46;
   }
 }
 
@@ -598,6 +599,11 @@ message SparkPartitionIdExecNode {
 }
 
 message NarrowCoalesceExecNode {
+  bytes input = 1;
+  uint64 target_partitions = 2;
+}
+
+message RoundRobinRepartitionExecNode {
   bytes input = 1;
   uint64 target_partitions = 2;
 }

--- a/crates/sail-execution/proto/sail/task/common.proto
+++ b/crates/sail-execution/proto/sail/task/common.proto
@@ -86,6 +86,7 @@ message TaskOutputHashDistribution {
 
 message TaskOutputRoundRobinDistribution {
   uint64 channels = 1;
+  bool row_level = 2;
 }
 
 message TaskOutputLocator {
@@ -102,4 +103,3 @@ message TaskOutputLocalLocator {
 message TaskOutputRemoteLocator {
   string uri = 1;
 }
-

--- a/crates/sail-execution/src/codec.rs
+++ b/crates/sail-execution/src/codec.rs
@@ -206,6 +206,7 @@ use sail_physical_plan::map_partitions::MapPartitionsExec;
 use sail_physical_plan::merge_cardinality_check::MergeCardinalityCheckExec;
 use sail_physical_plan::monotonic_id::MonotonicIdExec;
 use sail_physical_plan::range::RangeExec;
+use sail_physical_plan::repartition::NarrowCoalesceExec;
 use sail_physical_plan::schema_pivot::SchemaPivotExec;
 use sail_physical_plan::show_string::ShowStringExec;
 use sail_physical_plan::spark_partition_id::SparkPartitionIdExec;
@@ -1001,6 +1002,15 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                     Arc::new(schema),
                 )?))
             }
+            NodeKind::NarrowCoalesce(gen::NarrowCoalesceExecNode {
+                input,
+                target_partitions,
+            }) => Ok(Arc::new(NarrowCoalesceExec::try_new(
+                self.try_decode_plan(&input, ctx)?,
+                usize::try_from(target_partitions).map_err(|_| {
+                    plan_datafusion_err!("invalid number of partitions for narrow coalesce")
+                })?,
+            )?)),
             NodeKind::RelaxedTzCast(gen::RelaxedTzCastExecNode { input, schema }) => {
                 let input = self.try_decode_plan(&input, ctx)?;
                 let schema = Arc::new(self.try_decode_schema(&schema)?);
@@ -1689,6 +1699,16 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 input,
                 column_name: spark_partition_id.column_name().to_string(),
                 schema,
+            })
+        } else if let Some(narrow_coalesce) = node.as_any().downcast_ref::<NarrowCoalesceExec>() {
+            let input = self.try_encode_plan(narrow_coalesce.input().clone())?;
+            let target_partitions =
+                u64::try_from(narrow_coalesce.target_partitions()).map_err(|_| {
+                    plan_datafusion_err!("invalid number of partitions for narrow coalesce")
+                })?;
+            NodeKind::NarrowCoalesce(gen::NarrowCoalesceExecNode {
+                input,
+                target_partitions,
             })
         } else if let Some(relaxed_tz_cast) = node.as_any().downcast_ref::<RelaxedTzCastExec>() {
             let input = self.try_encode_plan(relaxed_tz_cast.input().clone())?;

--- a/crates/sail-execution/src/codec.rs
+++ b/crates/sail-execution/src/codec.rs
@@ -206,7 +206,7 @@ use sail_physical_plan::map_partitions::MapPartitionsExec;
 use sail_physical_plan::merge_cardinality_check::MergeCardinalityCheckExec;
 use sail_physical_plan::monotonic_id::MonotonicIdExec;
 use sail_physical_plan::range::RangeExec;
-use sail_physical_plan::repartition::NarrowCoalesceExec;
+use sail_physical_plan::repartition::{NarrowCoalesceExec, RoundRobinRepartitionExec};
 use sail_physical_plan::schema_pivot::SchemaPivotExec;
 use sail_physical_plan::show_string::ShowStringExec;
 use sail_physical_plan::spark_partition_id::SparkPartitionIdExec;
@@ -1011,6 +1011,15 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                     plan_datafusion_err!("invalid number of partitions for narrow coalesce")
                 })?,
             )?)),
+            NodeKind::RoundRobinRepartition(gen::RoundRobinRepartitionExecNode {
+                input,
+                target_partitions,
+            }) => Ok(Arc::new(RoundRobinRepartitionExec::try_new(
+                self.try_decode_plan(&input, ctx)?,
+                usize::try_from(target_partitions).map_err(|_| {
+                    plan_datafusion_err!("invalid number of partitions for round-robin repartition")
+                })?,
+            )?)),
             NodeKind::RelaxedTzCast(gen::RelaxedTzCastExecNode { input, schema }) => {
                 let input = self.try_decode_plan(&input, ctx)?;
                 let schema = Arc::new(self.try_decode_schema(&schema)?);
@@ -1707,6 +1716,17 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                     plan_datafusion_err!("invalid number of partitions for narrow coalesce")
                 })?;
             NodeKind::NarrowCoalesce(gen::NarrowCoalesceExecNode {
+                input,
+                target_partitions,
+            })
+        } else if let Some(round_robin) = node.as_any().downcast_ref::<RoundRobinRepartitionExec>()
+        {
+            let input = self.try_encode_plan(round_robin.input().clone())?;
+            let target_partitions =
+                u64::try_from(round_robin.target_partitions()).map_err(|_| {
+                    plan_datafusion_err!("invalid number of partitions for round-robin repartition")
+                })?;
+            NodeKind::RoundRobinRepartition(gen::RoundRobinRepartitionExecNode {
                 input,
                 target_partitions,
             })

--- a/crates/sail-execution/src/codec.rs
+++ b/crates/sail-execution/src/codec.rs
@@ -103,6 +103,7 @@ use sail_function::aggregate::max_min_by::{MaxByFunction, MinByFunction};
 use sail_function::aggregate::mode::ModeFunction;
 use sail_function::aggregate::percentile::PercentileFunction;
 use sail_function::aggregate::percentile_disc::PercentileDisc;
+use sail_function::aggregate::schema_of_variant_agg::SchemaOfVariantAggFunction;
 use sail_function::aggregate::skewness::SkewnessFunc;
 use sail_function::aggregate::try_avg::TryAvgFunction;
 use sail_function::scalar::array::arrays_zip::ArraysZip;
@@ -2392,6 +2393,9 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 "mode" => Ok(Arc::new(AggregateUDF::from(ModeFunction::new()))),
                 "percentile" => Ok(Arc::new(AggregateUDF::from(PercentileFunction::new()))),
                 "percentile_disc" => Ok(Arc::new(AggregateUDF::from(PercentileDisc::new()))),
+                "schema_of_variant_agg" => Ok(Arc::new(AggregateUDF::from(
+                    SchemaOfVariantAggFunction::new(),
+                ))),
                 "skewness" => Ok(Arc::new(AggregateUDF::from(SkewnessFunc::new()))),
                 "try_avg" => Ok(Arc::new(AggregateUDF::from(TryAvgFunction::new()))),
                 "try_sum" => Ok(Arc::new(AggregateUDF::from(SparkTrySum::new()))),
@@ -2476,7 +2480,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 let udaf = PySparkBatchCollectorUDF::new(input_types, input_names);
                 Ok(Arc::new(AggregateUDF::from(udaf)))
             }
-            None => plan_err!("ExtendedScalarUdf: no UDF found for {name}"),
+            None => plan_err!("ExtendedAggregateUdf: no UDF found for {name}"),
         }
     }
 
@@ -2490,6 +2494,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node.inner().as_any().is::<ModeFunction>()
             || node.inner().as_any().is::<PercentileFunction>()
             || node.inner().as_any().is::<PercentileDisc>()
+            || node.inner().as_any().is::<SchemaOfVariantAggFunction>()
             || node.inner().as_any().is::<SkewnessFunc>()
             || node.inner().as_any().is::<TryAvgFunction>()
             || node.inner().as_any().is::<SparkTrySum>()

--- a/crates/sail-execution/src/driver/job_scheduler/core.rs
+++ b/crates/sail-execution/src/driver/job_scheduler/core.rs
@@ -727,8 +727,12 @@ impl JobScheduler {
                     channels: *channels,
                 }
             }
-            OutputDistribution::RoundRobin { channels } => TaskOutputDistribution::RoundRobin {
+            OutputDistribution::RoundRobin {
+                channels,
+                row_level,
+            } => TaskOutputDistribution::RoundRobin {
                 channels: *channels,
+                row_level: *row_level,
             },
         };
         let locator = match stage.mode {

--- a/crates/sail-execution/src/job_graph/mod.rs
+++ b/crates/sail-execution/src/job_graph/mod.rs
@@ -180,6 +180,7 @@ pub enum OutputDistribution {
     },
     RoundRobin {
         channels: usize,
+        row_level: bool,
     },
 }
 
@@ -187,7 +188,7 @@ impl OutputDistribution {
     pub fn channels(&self) -> usize {
         match self {
             OutputDistribution::Hash { channels, .. } => *channels,
-            OutputDistribution::RoundRobin { channels } => *channels,
+            OutputDistribution::RoundRobin { channels, .. } => *channels,
         }
     }
 }
@@ -199,8 +200,15 @@ impl fmt::Display for OutputDistribution {
                 let keys = keys.iter().map(|k| k.to_string()).collect::<Vec<_>>();
                 write!(f, "Hash(keys=[{}], channels={})", keys.join(", "), channels)
             }
-            OutputDistribution::RoundRobin { channels } => {
-                write!(f, "RoundRobin(channels={})", channels)
+            OutputDistribution::RoundRobin {
+                channels,
+                row_level,
+            } => {
+                write!(
+                    f,
+                    "RoundRobin(channels={}, row_level={})",
+                    channels, row_level
+                )
             }
         }
     }

--- a/crates/sail-execution/src/job_graph/planner.rs
+++ b/crates/sail-execution/src/job_graph/planner.rs
@@ -17,6 +17,7 @@ use datafusion::physical_plan::{
 use sail_catalog_system::physical_plan::SystemTableExec;
 use sail_common_datafusion::utils::items::ItemTaker;
 use sail_physical_plan::catalog_command::CatalogCommandExec;
+use sail_physical_plan::repartition::RoundRobinRepartitionExec;
 
 use crate::error::{ExecutionError, ExecutionResult};
 use crate::job_graph::{
@@ -205,6 +206,7 @@ fn build_job_graph(
             build_job_graph(right.clone(), usage, graph)?,
         ]
     } else if plan.as_any().is::<RepartitionExec>()
+        || plan.as_any().is::<RoundRobinRepartitionExec>()
         || plan.as_any().is::<CoalescePartitionsExec>()
         || plan.as_any().is::<SortPreservingMergeExec>()
     {
@@ -250,6 +252,10 @@ fn build_job_graph(
                 create_shuffle(child, graph, properties, consumption)?
             }
         }
+    } else if let Some(repartition) = plan.as_any().downcast_ref::<RoundRobinRepartitionExec>() {
+        let properties = repartition.properties().clone();
+        let child = plan.children().one()?;
+        create_shuffle(child, graph, properties, consumption)?
     } else if let Some(coalesce) = plan.as_any().downcast_ref::<CoalescePartitionsExec>() {
         let properties = coalesce.properties().clone();
         let child = plan.children().one()?;

--- a/crates/sail-execution/src/job_graph/planner.rs
+++ b/crates/sail-execution/src/job_graph/planner.rs
@@ -40,7 +40,10 @@ impl JobGraph {
             plan: last,
             group: String::new(),
             mode: OutputMode::Pipelined,
-            distribution: OutputDistribution::RoundRobin { channels: 1 },
+            distribution: OutputDistribution::RoundRobin {
+                channels: 1,
+                row_level: false,
+            },
             placement: TaskPlacement::Worker,
         });
         Ok(graph)
@@ -246,21 +249,21 @@ fn build_job_graph(
                         .clone()
                         .with_partitioning(Partitioning::RoundRobinBatch(n)),
                 );
-                create_shuffle(child, graph, properties, consumption)?
+                create_shuffle(child, graph, properties, consumption, false)?
             }
             Partitioning::RoundRobinBatch(_) | Partitioning::Hash(_, _) => {
-                create_shuffle(child, graph, properties, consumption)?
+                create_shuffle(child, graph, properties, consumption, false)?
             }
         }
     } else if let Some(repartition) = plan.as_any().downcast_ref::<RoundRobinRepartitionExec>() {
         let properties = repartition.properties().clone();
         let child = plan.children().one()?;
-        create_shuffle(child, graph, properties, consumption)?
+        create_shuffle(child, graph, properties, consumption, true)?
     } else if let Some(coalesce) = plan.as_any().downcast_ref::<CoalescePartitionsExec>() {
         let properties = coalesce.properties().clone();
         let child = plan.children().one()?;
         let fetch = coalesce.fetch();
-        let shuffled = create_shuffle(child, graph, properties, consumption)?;
+        let shuffled = create_shuffle(child, graph, properties, consumption, false)?;
         if let Some(f) = fetch {
             Arc::new(GlobalLimitExec::new(shuffled, 0, Some(f))) as Arc<dyn ExecutionPlan>
         } else {
@@ -290,7 +293,10 @@ fn create_merge_input(
         plan,
         group: String::new(),
         mode: OutputMode::Pipelined,
-        distribution: OutputDistribution::RoundRobin { channels: 1 },
+        distribution: OutputDistribution::RoundRobin {
+            channels: 1,
+            row_level: false,
+        },
         placement: TaskPlacement::Worker,
     };
     let s = graph.stages.len();
@@ -311,10 +317,14 @@ fn create_shuffle(
     // which are different from the properties of the input plan.
     properties: Arc<PlanProperties>,
     consumption: ShuffleConsumption,
+    row_level_round_robin: bool,
 ) -> ExecutionResult<Arc<dyn ExecutionPlan>> {
     let distribution = match properties.partitioning.clone() {
         Partitioning::RoundRobinBatch(channels) | Partitioning::UnknownPartitioning(channels) => {
-            OutputDistribution::RoundRobin { channels }
+            OutputDistribution::RoundRobin {
+                channels,
+                row_level: row_level_round_robin,
+            }
         }
         Partitioning::Hash(keys, channels) => OutputDistribution::Hash { keys, channels },
     };
@@ -366,7 +376,10 @@ fn create_driver_stage(
         plan: plan.clone(),
         group: String::new(),
         mode: OutputMode::Pipelined,
-        distribution: OutputDistribution::RoundRobin { channels: 1 },
+        distribution: OutputDistribution::RoundRobin {
+            channels: 1,
+            row_level: false,
+        },
         placement: TaskPlacement::Driver,
     };
     let s = graph.stages.len();

--- a/crates/sail-execution/src/plan/shuffle_write.rs
+++ b/crates/sail-execution/src/plan/shuffle_write.rs
@@ -254,19 +254,21 @@ impl ShufflePartitioner {
                 input_partition,
                 input_partitions,
             )?)),
-            Partitioning::RoundRobinBatch(target_partitions) if row_level_round_robin => Ok(
-                Self::RowRoundRobin(RowRoundRobinBatchPartitioner::try_new(
+            Partitioning::RoundRobinBatch(target_partitions) if row_level_round_robin => {
+                Ok(Self::RowRoundRobin(RowRoundRobinBatchPartitioner::try_new(
                     target_partitions,
                     input_partition,
                     input_partitions,
-                )?),
-            ),
-            Partitioning::RoundRobinBatch(_) => Ok(Self::BatchRoundRobin(BatchPartitioner::try_new(
-                partitioning,
-                Default::default(),
-                input_partition,
-                input_partitions,
-            )?)),
+                )?))
+            }
+            Partitioning::RoundRobinBatch(_) => {
+                Ok(Self::BatchRoundRobin(BatchPartitioner::try_new(
+                    partitioning,
+                    Default::default(),
+                    input_partition,
+                    input_partitions,
+                )?))
+            }
             other => internal_err!("unsupported shuffle partitioning: {other}"),
         }
     }

--- a/crates/sail-execution/src/plan/shuffle_write.rs
+++ b/crates/sail-execution/src/plan/shuffle_write.rs
@@ -33,6 +33,7 @@ pub struct ShuffleWriteExec {
     locations: Vec<Vec<TaskWriteLocation>>,
     properties: Arc<PlanProperties>,
     writer: Arc<dyn TaskStreamWriter>,
+    row_level_round_robin: bool,
 }
 
 impl ShuffleWriteExec {
@@ -41,6 +42,7 @@ impl ShuffleWriteExec {
         locations: Vec<Vec<TaskWriteLocation>>,
         writer: Arc<dyn TaskStreamWriter>,
         partitioning: Partitioning,
+        row_level_round_robin: bool,
     ) -> Self {
         let partitioning = match partitioning {
             Partitioning::Hash(expr, n) if expr.is_empty() => Partitioning::UnknownPartitioning(n),
@@ -74,6 +76,7 @@ impl ShuffleWriteExec {
             locations,
             properties,
             writer,
+            row_level_round_robin,
         }
     }
 }
@@ -82,8 +85,9 @@ impl DisplayAs for ShuffleWriteExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "ShuffleWriteExec: partitioning={}, locations={}",
+            "ShuffleWriteExec: partitioning={}, row_level_round_robin={}, locations={}",
             self.shuffle_partitioning,
+            self.row_level_round_robin,
             ListListDisplay(&self.locations),
         )
     }
@@ -152,8 +156,12 @@ impl ExecutionPlan for ShuffleWriteExec {
             .properties()
             .output_partitioning()
             .partition_count();
-        let partitioner =
-            ShufflePartitioner::try_new(shuffle_partitioning, partition, num_input_partitions)?;
+        let partitioner = ShufflePartitioner::try_new(
+            shuffle_partitioning,
+            partition,
+            num_input_partitions,
+            self.row_level_round_robin,
+        )?;
         let empty = RecordBatch::new_empty(self.schema());
         let output = futures::stream::once(async move {
             shuffle_write(writer, stream, &locations, partitioner).await?;
@@ -228,7 +236,8 @@ async fn shuffle_write(
 
 enum ShufflePartitioner {
     Hash(BatchPartitioner),
-    RoundRobin(RowRoundRobinBatchPartitioner),
+    BatchRoundRobin(BatchPartitioner),
+    RowRoundRobin(RowRoundRobinBatchPartitioner),
 }
 
 impl ShufflePartitioner {
@@ -236,6 +245,7 @@ impl ShufflePartitioner {
         partitioning: Partitioning,
         input_partition: usize,
         input_partitions: usize,
+        row_level_round_robin: bool,
     ) -> Result<Self> {
         match partitioning {
             Partitioning::Hash(_, _) => Ok(Self::Hash(BatchPartitioner::try_new(
@@ -244,13 +254,19 @@ impl ShufflePartitioner {
                 input_partition,
                 input_partitions,
             )?)),
-            Partitioning::RoundRobinBatch(target_partitions) => {
-                Ok(Self::RoundRobin(RowRoundRobinBatchPartitioner::try_new(
+            Partitioning::RoundRobinBatch(target_partitions) if row_level_round_robin => Ok(
+                Self::RowRoundRobin(RowRoundRobinBatchPartitioner::try_new(
                     target_partitions,
                     input_partition,
                     input_partitions,
-                )?))
-            }
+                )?),
+            ),
+            Partitioning::RoundRobinBatch(_) => Ok(Self::BatchRoundRobin(BatchPartitioner::try_new(
+                partitioning,
+                Default::default(),
+                input_partition,
+                input_partitions,
+            )?)),
             other => internal_err!("unsupported shuffle partitioning: {other}"),
         }
     }
@@ -260,8 +276,10 @@ impl ShufflePartitioner {
         F: FnMut(usize, RecordBatch) -> Result<()>,
     {
         match self {
-            Self::Hash(partitioner) => partitioner.partition(batch, f),
-            Self::RoundRobin(partitioner) => {
+            Self::Hash(partitioner) | Self::BatchRoundRobin(partitioner) => {
+                partitioner.partition(batch, f)
+            }
+            Self::RowRoundRobin(partitioner) => {
                 for (partition, batch) in partitioner.partition(batch)? {
                     f(partition, batch)?;
                 }

--- a/crates/sail-execution/src/plan/shuffle_write.rs
+++ b/crates/sail-execution/src/plan/shuffle_write.rs
@@ -17,6 +17,7 @@ use datafusion::physical_plan::{
 };
 use futures::future::try_join_all;
 use futures::StreamExt;
+use sail_physical_plan::repartition::RowRoundRobinBatchPartitioner;
 
 use crate::plan::ListListDisplay;
 use crate::stream::writer::{TaskStreamSinkState, TaskStreamWriter, TaskWriteLocation};
@@ -151,12 +152,8 @@ impl ExecutionPlan for ShuffleWriteExec {
             .properties()
             .output_partitioning()
             .partition_count();
-        let partitioner = BatchPartitioner::try_new(
-            shuffle_partitioning,
-            Default::default(),
-            partition,
-            num_input_partitions,
-        )?;
+        let partitioner =
+            ShufflePartitioner::try_new(shuffle_partitioning, partition, num_input_partitions)?;
         let empty = RecordBatch::new_empty(self.schema());
         let output = futures::stream::once(async move {
             shuffle_write(writer, stream, &locations, partitioner).await?;
@@ -173,7 +170,7 @@ async fn shuffle_write(
     writer: Arc<dyn TaskStreamWriter>,
     mut stream: SendableRecordBatchStream,
     locations: &[TaskWriteLocation],
-    mut partitioner: BatchPartitioner,
+    mut partitioner: ShufflePartitioner,
 ) -> Result<()> {
     let schema = stream.schema();
     let mut partition_sinks = {
@@ -227,4 +224,49 @@ async fn shuffle_write(
         .filter_map(|s| s.map(|x| x.close()));
     try_join_all(futures).await?;
     Ok(())
+}
+
+enum ShufflePartitioner {
+    Hash(BatchPartitioner),
+    RoundRobin(RowRoundRobinBatchPartitioner),
+}
+
+impl ShufflePartitioner {
+    fn try_new(
+        partitioning: Partitioning,
+        input_partition: usize,
+        input_partitions: usize,
+    ) -> Result<Self> {
+        match partitioning {
+            Partitioning::Hash(_, _) => Ok(Self::Hash(BatchPartitioner::try_new(
+                partitioning,
+                Default::default(),
+                input_partition,
+                input_partitions,
+            )?)),
+            Partitioning::RoundRobinBatch(target_partitions) => {
+                Ok(Self::RoundRobin(RowRoundRobinBatchPartitioner::try_new(
+                    target_partitions,
+                    input_partition,
+                    input_partitions,
+                )?))
+            }
+            other => internal_err!("unsupported shuffle partitioning: {other}"),
+        }
+    }
+
+    fn partition<F>(&mut self, batch: RecordBatch, mut f: F) -> Result<()>
+    where
+        F: FnMut(usize, RecordBatch) -> Result<()>,
+    {
+        match self {
+            Self::Hash(partitioner) => partitioner.partition(batch, f),
+            Self::RoundRobin(partitioner) => {
+                for (partition, batch) in partitioner.partition(batch)? {
+                    f(partition, batch)?;
+                }
+                Ok(())
+            }
+        }
+    }
 }

--- a/crates/sail-execution/src/task/definition.rs
+++ b/crates/sail-execution/src/task/definition.rs
@@ -64,6 +64,7 @@ pub enum TaskOutputDistribution {
     },
     RoundRobin {
         channels: usize,
+        row_level: bool,
     },
 }
 
@@ -415,10 +416,14 @@ impl From<TaskOutputDistribution> for gen::TaskOutputDistribution {
                     channels: channels as u64,
                 })
             }
-            TaskOutputDistribution::RoundRobin { channels } => {
+            TaskOutputDistribution::RoundRobin {
+                channels,
+                row_level,
+            } => {
                 gen::task_output_distribution::Kind::RoundRobin(
                     gen::TaskOutputRoundRobinDistribution {
                         channels: channels as u64,
+                        row_level,
                     },
                 )
             }
@@ -440,9 +445,13 @@ impl TryFrom<gen::TaskOutputDistribution> for TaskOutputDistribution {
                 channels: channels as usize,
             }),
             Some(gen::task_output_distribution::Kind::RoundRobin(
-                gen::TaskOutputRoundRobinDistribution { channels },
+                gen::TaskOutputRoundRobinDistribution {
+                    channels,
+                    row_level,
+                },
             )) => Ok(TaskOutputDistribution::RoundRobin {
                 channels: channels as usize,
+                row_level,
             }),
             None => Err(ExecutionError::InvalidArgument(
                 "cannot decode empty task output distribution".to_string(),
@@ -606,7 +615,7 @@ impl TaskOutput {
                     .collect::<ExecutionResult<Vec<_>>>()?;
                 Ok(Partitioning::Hash(keys, *channels))
             }
-            TaskOutputDistribution::RoundRobin { channels } => {
+            TaskOutputDistribution::RoundRobin { channels, .. } => {
                 Ok(Partitioning::RoundRobinBatch(*channels))
             }
         }

--- a/crates/sail-execution/src/task/definition.rs
+++ b/crates/sail-execution/src/task/definition.rs
@@ -419,14 +419,12 @@ impl From<TaskOutputDistribution> for gen::TaskOutputDistribution {
             TaskOutputDistribution::RoundRobin {
                 channels,
                 row_level,
-            } => {
-                gen::task_output_distribution::Kind::RoundRobin(
-                    gen::TaskOutputRoundRobinDistribution {
-                        channels: channels as u64,
-                        row_level,
-                    },
-                )
-            }
+            } => gen::task_output_distribution::Kind::RoundRobin(
+                gen::TaskOutputRoundRobinDistribution {
+                    channels: channels as u64,
+                    row_level,
+                },
+            ),
         };
         gen::TaskOutputDistribution { kind: Some(kind) }
     }

--- a/crates/sail-execution/src/task_runner/core.rs
+++ b/crates/sail-execution/src/task_runner/core.rs
@@ -26,7 +26,7 @@ use crate::error::{ExecutionError, ExecutionResult};
 use crate::id::{TaskKey, TaskKeyDisplay};
 use crate::plan::{ShuffleReadExec, ShuffleWriteExec, StageInputExec};
 use crate::stream_accessor::{StreamAccessor, StreamAccessorMessage};
-use crate::task::definition::{TaskDefinition, TaskInput, TaskOutput};
+use crate::task::definition::{TaskDefinition, TaskInput, TaskOutput, TaskOutputDistribution};
 use crate::task_runner::monitor::TaskMonitor;
 use crate::task_runner::{TaskRunner, TaskRunnerMessage};
 
@@ -180,7 +180,20 @@ impl TaskRunner {
             }
         };
         let partitioning = output.partitioning(context, &schema, self.codec.as_ref())?;
-        let shuffle = ShuffleWriteExec::new(plan, locations, Arc::new(accessor), partitioning);
+        let row_level_round_robin = matches!(
+            &output.distribution,
+            TaskOutputDistribution::RoundRobin {
+                row_level: true,
+                ..
+            }
+        );
+        let shuffle = ShuffleWriteExec::new(
+            plan,
+            locations,
+            Arc::new(accessor),
+            partitioning,
+            row_level_round_robin,
+        );
         Ok(Arc::new(shuffle))
     }
 }

--- a/crates/sail-function/src/scalar/variant/utils/helper.rs
+++ b/crates/sail-function/src/scalar/variant/utils/helper.rs
@@ -16,15 +16,29 @@ pub fn try_field_as_variant_array(field: &Field) -> datafusion_common::Result<()
         return Ok(());
     }
 
-    ensure(
-        is_variant_field(field),
-        "field does not have extension type VariantType",
-    )?;
+    if !is_variant_field(field) {
+        ensure(
+            is_variant_storage_type(field.data_type()),
+            "field does not have extension type VariantType",
+        )?;
+    }
 
-    let variant_type = VariantType;
-    variant_type.supports_data_type(field.data_type())?;
+    VariantType.supports_data_type(field.data_type())?;
 
     Ok(())
+}
+
+fn is_variant_storage_type(data_type: &DataType) -> bool {
+    let DataType::Struct(fields) = data_type else {
+        return false;
+    };
+    fields.iter().any(|field| {
+        field.name() == "metadata"
+            && matches!(
+                field.data_type(),
+                DataType::Binary | DataType::LargeBinary | DataType::BinaryView
+            )
+    })
 }
 pub fn ensure(pred: bool, err_msg: &str) -> datafusion_common::Result<()> {
     if !pred {

--- a/crates/sail-logical-plan/src/repartition.rs
+++ b/crates/sail-logical-plan/src/repartition.rs
@@ -5,12 +5,24 @@ use datafusion::logical_expr::LogicalPlan;
 use datafusion_common::{plan_err, DFSchemaRef, Result};
 use datafusion_expr::{expr_vec_fmt, Expr, UserDefinedLogicalNodeCore};
 
+/// The explicit repartitioning strategy requested by the Spark client.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, PartialOrd)]
+pub enum ExplicitRepartitionKind {
+    /// `DataFrame.coalesce(n)`: reduce partitions without a shuffle.
+    Coalesce,
+    /// `DataFrame.repartition(n)`: shuffle records using round-robin partitioning.
+    RoundRobin,
+    /// `DataFrame.repartition(n, exprs...)`: shuffle records using hash partitioning.
+    Hash,
+}
+
 /// A logical plan node for explicit repartitioning in the query.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd)]
 pub struct ExplicitRepartitionNode {
     input: Arc<LogicalPlan>,
     num_partitions: Option<usize>,
     partitioning_expressions: Vec<Expr>,
+    kind: ExplicitRepartitionKind,
 }
 
 impl ExplicitRepartitionNode {
@@ -18,11 +30,13 @@ impl ExplicitRepartitionNode {
         input: Arc<LogicalPlan>,
         num_partitions: Option<usize>,
         partitioning_expressions: Vec<Expr>,
+        kind: ExplicitRepartitionKind,
     ) -> Self {
         Self {
             input,
             num_partitions,
             partitioning_expressions,
+            kind,
         }
     }
 
@@ -36,6 +50,10 @@ impl ExplicitRepartitionNode {
 
     pub fn partitioning_expressions(&self) -> &Vec<Expr> {
         &self.partitioning_expressions
+    }
+
+    pub fn kind(&self) -> ExplicitRepartitionKind {
+        self.kind
     }
 }
 
@@ -59,7 +77,8 @@ impl UserDefinedLogicalNodeCore for ExplicitRepartitionNode {
     fn fmt_for_explain(&self, f: &mut Formatter) -> std::fmt::Result {
         write!(
             f,
-            "ExplicitRepartition: n={:?}, expr=[{}]",
+            "ExplicitRepartition: kind={:?}, n={:?}, expr=[{}]",
+            self.kind,
             self.num_partitions,
             expr_vec_fmt!(self.partitioning_expressions)
         )
@@ -73,7 +92,12 @@ impl UserDefinedLogicalNodeCore for ExplicitRepartitionNode {
         let (Some(input), true) = (inputs.pop(), inputs.is_empty()) else {
             return plan_err!("{} expects exactly one input", self.name());
         };
-        Ok(Self::new(Arc::new(input), self.num_partitions, exprs))
+        Ok(Self::new(
+            Arc::new(input),
+            self.num_partitions,
+            exprs,
+            self.kind,
+        ))
     }
 
     fn necessary_children_exprs(&self, output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {

--- a/crates/sail-physical-optimizer/src/explicit_repartition.rs
+++ b/crates/sail-physical-optimizer/src/explicit_repartition.rs
@@ -10,7 +10,7 @@ use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 use datafusion_physical_expr::Partitioning;
 use sail_physical_plan::repartition::{
-    ExplicitRepartitionExec, ExplicitRepartitionKind, NarrowCoalesceExec,
+    ExplicitRepartitionExec, ExplicitRepartitionKind, NarrowCoalesceExec, RoundRobinRepartitionExec,
 };
 
 pub struct RewriteExplicitRepartition {}
@@ -38,12 +38,15 @@ impl PhysicalOptimizerRule for RewriteExplicitRepartition {
             if let Some(node) = plan.as_any().downcast_ref::<ExplicitRepartitionExec>() {
                 let partitioning = node.properties().output_partitioning().clone();
                 match node.kind() {
-                    ExplicitRepartitionKind::RoundRobin | ExplicitRepartitionKind::Hash => {
-                        Ok(Transformed::yes(Arc::new(RepartitionExec::try_new(
+                    ExplicitRepartitionKind::RoundRobin => Ok(Transformed::yes(Arc::new(
+                        RoundRobinRepartitionExec::try_new(
                             node.input().clone(),
-                            partitioning,
-                        )?)))
-                    }
+                            partitioning.partition_count(),
+                        )?,
+                    ))),
+                    ExplicitRepartitionKind::Hash => Ok(Transformed::yes(Arc::new(
+                        RepartitionExec::try_new(node.input().clone(), partitioning)?,
+                    ))),
                     ExplicitRepartitionKind::Coalesce => {
                         let target_partitions = partitioning.partition_count();
                         let input_partitions = node.input().output_partitioning().partition_count();

--- a/crates/sail-physical-optimizer/src/explicit_repartition.rs
+++ b/crates/sail-physical-optimizer/src/explicit_repartition.rs
@@ -1,16 +1,17 @@
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
-use datafusion::common::internal_err;
 use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::config::ConfigOptions;
 use datafusion::error::Result;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::repartition::RepartitionExec;
-use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 use datafusion_physical_expr::Partitioning;
-use sail_physical_plan::repartition::ExplicitRepartitionExec;
+use sail_physical_plan::repartition::{
+    ExplicitRepartitionExec, ExplicitRepartitionKind, NarrowCoalesceExec,
+};
 
 pub struct RewriteExplicitRepartition {}
 
@@ -36,18 +37,28 @@ impl PhysicalOptimizerRule for RewriteExplicitRepartition {
         let result = plan.transform_up(|plan| {
             if let Some(node) = plan.as_any().downcast_ref::<ExplicitRepartitionExec>() {
                 let partitioning = node.properties().output_partitioning().clone();
-                match partitioning {
-                    Partitioning::RoundRobinBatch(_) | Partitioning::Hash(_, _) => {
+                match node.kind() {
+                    ExplicitRepartitionKind::RoundRobin | ExplicitRepartitionKind::Hash => {
                         Ok(Transformed::yes(Arc::new(RepartitionExec::try_new(
                             node.input().clone(),
                             partitioning,
                         )?)))
                     }
-                    Partitioning::UnknownPartitioning(1) => Ok(Transformed::yes(Arc::new(
-                        CoalescePartitionsExec::new(node.input().clone()),
-                    ))),
-                    Partitioning::UnknownPartitioning(n) => {
-                        internal_err!("unknown explicit repartitioning with {n} partitions")
+                    ExplicitRepartitionKind::Coalesce => {
+                        let target_partitions = partitioning.partition_count();
+                        let input_partitions = node.input().output_partitioning().partition_count();
+                        if target_partitions >= input_partitions {
+                            Ok(Transformed::yes(node.input().clone()))
+                        } else if matches!(partitioning, Partitioning::UnknownPartitioning(1)) {
+                            Ok(Transformed::yes(Arc::new(CoalescePartitionsExec::new(
+                                node.input().clone(),
+                            ))))
+                        } else {
+                            Ok(Transformed::yes(Arc::new(NarrowCoalesceExec::try_new(
+                                node.input().clone(),
+                                target_partitions,
+                            )?)))
+                        }
                     }
                 }
             } else {

--- a/crates/sail-physical-plan/Cargo.toml
+++ b/crates/sail-physical-plan/Cargo.toml
@@ -13,6 +13,7 @@ sail-logical-plan = { path = "../sail-logical-plan" }
 
 datafusion = { workspace = true }
 datafusion-common = { workspace = true }
+datafusion-common-runtime = { workspace = true }
 datafusion-expr = { workspace = true }
 futures = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/sail-physical-plan/src/repartition.rs
+++ b/crates/sail-physical-plan/src/repartition.rs
@@ -148,6 +148,56 @@ impl ExecutionPlan for ExplicitRepartitionExec {
 type RoundRobinSender = Sender<Result<RecordBatch>>;
 type RoundRobinReceiver = Receiver<Result<RecordBatch>>;
 
+/// Partitions record batches using Spark-compatible row-level round-robin.
+pub struct RowRoundRobinBatchPartitioner {
+    target_partitions: usize,
+    next_partition: usize,
+}
+
+impl RowRoundRobinBatchPartitioner {
+    pub fn try_new(
+        target_partitions: usize,
+        input_partition: usize,
+        input_partitions: usize,
+    ) -> Result<Self> {
+        if target_partitions == 0 {
+            return plan_err!("number of round-robin partitions cannot be zero");
+        }
+        if input_partitions == 0 {
+            return plan_err!("number of input partitions cannot be zero");
+        }
+        Ok(Self {
+            target_partitions,
+            next_partition: input_partition * target_partitions / input_partitions,
+        })
+    }
+
+    pub fn partition(&mut self, batch: RecordBatch) -> Result<Vec<(usize, RecordBatch)>> {
+        let mut indices = vec![Vec::new(); self.target_partitions];
+        for row in 0..batch.num_rows() {
+            let row = u32::try_from(row)
+                .map_err(|_| DataFusionError::Execution("record batch has too many rows".into()))?;
+            indices[self.next_partition].push(row);
+            self.next_partition = (self.next_partition + 1) % self.target_partitions;
+        }
+
+        let mut output = Vec::new();
+        for (partition, indices) in indices.into_iter().enumerate() {
+            if indices.is_empty() {
+                continue;
+            }
+            let indices: PrimitiveArray<UInt32Type> = indices.into();
+            let columns = take_arrays(batch.columns(), &indices, None)?;
+            let options = RecordBatchOptions::new().with_row_count(Some(indices.len()));
+            output.push((
+                partition,
+                RecordBatch::try_new_with_options(batch.schema(), columns, &options)?,
+            ));
+        }
+        Ok(output)
+    }
+}
+
 /// A Spark-compatible row-level round-robin repartition.
 ///
 /// DataFusion's `RoundRobinBatch` repartitioning rotates whole `RecordBatch` values.
@@ -376,48 +426,21 @@ async fn pull_round_robin_input(
     senders: &mut [RoundRobinSender],
 ) -> Result<()> {
     let mut stream = input.execute(input_partition, context)?;
-    let mut next_partition = input_partition * target_partitions / input_partitions;
+    let mut partitioner = RowRoundRobinBatchPartitioner::try_new(
+        target_partitions,
+        input_partition,
+        input_partitions,
+    )?;
     while let Some(batch) = stream.next().await {
         let batch = batch?;
         if batch.num_rows() == 0 {
             continue;
         }
-        for (partition, batch) in
-            split_round_robin_batch(batch, &mut next_partition, target_partitions)?
-        {
+        for (partition, batch) in partitioner.partition(batch)? {
             let _ = senders[partition].send(Ok(batch)).await;
         }
     }
     Ok(())
-}
-
-fn split_round_robin_batch(
-    batch: RecordBatch,
-    next_partition: &mut usize,
-    target_partitions: usize,
-) -> Result<Vec<(usize, RecordBatch)>> {
-    let mut indices = vec![Vec::new(); target_partitions];
-    for row in 0..batch.num_rows() {
-        let row = u32::try_from(row)
-            .map_err(|_| DataFusionError::Execution("record batch has too many rows".into()))?;
-        indices[*next_partition].push(row);
-        *next_partition = (*next_partition + 1) % target_partitions;
-    }
-
-    let mut output = Vec::new();
-    for (partition, indices) in indices.into_iter().enumerate() {
-        if indices.is_empty() {
-            continue;
-        }
-        let indices: PrimitiveArray<UInt32Type> = indices.into();
-        let columns = take_arrays(batch.columns(), &indices, None)?;
-        let options = RecordBatchOptions::new().with_row_count(Some(indices.len()));
-        output.push((
-            partition,
-            RecordBatch::try_new_with_options(batch.schema(), columns, &options)?,
-        ));
-    }
-    Ok(output)
 }
 
 async fn send_round_robin_error(senders: &mut [RoundRobinSender], error: DataFusionError) {

--- a/crates/sail-physical-plan/src/repartition.rs
+++ b/crates/sail-physical-plan/src/repartition.rs
@@ -1,26 +1,39 @@
 use std::any::Any;
+use std::ops::Range;
+use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
-use datafusion::physical_expr::Partitioning;
+use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
 use datafusion::physical_plan::execution_plan::{
     CardinalityEffect, EvaluationType, SchedulingType,
 };
 use datafusion::physical_plan::{
-    DisplayAs, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+    RecordBatchStream,
 };
-use datafusion_common::{internal_err, plan_err, Result, Statistics};
+use datafusion_common::{exec_err, internal_err, plan_err, Result, Statistics};
+use futures::{Stream, StreamExt};
+pub use sail_logical_plan::repartition::ExplicitRepartitionKind;
 
 /// A physical plan node for explicit repartitioning in the query.
 /// This is a placeholder node that should be rewritten during physical optimization.
 #[derive(Debug)]
 pub struct ExplicitRepartitionExec {
     input: Arc<dyn ExecutionPlan>,
+    kind: ExplicitRepartitionKind,
     properties: Arc<PlanProperties>,
 }
 
 impl ExplicitRepartitionExec {
-    pub fn new(input: Arc<dyn ExecutionPlan>, partitioning: Partitioning) -> Self {
+    pub fn new(
+        input: Arc<dyn ExecutionPlan>,
+        partitioning: Partitioning,
+        kind: ExplicitRepartitionKind,
+    ) -> Self {
         let mut eq_properties = input.equivalence_properties().clone();
         if input.output_partitioning().partition_count() > 1 {
             eq_properties.clear_orderings();
@@ -36,11 +49,19 @@ impl ExplicitRepartitionExec {
             .with_scheduling_type(SchedulingType::Cooperative)
             .with_evaluation_type(EvaluationType::Eager),
         );
-        Self { input, properties }
+        Self {
+            input,
+            kind,
+            properties,
+        }
     }
 
     pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
         &self.input
+    }
+
+    pub fn kind(&self) -> ExplicitRepartitionKind {
+        self.kind
     }
 }
 
@@ -50,7 +71,7 @@ impl DisplayAs for ExplicitRepartitionExec {
         _t: datafusion::physical_plan::DisplayFormatType,
         f: &mut std::fmt::Formatter,
     ) -> std::fmt::Result {
-        write!(f, "{}", Self::static_name())
+        write!(f, "{}: kind={:?}", Self::static_name(), self.kind)
     }
 }
 
@@ -85,6 +106,7 @@ impl ExecutionPlan for ExplicitRepartitionExec {
         Ok(Arc::new(ExplicitRepartitionExec::new(
             child,
             self.properties.partitioning.clone(),
+            self.kind,
         )))
     }
 
@@ -117,4 +139,188 @@ impl ExecutionPlan for ExplicitRepartitionExec {
     //   push them down since the evaluation can be potentially expensive,
     //   and the presence of explicit repartitioning indicates that the user
     //   wants to evaluate these expressions after repartitioning.
+}
+
+/// A narrow, non-shuffling coalesce from M input partitions to N output partitions.
+///
+/// Each output partition reads a contiguous group of input partitions. This matches the
+/// important Spark `DataFrame.coalesce(n)` contract: reducing partitions does not shuffle
+/// records, while requesting more partitions than the input has is a no-op.
+#[derive(Debug)]
+pub struct NarrowCoalesceExec {
+    input: Arc<dyn ExecutionPlan>,
+    target_partitions: usize,
+    properties: Arc<PlanProperties>,
+}
+
+impl NarrowCoalesceExec {
+    pub fn try_new(input: Arc<dyn ExecutionPlan>, target_partitions: usize) -> Result<Self> {
+        if target_partitions == 0 {
+            return plan_err!("number of coalesce partitions cannot be zero");
+        }
+        let input_partitions = input.output_partitioning().partition_count();
+        let target_partitions = target_partitions.min(input_partitions);
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(input.schema()),
+            Partitioning::UnknownPartitioning(target_partitions),
+            input.pipeline_behavior(),
+            input.boundedness(),
+        ));
+        Ok(Self {
+            input,
+            target_partitions,
+            properties,
+        })
+    }
+
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
+    pub fn target_partitions(&self) -> usize {
+        self.target_partitions
+    }
+
+    fn input_partition_range(&self, output_partition: usize) -> Range<usize> {
+        let input_partitions = self.input.output_partitioning().partition_count();
+        let start = output_partition * input_partitions / self.target_partitions;
+        let end = (output_partition + 1) * input_partitions / self.target_partitions;
+        start..end
+    }
+}
+
+impl DisplayAs for NarrowCoalesceExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "NarrowCoalesceExec: target_partitions={}",
+            self.target_partitions
+        )
+    }
+}
+
+impl ExecutionPlan for NarrowCoalesceExec {
+    fn name(&self) -> &str {
+        Self::static_name()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        vec![false]
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let (Some(child), true) = (children.pop(), children.is_empty()) else {
+            return plan_err!("{} expects exactly one child", self.name());
+        };
+        Ok(Arc::new(Self::try_new(child, self.target_partitions)?))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        if partition >= self.target_partitions {
+            return exec_err!(
+                "{}: partition index {} out of range ({})",
+                self.name(),
+                partition,
+                self.target_partitions
+            );
+        }
+        Ok(Box::pin(NarrowCoalesceStream::new(
+            self.input.clone(),
+            self.input_partition_range(partition),
+            context,
+            self.schema(),
+        )))
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+        if partition.is_none() {
+            self.input.partition_statistics(None)
+        } else {
+            Ok(Statistics::new_unknown(&self.schema()))
+        }
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::Equal
+    }
+}
+
+struct NarrowCoalesceStream {
+    input: Arc<dyn ExecutionPlan>,
+    input_partitions: Range<usize>,
+    context: Arc<TaskContext>,
+    schema: SchemaRef,
+    current: Option<SendableRecordBatchStream>,
+}
+
+impl NarrowCoalesceStream {
+    fn new(
+        input: Arc<dyn ExecutionPlan>,
+        input_partitions: Range<usize>,
+        context: Arc<TaskContext>,
+        schema: SchemaRef,
+    ) -> Self {
+        Self {
+            input,
+            input_partitions,
+            context,
+            schema,
+            current: None,
+        }
+    }
+
+    fn poll_current(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<RecordBatch>>> {
+        loop {
+            if self.current.is_none() {
+                let Some(input_partition) = self.input_partitions.next() else {
+                    return Poll::Ready(None);
+                };
+                match self.input.execute(input_partition, self.context.clone()) {
+                    Ok(stream) => self.current = Some(stream),
+                    Err(error) => return Poll::Ready(Some(Err(error))),
+                }
+            }
+            let stream = self.current.as_mut().expect("stream is initialized");
+            match stream.poll_next_unpin(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Some(batch)) => return Poll::Ready(Some(batch)),
+                Poll::Ready(None) => {
+                    self.current = None;
+                }
+            }
+        }
+    }
+}
+
+impl Stream for NarrowCoalesceStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.poll_current(cx)
+    }
+}
+
+impl RecordBatchStream for NarrowCoalesceStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
 }

--- a/crates/sail-physical-plan/src/repartition.rs
+++ b/crates/sail-physical-plan/src/repartition.rs
@@ -19,8 +19,8 @@ use datafusion::physical_plan::{
 };
 use datafusion_common::{exec_err, internal_err, plan_err, DataFusionError, Result, Statistics};
 use datafusion_common_runtime::SpawnedTask;
-use futures::channel::mpsc::{self, Receiver, Sender};
-use futures::{SinkExt, Stream, StreamExt};
+use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
+use futures::{Stream, StreamExt};
 pub use sail_logical_plan::repartition::ExplicitRepartitionKind;
 
 /// A physical plan node for explicit repartitioning in the query.
@@ -145,8 +145,8 @@ impl ExecutionPlan for ExplicitRepartitionExec {
     //   wants to evaluate these expressions after repartitioning.
 }
 
-type RoundRobinSender = Sender<Result<RecordBatch>>;
-type RoundRobinReceiver = Receiver<Result<RecordBatch>>;
+type RoundRobinSender = UnboundedSender<Result<RecordBatch>>;
+type RoundRobinReceiver = UnboundedReceiver<Result<RecordBatch>>;
 
 /// Partitions record batches using Spark-compatible row-level round-robin.
 pub struct RowRoundRobinBatchPartitioner {
@@ -255,16 +255,15 @@ impl RoundRobinRepartitionExec {
             return Ok(());
         }
 
-        let queue_size = self.target_partitions.max(1);
-        let (senders, receivers): (Vec<_>, Vec<_>) = (0..self.target_partitions)
-            .map(|_| mpsc::channel(queue_size))
-            .unzip();
+        // Consumers such as global sort may not poll all output partitions concurrently.
+        let (senders, receivers): (Vec<_>, Vec<_>) =
+            (0..self.target_partitions).map(|_| unbounded()).unzip();
         let input_partitions = self.input.output_partitioning().partition_count();
         let mut tasks = Vec::with_capacity(input_partitions);
         for input_partition in 0..input_partitions {
             let input = self.input.clone();
             let context = context.clone();
-            let mut task_senders = senders.clone();
+            let task_senders = senders.clone();
             let target_partitions = self.target_partitions;
             tasks.push(SpawnedTask::spawn(async move {
                 if let Err(error) = pull_round_robin_input(
@@ -273,17 +272,17 @@ impl RoundRobinRepartitionExec {
                     input_partitions,
                     target_partitions,
                     context,
-                    &mut task_senders,
+                    &task_senders,
                 )
                 .await
                 {
-                    send_round_robin_error(&mut task_senders, error).await;
+                    send_round_robin_error(&task_senders, error);
                 }
             }));
         }
 
         state.receivers = Some(receivers.into_iter().map(Some).collect());
-        state.tasks = tasks;
+        state.tasks = Some(Arc::new(tasks));
         Ok(())
     }
 }
@@ -367,9 +366,13 @@ impl ExecutionPlan for RoundRobinRepartitionExec {
                     partition
                 ))
             })?;
+        let tasks = state.tasks.as_ref().cloned().ok_or_else(|| {
+            DataFusionError::Execution(format!("{}: input tasks were not initialized", self.name()))
+        })?;
         Ok(Box::pin(RoundRobinPartitionStream::new(
             self.schema(),
             receiver,
+            tasks,
         )))
     }
 
@@ -389,17 +392,27 @@ impl ExecutionPlan for RoundRobinRepartitionExec {
 #[derive(Default)]
 struct RoundRobinRepartitionState {
     receivers: Option<Vec<Option<RoundRobinReceiver>>>,
-    tasks: Vec<SpawnedTask<()>>,
+    tasks: Option<Arc<Vec<SpawnedTask<()>>>>,
 }
 
 struct RoundRobinPartitionStream {
     schema: SchemaRef,
     receiver: RoundRobinReceiver,
+    // Keep producer tasks alive even if the plan node is dropped after streams are created.
+    _tasks: Arc<Vec<SpawnedTask<()>>>,
 }
 
 impl RoundRobinPartitionStream {
-    fn new(schema: SchemaRef, receiver: RoundRobinReceiver) -> Self {
-        Self { schema, receiver }
+    fn new(
+        schema: SchemaRef,
+        receiver: RoundRobinReceiver,
+        tasks: Arc<Vec<SpawnedTask<()>>>,
+    ) -> Self {
+        Self {
+            schema,
+            receiver,
+            _tasks: tasks,
+        }
     }
 }
 
@@ -423,7 +436,7 @@ async fn pull_round_robin_input(
     input_partitions: usize,
     target_partitions: usize,
     context: Arc<TaskContext>,
-    senders: &mut [RoundRobinSender],
+    senders: &[RoundRobinSender],
 ) -> Result<()> {
     let mut stream = input.execute(input_partition, context)?;
     let mut partitioner = RowRoundRobinBatchPartitioner::try_new(
@@ -437,18 +450,16 @@ async fn pull_round_robin_input(
             continue;
         }
         for (partition, batch) in partitioner.partition(batch)? {
-            let _ = senders[partition].send(Ok(batch)).await;
+            let _ = senders[partition].unbounded_send(Ok(batch));
         }
     }
     Ok(())
 }
 
-async fn send_round_robin_error(senders: &mut [RoundRobinSender], error: DataFusionError) {
+fn send_round_robin_error(senders: &[RoundRobinSender], error: DataFusionError) {
     let message = error.to_string();
     for sender in senders {
-        let _ = sender
-            .send(Err(DataFusionError::Execution(message.clone())))
-            .await;
+        let _ = sender.unbounded_send(Err(DataFusionError::Execution(message.clone())));
     }
 }
 

--- a/crates/sail-physical-plan/src/repartition.rs
+++ b/crates/sail-physical-plan/src/repartition.rs
@@ -1,11 +1,13 @@
 use std::any::Any;
 use std::ops::Range;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
-use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::arrow::array::PrimitiveArray;
+use datafusion::arrow::compute::take_arrays;
+use datafusion::arrow::datatypes::{SchemaRef, UInt32Type};
+use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_expr::{EquivalenceProperties, Partitioning};
 use datafusion::physical_plan::execution_plan::{
@@ -15,8 +17,10 @@ use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
     RecordBatchStream,
 };
-use datafusion_common::{exec_err, internal_err, plan_err, Result, Statistics};
-use futures::{Stream, StreamExt};
+use datafusion_common::{exec_err, internal_err, plan_err, DataFusionError, Result, Statistics};
+use datafusion_common_runtime::SpawnedTask;
+use futures::channel::mpsc::{self, Receiver, Sender};
+use futures::{SinkExt, Stream, StreamExt};
 pub use sail_logical_plan::repartition::ExplicitRepartitionKind;
 
 /// A physical plan node for explicit repartitioning in the query.
@@ -139,6 +143,290 @@ impl ExecutionPlan for ExplicitRepartitionExec {
     //   push them down since the evaluation can be potentially expensive,
     //   and the presence of explicit repartitioning indicates that the user
     //   wants to evaluate these expressions after repartitioning.
+}
+
+type RoundRobinSender = Sender<Result<RecordBatch>>;
+type RoundRobinReceiver = Receiver<Result<RecordBatch>>;
+
+/// A Spark-compatible row-level round-robin repartition.
+///
+/// DataFusion's `RoundRobinBatch` repartitioning rotates whole `RecordBatch` values.
+/// Spark's `DataFrame.repartition(n)` rotates rows, so a single large input batch can
+/// still populate all requested output partitions.
+pub struct RoundRobinRepartitionExec {
+    input: Arc<dyn ExecutionPlan>,
+    target_partitions: usize,
+    state: Arc<Mutex<RoundRobinRepartitionState>>,
+    properties: Arc<PlanProperties>,
+}
+
+impl RoundRobinRepartitionExec {
+    pub fn try_new(input: Arc<dyn ExecutionPlan>, target_partitions: usize) -> Result<Self> {
+        if target_partitions == 0 {
+            return plan_err!("number of round-robin partitions cannot be zero");
+        }
+        let mut eq_properties = input.equivalence_properties().clone();
+        eq_properties.clear_orderings();
+        if input.output_partitioning().partition_count() > 1 {
+            eq_properties.clear_per_partition_constants();
+        }
+        let properties = Arc::new(
+            PlanProperties::new(
+                eq_properties,
+                Partitioning::RoundRobinBatch(target_partitions),
+                input.pipeline_behavior(),
+                input.boundedness(),
+            )
+            .with_scheduling_type(SchedulingType::Cooperative)
+            .with_evaluation_type(EvaluationType::Eager),
+        );
+        Ok(Self {
+            input,
+            target_partitions,
+            state: Arc::new(Mutex::new(RoundRobinRepartitionState::default())),
+            properties,
+        })
+    }
+
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
+    pub fn target_partitions(&self) -> usize {
+        self.target_partitions
+    }
+
+    fn initialize(
+        &self,
+        state: &mut RoundRobinRepartitionState,
+        context: Arc<TaskContext>,
+    ) -> Result<()> {
+        if state.receivers.is_some() {
+            return Ok(());
+        }
+
+        let queue_size = self.target_partitions.max(1);
+        let (senders, receivers): (Vec<_>, Vec<_>) = (0..self.target_partitions)
+            .map(|_| mpsc::channel(queue_size))
+            .unzip();
+        let input_partitions = self.input.output_partitioning().partition_count();
+        let mut tasks = Vec::with_capacity(input_partitions);
+        for input_partition in 0..input_partitions {
+            let input = self.input.clone();
+            let context = context.clone();
+            let mut task_senders = senders.clone();
+            let target_partitions = self.target_partitions;
+            tasks.push(SpawnedTask::spawn(async move {
+                if let Err(error) = pull_round_robin_input(
+                    input,
+                    input_partition,
+                    input_partitions,
+                    target_partitions,
+                    context,
+                    &mut task_senders,
+                )
+                .await
+                {
+                    send_round_robin_error(&mut task_senders, error).await;
+                }
+            }));
+        }
+
+        state.receivers = Some(receivers.into_iter().map(Some).collect());
+        state.tasks = tasks;
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for RoundRobinRepartitionExec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RoundRobinRepartitionExec")
+            .field("target_partitions", &self.target_partitions)
+            .finish()
+    }
+}
+
+impl DisplayAs for RoundRobinRepartitionExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "RoundRobinRepartitionExec: target_partitions={}",
+            self.target_partitions
+        )
+    }
+}
+
+impl ExecutionPlan for RoundRobinRepartitionExec {
+    fn name(&self) -> &str {
+        Self::static_name()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        vec![false]
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let (Some(child), true) = (children.pop(), children.is_empty()) else {
+            return plan_err!("{} expects exactly one child", self.name());
+        };
+        Ok(Arc::new(Self::try_new(child, self.target_partitions)?))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        if partition >= self.target_partitions {
+            return exec_err!(
+                "{}: partition index {} out of range ({})",
+                self.name(),
+                partition,
+                self.target_partitions
+            );
+        }
+
+        let mut state = self.state.lock().map_err(|_| {
+            DataFusionError::Execution(format!("{} state lock was poisoned", self.name()))
+        })?;
+        self.initialize(&mut state, context)?;
+        let receiver = state
+            .receivers
+            .as_mut()
+            .and_then(|receivers| receivers.get_mut(partition))
+            .and_then(Option::take)
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!(
+                    "{}: partition {} has already been executed",
+                    self.name(),
+                    partition
+                ))
+            })?;
+        Ok(Box::pin(RoundRobinPartitionStream::new(
+            self.schema(),
+            receiver,
+        )))
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Statistics> {
+        if partition.is_none() {
+            self.input.partition_statistics(None)
+        } else {
+            Ok(Statistics::new_unknown(&self.schema()))
+        }
+    }
+
+    fn cardinality_effect(&self) -> CardinalityEffect {
+        CardinalityEffect::Equal
+    }
+}
+
+#[derive(Default)]
+struct RoundRobinRepartitionState {
+    receivers: Option<Vec<Option<RoundRobinReceiver>>>,
+    tasks: Vec<SpawnedTask<()>>,
+}
+
+struct RoundRobinPartitionStream {
+    schema: SchemaRef,
+    receiver: RoundRobinReceiver,
+}
+
+impl RoundRobinPartitionStream {
+    fn new(schema: SchemaRef, receiver: RoundRobinReceiver) -> Self {
+        Self { schema, receiver }
+    }
+}
+
+impl Stream for RoundRobinPartitionStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.receiver.poll_next_unpin(cx)
+    }
+}
+
+impl RecordBatchStream for RoundRobinPartitionStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+async fn pull_round_robin_input(
+    input: Arc<dyn ExecutionPlan>,
+    input_partition: usize,
+    input_partitions: usize,
+    target_partitions: usize,
+    context: Arc<TaskContext>,
+    senders: &mut [RoundRobinSender],
+) -> Result<()> {
+    let mut stream = input.execute(input_partition, context)?;
+    let mut next_partition = input_partition * target_partitions / input_partitions;
+    while let Some(batch) = stream.next().await {
+        let batch = batch?;
+        if batch.num_rows() == 0 {
+            continue;
+        }
+        for (partition, batch) in
+            split_round_robin_batch(batch, &mut next_partition, target_partitions)?
+        {
+            let _ = senders[partition].send(Ok(batch)).await;
+        }
+    }
+    Ok(())
+}
+
+fn split_round_robin_batch(
+    batch: RecordBatch,
+    next_partition: &mut usize,
+    target_partitions: usize,
+) -> Result<Vec<(usize, RecordBatch)>> {
+    let mut indices = vec![Vec::new(); target_partitions];
+    for row in 0..batch.num_rows() {
+        let row = u32::try_from(row)
+            .map_err(|_| DataFusionError::Execution("record batch has too many rows".into()))?;
+        indices[*next_partition].push(row);
+        *next_partition = (*next_partition + 1) % target_partitions;
+    }
+
+    let mut output = Vec::new();
+    for (partition, indices) in indices.into_iter().enumerate() {
+        if indices.is_empty() {
+            continue;
+        }
+        let indices: PrimitiveArray<UInt32Type> = indices.into();
+        let columns = take_arrays(batch.columns(), &indices, None)?;
+        let options = RecordBatchOptions::new().with_row_count(Some(indices.len()));
+        output.push((
+            partition,
+            RecordBatch::try_new_with_options(batch.schema(), columns, &options)?,
+        ));
+    }
+    Ok(output)
+}
+
+async fn send_round_robin_error(senders: &mut [RoundRobinSender], error: DataFusionError) {
+    let message = error.to_string();
+    for sender in senders {
+        let _ = sender
+            .send(Err(DataFusionError::Execution(message.clone())))
+            .await;
+    }
 }
 
 /// A narrow, non-shuffling coalesce from M input partitions to N output partitions.
@@ -299,7 +587,9 @@ impl NarrowCoalesceStream {
                     Err(error) => return Poll::Ready(Some(Err(error))),
                 }
             }
-            let stream = self.current.as_mut().expect("stream is initialized");
+            let Some(stream) = self.current.as_mut() else {
+                continue;
+            };
             match stream.poll_next_unpin(cx) {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(Some(batch)) => return Poll::Ready(Some(batch)),

--- a/crates/sail-physical-plan/src/spark_partition_id.rs
+++ b/crates/sail-physical-plan/src/spark_partition_id.rs
@@ -106,6 +106,12 @@ impl ExecutionPlan for SparkPartitionIdExec {
         )?))
     }
 
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        // `spark_partition_id()` is user-visible and must observe the input partition
+        // numbering, so the optimizer must not add automatic repartitioning below it.
+        vec![false]
+    }
+
     fn execute(
         &self,
         partition: usize,

--- a/crates/sail-plan/src/function/scalar/conditional.rs
+++ b/crates/sail-plan/src/function/scalar/conditional.rs
@@ -1,8 +1,9 @@
 use arrow::datatypes::DataType;
 use datafusion::functions::expr_fn;
 use datafusion_common::ScalarValue;
-use datafusion_expr::{expr, lit, ExprSchemable};
+use datafusion_expr::{expr, lit, ExprSchemable, ScalarUDF};
 use sail_common_datafusion::utils::items::ItemTaker;
+use sail_function::scalar::spark_to_string::SparkToUtf8;
 
 use crate::error::PlanResult;
 use crate::function::common::{ScalarFunction, ScalarFunctionInput};
@@ -36,11 +37,54 @@ fn if_expr(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     }))
 }
 
+fn coalesce(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
+    let ScalarFunctionInput {
+        arguments,
+        function_context,
+    } = input;
+    let data_types = arguments
+        .iter()
+        .map(|arg| arg.get_type(function_context.schema))
+        .collect::<Result<Vec<_>, _>>()?;
+    let has_string = data_types.iter().any(is_string_type);
+    let has_temporal = data_types.iter().any(is_temporal_type);
+    let arguments = if has_string && has_temporal {
+        arguments
+            .into_iter()
+            .zip(data_types)
+            .map(|(arg, data_type)| {
+                if is_temporal_type(&data_type) {
+                    ScalarUDF::from(SparkToUtf8::new()).call(vec![arg])
+                } else {
+                    arg
+                }
+            })
+            .collect()
+    } else {
+        arguments
+    };
+    Ok(expr_fn::coalesce(arguments))
+}
+
+fn is_string_type(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
+    )
+}
+
+fn is_temporal_type(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Date32 | DataType::Date64 | DataType::Timestamp(_, _)
+    )
+}
+
 pub(super) fn list_built_in_conditional_functions() -> Vec<(&'static str, ScalarFunction)> {
     use crate::function::common::ScalarFunctionBuilder as F;
 
     vec![
-        ("coalesce", F::var_arg(expr_fn::coalesce)),
+        ("coalesce", F::custom(coalesce)),
         ("if", F::custom(if_expr)),
         ("ifnull", F::binary(expr_fn::nvl)),
         ("nanvl", F::binary(expr_fn::nanvl)),

--- a/crates/sail-plan/src/resolver/query/mod.rs
+++ b/crates/sail-plan/src/resolver/query/mod.rs
@@ -137,10 +137,9 @@ impl PlanResolver<'_> {
             QueryNode::Repartition {
                 input,
                 num_partitions,
-                // TODO: avoid unnecessary repartition if `shuffle` is false
-                shuffle: _,
+                shuffle,
             } => {
-                self.resolve_query_repartition(*input, num_partitions, state)
+                self.resolve_query_repartition(*input, num_partitions, shuffle, state)
                     .await?
             }
             QueryNode::ToDf {

--- a/crates/sail-plan/src/resolver/query/repartition.rs
+++ b/crates/sail-plan/src/resolver/query/repartition.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use datafusion_expr::{col, Extension, LogicalPlan};
+use datafusion_expr::{Extension, LogicalPlan};
 use sail_common::spec;
-use sail_logical_plan::repartition::ExplicitRepartitionNode;
+use sail_logical_plan::repartition::{ExplicitRepartitionKind, ExplicitRepartitionNode};
 
 use crate::error::PlanResult;
 use crate::resolver::state::PlanResolverState;
@@ -13,17 +13,23 @@ impl PlanResolver<'_> {
         &self,
         input: spec::QueryPlan,
         num_partitions: usize,
+        shuffle: bool,
         state: &mut PlanResolverState,
     ) -> PlanResult<LogicalPlan> {
         let input = self
             .resolve_query_plan_with_hidden_fields(input, state)
             .await?;
-        let expr = input.schema().columns().into_iter().map(col).collect();
+        let kind = if shuffle {
+            ExplicitRepartitionKind::RoundRobin
+        } else {
+            ExplicitRepartitionKind::Coalesce
+        };
         Ok(LogicalPlan::Extension(Extension {
             node: Arc::new(ExplicitRepartitionNode::new(
                 Arc::new(input),
                 Some(num_partitions),
-                expr,
+                vec![],
+                kind,
             )),
         }))
     }
@@ -47,6 +53,7 @@ impl PlanResolver<'_> {
                 Arc::new(input),
                 num_partitions,
                 expr,
+                ExplicitRepartitionKind::Hash,
             )),
         }))
     }

--- a/crates/sail-session/src/planner.rs
+++ b/crates/sail-session/src/planner.rs
@@ -28,7 +28,7 @@ use sail_logical_plan::map_partitions::MapPartitionsNode;
 use sail_logical_plan::merge::MergeIntoNode;
 use sail_logical_plan::monotonic_id::MonotonicIdNode;
 use sail_logical_plan::range::RangeNode;
-use sail_logical_plan::repartition::ExplicitRepartitionNode;
+use sail_logical_plan::repartition::{ExplicitRepartitionKind, ExplicitRepartitionNode};
 use sail_logical_plan::schema_pivot::SchemaPivotNode;
 use sail_logical_plan::show_string::ShowStringNode;
 use sail_logical_plan::sort::SortWithinPartitionsNode;
@@ -257,9 +257,14 @@ Ensure expand_row_level_op is enabled; MERGE is currently only supported for lak
                 input.as_ref(),
                 node.num_partitions(),
                 node.partitioning_expressions(),
+                node.kind(),
                 session_state,
             )?;
-            Arc::new(ExplicitRepartitionExec::new(input.clone(), partitioning))
+            Arc::new(ExplicitRepartitionExec::new(
+                input.clone(),
+                partitioning,
+                node.kind(),
+            ))
         } else if node.as_any().is::<StreamSourceAdapterNode>() {
             let [input] = physical_inputs else {
                 return internal_err!("StreamSourceExec requires exactly one physical input");
@@ -338,12 +343,37 @@ fn plan_explicit_partitioning(
     input: &dyn ExecutionPlan,
     num_partitions: Option<usize>,
     expressions: &[Expr],
+    kind: ExplicitRepartitionKind,
     session_state: &SessionState,
 ) -> datafusion_common::Result<Partitioning> {
-    match (num_partitions, expressions) {
-        (Some(0), _) => internal_err!("number of explicit partitions cannot be zero"),
-        (Some(1), _) => Ok(Partitioning::UnknownPartitioning(1)),
-        (Some(_) | None, expressions) => {
+    match kind {
+        ExplicitRepartitionKind::Coalesce => {
+            let Some(num_partitions) = num_partitions else {
+                return internal_err!("coalesce requires an explicit partition count");
+            };
+            if num_partitions == 0 {
+                return internal_err!("number of explicit partitions cannot be zero");
+            }
+            let input_partitions = input.properties().output_partitioning().partition_count();
+            Ok(Partitioning::UnknownPartitioning(
+                num_partitions.min(input_partitions),
+            ))
+        }
+        ExplicitRepartitionKind::RoundRobin => {
+            let Some(num_partitions) = num_partitions else {
+                return internal_err!(
+                    "round-robin repartition requires an explicit partition count"
+                );
+            };
+            if num_partitions == 0 {
+                return internal_err!("number of explicit partitions cannot be zero");
+            }
+            Ok(Partitioning::RoundRobinBatch(num_partitions))
+        }
+        ExplicitRepartitionKind::Hash => {
+            if matches!(num_partitions, Some(0)) {
+                return internal_err!("number of explicit partitions cannot be zero");
+            }
             if expressions.is_empty() {
                 return internal_err!(
                     "explicit repartitioning requires at least one partitioning expression"

--- a/python/pysail/tests/spark/function/features/coalesce.feature
+++ b/python/pysail/tests/spark/function/features/coalesce.feature
@@ -1,0 +1,108 @@
+Feature: coalesce returns the first non-null argument
+
+  Rule: Spark-compatible coercion for mixed string and temporal arguments
+
+    Scenario: Coalesce null string column falls back to date column as string
+      When query
+      """
+      WITH t(string_col, date_col) AS (
+        SELECT CAST(NULL AS STRING), DATE '2024-01-15'
+      )
+      SELECT
+        coalesce(string_col, date_col) AS result,
+        typeof(coalesce(string_col, date_col)) AS result_type
+      FROM t
+      """
+      Then query result
+      | result     | result_type |
+      | 2024-01-15 | string      |
+
+    Scenario: Coalesce null string column falls back to timestamp column as string
+      When query
+      """
+      WITH t(string_col, timestamp_col) AS (
+        SELECT CAST(NULL AS STRING), TIMESTAMP '2024-01-15 10:30:00'
+      )
+      SELECT
+        coalesce(string_col, timestamp_col) AS result,
+        typeof(coalesce(string_col, timestamp_col)) AS result_type
+      FROM t
+      """
+      Then query result
+      | result              | result_type |
+      | 2024-01-15 10:30:00 | string      |
+
+    Scenario: Coalesce string literal before a date column wins without temporal casting
+      When query
+      """
+      WITH t(date_col) AS (
+        SELECT DATE '2024-01-15'
+      )
+      SELECT
+        coalesce('default', date_col) AS result,
+        typeof(coalesce('default', date_col)) AS result_type
+      FROM t
+      """
+      Then query result
+      | result  | result_type |
+      | default | string      |
+
+    Scenario: Coalesce non-null string column before a date column wins without temporal casting
+      When query
+      """
+      WITH t(string_col, date_col) AS (
+        SELECT CAST('hello' AS STRING), DATE '2024-01-15'
+      )
+      SELECT
+        coalesce(string_col, date_col) AS result,
+        typeof(coalesce(string_col, date_col)) AS result_type
+      FROM t
+      """
+      Then query result
+      | result | result_type |
+      | hello  | string      |
+
+    Scenario: Coalesce date column before a string column returns a string value
+      When query
+      """
+      WITH t(date_col, string_col) AS (
+        SELECT DATE '2024-01-15', CAST('fallback' AS STRING)
+      )
+      SELECT
+        coalesce(date_col, string_col) AS result,
+        typeof(coalesce(date_col, string_col)) AS result_type
+      FROM t
+      """
+      Then query result
+      | result     | result_type |
+      | 2024-01-15 | string      |
+
+    Scenario: Coalesce multiple mixed temporal arguments still coerces to string
+      When query
+      """
+      SELECT
+        coalesce(
+          CAST(NULL AS STRING),
+          CAST(NULL AS DATE),
+          TIMESTAMP '2024-01-15 10:30:00'
+        ) AS result,
+        typeof(coalesce(
+          CAST(NULL AS STRING),
+          CAST(NULL AS DATE),
+          TIMESTAMP '2024-01-15 10:30:00'
+        )) AS result_type
+      """
+      Then query result
+      | result              | result_type |
+      | 2024-01-15 10:30:00 | string      |
+
+    Scenario: Coalesce all-null mixed string and date arguments returns null with string type
+      When query
+      """
+      SELECT
+        coalesce(CAST(NULL AS STRING), CAST(NULL AS DATE)) AS result,
+        typeof(coalesce(CAST(NULL AS STRING), CAST(NULL AS DATE))) AS result_type
+      """
+      Then query result
+      | result | result_type |
+      | NULL   | string      |

--- a/python/pysail/tests/spark/test_datetime.py
+++ b/python/pysail/tests/spark/test_datetime.py
@@ -1,9 +1,9 @@
 import platform
 from datetime import date, datetime, timezone
 
-import pytest
 import pyspark.sql.functions as F  # noqa: N812
-import pyspark.sql.types as T
+import pyspark.sql.types as T  # noqa: N812
+import pytest
 from pyspark.sql.types import Row
 
 from pysail.testing.spark.utils.sql import strict

--- a/python/pysail/tests/spark/test_datetime.py
+++ b/python/pysail/tests/spark/test_datetime.py
@@ -1,8 +1,9 @@
 import platform
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 import pytest
-from pyspark.sql.functions import lit
+import pyspark.sql.functions as F  # noqa: N812
+import pyspark.sql.types as T
 from pyspark.sql.types import Row
 
 from pysail.testing.spark.utils.sql import strict
@@ -44,4 +45,37 @@ from pysail.testing.spark.utils.sql import strict
 @pytest.mark.skipif(platform.system() == "Windows", reason="`time.tzset()` is not available on Windows")
 def test_datetime_literal(spark, session_timezone, local_timezone, data):  # noqa: ARG001
     for dt, k, v in data:
-        assert spark.range(1).select(lit(dt)).collect() == [strict(Row(**{f"TIMESTAMP '{k}'": v}))]
+        assert spark.range(1).select(F.lit(dt)).collect() == [strict(Row(**{f"TIMESTAMP '{k}'": v}))]
+
+
+def test_coalesce_mixed_string_temporal(spark):
+    date_schema = T.StructType(
+        [
+            T.StructField("string_col", T.StringType(), True),
+            T.StructField("date_col", T.DateType(), True),
+        ]
+    )
+    date_df = spark.createDataFrame([(None, date(2024, 1, 15))], date_schema)
+    date_result = date_df.select(F.coalesce(F.col("string_col"), F.col("date_col")).alias("c"))
+    assert date_result.schema.simpleString() == "struct<c:string>"
+    assert date_result.collect() == [Row(c="2024-01-15")]
+
+    timestamp_schema = T.StructType(
+        [
+            T.StructField("string_col", T.StringType(), True),
+            T.StructField("timestamp_col", T.TimestampType(), True),
+        ]
+    )
+    timestamp_df = spark.createDataFrame(
+        [(None, datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc))], timestamp_schema
+    )
+    timestamp_result = timestamp_df.select(F.coalesce(F.col("string_col"), F.col("timestamp_col")).alias("c"))
+    assert timestamp_result.schema.simpleString() == "struct<c:string>"
+    assert timestamp_result.collect() == [Row(c="2024-01-15 10:30:00")]
+
+    literal_df = spark.createDataFrame(
+        [(date(2024, 1, 15),)], T.StructType([T.StructField("date_col", T.DateType(), True)])
+    )
+    literal_result = literal_df.select(F.coalesce(F.lit("default"), F.col("date_col")).alias("c"))
+    assert literal_result.schema.simpleString() == "struct<c:string>"
+    assert literal_result.collect() == [Row(c="default")]

--- a/python/pysail/tests/spark/test_repartition.py
+++ b/python/pysail/tests/spark/test_repartition.py
@@ -1,5 +1,15 @@
+import io
+from contextlib import redirect_stdout
+
 import pandas as pd
 import pyspark.sql.functions as F  # noqa: N812
+
+
+def explain_string(df):
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        df.explain(True)
+    return buf.getvalue()
 
 
 def partition_count(df):
@@ -7,6 +17,11 @@ def partition_count(df):
         yield pd.DataFrame({"n": [1]})
 
     return df.mapInPandas(counter, schema="n: long").count()
+
+
+def partition_ids(df):
+    rows = df.select(F.spark_partition_id().alias("pid")).groupBy("pid").count().orderBy("pid").collect()
+    return [(row["pid"], row["count"]) for row in rows]
 
 
 def test_explicit_repartition(spark):
@@ -19,5 +34,18 @@ def test_explicit_repartition(spark):
 
 def test_explicit_coalesce(spark):
     assert partition_count(spark.range(0, 10, 1, 2).coalesce(1)) == 1
-    assert partition_count(spark.range(0, 10, 1, 2).coalesce(3)) == 3  # noqa: PLR2004
+    assert partition_count(spark.range(0, 10, 1, 2).coalesce(3)) == 2  # noqa: PLR2004
     assert partition_count(spark.range(0, 10, 1, 4).coalesce(2)) == 2  # noqa: PLR2004
+
+
+def test_spark_partition_id_observes_existing_partitions(spark):
+    assert partition_ids(spark.range(0, 10, 1, 2)) == [(0, 5), (1, 5)]
+    assert partition_ids(spark.range(0, 10, 1, 2).coalesce(1)) == [(0, 10)]
+    assert partition_ids(spark.range(0, 20, 1, 4).coalesce(2)) == [(0, 10), (1, 10)]
+
+
+def test_repartition_without_expressions_uses_round_robin(spark):
+    plan = explain_string(spark.range(0, 20, 1, 4).repartition(3))
+    assert "RoundRobin" in plan
+    assert "Hash(" not in plan
+    assert "hashpartitioning" not in plan

--- a/python/pysail/tests/spark/test_repartition.py
+++ b/python/pysail/tests/spark/test_repartition.py
@@ -49,3 +49,16 @@ def test_repartition_without_expressions_uses_round_robin(spark):
     assert "RoundRobin" in plan
     assert "Hash(" not in plan
     assert "hashpartitioning" not in plan
+
+
+def test_repartition_without_expressions_distributes_rows_round_robin(spark):
+    ids = [
+        row["pid"]
+        for row in spark.range(0, 64, 1, 9)
+        .repartition(10)
+        .select(F.spark_partition_id().alias("pid"))
+        .distinct()
+        .orderBy("pid")
+        .collect()
+    ]
+    assert ids == list(range(10))

--- a/python/pysail/tests/spark/test_repartition.py
+++ b/python/pysail/tests/spark/test_repartition.py
@@ -2,6 +2,7 @@ import io
 from contextlib import redirect_stdout
 
 import pandas as pd
+import pyarrow as pa
 import pyspark.sql.functions as F  # noqa: N812
 
 
@@ -62,3 +63,60 @@ def test_repartition_without_expressions_distributes_rows_round_robin(spark):
         .collect()
     ]
     assert ids == list(range(10))
+
+
+def test_repartition_before_global_sort_preserves_rows(spark):
+    rows = spark.range(0, 50_000).repartition(10).orderBy("id").collect()
+
+    assert len(rows) == 50_000  # noqa: PLR2004
+    assert rows[0]["id"] == 0
+    assert rows[-1]["id"] == 49_999  # noqa: PLR2004
+
+
+def test_repartition_before_python_map_udfs_preserves_rows(spark):
+    def pandas_mapper(iterator):
+        for _ in iterator:
+            yield pd.DataFrame({"value": list(range(100))})
+
+    pandas_values = {
+        row["value"] for row in spark.range(10).repartition(1).mapInPandas(pandas_mapper, "value long").collect()
+    }
+    assert pandas_values == set(range(100))
+
+    def arrow_mapper(iterator):
+        for _ in iterator:
+            yield pa.RecordBatch.from_pandas(pd.DataFrame({"value": list(range(100))}))
+
+    arrow_values = {
+        row["value"] for row in spark.range(10).repartition(1).mapInArrow(arrow_mapper, "value long").collect()
+    }
+    assert arrow_values == set(range(100))
+
+
+def test_repartition_before_grouped_pandas_udf_and_sort_preserves_groups(spark):
+    df = (
+        spark.range(2)
+        .join(spark.range(4).withColumnRenamed("id", "day"))
+        .join(spark.range(10_000).withColumnRenamed("id", "value"))
+        .repartition(10)
+    )
+
+    def count_group(pdf):
+        return pd.DataFrame(
+            {
+                "id": [pdf["id"][0]],
+                "day": [pdf["day"][0]],
+                "count": [len(pdf.index)],
+            }
+        )
+
+    rows = (
+        df.groupBy("id", "day")
+        .applyInPandas(count_group, "id long, day long, count long")
+        .orderBy("id", "day")
+        .collect()
+    )
+
+    assert [(row["id"], row["day"], row["count"]) for row in rows] == [
+        (group_id, day, 10_000) for group_id in range(2) for day in range(4)
+    ]


### PR DESCRIPTION
https://github.com/lakehq/sail/pull/1754
df.coalesce(n): no shuffle 
df.repartition(n): round robin shuffle 
df.repartition(n, exprs...): hash repartition