### PR TITLE
revert: add Kubernetes worker pod cleanup configuration

### DIFF
--- a/crates/sail-common/src/config/application.rs
+++ b/crates/sail-common/src/config/application.rs
@@ -318,16 +318,6 @@ pub struct KubernetesConfig {
     pub worker_pod_name_prefix: String,
     pub worker_service_account_name: String,
     pub worker_pod_template: String,
-    pub worker_pod_cleanup: KubernetesWorkerPodCleanup,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum KubernetesWorkerPodCleanup {
-    #[serde(alias = "server-termination")]
-    ServerTermination,
-    #[serde(alias = "session-end")]
-    SessionEnd,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/sail-common/src/config/application.yaml
+++ b/crates/sail-common/src/config/application.yaml
@@ -668,15 +668,6 @@
     If non-empty, a JSON string representing a Kubernetes Pod template
     with the schema of `PodTemplateSpec` in the Kubernetes API.
 
-- key: kubernetes.worker_pod_cleanup
-  type: string
-  default: "server_termination"
-  description: |
-    When to delete Kubernetes worker pods.
-    The default value `server_termination` configures worker pods to be deleted
-    after the server pod terminates.
-    The value `session_end` deletes worker pods when the Spark session ends.
-
 - key: catalog.list
   type: array
   default: '[{name="sail", type="memory", initial_database=["default"], initial_database_comment="default database"}]'

--- a/crates/sail-execution/src/worker_manager/kubernetes.rs
+++ b/crates/sail-execution/src/worker_manager/kubernetes.rs
@@ -7,7 +7,6 @@ use k8s_openapi::api::core::v1::{
 };
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ObjectMeta, OwnerReference};
 use k8s_openapi::{DeepMerge, Resource};
-use kube::api::{DeleteParams, ListParams};
 use kube::Api;
 use rand::distr::Uniform;
 use rand::RngExt;
@@ -29,7 +28,6 @@ pub struct KubernetesWorkerManagerOptions {
     pub worker_pod_name_prefix: String,
     pub worker_service_account_name: String,
     pub worker_pod_template: String,
-    pub delete_worker_pods_on_stop: bool,
 }
 
 pub struct KubernetesWorkerManager {
@@ -103,10 +101,6 @@ impl KubernetesWorkerManager {
             (
                 "app.kubernetes.io/instance".to_string(),
                 format!("{}-{}", self.name, id),
-            ),
-            (
-                "sail.lakesail.com/worker-manager".to_string(),
-                self.name.clone(),
             ),
         ])
     }
@@ -282,16 +276,6 @@ impl WorkerManager for KubernetesWorkerManager {
     }
 
     async fn stop(&self) -> ExecutionResult<()> {
-        if self.options.delete_worker_pods_on_stop {
-            self.pods()
-                .await?
-                .delete_collection(
-                    &DeleteParams::default(),
-                    &ListParams::default()
-                        .labels(&format!("sail.lakesail.com/worker-manager={}", self.name)),
-                )
-                .await?;
-        }
         Ok(())
     }
 }
@@ -344,10 +328,6 @@ mod tests {
                 "app.kubernetes.io/instance".to_string(),
                 "test-instance".to_string(),
             ),
-            (
-                "sail.lakesail.com/worker-manager".to_string(),
-                "test-manager".to_string(),
-            ),
         ]);
         labels.extend(default_labels.clone());
 
@@ -375,10 +355,6 @@ mod tests {
         assert_eq!(
             labels.get("app.kubernetes.io/instance"),
             Some(&"test-instance".to_string())
-        );
-        assert_eq!(
-            labels.get("sail.lakesail.com/worker-manager"),
-            Some(&"test-manager".to_string())
         );
     }
 }

--- a/crates/sail-session/src/session_factory/server.rs
+++ b/crates/sail-session/src/session_factory/server.rs
@@ -10,7 +10,7 @@ use datafusion::functions_aggregate::first_last::first_value_udaf;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion_expr::registry::FunctionRegistry;
 use sail_catalog_system::service::SystemTableService;
-use sail_common::config::{AppConfig, ExecutionMode, KubernetesWorkerPodCleanup};
+use sail_common::config::{AppConfig, ExecutionMode};
 use sail_common::runtime::RuntimeHandle;
 use sail_common_datafusion::session::activity::ActivityTracker;
 use sail_common_datafusion::session::job::{JobRunner, JobService};
@@ -176,10 +176,6 @@ impl ServerSessionFactory {
                         .worker_service_account_name
                         .clone(),
                     worker_pod_template: self.config.kubernetes.worker_pod_template.clone(),
-                    delete_worker_pods_on_stop: matches!(
-                        self.config.kubernetes.worker_pod_cleanup,
-                        KubernetesWorkerPodCleanup::SessionEnd
-                    ),
                 };
                 let worker_manager = Arc::new(KubernetesWorkerManager::new(options));
                 let options =

--- a/docs/guide/deployment/kubernetes.md
+++ b/docs/guide/deployment/kubernetes.md
@@ -107,19 +107,6 @@ kubectl apply -f k8s/sail.yaml
 By default, the worker pod spec is created programmatically. If the `kubernetes.worker_pod_template` configuration option is provided, it is merged into
 the generated spec, allowing you to customize the worker pods.
 
-### Configuring Worker Pod Cleanup
-
-By default, Sail configures worker pods to be removed after the server pod terminates. This preserves worker pod logs
-while the server is still running. For long-running servers that host multiple concurrent Spark sessions, you can instead
-delete worker pods when each session ends by setting `kubernetes.worker_pod_cleanup` to `session_end`.
-
-For example, add the following environment variable to the server container.
-
-```yaml
-- name: SAIL_KUBERNETES__WORKER_POD_CLEANUP
-  value: session_end
-```
-
 ### Using a Custom Pod Template
 
 You can use Kustomize to declaratively define the Kubernetes resources. This approach makes it easier to manage


### PR DESCRIPTION
This reverts #1850.

We need some more time for proper configuration options design so this PR reverts the changes for now to unblock the upcoming release.