### PR TITLE
perf: implement preimage hook on last_day for Parquet filter pushdown

### DIFF
--- a/crates/sail-function/src/scalar/datetime/spark_last_day.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_last_day.rs
@@ -6,7 +6,12 @@ use datafusion::arrow::array::{ArrayRef, AsArray, Date32Array};
 use datafusion::arrow::datatypes::{DataType, Date32Type};
 use datafusion_common::types::NativeType;
 use datafusion_common::{exec_datafusion_err, exec_err, plan_err, Result, ScalarValue};
-use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+use datafusion_expr::preimage::PreimageResult;
+use datafusion_expr::simplify::SimplifyContext;
+use datafusion_expr::{
+    ColumnarValue, Expr, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion_expr_common::interval_arithmetic::Interval;
 
 use crate::error::{invalid_arg_count_exec_err, unsupported_data_type_exec_err};
 
@@ -104,6 +109,51 @@ impl ScalarUDFImpl for SparkLastDay {
                 "The first argument of the Spark `last_day` function can only be a date, string or timestamp, but got {}", &arg_types[0]
             )
         }
+    }
+
+    fn preimage(
+        &self,
+        args: &[Expr],
+        lit_expr: &Expr,
+        _info: &SimplifyContext,
+    ) -> Result<PreimageResult> {
+        if args.len() != 1 {
+            return Ok(PreimageResult::None);
+        }
+        let Expr::Literal(lit, _) = lit_expr else {
+            return Ok(PreimageResult::None);
+        };
+        let Some(d) = lit_as_date32(lit) else {
+            return Ok(PreimageResult::None);
+        };
+        let Some(date) = Date32Type::to_naive_date_opt(d) else {
+            return Ok(PreimageResult::None);
+        };
+        let Some(next_day) = date.checked_add_signed(Duration::days(1)) else {
+            return Ok(PreimageResult::None);
+        };
+        // If D is not the last day of any month the equality is
+        // unsatisfiable; returning a Range here would be unsound because
+        // the rewrite replaces the predicate (no outer re-filter).
+        if next_day.day() != 1 {
+            return Ok(PreimageResult::None);
+        }
+        let Some(first_of_month) = NaiveDate::from_ymd_opt(date.year(), date.month(), 1) else {
+            return Ok(PreimageResult::None);
+        };
+        let lo = ScalarValue::Date32(Some(Date32Type::from_naive_date(first_of_month)));
+        let hi = ScalarValue::Date32(Some(Date32Type::from_naive_date(next_day)));
+        Ok(PreimageResult::Range {
+            expr: args[0].clone(),
+            interval: Box::new(Interval::try_new(lo, hi)?),
+        })
+    }
+}
+
+fn lit_as_date32(v: &ScalarValue) -> Option<i32> {
+    match v {
+        ScalarValue::Date32(Some(d)) => Some(*d),
+        _ => None,
     }
 }
 

--- a/python/pysail/testing/spark/steps/plan.py
+++ b/python/pysail/testing/spark/steps/plan.py
@@ -97,6 +97,13 @@ def normalize_plan_text(plan_text: str) -> str:
         text,
         flags=re.IGNORECASE,
     )
+    # Normalize Sail default CTAS parquet filenames: <16-char random>_<partition>.<codec>.parquet
+    # Preserve partition number so multi-file plans stay distinguishable.
+    text = re.sub(
+        r"[A-Za-z0-9]{16}_(\d+)\.(zst|snappy|gzip|lz4|brotli)\.parquet",
+        r"<id>_\1.\2.parquet",
+        text,
+    )
 
     # Normalize file_groups ordering: group ordering is not guaranteed (e.g. parallel listing / async head).
     # TODO: consider sorting the file groups during planner.

--- a/python/pysail/tests/spark/function/__snapshots__/features/last_day.yaml
+++ b/python/pysail/tests/spark/function/__snapshots__/features/last_day.yaml
@@ -1,0 +1,51 @@
+# serializer version: 1
+---
+name: "test_explain_last_day_filter_on_parquet_shows_preimage_pushdown"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#1@0 as d]
+      ProjectionExec: expr=[d@0 as #1]
+        FilterExec: d@0 >= 2024-04-01 AND d@0 < 2024-05-01
+          RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+            DataSourceExec: file_groups={1 group: [[<tmp>/explain_last_day_pushdown/<id>_0.zst.parquet]]}, projection=[d], file_type=parquet, predicate=d@0 >= 2024-04-01 AND d@0 < 2024-05-01, pruning_predicate=d_null_count@1 != row_count@2 AND d_max@0 >= 2024-04-01 AND d_null_count@1 != row_count@2 AND d_min@3 < 2024-05-01, required_guarantees=[]
+---
+name: "test_explain_last_day_less_or_equal_rewrites_to_upperbound_predicate"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#1@0 as d]
+      ProjectionExec: expr=[d@0 as #1]
+        FilterExec: d@0 < 2024-05-01
+          RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+            DataSourceExec: file_groups={1 group: [[<tmp>/explain_last_day_lte/<id>_0.zst.parquet]]}, projection=[d], file_type=parquet, predicate=d@0 < 2024-05-01, pruning_predicate=d_null_count@1 != row_count@2 AND d_min@0 < 2024-05-01, required_guarantees=[]
+---
+name: "test_explain_last_day_not_equal_rewrites_to_disjunction_over_the_gap_month"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#1@0 as d]
+      ProjectionExec: expr=[d@0 as #1]
+        FilterExec: d@0 < 2024-04-01 OR d@0 >= 2024-05-01
+          RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+            DataSourceExec: file_groups={1 group: [[<tmp>/explain_last_day_neq/<id>_0.zst.parquet]]}, projection=[d], file_type=parquet, predicate=d@0 < 2024-04-01 OR d@0 >= 2024-05-01, pruning_predicate=d_null_count@1 != row_count@2 AND d_min@0 < 2024-04-01 OR d_null_count@1 != row_count@2 AND d_max@3 >= 2024-05-01, required_guarantees=[]
+---
+name: "test_explain_last_day_with_midmonth_literal_does_not_rewrite"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#1@0 as d]
+      ProjectionExec: expr=[d@0 as #1]
+        FilterExec: spark_last_day(d@0) = 2024-04-15
+          RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+            DataSourceExec: file_groups={1 group: [[<tmp>/explain_last_day_unsat/<id>_0.zst.parquet]]}, projection=[d], file_type=parquet, predicate=spark_last_day(d@0) = 2024-04-15
+---
+name: "test_explain_literal_date_filter_on_parquet__baseline"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#1@0 as d], metrics=[output_rows=<metric>, elapsed_compute=<metric>, output_bytes=<metric>, output_batches=<metric>, expr_<metric>_eval_time=<metric>], statistics=[Rows=Inexact(1), Bytes=Inexact(<bytes>), [(Col[0]: Min=Inexact(Date32("2024-03-31")) Max=Inexact(Date32("2024-05-31")) Null=Inexact(0) ScanBytes=Inexact(<bytes>))]], schema=[d:Date32;N]
+      ProjectionExec: expr=[d@0 as #1], metrics=[output_rows=<metric>, elapsed_compute=<metric>, output_bytes=<metric>, output_batches=<metric>, expr_<metric>_eval_time=<metric>], statistics=[Rows=Inexact(1), Bytes=Inexact(<bytes>), [(Col[0]: Min=Inexact(Date32("2024-03-31")) Max=Inexact(Date32("2024-05-31")) Null=Inexact(0) ScanBytes=Inexact(<bytes>))]], schema=[#1:Date32;N]
+        FilterExec: d@0 >= 2024-04-01 AND d@0 < 2024-05-01, metrics=[output_rows=<metric>, elapsed_compute=<metric>, output_bytes=<metric>, output_batches=<metric>, selectivity=<metric>], statistics=[Rows=Inexact(1), Bytes=Inexact(<bytes>), [(Col[0]: Min=Inexact(Date32("2024-03-31")) Max=Inexact(Date32("2024-05-31")) Null=Inexact(0) ScanBytes=Inexact(<bytes>))]], schema=[d:Date32;N]
+          RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1, metrics=[output_rows=<metric>, elapsed_compute=<metric>, output_bytes=<metric>, output_batches=<metric>, spill_count=<metric>, spilled_bytes=<metric>, spilled_rows=<metric>, fetch_time=<metric>, repartition_time=<metric>, send_time=<metric>], statistics=[Rows=Inexact(5), Bytes=Inexact(<bytes>), [(Col[0]: Min=Inexact(Date32("2024-03-31")) Max=Inexact(Date32("2024-05-31")) Null=Inexact(0) ScanBytes=Inexact(<bytes>))]], schema=[d:Date32;N]
+            DataSourceExec: file_groups={1 group: [[<tmp>/explain_last_day_baseline/<id>_0.zst.parquet]]}, projection=[d], file_type=parquet, predicate=d@0 >= 2024-04-01 AND d@0 < 2024-05-01, pruning_predicate=d_null_count@1 != row_count@2 AND d_max@0 >= 2024-04-01 AND d_null_count@1 != row_count@2 AND d_min@3 < 2024-05-01, required_guarantees=[], metrics=[output_rows=<metric>, elapsed_compute=<metric>, output_bytes=<metric>, output_batches=<metric>, files_ranges_pruned_statistics=<metric>, row_groups_pruned_statistics=<metric>, row_groups_pruned_bloom_filter=<metric>, page_index_pages_pruned=<metric>, page_index_rows_pruned=<metric>, limit_pruned_row_groups=<metric>, batches_split=<metric>, bytes_scanned=<metric>, file_open_errors=<metric>, file_scan_errors=<metric>, num_predicate_creation_errors=<metric>, predicate_evaluation_errors=<metric>, pushdown_rows_matched=<metric>, pushdown_rows_pruned=<metric>, predicate_cache_inner_records=<metric>, predicate_cache_records=<metric>, bloom_filter_eval_time=<metric>, metadata_load_time=<metric>, page_index_eval_time=<metric>, row_pushdown_eval_time=<metric>, statistics_eval_time=<metric>, time_elapsed_opening=<metric>, time_elapsed_processing=<metric>, time_elapsed_scanning_total=<metric>, time_elapsed_scanning_until_data=<metric>, scan_efficiency_ratio=<metric>], statistics=[Rows=Inexact(5), Bytes=Inexact(<bytes>), [(Col[0]: Min=Inexact(Date32("2024-03-31")) Max=Inexact(Date32("2024-05-31")) Null=Inexact(0) ScanBytes=Inexact(<bytes>))]], schema=[d:Date32;N]

--- a/python/pysail/tests/spark/function/features/last_day.feature
+++ b/python/pysail/tests/spark/function/features/last_day.feature
@@ -231,3 +231,379 @@ Feature: last_day comprehensive tests
       Then query result
         | result     |
         | 0001-01-31 |
+
+  Rule: Filter pushdown — preimage rewrite preserves semantics for all 5 operators
+
+    Scenario: last_day equality with valid last day returns whole month
+      When query
+        """
+        SELECT d FROM VALUES
+          (DATE '2024-03-31'),
+          (DATE '2024-04-01'),
+          (DATE '2024-04-15'),
+          (DATE '2024-04-30'),
+          (DATE '2024-05-01'),
+          (DATE '2024-05-31')
+          AS t(d)
+        WHERE last_day(d) = DATE '2024-04-30'
+        ORDER BY d
+        """
+      Then query result ordered
+        | d          |
+        | 2024-04-01 |
+        | 2024-04-15 |
+        | 2024-04-30 |
+
+    Scenario: last_day strict less than excludes target month
+      When query
+        """
+        SELECT d FROM VALUES
+          (DATE '2024-03-31'),
+          (DATE '2024-04-01'),
+          (DATE '2024-04-30'),
+          (DATE '2024-05-01')
+          AS t(d)
+        WHERE last_day(d) < DATE '2024-04-30'
+        ORDER BY d
+        """
+      Then query result ordered
+        | d          |
+        | 2024-03-31 |
+
+    Scenario: last_day less or equal includes target month
+      When query
+        """
+        SELECT d FROM VALUES
+          (DATE '2024-03-31'),
+          (DATE '2024-04-01'),
+          (DATE '2024-04-30'),
+          (DATE '2024-05-01')
+          AS t(d)
+        WHERE last_day(d) <= DATE '2024-04-30'
+        ORDER BY d
+        """
+      Then query result ordered
+        | d          |
+        | 2024-03-31 |
+        | 2024-04-01 |
+        | 2024-04-30 |
+
+    Scenario: last_day strict greater than excludes target month
+      When query
+        """
+        SELECT d FROM VALUES
+          (DATE '2024-03-31'),
+          (DATE '2024-04-01'),
+          (DATE '2024-04-30'),
+          (DATE '2024-05-01'),
+          (DATE '2024-05-31')
+          AS t(d)
+        WHERE last_day(d) > DATE '2024-04-30'
+        ORDER BY d
+        """
+      Then query result ordered
+        | d          |
+        | 2024-05-01 |
+        | 2024-05-31 |
+
+    Scenario: last_day greater or equal includes target month
+      When query
+        """
+        SELECT d FROM VALUES
+          (DATE '2024-03-31'),
+          (DATE '2024-04-01'),
+          (DATE '2024-04-30'),
+          (DATE '2024-05-01'),
+          (DATE '2024-05-31')
+          AS t(d)
+        WHERE last_day(d) >= DATE '2024-04-30'
+        ORDER BY d
+        """
+      Then query result ordered
+        | d          |
+        | 2024-04-01 |
+        | 2024-04-30 |
+        | 2024-05-01 |
+        | 2024-05-31 |
+
+  Rule: Filter pushdown — unsatisfiable literal returns empty (no over-approx)
+
+    # Canary against over-approximation: D not being a month-end must
+    # leave the predicate unrewritten so per-row eval yields zero rows.
+
+    Scenario: last_day equality with mid-month date returns empty
+      When query
+        """
+        SELECT d FROM VALUES
+          (DATE '2024-04-01'),
+          (DATE '2024-04-15'),
+          (DATE '2024-04-30')
+          AS t(d)
+        WHERE last_day(d) = DATE '2024-04-15'
+        """
+      Then query result
+        | d |
+
+    Scenario: last_day equality with first of month returns empty
+      When query
+        """
+        SELECT d FROM VALUES
+          (DATE '2024-04-15'),
+          (DATE '2024-04-30')
+          AS t(d)
+        WHERE last_day(d) = DATE '2024-04-01'
+        """
+      Then query result
+        | d |
+
+    Scenario: last_day equality with day 30 in 31-day month returns empty
+      When query
+        """
+        SELECT d FROM VALUES
+          (DATE '2024-12-30'),
+          (DATE '2024-12-31')
+          AS t(d)
+        WHERE last_day(d) = DATE '2024-12-30'
+        """
+      Then query result
+        | d |
+
+  Rule: Filter pushdown — boundary cases for valid last days
+
+    Scenario: last_day equality at leap-year February 29
+      When query
+        """
+        SELECT d FROM VALUES
+          (DATE '2024-02-01'),
+          (DATE '2024-02-29'),
+          (DATE '2024-03-01')
+          AS t(d)
+        WHERE last_day(d) = DATE '2024-02-29'
+        ORDER BY d
+        """
+      Then query result ordered
+        | d          |
+        | 2024-02-01 |
+        | 2024-02-29 |
+
+    Scenario: last_day equality at non-leap February 28
+      When query
+        """
+        SELECT d FROM VALUES
+          (DATE '2025-02-01'),
+          (DATE '2025-02-28'),
+          (DATE '2025-03-01')
+          AS t(d)
+        WHERE last_day(d) = DATE '2025-02-28'
+        ORDER BY d
+        """
+      Then query result ordered
+        | d          |
+        | 2025-02-01 |
+        | 2025-02-28 |
+
+    Scenario: last_day equality at year-end December 31
+      When query
+        """
+        SELECT d FROM VALUES
+          (DATE '2024-11-30'),
+          (DATE '2024-12-01'),
+          (DATE '2024-12-31'),
+          (DATE '2025-01-01')
+          AS t(d)
+        WHERE last_day(d) = DATE '2024-12-31'
+        ORDER BY d
+        """
+      Then query result ordered
+        | d          |
+        | 2024-12-01 |
+        | 2024-12-31 |
+
+  Rule: Filter pushdown — NULL handling
+
+    Scenario: last_day equality drops NULL rows
+      When query
+        """
+        SELECT d FROM VALUES
+          (DATE '2024-04-15'),
+          (CAST(NULL AS DATE)),
+          (DATE '2024-04-30')
+          AS t(d)
+        WHERE last_day(d) = DATE '2024-04-30'
+        ORDER BY d
+        """
+      Then query result ordered
+        | d          |
+        | 2024-04-15 |
+        | 2024-04-30 |
+
+    Scenario: last_day equality with NULL literal returns empty
+      When query
+        """
+        SELECT d FROM VALUES
+          (DATE '2024-04-15'),
+          (DATE '2024-04-30')
+          AS t(d)
+        WHERE last_day(d) = CAST(NULL AS DATE)
+        """
+      Then query result
+        | d |
+
+  Rule: Filter pushdown — Timestamp input via implicit cast
+
+    Scenario: last_day on Timestamp column matches whole month
+      When query
+        """
+        SELECT ts FROM VALUES
+          (CAST('2024-04-30 00:00:00' AS TIMESTAMP)),
+          (CAST('2024-04-30 23:59:59' AS TIMESTAMP)),
+          (CAST('2024-05-01 00:00:00' AS TIMESTAMP)),
+          (CAST('2024-05-15 12:00:00' AS TIMESTAMP))
+          AS t(ts)
+        WHERE last_day(ts) = DATE '2024-04-30'
+        ORDER BY ts
+        """
+      Then query result ordered
+        | ts                  |
+        | 2024-04-30 00:00:00 |
+        | 2024-04-30 23:59:59 |
+
+    Scenario: last_day on Timestamp_NTZ column matches whole month
+      When query
+        """
+        SELECT ts FROM VALUES
+          (CAST('2024-04-15 10:30:00' AS TIMESTAMP_NTZ)),
+          (CAST('2024-05-01 00:00:00' AS TIMESTAMP_NTZ))
+          AS t(ts)
+        WHERE last_day(ts) = DATE '2024-04-30'
+        ORDER BY ts
+        """
+      Then query result ordered
+        | ts                  |
+        | 2024-04-15 10:30:00 |
+
+  Rule: Plan snapshot — filter pushdown on Parquet (preimage)
+
+    @sail-only
+    Scenario: EXPLAIN literal Date filter on Parquet — baseline
+      Given variable location for temporary directory explain_last_day_baseline
+      Given final statement
+        """
+        DROP TABLE IF EXISTS explain_last_day_baseline_parquet
+        """
+      Given statement template
+        """
+        CREATE TABLE explain_last_day_baseline_parquet
+        USING PARQUET
+        LOCATION {{ location.sql }}
+        AS SELECT * FROM VALUES
+          (DATE '2024-03-31'),
+          (DATE '2024-04-01'),
+          (DATE '2024-04-15'),
+          (DATE '2024-04-30'),
+          (DATE '2024-05-31')
+        AS t(d)
+        """
+      When query
+        """
+        EXPLAIN ANALYZE SELECT d FROM explain_last_day_baseline_parquet WHERE d >= DATE '2024-04-01' AND d < DATE '2024-05-01'
+        """
+      Then query plan matches snapshot
+
+    @sail-only
+    Scenario: EXPLAIN last_day filter on Parquet shows preimage pushdown
+      Given variable location for temporary directory explain_last_day_pushdown
+      Given final statement
+        """
+        DROP TABLE IF EXISTS explain_last_day_pushdown_parquet
+        """
+      Given statement template
+        """
+        CREATE TABLE explain_last_day_pushdown_parquet
+        USING PARQUET
+        LOCATION {{ location.sql }}
+        AS SELECT * FROM VALUES
+          (DATE '2024-03-31'),
+          (DATE '2024-04-01'),
+          (DATE '2024-04-15'),
+          (DATE '2024-04-30'),
+          (DATE '2024-05-31')
+        AS t(d)
+        """
+      When query
+        """
+        EXPLAIN SELECT d FROM explain_last_day_pushdown_parquet WHERE last_day(d) = DATE '2024-04-30'
+        """
+      Then query plan matches snapshot
+
+    @sail-only
+    Scenario: EXPLAIN last_day with mid-month literal does NOT rewrite
+      Given variable location for temporary directory explain_last_day_unsat
+      Given final statement
+        """
+        DROP TABLE IF EXISTS explain_last_day_unsat_parquet
+        """
+      Given statement template
+        """
+        CREATE TABLE explain_last_day_unsat_parquet
+        USING PARQUET
+        LOCATION {{ location.sql }}
+        AS SELECT * FROM VALUES
+          (DATE '2024-04-15'),
+          (DATE '2024-04-30')
+        AS t(d)
+        """
+      When query
+        """
+        EXPLAIN SELECT d FROM explain_last_day_unsat_parquet WHERE last_day(d) = DATE '2024-04-15'
+        """
+      Then query plan matches snapshot
+
+    @sail-only
+    Scenario: EXPLAIN last_day less or equal rewrites to upper-bound predicate
+      Given variable location for temporary directory explain_last_day_lte
+      Given final statement
+        """
+        DROP TABLE IF EXISTS explain_last_day_lte_parquet
+        """
+      Given statement template
+        """
+        CREATE TABLE explain_last_day_lte_parquet
+        USING PARQUET
+        LOCATION {{ location.sql }}
+        AS SELECT * FROM VALUES
+          (DATE '2024-03-31'),
+          (DATE '2024-04-30'),
+          (DATE '2024-05-31')
+        AS t(d)
+        """
+      When query
+        """
+        EXPLAIN SELECT d FROM explain_last_day_lte_parquet WHERE last_day(d) <= DATE '2024-04-30'
+        """
+      Then query plan matches snapshot
+
+    @sail-only
+    Scenario: EXPLAIN last_day not equal rewrites to disjunction over the gap month
+      Given variable location for temporary directory explain_last_day_neq
+      Given final statement
+        """
+        DROP TABLE IF EXISTS explain_last_day_neq_parquet
+        """
+      Given statement template
+        """
+        CREATE TABLE explain_last_day_neq_parquet
+        USING PARQUET
+        LOCATION {{ location.sql }}
+        AS SELECT * FROM VALUES
+          (DATE '2024-03-31'),
+          (DATE '2024-04-15'),
+          (DATE '2024-04-30'),
+          (DATE '2024-05-31')
+        AS t(d)
+        """
+      When query
+        """
+        EXPLAIN SELECT d FROM explain_last_day_neq_parquet WHERE last_day(d) != DATE '2024-04-30'
+        """
+      Then query plan matches snapshot


### PR DESCRIPTION
The preimage of `last_day(ts) = D` is the closed-open month containing D: `ts ∈ [first_of_month(D), first_of_month(D) + 1 month)`. This fits `PreimageResult::Range` exactly, and `udf_preimage` derives the rewrite for all 5 comparison operators plus `!=` from the equality preimage.


## Correctness invariant

The preimage rule REPLACES the original predicate (no outer FilterExec re-checks the UDF). Returning a Range for an unsatisfiable D would over-approximate to the full month and include rows where last_day(x) ≠ D — silent correctness bug. The hook returns PreimageResult::None for such inputs so the predicate falls through to per-row UDF evaluation, which correctly yields zero rows.

A dedicated plan snapshot scenario (last_day(d) = '2024-04-15') asserts the predicate remains UNCHANGED in this case, locking in the satisfiability check as a CI canary against future regressions.
