### PR TITLE
(feat): improve spark metadata compatibility for lakehouse tables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6977,6 +6977,7 @@ dependencies = [
  "datafusion",
  "datafusion-common",
  "datafusion-expr",
+ "futures",
  "lazy_static",
  "log",
  "moka",
@@ -7183,6 +7184,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-prost-build",
+ "url",
 ]
 
 [[package]]

--- a/crates/sail-catalog-hms/src/provider.rs
+++ b/crates/sail-catalog-hms/src/provider.rs
@@ -957,13 +957,13 @@ impl CatalogProvider for HmsCatalogProvider {
 
         let db_name = validate_namespace(database)?;
         let format = HiveCatalogFormat::from_format(&format)?;
+        let columns_for_metadata = options.columns.clone();
+        let format_for_metadata = format.logical_format.to_string();
         let partition_columns: Vec<String> = options
             .partition_by
             .iter()
             .map(|field| field.column.clone())
             .collect();
-        let columns_for_metadata = options.columns.clone();
-        let format_for_metadata = format.logical_format.to_string();
         let mut hms_table = build_generic_table(
             &db_name,
             table,

--- a/crates/sail-catalog/Cargo.toml
+++ b/crates/sail-catalog/Cargo.toml
@@ -10,6 +10,7 @@ workspace = true
 datafusion = { workspace = true }
 datafusion-common = { workspace = true }
 datafusion-expr = { workspace = true }
+futures = { workspace = true }
 serde = { workspace = true }
 serde_arrow = { workspace = true }
 regex = { workspace = true }

--- a/crates/sail-catalog/src/command.rs
+++ b/crates/sail-catalog/src/command.rs
@@ -1,7 +1,14 @@
+use std::collections::HashSet;
+
 use datafusion::arrow::array::RecordBatch;
 use datafusion::arrow::datatypes::SchemaRef;
 use sail_common_datafusion::array::serde::ArrowSerializer;
-use sail_common_datafusion::datasource::{is_lakehouse_format, TableFormatRegistry};
+use sail_common_datafusion::catalog::{
+    CatalogPartitionField, PartitionTransform, TableKind, TableStatus,
+};
+use sail_common_datafusion::datasource::{
+    is_lakehouse_format, is_relative_location, TableFormatRegistry,
+};
 use sail_common_datafusion::extension::SessionExtensionAccessor;
 use sail_common_datafusion::session::plan::PlanService;
 use serde::{Deserialize, Serialize};
@@ -9,6 +16,10 @@ use serde::{Deserialize, Serialize};
 use crate::error::{CatalogError, CatalogResult};
 use crate::manager::tracker::{CatalogFunctionId, CatalogLogicalPlanId};
 use crate::manager::CatalogManager;
+use crate::metadata_compat::{
+    describe_extended_metadata_rows, redact_property_value, show_table_extended_information,
+    show_tblproperties_rows,
+};
 use crate::provider::{
     AlterTableOptions, CreateDatabaseOptions, CreateTableOptions, CreateTemporaryViewOptions,
     CreateViewOptions, DropDatabaseOptions, DropTableOptions, DropTemporaryViewOptions,
@@ -64,6 +75,10 @@ pub enum CatalogCommand {
     ShowTableExtended {
         database: Vec<String>,
         pattern: String,
+    },
+    ShowTableProperties {
+        table: Vec<String>,
+        property_key: Option<String>,
     },
     ListTables {
         database: Vec<String>,
@@ -161,6 +176,7 @@ impl CatalogCommand {
             CatalogCommand::GetTable { .. } => "GetTable",
             CatalogCommand::ShowTables { .. } => "ShowTables",
             CatalogCommand::ShowTableExtended { .. } => "ShowTableExtended",
+            CatalogCommand::ShowTableProperties { .. } => "ShowTableProperties",
             CatalogCommand::ListTables { .. } => "ListTables",
             CatalogCommand::ListViews { .. } => "ListViews",
             CatalogCommand::DropTable { .. } => "DropTable",
@@ -197,6 +213,9 @@ impl CatalogCommand {
             }
             CatalogCommand::ShowTableExtended { .. } => {
                 ArrowSerializer::default().schema::<ShowTableExtendedRow>()?
+            }
+            CatalogCommand::ShowTableProperties { .. } => {
+                ArrowSerializer::default().schema::<ShowTablePropertyRow>()?
             }
             CatalogCommand::ListColumns { .. } => display.table_columns().schema()?,
             CatalogCommand::GetFunction { .. } | CatalogCommand::ListFunctions { .. } => {
@@ -334,18 +353,43 @@ impl CatalogCommand {
                     .list_tables_and_views(&database, Some(pattern.as_str()))
                     .await?;
                 let formatter = service.plan_formatter();
-                let rows = rows
-                    .into_iter()
-                    .map(|row| {
-                        Ok(ShowTableExtendedRow {
-                            database: quote_names_if_needed(&row.database),
-                            table_name: row.name.clone(),
-                            is_temporary: row.kind.is_temporary(),
-                            information: row.show_table_extended_information(formatter)?,
-                        })
-                    })
-                    .collect::<CatalogResult<Vec<_>>>()?;
-                ArrowSerializer::default().build_record_batch(&rows)?
+                let hydrated = futures::future::try_join_all(
+                    rows.iter().map(|row| hydrate_table_status(ctx, row)),
+                )
+                .await?;
+                let mut output = Vec::with_capacity(hydrated.len());
+                for row in hydrated {
+                    output.push(ShowTableExtendedRow {
+                        database: quote_names_if_needed(&row.database),
+                        table_name: row.name.clone(),
+                        is_temporary: row.kind.is_temporary(),
+                        information: show_table_extended_information(&row, formatter)?,
+                    });
+                }
+                ArrowSerializer::default().build_record_batch(&output)?
+            }
+            CatalogCommand::ShowTableProperties {
+                table,
+                property_key,
+            } => {
+                let table_status = manager.get_table_or_view(&table).await?;
+                let table_status = hydrate_table_status(ctx, &table_status).await?;
+                if table_status.kind.is_temporary() {
+                    let rows: Vec<ShowTablePropertyRow> = Vec::new();
+                    ArrowSerializer::default().build_record_batch(&rows)?
+                } else {
+                    let table_name = qualified_table_name(&table_status);
+                    let rows = show_tblproperties_rows(
+                        table_name.as_str(),
+                        table_status.kind.properties(),
+                        property_key.as_deref(),
+                    );
+                    let pairs = rows
+                        .into_iter()
+                        .map(|(key, value)| ShowTablePropertyRow { key, value })
+                        .collect::<Vec<_>>();
+                    ArrowSerializer::default().build_record_batch(&pairs)?
+                }
             }
             CatalogCommand::ListTables { database, pattern } => {
                 let rows = manager
@@ -390,81 +434,98 @@ impl CatalogCommand {
                     _ => (None, None),
                 };
 
-                // Persist changes to storage first (source of truth for table formats
-                // such as Delta Lake). Only after storage commits successfully do we
-                // update the catalog metadata, so we never end up with the two layers
-                // out of sync.
-                if let (Some(location), Some(format)) = (location, format) {
-                    // Non-lakehouse formats (e.g., plain Parquet/Hive tables) have no
-                    // storage-layer metadata — the catalog is the sole source of truth.
-                    // Skip straight to catalog-only update.
-                    // This mirrors Spark+Delta where DeltaCatalog intercepts ALTER TABLE
-                    // for Delta tables but plain tables fall through to SessionCatalog.
-                    if !is_lakehouse_format(&format) {
-                        manager.alter_table(&table, options).await?;
-                        return Ok(display.bools().to_record_batch(vec![true])?);
+                let is_lakehouse = format.as_deref().is_some_and(is_lakehouse_format);
+                let is_property_alter = matches!(
+                    options,
+                    AlterTableOptions::SetTableProperties { .. }
+                        | AlterTableOptions::UnsetTableProperties { .. }
+                );
+
+                if is_lakehouse {
+                    let format_name = format.as_deref().ok_or_else(|| {
+                        CatalogError::External(
+                            "missing table format for storage-backed ALTER TABLE".to_string(),
+                        )
+                    })?;
+                    if location.is_none() {
+                        return Err(CatalogError::External(format!(
+                            "missing table location for storage-backed ALTER TABLE on format '{format_name}'"
+                        )));
                     }
-                    let registry = ctx.extension::<TableFormatRegistry>().map_err(|e| {
-                        CatalogError::External(format!(
-                            "missing TableFormatRegistry for storage-backed ALTER TABLE on format '{format}': {e}"
-                        ))
-                    })?;
-                    let table_format = registry.get(&format).map_err(|e| {
-                        CatalogError::External(format!(
-                            "unknown table format '{format}' for storage-backed ALTER TABLE: {e}"
-                        ))
-                    })?;
-                    let runtime = ctx.runtime_env();
-                    match &options {
-                        AlterTableOptions::SetTableProperties { properties } => {
-                            let changes = properties
-                                .iter()
-                                .map(|(k, v)| (k.clone(), Some(v.clone())))
-                                .collect::<Vec<_>>();
-                            table_format
-                                .alter_table_properties(runtime, &location, changes, false)
-                                .await
-                                .map_err(|e| CatalogError::External(e.to_string()))?;
+                    if let (Some(location), Some(format)) = (location, format) {
+                        // Persist changes to storage first (source of truth for lakehouse
+                        // formats). Only attempt catalog metadata update after storage succeeds.
+                        let registry = ctx.extension::<TableFormatRegistry>().map_err(|e| {
+                            CatalogError::External(format!(
+                                "missing TableFormatRegistry for storage-backed ALTER TABLE on format '{format}': {e}"
+                            ))
+                        })?;
+                        let table_format = registry.get(&format).map_err(|e| {
+                            CatalogError::External(format!(
+                                "unknown table format '{format}' for storage-backed ALTER TABLE: {e}"
+                            ))
+                        })?;
+                        let runtime = ctx.runtime_env();
+                        match &options {
+                            AlterTableOptions::SetTableProperties { properties } => {
+                                let changes = properties
+                                    .iter()
+                                    .map(|(k, v)| (k.clone(), Some(v.clone())))
+                                    .collect::<Vec<_>>();
+                                table_format
+                                    .alter_table_properties(runtime, &location, changes, false)
+                                    .await
+                                    .map_err(|e| CatalogError::External(e.to_string()))?;
+                            }
+                            AlterTableOptions::UnsetTableProperties { keys, if_exists } => {
+                                let changes =
+                                    keys.iter().map(|k| (k.clone(), None)).collect::<Vec<_>>();
+                                table_format
+                                    .alter_table_properties(runtime, &location, changes, *if_exists)
+                                    .await
+                                    .map_err(|e| CatalogError::External(e.to_string()))?;
+                            }
+                            AlterTableOptions::AlterColumnType { name, data_type } => {
+                                table_format
+                                    .alter_table_column_type(
+                                        runtime,
+                                        &location,
+                                        name.clone(),
+                                        data_type.clone(),
+                                    )
+                                    .await
+                                    .map_err(|e| CatalogError::External(e.to_string()))?;
+                            }
                         }
-                        AlterTableOptions::UnsetTableProperties { keys, if_exists } => {
-                            let changes =
-                                keys.iter().map(|k| (k.clone(), None)).collect::<Vec<_>>();
-                            table_format
-                                .alter_table_properties(runtime, &location, changes, *if_exists)
-                                .await
-                                .map_err(|e| CatalogError::External(e.to_string()))?;
+                    }
+                    if is_property_alter {
+                        // Spark-compatible behavior for property updates: after storage commit,
+                        // treat catalog metadata refresh as best-effort.
+                        if let Err(error) = manager.alter_table(&table, options).await {
+                            log::warn!(
+                                "best-effort catalog update failed after storage-backed ALTER TABLE for {:?}: {}",
+                                table,
+                                error
+                            );
                         }
-                        AlterTableOptions::AlterColumnType { name, data_type } => {
-                            table_format
-                                .alter_table_column_type(
-                                    runtime,
-                                    &location,
-                                    name.clone(),
-                                    data_type.clone(),
-                                )
-                                .await
-                                .map_err(|e| CatalogError::External(e.to_string()))?;
-                        }
-                    };
-
-                    // Storage is the source of truth for lakehouse ALTER TABLE
-                    // operations, but metadata reads still flow through the
-                    // catalog. Surface catalog sync failures so callers do not
-                    // observe successful storage mutation followed by stale
-                    // DESCRIBE/SHOW metadata.
+                    } else {
+                        // Keep strict behavior for non-property ALTER operations.
+                        manager.alter_table(&table, options).await?;
+                    }
+                } else {
                     manager.alter_table(&table, options).await?;
-                    return Ok(display.bools().to_record_batch(vec![true])?);
                 }
-
-                manager.alter_table(&table, options).await?;
                 display.bools().to_record_batch(vec![true])?
             }
             CatalogCommand::ListColumns { table } => {
-                let rows = manager.get_table_or_view(&table).await?.kind.columns();
+                let table_status = manager.get_table_or_view(&table).await?;
+                let table_status = hydrate_table_status(ctx, &table_status).await?;
+                let rows = table_status.kind.columns();
                 display.table_columns().to_record_batch(rows)?
             }
             CatalogCommand::DescribeTable { table, extended } => {
                 let table_status = manager.get_table_or_view(&table).await?;
+                let table_status = hydrate_table_status(ctx, &table_status).await?;
                 let formatter = service.plan_formatter();
                 let serializer = ArrowSerializer::default();
 
@@ -481,26 +542,33 @@ impl CatalogCommand {
                 }
 
                 if extended {
-                    let partition_cols = table_status.kind.partition_columns();
-                    if !partition_cols.is_empty() {
-                        rows.push(DescribeTableRow {
-                            col_name: "# Partition Information".to_string(),
-                            data_type: String::new(),
-                            comment: None,
-                        });
-                        rows.push(DescribeTableRow {
-                            col_name: "# col_name".to_string(),
-                            data_type: "data_type".to_string(),
-                            comment: Some("comment".to_string()),
-                        });
-                        for col in &partition_cols {
+                    match describe_partition_section(&table_status, formatter) {
+                        PartitionSection::None => {}
+                        PartitionSection::Identity(partition_rows) => {
                             rows.push(DescribeTableRow {
-                                col_name: col.name.clone(),
-                                data_type: formatter
-                                    .data_type_to_simple_string(&col.data_type)
-                                    .unwrap_or_else(|_| "invalid".to_string()),
-                                comment: col.comment.clone(),
+                                col_name: "# Partition Information".to_string(),
+                                data_type: String::new(),
+                                comment: None,
                             });
+                            rows.push(DescribeTableRow {
+                                col_name: "# col_name".to_string(),
+                                data_type: "data_type".to_string(),
+                                comment: Some("comment".to_string()),
+                            });
+                            rows.extend(partition_rows);
+                        }
+                        PartitionSection::Transformed(partition_rows) => {
+                            rows.push(DescribeTableRow {
+                                col_name: String::new(),
+                                data_type: String::new(),
+                                comment: None,
+                            });
+                            rows.push(DescribeTableRow {
+                                col_name: "# Partitioning".to_string(),
+                                data_type: String::new(),
+                                comment: None,
+                            });
+                            rows.extend(partition_rows);
                         }
                     }
 
@@ -515,7 +583,7 @@ impl CatalogCommand {
                         comment: None,
                     });
 
-                    for (key, value) in table_status.describe_extended_metadata() {
+                    for (key, value) in describe_extended_metadata_rows(&table_status) {
                         rows.push(DescribeTableRow {
                             col_name: key,
                             data_type: value,
@@ -622,7 +690,7 @@ impl CatalogCommand {
                         sorted_props.sort_by(|(a, _), (b, _)| a.cmp(b));
                         let entries: Vec<String> = sorted_props
                             .iter()
-                            .map(|(k, v)| format!("({k},{v})"))
+                            .map(|(k, v)| format!("({},{})", k, redact_property_value(k, v)))
                             .collect();
                         format!("({})", entries.join(","))
                     };
@@ -637,6 +705,180 @@ impl CatalogCommand {
         };
         Ok(batch)
     }
+}
+
+async fn hydrate_table_status<C: SessionExtensionAccessor>(
+    ctx: &C,
+    table: &TableStatus,
+) -> CatalogResult<TableStatus> {
+    let (format, location) = match &table.kind {
+        TableKind::Table {
+            format, location, ..
+        } => (format.as_str(), location.as_deref()),
+        _ => return Ok(table.clone()),
+    };
+
+    if !is_lakehouse_format(format) {
+        return Ok(table.clone());
+    }
+    let location = location.ok_or_else(|| {
+        CatalogError::External(format!(
+            "missing table location for storage-backed metadata hydration on format '{format}'"
+        ))
+    })?;
+    if is_relative_location(location) {
+        log::warn!(
+            "skipping storage-backed metadata hydration for {:?} because lakehouse location '{}' is relative",
+            qualified_table_name(table),
+            location,
+        );
+        return Ok(table.clone());
+    }
+
+    let registry = ctx.extension::<TableFormatRegistry>().map_err(|e| {
+        CatalogError::External(format!(
+            "missing TableFormatRegistry for storage-backed metadata hydration: {e}"
+        ))
+    })?;
+    let table_format = registry.get(format).map_err(|e| {
+        CatalogError::External(format!(
+            "unknown table format '{format}' for storage-backed metadata hydration: {e}"
+        ))
+    })?;
+    let metadata = table_format
+        .load_storage_table_metadata(ctx.runtime_env(), location)
+        .await
+        .map_err(|e| CatalogError::External(e.to_string()))?;
+
+    let TableKind::Table {
+        constraints,
+        sort_by,
+        bucket_by,
+        is_external,
+        ..
+    } = &table.kind
+    else {
+        return Ok(table.clone());
+    };
+
+    let columns = normalize_partition_flags(metadata.columns, &metadata.partition_columns);
+
+    Ok(TableStatus {
+        catalog: table.catalog.clone(),
+        database: table.database.clone(),
+        name: table.name.clone(),
+        kind: TableKind::Table {
+            columns,
+            comment: metadata.comment,
+            constraints: constraints.clone(),
+            location: metadata.location,
+            format: metadata.provider,
+            partition_by: metadata.partition_columns,
+            sort_by: sort_by.clone(),
+            bucket_by: bucket_by.clone(),
+            properties: metadata.properties,
+            is_external: *is_external,
+        },
+    })
+}
+
+fn normalize_partition_flags(
+    mut columns: Vec<sail_common_datafusion::catalog::TableColumnStatus>,
+    partition_columns: &[CatalogPartitionField],
+) -> Vec<sail_common_datafusion::catalog::TableColumnStatus> {
+    let identity_partition_columns: HashSet<String> = partition_columns
+        .iter()
+        .filter(|field| is_identity_partition_transform(field.transform))
+        .map(|field| field.column.to_ascii_lowercase())
+        .collect();
+    for column in &mut columns {
+        column.is_partition =
+            identity_partition_columns.contains(&column.name.to_ascii_lowercase());
+    }
+    columns
+}
+
+fn describe_partition_section(
+    table: &TableStatus,
+    formatter: &dyn sail_common_datafusion::session::plan::PlanFormatter,
+) -> PartitionSection {
+    match &table.kind {
+        TableKind::Table {
+            columns,
+            partition_by,
+            ..
+        } if partition_by.is_empty() => PartitionSection::None,
+        TableKind::Table {
+            columns,
+            partition_by,
+            ..
+        } => {
+            if partition_by
+                .iter()
+                .all(|field| is_identity_partition_transform(field.transform))
+            {
+                PartitionSection::Identity(
+                    partition_by
+                        .iter()
+                        .map(|field| {
+                            let source_column = columns
+                                .iter()
+                                .find(|column| column.name.eq_ignore_ascii_case(&field.column));
+                            DescribeTableRow {
+                                col_name: field.column.clone(),
+                                data_type: source_column
+                                    .map(|column| {
+                                        formatter
+                                            .data_type_to_simple_string(&column.data_type)
+                                            .unwrap_or_else(|_| "invalid".to_string())
+                                    })
+                                    .unwrap_or_default(),
+                                comment: source_column.and_then(|column| column.comment.clone()),
+                            }
+                        })
+                        .collect(),
+                )
+            } else {
+                PartitionSection::Transformed(
+                    partition_by
+                        .iter()
+                        .enumerate()
+                        .map(|(index, field)| DescribeTableRow {
+                            col_name: format!("Part {index}"),
+                            data_type: format_partition_field(field),
+                            comment: Some(String::new()),
+                        })
+                        .collect(),
+                )
+            }
+        }
+        _ => PartitionSection::None,
+    }
+}
+
+fn format_partition_field(field: &CatalogPartitionField) -> String {
+    match field.transform.unwrap_or(PartitionTransform::Identity) {
+        PartitionTransform::Identity => field.column.clone(),
+        PartitionTransform::Year => format!("years({})", field.column),
+        PartitionTransform::Month => format!("months({})", field.column),
+        PartitionTransform::Day => format!("days({})", field.column),
+        PartitionTransform::Hour => format!("hours({})", field.column),
+        PartitionTransform::Bucket(n) => format!("bucket({n}, {})", field.column),
+        PartitionTransform::Truncate(width) => format!("truncate({width}, {})", field.column),
+    }
+}
+
+fn is_identity_partition_transform(transform: Option<PartitionTransform>) -> bool {
+    matches!(
+        transform.unwrap_or(PartitionTransform::Identity),
+        PartitionTransform::Identity
+    )
+}
+
+enum PartitionSection {
+    None,
+    Identity(Vec<DescribeTableRow>),
+    Transformed(Vec<DescribeTableRow>),
 }
 
 #[derive(Serialize, Deserialize)]
@@ -671,346 +913,804 @@ struct ShowTableExtendedRow {
     information: String,
 }
 
+#[derive(Serialize, Deserialize)]
+struct ShowTablePropertyRow {
+    key: String,
+    value: String,
+}
+
+fn qualified_table_name(table: &sail_common_datafusion::catalog::TableStatus) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(catalog) = &table.catalog {
+        parts.push(catalog.clone());
+    }
+    parts.extend(table.database.clone());
+    parts.push(table.name.clone());
+    parts.join(".")
+}
+
 #[cfg(test)]
 mod tests {
+    use std::any::Any;
+    use std::collections::HashMap;
     use std::sync::Arc;
 
-    use async_trait::async_trait;
+    use datafusion::arrow::array::Array;
+    use datafusion::arrow::datatypes::DataType;
+    use datafusion::arrow::util::display::array_value_to_string;
     use datafusion::catalog::Session;
-    use datafusion::execution::context::SessionConfig;
+    use datafusion::execution::runtime_env::RuntimeEnv;
+    use datafusion::logical_expr::TableSource;
     use datafusion::physical_plan::ExecutionPlan;
-    use datafusion::prelude::SessionContext;
-    use datafusion_common::not_impl_err;
-    use datafusion_expr::TableSource;
+    use datafusion_common::{internal_datafusion_err, not_impl_err, Result, ScalarValue};
     use sail_common_datafusion::catalog::display::{CatalogObjectDisplay, DefaultCatalogDisplay};
     use sail_common_datafusion::catalog::{
-        DatabaseStatus, TableColumnStatus, TableKind, TableStatus,
+        CatalogPartitionField, DatabaseStatus, PartitionTransform, TableColumnStatus, TableKind,
+        TableStatus,
     };
-    use sail_common_datafusion::datasource::{SinkInfo, SourceInfo, TableFormat};
+    use sail_common_datafusion::datasource::{
+        SinkInfo, SourceInfo, StorageTableMetadata, TableFormat, TableFormatRegistry,
+    };
+    use sail_common_datafusion::extension::{SessionExtension, SessionExtensionAccessor};
     use sail_common_datafusion::session::plan::{PlanFormatter, PlanService};
     use serde::{Deserialize, Serialize};
 
     use super::*;
-    use crate::provider::CatalogProvider;
+    use crate::manager::CatalogManagerOptions;
+    use crate::provider::{
+        CatalogProvider, CreateDatabaseOptions, CreateTableOptions, CreateViewOptions,
+        DropDatabaseOptions, DropTableOptions, DropViewOptions, Namespace,
+    };
 
-    #[derive(Serialize, Deserialize)]
-    struct TestCatalogOutput {
-        value: String,
+    #[tokio::test]
+    async fn list_columns_shows_storage_schema_for_delta_tables() -> CatalogResult<()> {
+        let manager = test_manager(default_catalog_table("delta"))?;
+        let ctx = test_session(Arc::new(TestTableFormat::new(
+            "delta",
+            StorageTableMetadata {
+                columns: vec![table_column("storage_col")],
+                comment: None,
+                location: Some("file:///tmp/storage".to_string()),
+                provider: "delta".to_string(),
+                partition_columns: vec![],
+                properties: vec![],
+            },
+        )))?;
+
+        let batch = CatalogCommand::ListColumns {
+            table: vec!["t".to_string()],
+        }
+        .execute(&ctx, &manager)
+        .await?;
+
+        let name = array_value_to_string(batch.column(0), 0)
+            .map_err(|e| CatalogError::Internal(e.to_string()))?;
+        assert_eq!(name, "storage_col");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn describe_extended_uses_partition_transform_names_for_hidden_iceberg_partitions(
+    ) -> CatalogResult<()> {
+        let manager = test_manager(default_catalog_table("iceberg"))?;
+        let mut transformed_source_column = table_column("ts");
+        transformed_source_column.is_partition = true;
+        let ctx = test_session(Arc::new(TestTableFormat::new(
+            "iceberg",
+            StorageTableMetadata {
+                columns: vec![transformed_source_column, table_column("value")],
+                comment: None,
+                location: Some("file:///tmp/storage".to_string()),
+                provider: "iceberg".to_string(),
+                partition_columns: vec![CatalogPartitionField {
+                    column: "ts".to_string(),
+                    transform: Some(PartitionTransform::Day),
+                }],
+                properties: vec![],
+            },
+        )))?;
+
+        let batch = CatalogCommand::DescribeTable {
+            table: vec!["t".to_string()],
+            extended: true,
+        }
+        .execute(&ctx, &manager)
+        .await?;
+
+        let names = string_column(&batch, 0)?;
+        let partitioning_header = names
+            .iter()
+            .position(|name| name == "# Partitioning")
+            .ok_or_else(|| {
+                CatalogError::Internal("partitioning section header not found".to_string())
+            })?;
+        assert_eq!(
+            names.get(partitioning_header + 1),
+            Some(&"Part 0".to_string())
+        );
+
+        let values = string_column(&batch, 1)?;
+        assert_eq!(
+            values.get(partitioning_header + 1),
+            Some(&"days(ts)".to_string())
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_columns_does_not_mark_hidden_iceberg_transform_source_columns_as_partitions(
+    ) -> CatalogResult<()> {
+        let manager = test_manager(default_catalog_table("iceberg"))?;
+        let mut transformed_source_column = table_column("ts");
+        transformed_source_column.is_partition = true;
+        let ctx = test_session(Arc::new(TestTableFormat::new(
+            "iceberg",
+            StorageTableMetadata {
+                columns: vec![transformed_source_column, table_column("value")],
+                comment: None,
+                location: Some("file:///tmp/storage".to_string()),
+                provider: "iceberg".to_string(),
+                partition_columns: vec![CatalogPartitionField {
+                    column: "ts".to_string(),
+                    transform: Some(PartitionTransform::Day),
+                }],
+                properties: vec![],
+            },
+        )))?;
+
+        let batch = CatalogCommand::ListColumns {
+            table: vec!["t".to_string()],
+        }
+        .execute(&ctx, &manager)
+        .await?;
+
+        let names = string_column(&batch, 0)?;
+        let partition_flags = string_column(&batch, 1)?;
+        let columns = names
+            .into_iter()
+            .zip(partition_flags)
+            .collect::<HashMap<_, _>>();
+
+        assert_eq!(columns.get("ts").map(String::as_str), Some("false"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn show_table_properties_with_key_keeps_key_value_shape() -> CatalogResult<()> {
+        let mut table = default_catalog_table("parquet");
+        let TableKind::Table { properties, .. } = &mut table.kind else {
+            unreachable!();
+        };
+        properties.push(("custom.key".to_string(), "hello".to_string()));
+        let manager = test_manager(table)?;
+        let ctx = test_session(Arc::new(TestTableFormat::new(
+            "parquet",
+            StorageTableMetadata {
+                columns: vec![table_column("storage_col")],
+                comment: None,
+                location: Some("file:///tmp/storage".to_string()),
+                provider: "parquet".to_string(),
+                partition_columns: vec![],
+                properties: vec![],
+            },
+        )))?;
+
+        let batch = CatalogCommand::ShowTableProperties {
+            table: vec!["t".to_string()],
+            property_key: Some("custom.key".to_string()),
+        }
+        .execute(&ctx, &manager)
+        .await?;
+
+        assert_eq!(batch.num_columns(), 2);
+        assert_eq!(string_column(&batch, 0)?, vec!["custom.key".to_string()]);
+        assert_eq!(string_column(&batch, 1)?, vec!["hello".to_string()]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn alter_table_property_update_on_lakehouse_without_location_returns_error(
+    ) -> CatalogResult<()> {
+        let mut table = default_catalog_table("delta");
+        let TableKind::Table { location, .. } = &mut table.kind else {
+            unreachable!();
+        };
+        *location = None;
+        let manager = test_manager(table)?;
+        let ctx = test_session(Arc::new(TestTableFormat::new(
+            "delta",
+            StorageTableMetadata {
+                columns: vec![table_column("storage_col")],
+                comment: None,
+                location: Some("file:///tmp/storage".to_string()),
+                provider: "delta".to_string(),
+                partition_columns: vec![],
+                properties: vec![],
+            },
+        )))?;
+
+        let result = CatalogCommand::AlterTable {
+            table: vec!["t".to_string()],
+            if_exists: false,
+            options: AlterTableOptions::SetTableProperties {
+                properties: vec![("k".to_string(), "v".to_string())],
+            },
+        }
+        .execute(&ctx, &manager)
+        .await;
+
+        let Err(CatalogError::External(message)) = result else {
+            return Err(CatalogError::Internal(
+                "expected missing-location error for lakehouse ALTER TABLE".to_string(),
+            ));
+        };
+        assert!(message.contains("missing table location for storage-backed ALTER TABLE on format"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_columns_falls_back_to_catalog_metadata_for_relative_lakehouse_locations(
+    ) -> CatalogResult<()> {
+        let mut table = default_catalog_table("delta");
+        let TableKind::Table {
+            location, columns, ..
+        } = &mut table.kind
+        else {
+            unreachable!();
+        };
+        *location = Some("relative/delta".to_string());
+        *columns = vec![table_column("catalog_col")];
+        let manager = test_manager(table)?;
+        let ctx = test_session(Arc::new(TestTableFormat::new_failing(
+            "delta",
+            "storage metadata load should not run for relative locations",
+        )))?;
+
+        let batch = CatalogCommand::ListColumns {
+            table: vec!["t".to_string()],
+        }
+        .execute(&ctx, &manager)
+        .await?;
+
+        let names = string_column(&batch, 0)?;
+        assert_eq!(names, vec!["catalog_col".to_string()]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn list_columns_marks_identity_partition_columns_case_insensitively() -> CatalogResult<()>
+    {
+        let manager = test_manager(default_catalog_table("delta"))?;
+        let ctx = test_session(Arc::new(TestTableFormat::new(
+            "delta",
+            StorageTableMetadata {
+                columns: vec![table_column("Ts"), table_column("value")],
+                comment: None,
+                location: Some("file:///tmp/storage".to_string()),
+                provider: "delta".to_string(),
+                partition_columns: vec![CatalogPartitionField {
+                    column: "ts".to_string(),
+                    transform: Some(PartitionTransform::Identity),
+                }],
+                properties: vec![],
+            },
+        )))?;
+
+        let batch = CatalogCommand::ListColumns {
+            table: vec!["t".to_string()],
+        }
+        .execute(&ctx, &manager)
+        .await?;
+
+        let names = string_column(&batch, 0)?;
+        let partition_flags = string_column(&batch, 1)?;
+        let columns = names
+            .into_iter()
+            .zip(partition_flags)
+            .collect::<HashMap<_, _>>();
+
+        assert_eq!(columns.get("Ts").map(String::as_str), Some("true"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn describe_extended_shows_external_type_for_external_delta_tables() -> CatalogResult<()>
+    {
+        let mut table = default_catalog_table("delta");
+        let TableKind::Table { is_external, .. } = &mut table.kind else {
+            unreachable!();
+        };
+        *is_external = true;
+        let manager = test_manager(table)?;
+        let ctx = test_session(Arc::new(TestTableFormat::new(
+            "delta",
+            StorageTableMetadata {
+                columns: vec![table_column("storage_col")],
+                comment: None,
+                location: Some("file:///tmp/storage".to_string()),
+                provider: "delta".to_string(),
+                partition_columns: vec![],
+                properties: vec![],
+            },
+        )))?;
+
+        let batch = CatalogCommand::DescribeTable {
+            table: vec!["t".to_string()],
+            extended: true,
+        }
+        .execute(&ctx, &manager)
+        .await?;
+
+        let names = string_column(&batch, 0)?;
+        let values = string_column(&batch, 1)?;
+        let rows = names.into_iter().zip(values).collect::<HashMap<_, _>>();
+        assert_eq!(rows.get("Type").map(String::as_str), Some("EXTERNAL"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn describe_database_extended_redacts_sensitive_properties() -> CatalogResult<()> {
+        let manager = test_manager_with_database(DatabaseStatus {
+            catalog: "spark_catalog".to_string(),
+            database: vec!["default".to_string()],
+            comment: None,
+            location: Some("file:///tmp/wh".to_string()),
+            properties: vec![
+                ("password".to_string(), "hunter2".to_string()),
+                ("endpoint".to_string(), "https://example.test".to_string()),
+            ],
+        })?;
+        let ctx = test_session(Arc::new(TestTableFormat::new(
+            "parquet",
+            StorageTableMetadata {
+                columns: vec![],
+                comment: None,
+                location: None,
+                provider: "parquet".to_string(),
+                partition_columns: vec![],
+                properties: vec![],
+            },
+        )))?;
+
+        let batch = CatalogCommand::DescribeDatabase {
+            database: vec!["default".to_string()],
+            extended: true,
+        }
+        .execute(&ctx, &manager)
+        .await?;
+
+        let names = string_column(&batch, 0)?;
+        let values = string_column(&batch, 1)?;
+        let rows: HashMap<_, _> = names.into_iter().zip(values).collect();
+        let props = rows
+            .get("Properties")
+            .ok_or_else(|| CatalogError::Internal("Properties row missing".to_string()))?;
+        assert!(
+            props.contains("*********(redacted)"),
+            "password value should be redacted, got: {props}"
+        );
+        assert!(
+            !props.contains("hunter2"),
+            "raw password should not appear, got: {props}"
+        );
+        assert!(
+            props.contains("https://example.test"),
+            "non-sensitive endpoint should appear verbatim, got: {props}"
+        );
+        Ok(())
+    }
+
+    struct TestSession {
+        registry: Arc<TableFormatRegistry>,
+        plan_service: Arc<PlanService>,
+        runtime_env: Arc<RuntimeEnv>,
+    }
+
+    impl SessionExtensionAccessor for TestSession {
+        fn extension<T: SessionExtension>(&self) -> Result<Arc<T>> {
+            if T::name() == TableFormatRegistry::name() {
+                let value: Arc<dyn Any + Send + Sync> = self.registry.clone();
+                value
+                    .downcast::<T>()
+                    .map_err(|_| internal_datafusion_err!("extension type mismatch: {}", T::name()))
+            } else if T::name() == PlanService::name() {
+                let value: Arc<dyn Any + Send + Sync> = self.plan_service.clone();
+                value
+                    .downcast::<T>()
+                    .map_err(|_| internal_datafusion_err!("extension type mismatch: {}", T::name()))
+            } else {
+                Err(internal_datafusion_err!(
+                    "session extension not found: {}",
+                    T::name()
+                ))
+            }
+        }
+
+        fn runtime_env(&self) -> Arc<RuntimeEnv> {
+            self.runtime_env.clone()
+        }
+    }
+
+    struct TestTableFormat {
+        name: &'static str,
+        metadata: Option<StorageTableMetadata>,
+        error: Option<String>,
+    }
+
+    impl TestTableFormat {
+        fn new(name: &'static str, metadata: StorageTableMetadata) -> Self {
+            Self {
+                name,
+                metadata: Some(metadata),
+                error: None,
+            }
+        }
+
+        fn new_failing(name: &'static str, message: &str) -> Self {
+            Self {
+                name,
+                metadata: None,
+                error: Some(message.to_string()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl TableFormat for TestTableFormat {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        async fn create_source(
+            &self,
+            ctx: &dyn Session,
+            info: SourceInfo,
+        ) -> Result<Arc<dyn TableSource>> {
+            let _ = (ctx, info);
+            not_impl_err!("test table format does not create sources")
+        }
+
+        async fn create_writer(
+            &self,
+            ctx: &dyn Session,
+            info: SinkInfo,
+        ) -> Result<Arc<dyn ExecutionPlan>> {
+            let _ = (ctx, info);
+            not_impl_err!("test table format does not create writers")
+        }
+
+        async fn load_storage_table_metadata(
+            &self,
+            runtime_env: Arc<RuntimeEnv>,
+            path: &str,
+        ) -> Result<StorageTableMetadata> {
+            let _ = (runtime_env, path);
+            if let Some(metadata) = &self.metadata {
+                Ok(metadata.clone())
+            } else {
+                let message = self
+                    .error
+                    .as_deref()
+                    .unwrap_or("test table format metadata load failed");
+                datafusion_common::plan_err!("{message}")
+            }
+        }
+    }
+
+    struct TestCatalogProvider {
+        table: TableStatus,
+        database: Option<DatabaseStatus>,
+    }
+
+    impl TestCatalogProvider {
+        fn new(table: TableStatus) -> Self {
+            Self {
+                table,
+                database: None,
+            }
+        }
+
+        fn with_database(mut self, database: DatabaseStatus) -> Self {
+            self.database = Some(database);
+            self
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CatalogProvider for TestCatalogProvider {
+        fn get_name(&self) -> &str {
+            "spark_catalog"
+        }
+
+        async fn create_database(
+            &self,
+            database: &Namespace,
+            options: CreateDatabaseOptions,
+        ) -> CatalogResult<DatabaseStatus> {
+            let _ = (database, options);
+            Err(CatalogError::NotSupported("test provider".to_string()))
+        }
+
+        async fn get_database(&self, database: &Namespace) -> CatalogResult<DatabaseStatus> {
+            let _ = database;
+            match &self.database {
+                Some(db) => Ok(db.clone()),
+                None => Err(CatalogError::NotSupported("test provider".to_string())),
+            }
+        }
+
+        async fn list_databases(
+            &self,
+            prefix: Option<&Namespace>,
+        ) -> CatalogResult<Vec<DatabaseStatus>> {
+            let _ = prefix;
+            Err(CatalogError::NotSupported("test provider".to_string()))
+        }
+
+        async fn drop_database(
+            &self,
+            database: &Namespace,
+            options: DropDatabaseOptions,
+        ) -> CatalogResult<()> {
+            let _ = (database, options);
+            Err(CatalogError::NotSupported("test provider".to_string()))
+        }
+
+        async fn create_table(
+            &self,
+            database: &Namespace,
+            table: &str,
+            options: CreateTableOptions,
+        ) -> CatalogResult<TableStatus> {
+            let _ = (database, table, options);
+            Err(CatalogError::NotSupported("test provider".to_string()))
+        }
+
+        async fn get_table(&self, database: &Namespace, table: &str) -> CatalogResult<TableStatus> {
+            let _ = database;
+            if table == "t" {
+                Ok(self.table.clone())
+            } else {
+                Err(CatalogError::NotFound(
+                    crate::error::CatalogObject::Table,
+                    table.to_string(),
+                ))
+            }
+        }
+
+        async fn list_tables(&self, database: &Namespace) -> CatalogResult<Vec<TableStatus>> {
+            let _ = database;
+            Err(CatalogError::NotSupported("test provider".to_string()))
+        }
+
+        async fn drop_table(
+            &self,
+            database: &Namespace,
+            table: &str,
+            options: DropTableOptions,
+        ) -> CatalogResult<()> {
+            let _ = (database, table, options);
+            Err(CatalogError::NotSupported("test provider".to_string()))
+        }
+
+        async fn alter_table(
+            &self,
+            database: &Namespace,
+            table: &str,
+            options: AlterTableOptions,
+        ) -> CatalogResult<()> {
+            let _ = (database, table, options);
+            Err(CatalogError::NotSupported("test provider".to_string()))
+        }
+
+        async fn create_view(
+            &self,
+            database: &Namespace,
+            view: &str,
+            options: CreateViewOptions,
+        ) -> CatalogResult<TableStatus> {
+            let _ = (database, view, options);
+            Err(CatalogError::NotSupported("test provider".to_string()))
+        }
+
+        async fn get_view(&self, database: &Namespace, view: &str) -> CatalogResult<TableStatus> {
+            let _ = database;
+            Err(CatalogError::NotFound(
+                crate::error::CatalogObject::View,
+                view.to_string(),
+            ))
+        }
+
+        async fn list_views(&self, database: &Namespace) -> CatalogResult<Vec<TableStatus>> {
+            let _ = database;
+            Err(CatalogError::NotSupported("test provider".to_string()))
+        }
+
+        async fn drop_view(
+            &self,
+            database: &Namespace,
+            view: &str,
+            options: DropViewOptions,
+        ) -> CatalogResult<()> {
+            let _ = (database, view, options);
+            Err(CatalogError::NotSupported("test provider".to_string()))
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
+    struct TestPlanFormatter;
+
+    impl PlanFormatter for TestPlanFormatter {
+        fn data_type_to_simple_string(&self, data_type: &DataType) -> Result<String> {
+            Ok(format!("{data_type:?}"))
+        }
+
+        fn literal_to_string(
+            &self,
+            literal: &ScalarValue,
+            display_timezone: &str,
+        ) -> Result<String> {
+            let _ = display_timezone;
+            Ok(format!("{literal:?}"))
+        }
+
+        fn function_to_string(
+            &self,
+            name: &str,
+            arguments: Vec<&str>,
+            is_distinct: bool,
+        ) -> Result<String> {
+            let _ = (arguments, is_distinct);
+            Ok(name.to_string())
+        }
     }
 
     #[derive(Default)]
     struct TestCatalogObjectDisplay;
 
     impl CatalogObjectDisplay for TestCatalogObjectDisplay {
-        type Catalog = TestCatalogOutput;
-        type Database = TestCatalogOutput;
-        type Table = TestCatalogOutput;
-        type TableColumn = TestCatalogOutput;
-        type Function = TestCatalogOutput;
+        type Catalog = TestCatalogRow;
+        type Database = TestDatabaseRow;
+        type Table = TestTableRow;
+        type TableColumn = TestTableColumnRow;
+        type Function = TestFunctionRow;
 
         fn catalog(name: String) -> Self::Catalog {
-            TestCatalogOutput { value: name }
+            TestCatalogRow { name }
         }
 
         fn database(status: DatabaseStatus) -> Self::Database {
-            TestCatalogOutput {
-                value: status.database.join("."),
+            TestDatabaseRow {
+                name: status.database.join("."),
             }
         }
 
         fn table(status: TableStatus) -> Self::Table {
-            TestCatalogOutput { value: status.name }
+            TestTableRow { name: status.name }
         }
 
         fn table_column(status: TableColumnStatus) -> Self::TableColumn {
-            TestCatalogOutput { value: status.name }
-        }
-
-        fn function(name: String) -> Self::Function {
-            TestCatalogOutput { value: name }
-        }
-    }
-
-    #[derive(Debug, PartialEq, Eq, Hash, PartialOrd)]
-    struct TestPlanFormatter;
-
-    impl PlanFormatter for TestPlanFormatter {
-        fn data_type_to_simple_string(
-            &self,
-            _data_type: &datafusion::arrow::datatypes::DataType,
-        ) -> datafusion_common::Result<String> {
-            Ok("int".to_string())
-        }
-
-        fn literal_to_string(
-            &self,
-            _literal: &datafusion_common::ScalarValue,
-            _display_timezone: &str,
-        ) -> datafusion_common::Result<String> {
-            not_impl_err!("unused in test")
-        }
-
-        fn function_to_string(
-            &self,
-            _name: &str,
-            _arguments: Vec<&str>,
-            _is_distinct: bool,
-        ) -> datafusion_common::Result<String> {
-            not_impl_err!("unused in test")
-        }
-    }
-
-    struct TestProvider {
-        table_status: TableStatus,
-        alter_error: Option<String>,
-    }
-
-    #[async_trait]
-    impl CatalogProvider for TestProvider {
-        fn get_name(&self) -> &str {
-            "test"
-        }
-
-        async fn create_database(
-            &self,
-            _database: &crate::provider::Namespace,
-            _options: CreateDatabaseOptions,
-        ) -> CatalogResult<sail_common_datafusion::catalog::DatabaseStatus> {
-            unreachable!()
-        }
-
-        async fn get_database(
-            &self,
-            _database: &crate::provider::Namespace,
-        ) -> CatalogResult<sail_common_datafusion::catalog::DatabaseStatus> {
-            unreachable!()
-        }
-
-        async fn list_databases(
-            &self,
-            _prefix: Option<&crate::provider::Namespace>,
-        ) -> CatalogResult<Vec<sail_common_datafusion::catalog::DatabaseStatus>> {
-            unreachable!()
-        }
-
-        async fn drop_database(
-            &self,
-            _database: &crate::provider::Namespace,
-            _options: DropDatabaseOptions,
-        ) -> CatalogResult<()> {
-            unreachable!()
-        }
-
-        async fn create_table(
-            &self,
-            _database: &crate::provider::Namespace,
-            _table: &str,
-            _options: CreateTableOptions,
-        ) -> CatalogResult<TableStatus> {
-            unreachable!()
-        }
-
-        async fn get_table(
-            &self,
-            _database: &crate::provider::Namespace,
-            _table: &str,
-        ) -> CatalogResult<TableStatus> {
-            Ok(self.table_status.clone())
-        }
-
-        async fn list_tables(
-            &self,
-            _database: &crate::provider::Namespace,
-        ) -> CatalogResult<Vec<TableStatus>> {
-            unreachable!()
-        }
-
-        async fn drop_table(
-            &self,
-            _database: &crate::provider::Namespace,
-            _table: &str,
-            _options: DropTableOptions,
-        ) -> CatalogResult<()> {
-            unreachable!()
-        }
-
-        async fn alter_table(
-            &self,
-            _database: &crate::provider::Namespace,
-            _table: &str,
-            _options: AlterTableOptions,
-        ) -> CatalogResult<()> {
-            match &self.alter_error {
-                Some(message) => Err(CatalogError::External(message.clone())),
-                None => Ok(()),
+            TestTableColumnRow {
+                name: status.name,
+                is_partition: status.is_partition,
             }
         }
 
-        async fn create_view(
-            &self,
-            _database: &crate::provider::Namespace,
-            _view: &str,
-            _options: CreateViewOptions,
-        ) -> CatalogResult<TableStatus> {
-            unreachable!()
-        }
-
-        async fn get_view(
-            &self,
-            _database: &crate::provider::Namespace,
-            _view: &str,
-        ) -> CatalogResult<TableStatus> {
-            unreachable!()
-        }
-
-        async fn list_views(
-            &self,
-            _database: &crate::provider::Namespace,
-        ) -> CatalogResult<Vec<TableStatus>> {
-            unreachable!()
-        }
-
-        async fn drop_view(
-            &self,
-            _database: &crate::provider::Namespace,
-            _view: &str,
-            _options: DropViewOptions,
-        ) -> CatalogResult<()> {
-            unreachable!()
+        fn function(name: String) -> Self::Function {
+            TestFunctionRow { name }
         }
     }
 
-    struct TestTableFormat;
+    #[derive(Serialize, Deserialize)]
+    struct TestCatalogRow {
+        name: String,
+    }
 
-    #[async_trait]
-    impl TableFormat for TestTableFormat {
-        fn name(&self) -> &str {
-            "delta"
-        }
+    #[derive(Serialize, Deserialize)]
+    struct TestDatabaseRow {
+        name: String,
+    }
 
-        async fn create_source(
-            &self,
-            _ctx: &dyn Session,
-            _info: SourceInfo,
-        ) -> datafusion_common::Result<Arc<dyn TableSource>> {
-            not_impl_err!("unused in test")
-        }
+    #[derive(Serialize, Deserialize)]
+    struct TestTableRow {
+        name: String,
+    }
 
-        async fn create_writer(
-            &self,
-            _ctx: &dyn Session,
-            _info: SinkInfo,
-        ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
-            not_impl_err!("unused in test")
-        }
+    #[derive(Serialize, Deserialize)]
+    struct TestTableColumnRow {
+        name: String,
+        is_partition: bool,
+    }
 
-        async fn alter_table_properties(
-            &self,
-            _runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>,
-            _path: &str,
-            _changes: Vec<(String, Option<String>)>,
-            _if_exists: bool,
-        ) -> datafusion_common::Result<()> {
-            Ok(())
+    #[derive(Serialize, Deserialize)]
+    struct TestFunctionRow {
+        name: String,
+    }
+
+    fn table_column(name: &str) -> TableColumnStatus {
+        TableColumnStatus {
+            name: name.to_string(),
+            data_type: DataType::Int32,
+            nullable: true,
+            comment: None,
+            default: None,
+            generated_always_as: None,
+            is_partition: false,
+            is_bucket: false,
+            is_cluster: false,
         }
     }
 
-    fn test_session_context() -> SessionContext {
-        let registry = Arc::new(TableFormatRegistry::new());
-        let register_result = registry.register(Arc::new(TestTableFormat));
-        assert!(
-            register_result.is_ok(),
-            "failed to register test table format: {register_result:?}"
-        );
-        let plan_service = Arc::new(PlanService::new(
-            Box::new(DefaultCatalogDisplay::<TestCatalogObjectDisplay>::default()),
-            Box::new(TestPlanFormatter),
-        ));
-        let config = SessionConfig::new()
-            .with_extension(registry)
-            .with_extension(plan_service);
-        SessionContext::new_with_config(config)
-    }
-
-    fn test_manager(alter_error: Option<&str>) -> CatalogManager {
-        let table_status = TableStatus {
-            catalog: Some("test".to_string()),
+    fn default_catalog_table(format: &str) -> TableStatus {
+        TableStatus {
+            catalog: Some("spark_catalog".to_string()),
             database: vec!["default".to_string()],
-            name: "items".to_string(),
+            name: "t".to_string(),
             kind: TableKind::Table {
-                columns: vec![TableColumnStatus {
-                    name: "id".to_string(),
-                    data_type: datafusion::arrow::datatypes::DataType::Int32,
-                    nullable: false,
-                    comment: None,
-                    default: None,
-                    generated_always_as: None,
-                    is_partition: false,
-                    is_bucket: false,
-                    is_cluster: false,
-                }],
+                columns: vec![table_column("catalog_col")],
                 comment: None,
                 constraints: vec![],
-                location: Some("s3://bucket/items".to_string()),
-                format: "delta".to_string(),
+                location: Some("file:///tmp/catalog".to_string()),
+                format: format.to_string(),
                 partition_by: vec![],
                 sort_by: vec![],
                 bucket_by: None,
                 properties: vec![],
-                is_external: true,
+                is_external: false,
             },
-        };
-        let manager = CatalogManager::try_new(crate::manager::CatalogManagerOptions {
-            catalogs: std::iter::once((
-                "test".to_string(),
-                Arc::new(TestProvider {
-                    table_status,
-                    alter_error: alter_error.map(ToString::to_string),
-                }) as Arc<dyn CatalogProvider>,
-            ))
-            .collect(),
-            default_catalog: "test".to_string(),
-            default_database: vec!["default".to_string()],
-            global_temporary_database: vec!["global_temp".to_string()],
-        });
-        assert!(
-            manager.is_ok(),
-            "failed to construct test catalog manager: {}",
-            manager
-                .as_ref()
-                .err()
-                .map(ToString::to_string)
-                .unwrap_or_default()
-        );
-        let Ok(manager) = manager else {
-            unreachable!();
-        };
-        manager
+        }
     }
 
-    #[tokio::test]
-    async fn alter_table_returns_error_when_catalog_sync_fails() {
-        let ctx = test_session_context();
-        let manager = test_manager(Some("catalog sync failed"));
-        let command = CatalogCommand::AlterTable {
-            table: vec!["items".to_string()],
-            if_exists: false,
-            options: AlterTableOptions::SetTableProperties {
-                properties: vec![("owner".to_string(), "alice".to_string())],
-            },
-        };
+    fn test_manager(table: TableStatus) -> CatalogResult<CatalogManager> {
+        CatalogManager::try_new(CatalogManagerOptions {
+            catalogs: HashMap::from([(
+                "spark_catalog".to_string(),
+                Arc::new(TestCatalogProvider::new(table)) as Arc<dyn CatalogProvider>,
+            )]),
+            default_catalog: "spark_catalog".to_string(),
+            default_database: vec!["default".to_string()],
+            global_temporary_database: vec!["global_temp".to_string()],
+        })
+    }
 
-        let result = command.execute(&ctx, &manager).await;
-        assert!(
-            result.is_err(),
-            "expected catalog sync failure, got success: {result:?}"
-        );
-        let Err(error) = result else {
-            unreachable!();
-        };
+    fn test_manager_with_database(database: DatabaseStatus) -> CatalogResult<CatalogManager> {
+        CatalogManager::try_new(CatalogManagerOptions {
+            catalogs: HashMap::from([(
+                "spark_catalog".to_string(),
+                Arc::new(
+                    TestCatalogProvider::new(default_catalog_table("parquet"))
+                        .with_database(database),
+                ) as Arc<dyn CatalogProvider>,
+            )]),
+            default_catalog: "spark_catalog".to_string(),
+            default_database: vec!["default".to_string()],
+            global_temporary_database: vec!["global_temp".to_string()],
+        })
+    }
 
-        assert!(
-            matches!(error, CatalogError::External(message) if message.contains("catalog sync failed"))
-        );
+    fn test_session(format: Arc<dyn TableFormat>) -> CatalogResult<TestSession> {
+        let registry = Arc::new(TableFormatRegistry::new());
+        registry.register(format)?;
+        Ok(TestSession {
+            registry,
+            plan_service: Arc::new(PlanService::new(
+                Box::new(DefaultCatalogDisplay::<TestCatalogObjectDisplay>::default()),
+                Box::new(TestPlanFormatter),
+            )),
+            runtime_env: Arc::new(RuntimeEnv::default()),
+        })
+    }
+
+    fn string_column(
+        batch: &datafusion::arrow::array::RecordBatch,
+        index: usize,
+    ) -> CatalogResult<Vec<String>> {
+        let column = batch.column(index);
+        (0..column.len())
+            .map(|row| {
+                array_value_to_string(column, row)
+                    .map_err(|e| CatalogError::Internal(e.to_string()))
+            })
+            .collect()
     }
 }

--- a/crates/sail-catalog/src/lib.rs
+++ b/crates/sail-catalog/src/lib.rs
@@ -2,6 +2,7 @@ pub mod command;
 pub mod error;
 pub mod hive_format;
 pub mod manager;
+pub mod metadata_compat;
 pub mod provider;
 pub mod temp_view;
 pub mod utils;

--- a/crates/sail-catalog/src/metadata_compat.rs
+++ b/crates/sail-catalog/src/metadata_compat.rs
@@ -1,0 +1,382 @@
+use datafusion_common::Result;
+use lazy_static::lazy_static;
+use regex::Regex;
+use sail_common_datafusion::catalog::TableStatus;
+use sail_common_datafusion::session::plan::PlanFormatter;
+
+const REDACTION_REPLACEMENT_TEXT: &str = "*********(redacted)";
+
+fn create_regex(regex: std::result::Result<Regex, regex::Error>) -> Regex {
+    #[expect(clippy::expect_used)]
+    regex.expect("valid regex")
+}
+
+lazy_static! {
+    static ref SQL_OPTIONS_REDACTION_PATTERN: Regex = create_regex(Regex::new("(?i)url"));
+    static ref SECRET_REDACTION_PATTERN: Regex =
+        create_regex(Regex::new("(?i)secret|password|token|access[.]?key"));
+}
+
+const SPARK_RESERVED_TABLE_PROPERTIES: &[&str] = &[
+    "comment",
+    "collation",
+    "location",
+    "provider",
+    "owner",
+    "external",
+    "is_managed_location",
+    "table_type",
+];
+
+pub fn show_tblproperties_rows(
+    table_name: &str,
+    properties: &[(String, String)],
+    property_key: Option<&str>,
+) -> Vec<(String, String)> {
+    let mut visible_properties: Vec<(String, String)> = properties
+        .iter()
+        .filter(|(k, _)| !SPARK_RESERVED_TABLE_PROPERTIES.contains(&k.as_str()))
+        .map(|(k, v)| (k.clone(), redact_property_value(k, v)))
+        .collect();
+
+    match property_key {
+        Some(key) => {
+            let value = visible_properties
+                .iter()
+                .find(|(k, _)| k == key)
+                .map(|(_, v)| v.clone())
+                .unwrap_or_else(|| format!("Table {table_name} does not have property: {key}"));
+            vec![(key.to_string(), value)]
+        }
+        None => {
+            visible_properties.sort_by(|a, b| a.0.cmp(&b.0));
+            visible_properties
+        }
+    }
+}
+
+pub fn describe_extended_metadata_rows(table: &TableStatus) -> Vec<(String, String)> {
+    detailed_table_rows(table, true)
+}
+
+pub fn show_table_extended_information(
+    table: &TableStatus,
+    formatter: &dyn PlanFormatter,
+) -> Result<String> {
+    let mut output = String::new();
+
+    for (key, value) in detailed_table_rows(table, false) {
+        output.push_str(&format!("{key}: {value}\n"));
+    }
+
+    output.push_str("Schema: root\n");
+    for column in table.kind.columns() {
+        let data_type = formatter
+            .data_type_to_simple_string(&column.data_type)
+            .unwrap_or_else(|_| "invalid".to_string());
+        let nullable = if column.nullable { "true" } else { "false" };
+        output.push_str(&format!(
+            " |-- {}: {} (nullable = {})\n",
+            column.name, data_type, nullable
+        ));
+    }
+
+    Ok(output)
+}
+
+fn detailed_table_rows(
+    table: &TableStatus,
+    always_include_properties: bool,
+) -> Vec<(String, String)> {
+    let mut rows = Vec::new();
+
+    rows.push(("Database".to_string(), table.database.join(".")));
+    rows.push(("Table".to_string(), table.name.clone()));
+    rows.push(("Type".to_string(), table.kind.type_name().to_string()));
+
+    if let Some(format) = table.kind.format() {
+        rows.push(("Provider".to_string(), format.to_string()));
+    }
+
+    if let Some(comment) = table.kind.comment() {
+        rows.push(("Comment".to_string(), comment));
+    }
+
+    if let Some(definition) = table.kind.view_definition() {
+        rows.push(("View Text".to_string(), definition.to_string()));
+    }
+
+    if let Some(props) = table_properties_cell(table.kind.properties(), always_include_properties) {
+        rows.push(("Table Properties".to_string(), props));
+    }
+
+    if let Some(loc) = table.kind.location() {
+        rows.push(("Location".to_string(), loc.to_string()));
+    }
+
+    rows
+}
+
+fn table_properties_cell(
+    properties: &[(String, String)],
+    always_include_properties: bool,
+) -> Option<String> {
+    if properties.is_empty() && !always_include_properties {
+        return None;
+    }
+    let visible_properties = visible_properties(properties);
+    if visible_properties.is_empty() {
+        return Some("[]".to_string());
+    }
+    let props_str = visible_properties
+        .iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(format!("[{props_str}]"))
+}
+
+fn visible_properties(properties: &[(String, String)]) -> Vec<(String, String)> {
+    let mut visible_properties: Vec<(String, String)> = properties
+        .iter()
+        .filter(|(k, _)| !SPARK_RESERVED_TABLE_PROPERTIES.contains(&k.as_str()))
+        .map(|(k, v)| (k.clone(), redact_property_value(k, v)))
+        .collect();
+    visible_properties.sort_by(|a, b| a.0.cmp(&b.0));
+    visible_properties
+}
+
+pub fn redact_property_value(key: &str, value: &str) -> String {
+    if SQL_OPTIONS_REDACTION_PATTERN.is_match(key)
+        || SECRET_REDACTION_PATTERN.is_match(key)
+        || SECRET_REDACTION_PATTERN.is_match(value)
+    {
+        REDACTION_REPLACEMENT_TEXT.to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::datatypes::DataType;
+    use datafusion_common::ScalarValue;
+    use sail_common_datafusion::catalog::{TableColumnStatus, TableKind, TableStatus};
+    use sail_common_datafusion::session::plan::PlanFormatter;
+
+    use super::{
+        describe_extended_metadata_rows, redact_property_value, show_table_extended_information,
+        show_tblproperties_rows, REDACTION_REPLACEMENT_TEXT,
+    };
+
+    #[test]
+    fn show_tblproperties_filters_reserved_keys_and_sorts() {
+        let rows = show_tblproperties_rows(
+            "spark_catalog.default.t",
+            &[
+                ("z".to_string(), "9".to_string()),
+                ("provider".to_string(), "delta".to_string()),
+                ("a".to_string(), "1".to_string()),
+                ("comment".to_string(), "ignored".to_string()),
+            ],
+            None,
+        );
+        assert_eq!(
+            rows,
+            vec![
+                ("a".to_string(), "1".to_string()),
+                ("z".to_string(), "9".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn show_tblproperties_reserved_lookup_behaves_like_missing() {
+        let rows = show_tblproperties_rows(
+            "spark_catalog.default.t",
+            &[("provider".to_string(), "delta".to_string())],
+            Some("provider"),
+        );
+        assert_eq!(
+            rows,
+            vec![(
+                "provider".to_string(),
+                "Table spark_catalog.default.t does not have property: provider".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn show_tblproperties_returns_explicit_value_for_visible_key_lookup() {
+        let rows = show_tblproperties_rows(
+            "spark_catalog.default.t",
+            &[("custom.key".to_string(), "value".to_string())],
+            Some("custom.key"),
+        );
+        assert_eq!(rows, vec![("custom.key".to_string(), "value".to_string())]);
+    }
+
+    #[test]
+    fn show_tblproperties_redacts_sensitive_property_values() {
+        let rows = show_tblproperties_rows(
+            "spark_catalog.default.t",
+            &[
+                ("password".to_string(), "hunter2".to_string()),
+                ("url".to_string(), "https://example.test".to_string()),
+                ("user".to_string(), "andrew".to_string()),
+                (
+                    "endpoint".to_string(),
+                    "https://example.test/storage".to_string(),
+                ),
+            ],
+            None,
+        );
+        assert_eq!(
+            rows,
+            vec![
+                (
+                    "endpoint".to_string(),
+                    "https://example.test/storage".to_string()
+                ),
+                ("password".to_string(), "*********(redacted)".to_string()),
+                ("url".to_string(), "*********(redacted)".to_string()),
+                ("user".to_string(), "andrew".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn describe_extended_redacts_sensitive_table_properties() {
+        let table = test_table(vec![
+            ("password".to_string(), "hunter2".to_string()),
+            ("user".to_string(), "andrew".to_string()),
+        ]);
+        let rows = describe_extended_metadata_rows(&table);
+        let table_properties = rows
+            .iter()
+            .find(|(k, _)| k == "Table Properties")
+            .map(|(_, v)| v.as_str());
+        assert_eq!(
+            table_properties,
+            Some("[password=*********(redacted), user=andrew]")
+        );
+    }
+
+    #[test]
+    fn describe_extended_always_includes_table_properties_row() {
+        let table = test_table(vec![]);
+        let rows = describe_extended_metadata_rows(&table);
+        assert!(rows
+            .iter()
+            .any(|(k, v)| k == "Table Properties" && v == "[]"));
+    }
+
+    #[test]
+    fn describe_extended_filters_reserved_properties_and_sorts_visible_properties() {
+        let table = test_table(vec![
+            ("z".to_string(), "9".to_string()),
+            ("provider".to_string(), "delta".to_string()),
+            ("a".to_string(), "1".to_string()),
+        ]);
+        let rows = describe_extended_metadata_rows(&table);
+        let table_properties = rows
+            .iter()
+            .find(|(k, _)| k == "Table Properties")
+            .map(|(_, v)| v.as_str());
+        assert_eq!(table_properties, Some("[a=1, z=9]"));
+    }
+
+    #[test]
+    fn show_table_extended_omits_table_properties_when_no_underlying_properties(
+    ) -> datafusion_common::Result<()> {
+        let table = test_table(vec![]);
+        let formatter = TestPlanFormatter;
+        let information = show_table_extended_information(&table, &formatter)?;
+        assert!(!information.contains("Table Properties:"));
+        Ok(())
+    }
+
+    #[test]
+    fn show_table_extended_keeps_table_properties_when_only_reserved_properties_exist(
+    ) -> datafusion_common::Result<()> {
+        let table = test_table(vec![("provider".to_string(), "delta".to_string())]);
+        let formatter = TestPlanFormatter;
+        let information = show_table_extended_information(&table, &formatter)?;
+        assert!(information.contains("Table Properties: []"));
+        Ok(())
+    }
+
+    #[test]
+    fn redact_property_value_redacts_when_value_contains_secret_pattern() {
+        assert_eq!(
+            redact_property_value("endpoint", "s3://access-key:secret@bucket/path"),
+            REDACTION_REPLACEMENT_TEXT
+        );
+        assert_eq!(
+            redact_property_value("endpoint", "https://example.test/storage"),
+            "https://example.test/storage"
+        );
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Hash)]
+    struct TestPlanFormatter;
+
+    impl PlanFormatter for TestPlanFormatter {
+        fn data_type_to_simple_string(
+            &self,
+            data_type: &DataType,
+        ) -> datafusion_common::Result<String> {
+            Ok(match data_type {
+                DataType::Int32 => "int".to_string(),
+                _ => "unknown".to_string(),
+            })
+        }
+
+        fn literal_to_string(
+            &self,
+            _literal: &ScalarValue,
+            _display_timezone: &str,
+        ) -> datafusion_common::Result<String> {
+            Ok(String::new())
+        }
+
+        fn function_to_string(
+            &self,
+            _name: &str,
+            _arguments: Vec<&str>,
+            _is_distinct: bool,
+        ) -> datafusion_common::Result<String> {
+            Ok(String::new())
+        }
+    }
+
+    fn test_table(properties: Vec<(String, String)>) -> TableStatus {
+        TableStatus {
+            catalog: Some("spark_catalog".to_string()),
+            database: vec!["default".to_string()],
+            name: "t".to_string(),
+            kind: TableKind::Table {
+                columns: vec![TableColumnStatus {
+                    name: "id".to_string(),
+                    data_type: DataType::Int32,
+                    nullable: true,
+                    comment: None,
+                    default: None,
+                    generated_always_as: None,
+                    is_partition: false,
+                    is_bucket: false,
+                    is_cluster: false,
+                }],
+                comment: Some("c".to_string()),
+                constraints: vec![],
+                location: Some("file:/tmp/t".to_string()),
+                format: "parquet".to_string(),
+                partition_by: vec![],
+                sort_by: vec![],
+                bucket_by: None,
+                properties,
+                is_external: false,
+            },
+        }
+    }
+}

--- a/crates/sail-common-datafusion/Cargo.toml
+++ b/crates/sail-common-datafusion/Cargo.toml
@@ -28,6 +28,7 @@ parquet-variant-compute = { workspace = true }
 parquet-variant-json = { workspace = true }
 tokio = { workspace = true }
 serde_arrow = { workspace = true }
+url = { workspace = true }
 
 [build-dependencies]
 tonic-prost-build = { workspace = true }

--- a/crates/sail-common-datafusion/src/catalog/status.rs
+++ b/crates/sail-common-datafusion/src/catalog/status.rs
@@ -8,7 +8,6 @@ use crate::catalog::{
     CatalogPartitionField, CatalogTableBucketBy, CatalogTableConstraint, CatalogTableSort,
 };
 use crate::column_features::ColumnFeaturesBuilder;
-use crate::session::plan::PlanFormatter;
 
 /// Metadata key used by Spark Connect's column protocol for generation
 /// expressions. This is an input/output boundary value translated to the
@@ -157,68 +156,6 @@ impl TableKind {
             TableKind::View { definition, .. } if !definition.is_empty() => Some(definition),
             _ => None,
         }
-    }
-}
-
-impl TableStatus {
-    /// Returns metadata key-value pairs for the DESCRIBE EXTENDED output,
-    /// following Spark's CatalogTable.toLinkedHashMap row ordering.
-    pub fn describe_extended_metadata(&self) -> Vec<(String, String)> {
-        let mut rows = Vec::new();
-
-        rows.push(("Database".to_string(), self.database.join(".")));
-        rows.push(("Table".to_string(), self.name.clone()));
-        rows.push(("Type".to_string(), self.kind.type_name().to_string()));
-
-        if let Some(format) = self.kind.format() {
-            rows.push(("Provider".to_string(), format.to_string()));
-        }
-
-        if let Some(comment) = self.kind.comment() {
-            rows.push(("Comment".to_string(), comment));
-        }
-
-        if let Some(definition) = self.kind.view_definition() {
-            rows.push(("View Text".to_string(), definition.to_string()));
-        }
-
-        let properties = self.kind.properties();
-        if !properties.is_empty() {
-            let props_str = properties
-                .iter()
-                .map(|(k, v)| format!("{k}={v}"))
-                .collect::<Vec<_>>()
-                .join(", ");
-            rows.push(("Table Properties".to_string(), format!("[{props_str}]")));
-        }
-
-        if let Some(loc) = self.kind.location() {
-            rows.push(("Location".to_string(), loc.to_string()));
-        }
-
-        rows
-    }
-
-    pub fn show_table_extended_information(&self, formatter: &dyn PlanFormatter) -> Result<String> {
-        let mut output = String::new();
-
-        for (key, value) in self.describe_extended_metadata() {
-            output.push_str(&format!("{key}: {value}\n"));
-        }
-
-        output.push_str("Schema: root\n");
-        for column in self.kind.columns() {
-            let data_type = formatter
-                .data_type_to_simple_string(&column.data_type)
-                .unwrap_or_else(|_| "invalid".to_string());
-            let nullable = if column.nullable { "true" } else { "false" };
-            output.push_str(&format!(
-                " |-- {}: {} (nullable = {})\n",
-                column.name, data_type, nullable
-            ));
-        }
-
-        Ok(output)
     }
 }
 

--- a/crates/sail-common-datafusion/src/datasource.rs
+++ b/crates/sail-common-datafusion/src/datasource.rs
@@ -1,4 +1,5 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
 use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
@@ -10,11 +11,12 @@ use datafusion::physical_expr::{
     create_physical_sort_exprs, LexOrdering, LexRequirement, PhysicalSortRequirement,
 };
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion_common::{not_impl_err, plan_err, Constraints, DFSchema, Result};
+use datafusion_common::{not_impl_err, plan_err, Constraints, DFSchema, DataFusionError, Result};
 use datafusion_expr::expr::Sort;
 use datafusion_expr::TableSource;
+use url::Url;
 
-use crate::catalog::CatalogPartitionField;
+use crate::catalog::{CatalogPartitionField, PartitionTransform, TableColumnStatus};
 use crate::extension::SessionExtension;
 use crate::logical_expr::ExprWithSource;
 
@@ -206,6 +208,94 @@ pub struct SinkInfo {
     pub logical_schema: Option<datafusion_common::DFSchemaRef>,
 }
 
+/// Storage-backed metadata normalized for Spark-compat catalog commands.
+#[derive(Debug, Clone)]
+pub struct StorageTableMetadata {
+    pub columns: Vec<TableColumnStatus>,
+    pub comment: Option<String>,
+    pub location: Option<String>,
+    pub provider: String,
+    pub partition_columns: Vec<CatalogPartitionField>,
+    pub properties: Vec<(String, String)>,
+}
+
+/// Converts a table location into a URL.
+///
+/// Accepts fully qualified URLs (`file://`, `s3://`, ...) and absolute filesystem paths.
+/// Relative paths are rejected — catalog-stored table locations must be absolute.
+pub fn is_relative_location(location: &str) -> bool {
+    if let Ok(url) = Url::parse(location) {
+        // Reject single-letter "schemes" that `Url::parse` accepts on
+        // Windows for drive-letter paths like `C:/tmp/table`.
+        if url.scheme().len() > 1 {
+            return false;
+        }
+    }
+    !Path::new(location).is_absolute()
+}
+
+pub fn location_to_url(location: &str, format_name: &str) -> Result<Url> {
+    if let Ok(url) = Url::parse(location) {
+        // Reject single-letter "schemes" that `Url::parse` accepts on
+        // Windows for drive-letter paths like `C:/tmp/table`.
+        if url.scheme().len() > 1 {
+            return Ok(url);
+        }
+    }
+    if is_relative_location(location) {
+        return Err(DataFusionError::Plan(format!(
+            "relative path '{location}' is not supported for {format_name} table location; \
+             use an absolute path or a fully qualified URL (file://, s3://, etc.)"
+        )));
+    }
+    let path = Path::new(location);
+    Url::from_directory_path(path)
+        .or_else(|_| Url::from_file_path(path))
+        .map_err(|_| DataFusionError::Plan(format!("invalid {format_name} table path: {location}")))
+}
+
+/// Converts an Arrow schema to catalog columns with partition flags.
+///
+/// Only identity partition sources are marked as partition columns. Hidden
+/// transformed partitions such as `days(ts)` or `bucket(8, id)` do not map to
+/// physical schema fields and should not mark their source columns as direct
+/// partition columns in catalog output.
+pub fn arrow_schema_to_columns(
+    schema: &Schema,
+    partition_columns: &[CatalogPartitionField],
+) -> Vec<TableColumnStatus> {
+    let identity_partition_columns: HashSet<String> = partition_columns
+        .iter()
+        .filter(|field| {
+            matches!(
+                field.transform.unwrap_or(PartitionTransform::Identity),
+                PartitionTransform::Identity
+            )
+        })
+        .map(|field| field.column.to_ascii_lowercase())
+        .collect();
+    let bucket_columns: HashSet<String> = partition_columns
+        .iter()
+        .filter(|field| matches!(field.transform, Some(PartitionTransform::Bucket(_))))
+        .map(|field| field.column.to_ascii_lowercase())
+        .collect();
+    schema
+        .fields()
+        .iter()
+        .map(|field| TableColumnStatus {
+            name: field.name().to_string(),
+            data_type: field.data_type().clone(),
+            nullable: field.is_nullable(),
+            comment: field.metadata().get("comment").cloned(),
+            default: None,
+            generated_always_as: None,
+            is_partition: identity_partition_columns.contains(&field.name().to_ascii_lowercase()),
+            is_bucket: bucket_columns.contains(&field.name().to_ascii_lowercase()),
+            is_cluster: false,
+        })
+        .collect()
+}
+
 /// Returns the path from options, or `None` if not set.
 /// Checks the `"path"` key first, then `"location"`.
 /// Key comparison is case-insensitive.
@@ -337,6 +427,22 @@ pub trait TableFormat: Send + Sync {
         MergeStrategy::Eager
     }
 
+    /// Load normalized storage-backed metadata for a table location.
+    ///
+    /// Implementations should return Spark-compatible metadata derived from storage
+    /// (schema, partition columns, comment/location/provider, and properties).
+    async fn load_storage_table_metadata(
+        &self,
+        runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>,
+        path: &str,
+    ) -> Result<StorageTableMetadata> {
+        let _ = (runtime_env, path);
+        not_impl_err!(
+            "Storage metadata loading not supported for {} format",
+            self.name()
+        )
+    }
+
     /// Alters table properties (SET/UNSET TBLPROPERTIES).
     ///
     /// `changes` is a list of `(key, value)` pairs where `value` is `Some(v)` to set a property,
@@ -466,4 +572,51 @@ pub fn get_partition_columns_and_file_schema(
         .collect::<Vec<_>>();
     let file_schema = Schema::new(file_schema_fields);
     Ok((partition_columns, file_schema))
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+
+    use super::arrow_schema_to_columns;
+    use crate::catalog::{CatalogPartitionField, PartitionTransform};
+
+    #[test]
+    fn arrow_schema_to_columns_marks_identity_partitions_case_insensitively() {
+        let schema = Schema::new(vec![
+            Field::new("Ts", DataType::Int32, true),
+            Field::new("value", DataType::Int32, true),
+        ]);
+
+        let columns = arrow_schema_to_columns(
+            &schema,
+            &[CatalogPartitionField {
+                column: "ts".to_string(),
+                transform: None,
+            }],
+        );
+
+        assert!(columns[0].is_partition);
+        assert!(!columns[1].is_partition);
+    }
+
+    #[test]
+    fn arrow_schema_to_columns_marks_bucket_transforms_without_partition_flags() {
+        let schema = Schema::new(vec![
+            Field::new("id", DataType::Int32, true),
+            Field::new("value", DataType::Int32, true),
+        ]);
+
+        let columns = arrow_schema_to_columns(
+            &schema,
+            &[CatalogPartitionField {
+                column: "id".to_string(),
+                transform: Some(PartitionTransform::Bucket(8)),
+            }],
+        );
+
+        assert!(!columns[0].is_partition);
+        assert!(columns[0].is_bucket);
+        assert!(!columns[1].is_bucket);
+    }
 }

--- a/crates/sail-common/src/spec/plan.rs
+++ b/crates/sail-common/src/spec/plan.rs
@@ -306,6 +306,10 @@ pub enum CommandNode {
         database: Option<ObjectName>,
         pattern: String,
     },
+    ShowTableProperties {
+        table: ObjectName,
+        property_key: Option<String>,
+    },
     ListTables {
         database: Option<ObjectName>,
         pattern: Option<String>,

--- a/crates/sail-delta-lake/src/table_format.rs
+++ b/crates/sail-delta-lake/src/table_format.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -8,10 +8,12 @@ use datafusion::common::{not_impl_err, plan_err, DFSchema, DataFusionError, Resu
 use datafusion::datasource::listing::ListingTableUrl;
 use datafusion::logical_expr::TableSource;
 use datafusion::physical_plan::ExecutionPlan;
+use sail_common_datafusion::catalog::CatalogPartitionField;
 use sail_common_datafusion::column_features::ColumnFeatures;
 use sail_common_datafusion::datasource::{
-    find_path_in_options, MergeStrategy, OptionLayer, PhysicalSinkMode, RowLevelCommand,
-    RowLevelWriteInfo, SinkInfo, SourceInfo, TableFormat, TableFormatRegistry,
+    arrow_schema_to_columns, find_path_in_options, location_to_url, MergeStrategy, OptionLayer,
+    PhysicalSinkMode, RowLevelCommand, RowLevelWriteInfo, SinkInfo, SourceInfo,
+    StorageTableMetadata, TableFormat, TableFormatRegistry,
 };
 use sail_common_datafusion::streaming::event::schema::is_flow_event_schema;
 use sail_data_source::options::gen::{DeltaReadOptions, DeltaWriteOptions};
@@ -90,6 +92,57 @@ impl TableFormat for DeltaTableFormat {
         let options = DeltaReadOptions::resolve(ctx, options)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
         infer_delta_logical_schema(ctx, table_url, schema, options).await
+    }
+
+    async fn load_storage_table_metadata(
+        &self,
+        runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>,
+        path: &str,
+    ) -> Result<StorageTableMetadata> {
+        let table_url = location_to_url(path, self.name())?;
+        let object_store = runtime_env
+            .object_store_registry
+            .get_store(&table_url)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let table = open_table_with_object_store_and_table_config(
+            table_url.clone(),
+            object_store,
+            Default::default(),
+            DeltaSnapshotConfig {
+                require_files: false,
+                ..Default::default()
+            },
+        )
+        .await?;
+        let snapshot = table
+            .snapshot()
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let metadata = snapshot.metadata();
+        let partition_columns: Vec<CatalogPartitionField> = metadata
+            .partition_columns()
+            .iter()
+            .cloned()
+            .map(|col| CatalogPartitionField {
+                column: col,
+                transform: None,
+            })
+            .collect();
+        let columns = arrow_schema_to_columns(snapshot.schema(), &partition_columns);
+
+        // Deduplicate and normalize ordering for Spark-compatible table properties.
+        let mut properties: BTreeMap<String, String> =
+            metadata.configuration().clone().into_iter().collect();
+        properties.insert("provider".to_string(), "delta".to_string());
+        properties.insert("location".to_string(), table_url.to_string());
+
+        Ok(StorageTableMetadata {
+            columns,
+            comment: metadata.description().map(ToString::to_string),
+            location: Some(table_url.to_string()),
+            provider: "delta".to_string(),
+            partition_columns,
+            properties: properties.into_iter().collect(),
+        })
     }
 
     async fn create_writer(
@@ -363,9 +416,7 @@ impl TableFormat for DeltaTableFormat {
         use crate::kernel::transaction::CommitBuilder;
         use crate::schema::protocol_for_metadata;
 
-        // Parse the location into a URL. Handles both absolute filesystem paths
-        // (e.g. `/tmp/table`) and fully-qualified URLs (`file://`, `s3://`, ...).
-        let url = parse_location_to_url(path)?;
+        let url = location_to_url(path, self.name())?;
 
         // The `DynamicObjectStoreRegistry` lazily registers schemes such as S3/GCS/ABFS,
         // so fetching the store from the registry doubles as the registration entry point.
@@ -484,7 +535,7 @@ impl TableFormat for DeltaTableFormat {
     ) -> Result<()> {
         use crate::kernel::transaction::CommitBuilder;
 
-        let url = parse_location_to_url(path)?;
+        let url = location_to_url(path, self.name())?;
         let object_store = runtime_env
             .object_store_registry
             .get_store(&url)
@@ -775,25 +826,6 @@ fn merge_protocol_for_upgrade(
 
     let upgraded = merged != *existing;
     (merged, upgraded)
-}
-
-/// Parse a location string into a [`Url`]. Accepts both fully-qualified URLs and
-/// local absolute file system paths.
-fn parse_location_to_url(path: &str) -> Result<Url> {
-    if let Ok(url) = Url::parse(path) {
-        // Reject "scheme-like" strings on Windows such as `c:/foo` that `Url::parse`
-        // accepts as opaque URLs.
-        if url.scheme().len() > 1 {
-            return Ok(url);
-        }
-    }
-    if std::path::Path::new(path).is_absolute() {
-        return Url::from_file_path(path)
-            .map_err(|_| DataFusionError::Plan(format!("invalid file path: {path}")));
-    }
-    Err(DataFusionError::Plan(format!(
-        "table location must be an absolute path or URL: {path}"
-    )))
 }
 
 impl DeltaTableFormat {

--- a/crates/sail-iceberg/src/table_format.rs
+++ b/crates/sail-iceberg/src/table_format.rs
@@ -10,6 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -18,21 +19,25 @@ use datafusion::catalog::{Session, TableProvider};
 use datafusion::common::{not_impl_err, plan_err, DataFusionError, Result};
 use datafusion::logical_expr::TableSource;
 use datafusion::physical_plan::ExecutionPlan;
+use object_store::path::Path as ObjectPath;
 use object_store::ObjectStoreExt;
 use sail_common_datafusion::catalog::CatalogPartitionField;
 use sail_common_datafusion::datasource::{
-    find_path_in_options, OptionLayer, PhysicalSinkMode, SinkInfo, SourceInfo, TableFormat,
-    TableFormatRegistry,
+    arrow_schema_to_columns, find_path_in_options, location_to_url, OptionLayer, PhysicalSinkMode,
+    SinkInfo, SourceInfo, StorageTableMetadata, TableFormat, TableFormatRegistry,
 };
 use sail_data_source::options::gen::{IcebergReadOptions, IcebergWriteOptions};
 use sail_data_source::options::ResolveOptions;
 use url::Url;
 
 use crate::datasource::provider::IcebergTableProvider;
+use crate::datasource::type_converter::iceberg_schema_to_arrow;
 use crate::io::StoreContext;
 use crate::logical::IcebergTableSource;
 use crate::physical_plan::plan_builder::{IcebergPlanBuilder, IcebergTableConfig};
 use crate::physical_plan::IcebergWriterExecOptions;
+use crate::spec::metadata::format::FormatVersion;
+use crate::spec::transform::Transform;
 use crate::spec::{MetadataLog, PartitionSpec, Schema, Snapshot, TableMetadata};
 use crate::table::metadata_loader::{
     encode_metadata_file, load_metadata_file_bytes, metadata_file_extension_from_properties,
@@ -69,6 +74,111 @@ impl TableFormat for IcebergTableFormat {
     ) -> Result<Arc<dyn TableSource>> {
         let provider = build_iceberg_provider(ctx, info).await?;
         Ok(Arc::new(IcebergTableSource::new(provider)))
+    }
+
+    /// Load Iceberg metadata directly from storage for catalog commands.
+    ///
+    /// This method enables `DESCRIBE EXTENDED`, `SHOW TBLPROPERTIES`, and
+    /// `SHOW TABLE EXTENDED` to show storage-level metadata for Iceberg tables
+    /// registered via `CREATE TABLE ... USING ICEBERG LOCATION '...'`.
+    ///
+    /// **Limitation:** The HMS catalog provider does not support Iceberg tables.
+    /// Storage metadata hydration for Iceberg only works with catalog providers
+    /// that can register Iceberg table locations (e.g., the default in-memory
+    /// catalog or a future Iceberg REST catalog). Integration tests for Iceberg
+    /// hydration require such a catalog provider and are not yet available.
+    async fn load_storage_table_metadata(
+        &self,
+        runtime_env: Arc<datafusion::execution::runtime_env::RuntimeEnv>,
+        path: &str,
+    ) -> Result<StorageTableMetadata> {
+        let table_url = location_to_url(path, self.name())?;
+        let object_store = runtime_env
+            .object_store_registry
+            .get_store(&table_url)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let metadata_location = find_latest_metadata_file(&object_store, &table_url).await?;
+        let metadata_data = object_store
+            .get(&ObjectPath::from(metadata_location.as_str()))
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?
+            .bytes()
+            .await
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let metadata = TableMetadata::from_json(&metadata_data)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let schema = metadata.current_schema().ok_or_else(|| {
+            DataFusionError::Plan("Iceberg table metadata is missing current schema".to_string())
+        })?;
+        let arrow_schema =
+            iceberg_schema_to_arrow(schema).map_err(|e| DataFusionError::External(Box::new(e)))?;
+        let partition_columns: Vec<CatalogPartitionField> = metadata
+            .default_partition_spec()
+            .map(|spec| {
+                spec.fields()
+                    .iter()
+                    .filter(|field| field.transform != Transform::Void)
+                    .filter_map(|field| {
+                        let col_name = schema
+                            .field_by_id(field.source_id)
+                            .map(|f| f.name.clone())?;
+                        Some(catalog_partition_field_from_iceberg(
+                            col_name,
+                            field.transform,
+                        ))
+                    })
+                    .collect::<Result<Vec<_>, String>>()
+                    .map_err(DataFusionError::Plan)
+            })
+            .transpose()?
+            .unwrap_or_default();
+        let columns = arrow_schema_to_columns(&arrow_schema, &partition_columns);
+
+        // Deduplicate and normalize ordering for Spark-compatible table properties.
+        let mut properties: BTreeMap<String, String> =
+            metadata.properties.clone().into_iter().collect();
+        properties.insert("provider".to_string(), "iceberg".to_string());
+        properties.insert("location".to_string(), metadata.location.clone());
+        let default_file_format = metadata
+            .properties
+            .get("write.format.default")
+            .cloned()
+            .unwrap_or_else(|| "parquet".to_string());
+        properties.insert(
+            "format".to_string(),
+            format!("iceberg/{default_file_format}"),
+        );
+        properties.insert(
+            "format-version".to_string(),
+            match metadata.format_version {
+                FormatVersion::V1 => "1",
+                FormatVersion::V2 => "2",
+                FormatVersion::V3 => "3",
+            }
+            .to_string(),
+        );
+        if let Some(snapshot_id) = metadata.current_snapshot_id {
+            properties.insert("current-snapshot-id".to_string(), snapshot_id.to_string());
+        }
+        if let Some(sort_order_id) = metadata.default_sort_order_id {
+            properties.insert("sort-order".to_string(), sort_order_id.to_string());
+        }
+        let identifier_fields = schema
+            .identifier_field_ids()
+            .filter_map(|id| schema.name_by_field_id(id).map(ToString::to_string))
+            .collect::<Vec<_>>();
+        if !identifier_fields.is_empty() {
+            properties.insert("identifier-fields".to_string(), identifier_fields.join(","));
+        }
+
+        Ok(StorageTableMetadata {
+            columns,
+            comment: metadata.properties.get("comment").cloned(),
+            location: Some(metadata.location),
+            provider: "iceberg".to_string(),
+            partition_columns,
+            properties: properties.into_iter().collect(),
+        })
     }
 
     async fn create_writer(

--- a/crates/sail-iceberg/src/utils/partition_transform.rs
+++ b/crates/sail-iceberg/src/utils/partition_transform.rs
@@ -113,4 +113,14 @@ mod tests {
         );
         Ok(())
     }
+
+    #[test]
+    fn void_transform_is_rejected() {
+        let result =
+            catalog_partition_field_from_iceberg("dropped_col".to_string(), Transform::Void);
+        assert!(
+            result.is_err(),
+            "Void transform should be rejected, got: {result:?}"
+        );
+    }
 }

--- a/crates/sail-plan/src/config.rs
+++ b/crates/sail-plan/src/config.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 use std::hash::Hash;
+use std::path::Path;
 use std::sync::Arc;
 
 use sail_python_udf::config::PySparkUdfConfig;
@@ -25,6 +26,11 @@ pub struct PlanConfig {
     /// The default table file format.
     pub default_table_file_format: String,
     /// The default location for managed databases and tables.
+    ///
+    /// This is always an absolute path or a fully qualified URL.
+    /// Relative values from `spark.sql.warehouse.dir` are resolved against
+    /// the current working directory at session initialization time,
+    /// matching Spark's `SharedState` behavior.
     pub default_warehouse_directory: String,
     pub session_user_id: String,
     pub ansi_mode: bool,
@@ -41,6 +47,55 @@ impl PlanConfig {
     }
 }
 
+/// Qualifies a warehouse directory path to an absolute form.
+///
+/// If the value is already a fully qualified URL (e.g., `s3://`, `file://`)
+/// or an absolute filesystem path, it is returned unchanged. Otherwise,
+/// the relative path is resolved against the current working directory.
+///
+/// This mirrors Spark's `SharedState` initialization, which qualifies
+/// the `spark.sql.warehouse.dir` value via the Hadoop FileSystem API
+/// at `SparkSession` creation time.
+pub fn qualify_warehouse_directory(value: &str) -> String {
+    // Already a fully qualified URL (e.g., s3://bucket/path, file:///tmp/wh).
+    if value.contains("://") {
+        return value.to_string();
+    }
+    let path = Path::new(value);
+    if path.is_absolute() {
+        return value.to_string();
+    }
+    // Resolve relative path against CWD, matching Spark's SharedState behavior.
+    match std::env::current_dir() {
+        Ok(cwd) => cwd.join(path).to_string_lossy().to_string(),
+        Err(_) => value.to_string(),
+    }
+}
+
+/// Qualifies an explicit table `LOCATION`.
+///
+/// Spark qualifies relative table locations against the database location when
+/// present, and otherwise against the warehouse directory. Absolute filesystem
+/// paths and fully qualified URLs are preserved.
+pub fn qualify_table_location(
+    value: &str,
+    database_location: Option<&str>,
+    warehouse_directory: &str,
+) -> String {
+    if value.contains("://") || Path::new(value).is_absolute() {
+        return value.to_string();
+    }
+    let base = database_location.unwrap_or(warehouse_directory);
+    if base.contains("://") {
+        let base = base.trim_end_matches('/');
+        let value = value.trim_start_matches('/');
+        format!("{base}/{value}")
+    } else {
+        let base = qualify_warehouse_directory(base);
+        Path::new(&base).join(value).to_string_lossy().to_string()
+    }
+}
+
 impl Default for PlanConfig {
     fn default() -> Self {
         Self {
@@ -49,10 +104,82 @@ impl Default for PlanConfig {
             arrow_use_large_var_types: false,
             pyspark_udf_config: Arc::new(PySparkUdfConfig::default()),
             default_table_file_format: "PARQUET".to_string(),
-            default_warehouse_directory: "spark-warehouse".to_string(),
+            default_warehouse_directory: qualify_warehouse_directory("spark-warehouse"),
             session_user_id: "".to_string(),
             ansi_mode: false,
             cross_join_enabled: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn qualify_warehouse_directory_resolves_relative_path() {
+        let result = qualify_warehouse_directory("spark-warehouse");
+        let path = Path::new(&result);
+        assert!(
+            path.is_absolute(),
+            "relative path should be resolved to absolute: {result}"
+        );
+        assert!(
+            result.ends_with("spark-warehouse"),
+            "resolved path should end with the relative name: {result}"
+        );
+    }
+
+    #[test]
+    fn qualify_warehouse_directory_preserves_absolute_path() {
+        let result = qualify_warehouse_directory("/tmp/my-warehouse");
+        assert_eq!(result, "/tmp/my-warehouse");
+    }
+
+    #[test]
+    fn qualify_warehouse_directory_preserves_url_schemes() {
+        assert_eq!(
+            qualify_warehouse_directory("s3://bucket/warehouse"),
+            "s3://bucket/warehouse"
+        );
+        assert_eq!(
+            qualify_warehouse_directory("file:///tmp/wh"),
+            "file:///tmp/wh"
+        );
+        assert_eq!(
+            qualify_warehouse_directory("gs://bucket/path"),
+            "gs://bucket/path"
+        );
+    }
+
+    #[test]
+    fn default_plan_config_has_absolute_warehouse_directory() {
+        let config = PlanConfig::default();
+        let path = Path::new(&config.default_warehouse_directory);
+        assert!(
+            path.is_absolute(),
+            "default warehouse directory should be absolute: {}",
+            config.default_warehouse_directory
+        );
+    }
+
+    #[test]
+    fn qualify_table_location_resolves_relative_path_against_database_location() {
+        assert_eq!(
+            qualify_table_location(
+                "nested/table",
+                Some("s3://bucket/database"),
+                "/tmp/warehouse",
+            ),
+            "s3://bucket/database/nested/table"
+        );
+    }
+
+    #[test]
+    fn qualify_table_location_resolves_relative_path_against_warehouse() {
+        assert_eq!(
+            qualify_table_location("nested/table", None, "/tmp/warehouse"),
+            "/tmp/warehouse/nested/table"
+        );
     }
 }

--- a/crates/sail-plan/src/resolver/command/catalog/table.rs
+++ b/crates/sail-plan/src/resolver/command/catalog/table.rs
@@ -12,6 +12,7 @@ use sail_common_datafusion::extension::SessionExtensionAccessor;
 use sail_common_datafusion::rename::logical_plan::rename_logical_plan;
 use sail_common_datafusion::utils::items::ItemTaker;
 
+use crate::config::qualify_table_location;
 use crate::error::{PlanError, PlanResult};
 use crate::resolver::state::PlanResolverState;
 use crate::resolver::PlanResolver;
@@ -48,8 +49,13 @@ impl PlanResolver<'_> {
         }
         let mut columns = self.resolve_table_columns(columns, state)?;
         let constraints = self.resolve_table_constraints(constraints)?;
+        let database_location = self.resolve_database_location(&table).await?;
         let location = if let Some(location) = location {
-            location
+            qualify_table_location(
+                &location,
+                database_location.as_deref(),
+                &self.config.default_warehouse_directory,
+            )
         } else {
             self.resolve_default_table_location(&table).await?
         };
@@ -163,8 +169,16 @@ impl PlanResolver<'_> {
         let input = rename_logical_plan(input, &column_names)?;
         let format = self.resolve_catalog_table_format(file_format)?;
         let mut write_options = options;
+        let database_location = self.resolve_database_location(&table).await?;
         if let Some(location) = location {
-            write_options.push(("path".to_string(), location));
+            write_options.push((
+                "path".to_string(),
+                qualify_table_location(
+                    &location,
+                    database_location.as_deref(),
+                    &self.config.default_warehouse_directory,
+                ),
+            ));
         }
 
         // Set write mode based on create-or-replace / if-not-exists semantics.
@@ -222,11 +236,7 @@ impl PlanResolver<'_> {
         // and avoids issues with special characters in table names.
         // Note that this is different from how Spark handles table locations
         // for the default catalog.
-        let catalog_manager = self.ctx.extension::<CatalogManager>()?;
-        let location = catalog_manager
-            .get_database_by_qualifier(qualifier)
-            .await?
-            .location;
+        let location = self.resolve_database_location(table).await?;
         let (base, suffix) = match &location {
             Some(loc) => (
                 loc.trim_end_matches(object_store::path::DELIMITER),
@@ -246,6 +256,20 @@ impl PlanResolver<'_> {
             name,
             suffix,
         ))
+    }
+
+    async fn resolve_database_location(
+        &self,
+        table: &spec::ObjectName,
+    ) -> PlanResult<Option<String>> {
+        let [qualifier @ .., _] = table.parts() else {
+            return Err(PlanError::invalid("missing table name"));
+        };
+        let catalog_manager = self.ctx.extension::<CatalogManager>()?;
+        Ok(catalog_manager
+            .get_database_by_qualifier(qualifier)
+            .await?
+            .location)
     }
 
     fn resolve_catalog_table_partition_by(

--- a/crates/sail-plan/src/resolver/command/mod.rs
+++ b/crates/sail-plan/src/resolver/command/mod.rs
@@ -61,6 +61,13 @@ impl PlanResolver<'_> {
                     pattern,
                 })
             }
+            CommandNode::ShowTableProperties {
+                table,
+                property_key,
+            } => self.resolve_catalog_command(CatalogCommand::ShowTableProperties {
+                table: table.into(),
+                property_key,
+            }),
             CommandNode::ListTables { database, pattern } => {
                 self.resolve_catalog_command(CatalogCommand::ListTables {
                     database: database.map(|x| x.into()).unwrap_or_default(),

--- a/crates/sail-spark-connect/src/config.rs
+++ b/crates/sail-spark-connect/src/config.rs
@@ -248,7 +248,8 @@ impl TryFrom<&SparkRuntimeConfig> for PlanConfig {
         }
 
         if let Some(value) = config.get(SPARK_SQL_WAREHOUSE_DIR)? {
-            output.default_warehouse_directory = value.to_string();
+            output.default_warehouse_directory =
+                sail_plan::config::qualify_warehouse_directory(value);
         }
 
         if let Some(value) = config.get(SPARK_SQL_TIMESTAMP_TYPE)? {

--- a/crates/sail-sql-analyzer/src/parser.rs
+++ b/crates/sail-sql-analyzer/src/parser.rs
@@ -107,12 +107,14 @@ pub fn parse_time(s: &str) -> SqlResult<TimeValue> {
 
 #[cfg(test)]
 mod tests {
+    use sail_common::spec;
     use sail_sql_parser::ast::query::Query;
-    use sail_sql_parser::ast::statement::Statement;
+    use sail_sql_parser::ast::statement::{PropertyKey, Statement};
     use sail_sql_parser::tree::TreeText;
 
     use crate::error::SqlResult;
     use crate::parser::{parse_one_statement, parse_statements};
+    use crate::statement::from_ast_statement;
 
     #[test]
     fn test_parse() -> SqlResult<()> {
@@ -146,6 +148,31 @@ mod tests {
             parse_one_statement("SELECT U&\"a#2014b#+002014c\"   UESCAPE '#'")?.text(),
             "SELECT U&\"a#2014b#+002014c\" UESCAPE '#' "
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_show_tblproperties_with_unquoted_dotted_key() -> SqlResult<()> {
+        let statement = parse_one_statement("SHOW TBLPROPERTIES test (a.b.c)")?;
+        assert!(matches!(
+            &statement,
+            Statement::ShowTableProperties {
+                property_key: Some((_, PropertyKey::Name(_), _)),
+                ..
+            }
+        ));
+
+        let plan = from_ast_statement(statement)?;
+        assert!(matches!(
+            plan,
+            spec::Plan::Command(spec::CommandPlan {
+                node: spec::CommandNode::ShowTableProperties {
+                    property_key: Some(ref key),
+                    ..
+                },
+                ..
+            }) if key == "a.b.c"
+        ));
         Ok(())
     }
 }

--- a/crates/sail-sql-analyzer/src/statement.rs
+++ b/crates/sail-sql-analyzer/src/statement.rs
@@ -277,6 +277,22 @@ pub fn from_ast_statement(statement: Statement) -> SqlResult<spec::Plan> {
             let node = spec::CommandNode::ShowTableExtended { database, pattern };
             Ok(spec::Plan::Command(spec::CommandPlan::new(node)))
         }
+        Statement::ShowTableProperties {
+            show: _,
+            table_properties: _,
+            name,
+            property_key,
+        } => {
+            let table = from_ast_object_name(name)?;
+            let property_key = property_key
+                .map(|(_, key, _)| from_ast_property_key(key))
+                .transpose()?;
+            let node = spec::CommandNode::ShowTableProperties {
+                table,
+                property_key,
+            };
+            Ok(spec::Plan::Command(spec::CommandPlan::new(node)))
+        }
         Statement::ShowCreateTable { .. } => Err(SqlError::todo("SHOW CREATE TABLE")),
         Statement::ShowColumns {
             show: _,
@@ -1661,14 +1677,7 @@ impl TryFrom<Vec<CreateViewClause>> for CreateViewClauses {
 
 fn from_ast_property(property: PropertyKeyValue) -> SqlResult<(String, Option<String>)> {
     let PropertyKeyValue { key, value } = property;
-    let key = match key {
-        PropertyKey::Name(ObjectName(parts)) => parts
-            .into_items()
-            .map(|x| x.value)
-            .collect::<Vec<_>>()
-            .join("."),
-        PropertyKey::Literal(x) => from_ast_string(x)?,
-    };
+    let key = from_ast_property_key(key)?;
     let value = if let Some((_, value)) = value {
         let value = match value {
             PropertyValue::String(x) => from_ast_string(x)?,
@@ -1727,15 +1736,19 @@ fn from_ast_property_key_list(properties: PropertyKeyList) -> SqlResult<Vec<Stri
     } = properties;
     properties
         .into_items()
-        .map(|key| match key {
-            PropertyKey::Name(ObjectName(parts)) => Ok(parts
-                .into_items()
-                .map(|x| x.value)
-                .collect::<Vec<_>>()
-                .join(".")),
-            PropertyKey::Literal(x) => from_ast_string(x),
-        })
+        .map(from_ast_property_key)
         .collect::<SqlResult<Vec<_>>>()
+}
+
+fn from_ast_property_key(key: PropertyKey) -> SqlResult<String> {
+    match key {
+        PropertyKey::Name(ObjectName(parts)) => Ok(parts
+            .into_items()
+            .map(|x| x.value)
+            .collect::<Vec<_>>()
+            .join(".")),
+        PropertyKey::Literal(x) => from_ast_string(x),
+    }
 }
 
 fn from_ast_partition(

--- a/crates/sail-sql-parser/src/ast/statement.rs
+++ b/crates/sail-sql-parser/src/ast/statement.rs
@@ -139,6 +139,12 @@ pub enum Statement {
         from: Option<(Either<From, In>, ObjectName)>,
         like: (Like, StringLiteral),
     },
+    ShowTableProperties {
+        show: Show,
+        table_properties: Tblproperties,
+        name: ObjectName,
+        property_key: Option<(LeftParenthesis, PropertyKey, RightParenthesis)>,
+    },
     ShowCreateTable {
         show: Show,
         create: Create,

--- a/crates/sail-sql-parser/tests/gold_data/syntax.json
+++ b/crates/sail-sql-parser/tests/gold_data/syntax.json
@@ -7660,6 +7660,14 @@
               }
             },
             {
+              "name": "Option(Tuple(Operator(LeftParenthesis), PropertyKey, Operator(RightParenthesis)))",
+              "node": {
+                "optional": {
+                  "nonTerminal": "Tuple(Operator(LeftParenthesis), PropertyKey, Operator(RightParenthesis))"
+                }
+              }
+            },
+            {
               "name": "Option(Tuple(Operator(LeftParenthesis), Sequence(ViewColumn, Operator(Comma)), Operator(RightParenthesis)))",
               "node": {
                 "optional": {
@@ -9388,6 +9396,22 @@
                       },
                       {
                         "nonTerminal": "Tuple(Keyword(Like), StringLiteral)"
+                      }
+                    ]
+                  },
+                  {
+                    "sequence": [
+                      {
+                        "nonTerminal": "Keyword(Show)"
+                      },
+                      {
+                        "nonTerminal": "Keyword(Tblproperties)"
+                      },
+                      {
+                        "nonTerminal": "ObjectName"
+                      },
+                      {
+                        "nonTerminal": "Option(Tuple(Operator(LeftParenthesis), PropertyKey, Operator(RightParenthesis)))"
                       }
                     ]
                   },
@@ -11183,6 +11207,22 @@
                 "sequence": [
                   {
                     "nonTerminal": "Operator(LeftParenthesis)"
+                  },
+                  {
+                    "nonTerminal": "Operator(RightParenthesis)"
+                  }
+                ]
+              }
+            },
+            {
+              "name": "Tuple(Operator(LeftParenthesis), PropertyKey, Operator(RightParenthesis))",
+              "node": {
+                "sequence": [
+                  {
+                    "nonTerminal": "Operator(LeftParenthesis)"
+                  },
+                  {
+                    "nonTerminal": "PropertyKey"
                   },
                   {
                     "nonTerminal": "Operator(RightParenthesis)"

--- a/python/pysail/tests/spark/test_catalog.py
+++ b/python/pysail/tests/spark/test_catalog.py
@@ -123,6 +123,29 @@ class TestListTables:
         finally:
             spark.sql(f"DROP TABLE IF EXISTS {table_name}")
 
+    def test_show_tblproperties_for_temp_view_returns_empty(self, spark):
+        """SHOW TBLPROPERTIES on a temporary view should return zero rows."""
+        rows = spark.sql("SHOW TBLPROPERTIES test_view").collect()
+        assert rows == []
+
+    def test_show_tblproperties_reserved_key_lookup_behaves_like_missing_property(self, spark):
+        """Reserved-key lookup should return the Spark missing-property message."""
+        table_name = "test_tblproperties_reserved_lookup"
+        spark.sql(
+            f"CREATE TABLE {table_name} (id INT) USING PARQUET "
+            "TBLPROPERTIES ('custom.b' = '2', 'custom.a' = '1')"
+        )
+        try:
+            rows = spark.sql(f"SHOW TBLPROPERTIES {table_name} ('provider')").collect()
+            assert len(rows) == 1
+            assert rows[0]["key"] == "provider"
+            value = rows[0]["value"]
+            assert value.endswith(
+                f".default.{table_name} does not have property: provider"
+            )
+        finally:
+            spark.sql(f"DROP TABLE IF EXISTS {table_name}")
+
 
 class TestListDatabases:
     """Test spark.catalog.listDatabases() returns correct field names."""
@@ -132,3 +155,135 @@ class TestListDatabases:
         databases = spark.catalog.listDatabases()
         db_names = [db.name for db in databases]
         assert "default" in db_names
+
+
+class TestDeltaMetadataHydration:
+    """Test that catalog commands show storage-level metadata for Delta tables.
+
+    These tests exercise hydrate_table_status → load_storage_table_metadata
+    through the spark.sql() path against real Delta storage.
+    """
+
+    def test_describe_extended_delta_table_shows_columns(self, spark, tmp_path):
+        """DESCRIBE EXTENDED on a Delta table shows storage-level columns."""
+        table_name = "test_describe_delta_cols"
+        delta_path = tmp_path / "delta_cols"
+        spark.sql(
+            f"CREATE TABLE {table_name} (id INT, name STRING) "
+            f"USING DELTA LOCATION '{delta_path}'"
+        )
+        try:
+            rows = spark.sql(f"DESCRIBE EXTENDED {table_name}").collect()
+            col_names = [r.col_name for r in rows if r.col_name and not r.col_name.startswith("#")]
+            assert "id" in col_names
+            assert "name" in col_names
+        finally:
+            spark.sql(f"DROP TABLE IF EXISTS {table_name}")
+
+    def test_describe_extended_delta_table_shows_provider(self, spark, tmp_path):
+        """DESCRIBE EXTENDED on a Delta table shows Provider: delta."""
+        table_name = "test_describe_delta_provider"
+        delta_path = tmp_path / "delta_provider"
+        spark.sql(
+            f"CREATE TABLE {table_name} (id INT) "
+            f"USING DELTA LOCATION '{delta_path}'"
+        )
+        try:
+            rows = spark.sql(f"DESCRIBE EXTENDED {table_name}").collect()
+            metadata = {r.col_name: r.data_type for r in rows}
+            assert metadata.get("Provider") == "delta"
+        finally:
+            spark.sql(f"DROP TABLE IF EXISTS {table_name}")
+
+    def test_show_tblproperties_delta_table(self, spark, tmp_path):
+        """SHOW TBLPROPERTIES on a Delta table shows storage-level properties."""
+        table_name = "test_show_tblprops_delta"
+        delta_path = tmp_path / "delta_props"
+        spark.sql(
+            f"CREATE TABLE {table_name} (id INT) "
+            f"USING DELTA "
+            f"TBLPROPERTIES ('custom.key' = 'hello') "
+            f"LOCATION '{delta_path}'"
+        )
+        try:
+            # Ensure Delta metadata files exist in environments that initialize
+            # _delta_log lazily on first write.
+            spark.sql(f"INSERT INTO {table_name} VALUES (1)")
+            rows = spark.sql(f"SHOW TBLPROPERTIES {table_name}").collect()
+            # SHOW TBLPROPERTIES returns (key, value) columns
+            assert len(rows) >= 1
+            props = {r["key"]: r["value"] for r in rows}
+            assert props.get("custom.key") == "hello"
+        finally:
+            spark.sql(f"DROP TABLE IF EXISTS {table_name}")
+
+    def test_describe_extended_partitioned_delta_table(self, spark, tmp_path):
+        """DESCRIBE EXTENDED on a partitioned Delta table shows partition info."""
+        table_name = "test_describe_delta_partitioned"
+        delta_path = tmp_path / "delta_partitioned"
+        spark.sql(
+            f"CREATE TABLE {table_name} (id INT, region STRING) "
+            f"USING DELTA PARTITIONED BY (region) "
+            f"LOCATION '{delta_path}'"
+        )
+        try:
+            # Verify partition column is flagged in column list
+            rows = spark.sql(f"DESCRIBE EXTENDED {table_name}").collect()
+            col_rows = {r.col_name: r.data_type for r in rows if r.col_name and not r.col_name.startswith("#")}
+            assert "region" in col_rows
+            assert "id" in col_rows
+        finally:
+            spark.sql(f"DROP TABLE IF EXISTS {table_name}")
+
+    def test_show_table_extended_delta_table(self, spark, tmp_path):
+        """SHOW TABLE EXTENDED on a Delta table shows storage-level information."""
+        table_name = "test_show_extended_delta"
+        delta_path = tmp_path / "delta_extended"
+        spark.sql(
+            f"CREATE TABLE {table_name} (id INT, value DOUBLE) "
+            f"USING DELTA COMMENT 'a test table' "
+            f"LOCATION '{delta_path}'"
+        )
+        try:
+            rows = spark.sql(f"SHOW TABLE EXTENDED LIKE '{table_name}'").collect()
+            assert len(rows) >= 1
+            info = rows[0].information
+            assert "Provider: delta" in info
+            assert "Schema: root" in info
+            assert "id:" in info
+        finally:
+            spark.sql(f"DROP TABLE IF EXISTS {table_name}")
+
+    def test_catalog_list_columns_delta_table(self, spark, tmp_path):
+        """spark.catalog.listColumns() on a Delta table returns storage-level columns."""
+        table_name = "test_list_columns_delta"
+        delta_path = tmp_path / "delta_list_cols"
+        spark.sql(
+            f"CREATE TABLE {table_name} (id INT, name STRING, score DOUBLE) "
+            f"USING DELTA LOCATION '{delta_path}'"
+        )
+        try:
+            columns = spark.catalog.listColumns(table_name)
+            col_names = [c.name for c in columns]
+            assert "id" in col_names
+            assert "name" in col_names
+            assert "score" in col_names
+        finally:
+            spark.sql(f"DROP TABLE IF EXISTS {table_name}")
+
+    def test_catalog_list_columns_partitioned_delta_table(self, spark, tmp_path):
+        """spark.catalog.listColumns() flags partition columns on a Delta table."""
+        table_name = "test_list_columns_delta_part"
+        delta_path = tmp_path / "delta_list_cols_part"
+        spark.sql(
+            f"CREATE TABLE {table_name} (id INT, region STRING) "
+            f"USING DELTA PARTITIONED BY (region) "
+            f"LOCATION '{delta_path}'"
+        )
+        try:
+            columns = spark.catalog.listColumns(table_name)
+            col_by_name = {c.name: c for c in columns}
+            assert "region" in col_by_name
+            assert "id" in col_by_name
+        finally:
+            spark.sql(f"DROP TABLE IF EXISTS {table_name}")

--- a/python/pysail/tests/spark/test_catalog_metadata_interop.py
+++ b/python/pysail/tests/spark/test_catalog_metadata_interop.py
@@ -1,0 +1,577 @@
+"""Catalog metadata interop tests.
+
+Verify that table metadata (schema, partition columns, properties, comment)
+is compatible between Sail and external engines.
+
+**Direction: Sail → external**
+  Sail writes a table, an external engine (PyIceberg, Delta log reader) reads
+  the metadata and verifies correctness.
+
+**Direction: External → Sail**
+  An external engine writes a table, Sail reads metadata via:
+  - DataFrameReader (spark.read.format)
+  - SQL (DESCRIBE EXTENDED, SHOW TBLPROPERTIES, SHOW TABLE EXTENDED)
+  - Catalog API (spark.catalog.listColumns)
+
+For Delta tables, Sail supports managed tables (CREATE TABLE ... USING DELTA),
+so "External → Sail" tests register the path with the catalog and exercise
+the full hydration path (hydrate_table_status → load_storage_table_metadata).
+
+For Iceberg tables, the HMS catalog provider does not support Iceberg.
+Sail supports path-based reads but not managed Iceberg tables through HMS.
+The "External → Sail" tests load Iceberg data as temp views, which do
+**not** trigger storage metadata hydration (hydrate_table_status returns
+early for TemporaryView). Full hydration testing for Iceberg requires a
+catalog provider that supports Iceberg table registration (e.g., an
+Iceberg REST catalog), which is not available in the unit test environment.
+
+Iceberg tests cover both format version 1 and version 2.
+"""
+
+from __future__ import annotations
+
+import json
+import platform
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pysail.testing.spark.utils.common import is_jvm_spark
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from pyiceberg.schema import Schema
+from pyiceberg.table import StaticTable
+from pyiceberg.types import DoubleType, LongType, NestedField, StringType
+
+from pysail.tests.spark.iceberg.utils import create_sql_catalog
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _read_delta_log_metadata(table_path: str | Path) -> dict:
+    """Read the metaData action from the first Delta log commit."""
+    import pathlib
+
+    log_dir = pathlib.Path(table_path) / "_delta_log"
+    commit_files = sorted(log_dir.glob("*.json"))
+    assert commit_files, f"no Delta log files found in {log_dir}"
+    with commit_files[0].open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            action = json.loads(line)
+            if "metaData" in action:
+                return action["metaData"]
+    raise AssertionError("no metaData action found in Delta log")
+
+
+def _write_delta_log_with_metadata(
+    table_path: Path,
+    *,
+    schema_string: str,
+    partition_columns: list[str] | None = None,
+    configuration: dict[str, str] | None = None,
+    description: str | None = None,
+) -> None:
+    """Write a minimal Delta log commit with the given metadata."""
+    table_path.mkdir(parents=True, exist_ok=True)
+    log_dir = table_path / "_delta_log"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    actions = [
+        {"protocol": {"minReaderVersion": 1, "minWriterVersion": 2}},
+        {
+            "metaData": {
+                "id": str(uuid.uuid4()),
+                "name": None,
+                "description": description,
+                "format": {"provider": "parquet", "options": {}},
+                "schemaString": schema_string,
+                "partitionColumns": partition_columns or [],
+                "configuration": configuration or {},
+                "createdTime": 1700000000000,
+            }
+        },
+    ]
+
+    commit_file = log_dir / "00000000000000000000.json"
+    with commit_file.open("w", encoding="utf-8") as f:
+        for action in actions:
+            f.write(json.dumps(action))
+            f.write("\n")
+
+
+def _simple_iceberg_schema() -> Schema:
+    return Schema(
+        NestedField(field_id=1, name="id", field_type=LongType(), required=False),
+        NestedField(field_id=2, name="event", field_type=StringType(), required=False),
+        NestedField(field_id=3, name="score", field_type=DoubleType(), required=False),
+    )
+
+
+# =========================================================================
+# Iceberg interop
+# =========================================================================
+
+# ---------------------------------------------------------------------------
+# Iceberg: Sail → PyIceberg
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="not working on Windows")
+class TestIcebergSailToPyiceberg:
+    """Sail writes Iceberg tables; PyIceberg verifies the metadata."""
+
+    def test_sail_write_schema_readable_by_pyiceberg(self, spark, tmp_path):
+        """Sail writes an Iceberg table and PyIceberg can load the schema."""
+        catalog = create_sql_catalog(tmp_path)
+        identifier = "default.interop_schema"
+        schema = _simple_iceberg_schema()
+        table = catalog.create_table(identifier=identifier, schema=schema)
+        try:
+            df = spark.createDataFrame(
+                [(1, "alpha", 0.5), (2, "beta", 0.9)],
+                schema="id LONG, event STRING, score DOUBLE",
+            )
+            df.write.format("iceberg").mode("overwrite").save(table.location())
+
+            py_tbl = StaticTable.from_metadata(table.location())
+            assert len(py_tbl.schema().fields) == 3
+            field_names = [f.name for f in py_tbl.schema().fields]
+            assert field_names == ["id", "event", "score"]
+        finally:
+            catalog.drop_table(identifier)
+
+    def test_sail_write_properties_readable_by_pyiceberg(self, spark, tmp_path):
+        """Sail writes an Iceberg table; PyIceberg sees location metadata."""
+        catalog = create_sql_catalog(tmp_path)
+        identifier = "default.interop_props"
+        schema = _simple_iceberg_schema()
+        table = catalog.create_table(identifier=identifier, schema=schema)
+        try:
+            df = spark.createDataFrame(
+                [(1, "a", 1.0)],
+                schema="id LONG, event STRING, score DOUBLE",
+            )
+            df.write.format("iceberg").mode("overwrite").save(table.location())
+
+            py_tbl = StaticTable.from_metadata(table.location())
+            assert py_tbl.metadata.location == table.location()
+        finally:
+            catalog.drop_table(identifier)
+
+
+# ---------------------------------------------------------------------------
+# Iceberg: PyIceberg → Sail (DataFrameReader)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="not working on Windows")
+class TestIcebergPyicebergToSailReader:
+    """PyIceberg creates Iceberg tables; Sail reads data via DataFrameReader."""
+
+    def test_sail_reads_data_from_pyiceberg_table(self, spark, tmp_path):
+        """PyIceberg creates a table with data; Sail reads it back."""
+        catalog = create_sql_catalog(tmp_path)
+        identifier = "default.interop_reader"
+        schema = _simple_iceberg_schema()
+        table = catalog.create_table(identifier=identifier, schema=schema)
+        try:
+            df = spark.createDataFrame(
+                [(1, "x", 0.1)],
+                schema="id LONG, event STRING, score DOUBLE",
+            )
+            df.write.format("iceberg").mode("overwrite").save(table.location())
+
+            result = spark.read.format("iceberg").load(table.location()).collect()
+            assert len(result) == 1
+            assert result[0]["id"] == 1
+        finally:
+            catalog.drop_table(identifier)
+
+
+# ---------------------------------------------------------------------------
+# Iceberg: PyIceberg → Sail (SQL + Catalog API via temp view)
+#
+# NOTE: These tests load Iceberg data as temp views. Temp views do NOT
+# trigger storage metadata hydration (hydrate_table_status returns early
+# for TemporaryView). They test the temp view code path for DESCRIBE
+# EXTENDED / SHOW TBLPROPERTIES / listColumns. Full hydration testing
+# for Iceberg requires catalog integration with an Iceberg REST catalog.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="not working on Windows")
+@pytest.mark.skipif(is_jvm_spark(), reason="Sail-specific catalog commands")
+class TestIcebergPyicebergToSailTempView:
+    """PyIceberg creates tables; Sail reads metadata via temp view (no hydration)."""
+
+    def test_describe_extended_on_iceberg_temp_view(self, spark, tmp_path):
+        """DESCRIBE EXTENDED on an Iceberg temp view shows columns from the loaded schema."""
+        catalog = create_sql_catalog(tmp_path)
+        identifier = "default.interop_tv_describe"
+        schema = _simple_iceberg_schema()
+        table = catalog.create_table(identifier=identifier, schema=schema)
+        try:
+            df = spark.createDataFrame(
+                [(1, "a", 1.0), (2, "b", 2.0)],
+                schema="id LONG, event STRING, score DOUBLE",
+            )
+            df.write.format("iceberg").mode("overwrite").save(table.location())
+
+            spark.read.format("iceberg").load(table.location()).createOrReplaceTempView("iceberg_tv_v")
+
+            rows = spark.sql("DESCRIBE EXTENDED iceberg_tv_v").collect()
+            col_names = [r.col_name for r in rows if r.col_name and not r.col_name.startswith("#")]
+            assert "id" in col_names
+            assert "event" in col_names
+            assert "score" in col_names
+        finally:
+            catalog.drop_table(identifier)
+            spark.catalog.dropTempView("iceberg_tv_v")
+
+    def test_show_tblproperties_on_iceberg_temp_view_returns_empty(self, spark, tmp_path):
+        """SHOW TBLPROPERTIES on a temp view returns empty (no managed table properties)."""
+        catalog = create_sql_catalog(tmp_path)
+        identifier = "default.interop_tv_props"
+        schema = _simple_iceberg_schema()
+        table = catalog.create_table(identifier=identifier, schema=schema)
+        try:
+            df = spark.createDataFrame([(1, "a", 1.0)], schema="id LONG, event STRING, score DOUBLE")
+            df.write.format("iceberg").mode("overwrite").save(table.location())
+
+            spark.read.format("iceberg").load(table.location()).createOrReplaceTempView("iceberg_tv_props_v")
+
+            rows = spark.sql("SHOW TBLPROPERTIES iceberg_tv_props_v").collect()
+            assert rows == []
+        finally:
+            catalog.drop_table(identifier)
+            spark.catalog.dropTempView("iceberg_tv_props_v")
+
+    def test_list_columns_on_iceberg_temp_view(self, spark, tmp_path):
+        """spark.catalog.listColumns() on an Iceberg temp view shows columns."""
+        catalog = create_sql_catalog(tmp_path)
+        identifier = "default.interop_tv_cols"
+        schema = _simple_iceberg_schema()
+        table = catalog.create_table(identifier=identifier, schema=schema)
+        try:
+            df = spark.createDataFrame([(1, "a", 1.0)], schema="id LONG, event STRING, score DOUBLE")
+            df.write.format("iceberg").mode("overwrite").save(table.location())
+
+            spark.read.format("iceberg").load(table.location()).createOrReplaceTempView("iceberg_tv_cols_v")
+
+            columns = spark.catalog.listColumns("iceberg_tv_cols_v")
+            col_names = [c.name for c in columns]
+            assert "id" in col_names
+            assert "event" in col_names
+            assert "score" in col_names
+        finally:
+            catalog.drop_table(identifier)
+            spark.catalog.dropTempView("iceberg_tv_cols_v")
+
+
+# ---------------------------------------------------------------------------
+# Iceberg format version 2 interop
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="not working on Windows")
+class TestIcebergV2Interop:
+    """Verify Sail can read Iceberg v2 tables created by PyIceberg."""
+
+    def test_sail_reader_reads_v2_table(self, spark, tmp_path):
+        """PyIceberg creates a v2 table; Sail reads it via DataFrameReader."""
+        catalog = create_sql_catalog(tmp_path)
+        identifier = "default.interop_v2_reader"
+        schema = _simple_iceberg_schema()
+        table = catalog.create_table(identifier=identifier, schema=schema)
+        try:
+            df = spark.createDataFrame(
+                [(10, "A", 0.98), (11, "B", 0.54)],
+                schema="id LONG, event STRING, score DOUBLE",
+            )
+            df.write.format("iceberg").mode("overwrite").save(table.location())
+
+            result = (
+                spark.read.format("iceberg")
+                .load(table.location())
+                .sort("id")
+                .collect()
+            )
+            assert len(result) == 2
+            assert result[0]["id"] == 10
+            assert result[1]["id"] == 11
+
+            static_table = StaticTable.from_metadata(table.location())
+            assert static_table.metadata.format_version == 2
+        finally:
+            catalog.drop_table(identifier)
+
+
+# =========================================================================
+# Delta interop
+# =========================================================================
+
+# ---------------------------------------------------------------------------
+# Delta: Sail → Delta log
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(is_jvm_spark(), reason="Sail-specific metadata writing")
+class TestDeltaSailToDeltaLog:
+    """Sail writes Delta tables; the JSON log is inspected for metadata correctness."""
+
+    def test_sail_write_schema_in_delta_log(self, spark, tmp_path):
+        """Sail creates a Delta table and the log contains the correct schema."""
+        delta_path = tmp_path / "delta_interop_schema"
+        spark.sql(
+            f"CREATE TABLE delta_interop_schema (id INT, name STRING) "
+            f"USING DELTA LOCATION '{delta_path}'"
+        )
+        try:
+            metadata = _read_delta_log_metadata(delta_path)
+            schema = json.loads(metadata["schemaString"])
+            field_names = [f["name"] for f in schema["fields"]]
+            assert field_names == ["id", "name"]
+        finally:
+            spark.sql("DROP TABLE IF EXISTS delta_interop_schema")
+
+    def test_sail_write_partition_columns_in_delta_log(self, spark, tmp_path):
+        """Sail creates a partitioned Delta table and the log records partition columns."""
+        delta_path = tmp_path / "delta_interop_partitions"
+        spark.sql(
+            f"CREATE TABLE delta_interop_partitions (id INT, category STRING, value DOUBLE) "
+            f"USING DELTA PARTITIONED BY (category) LOCATION '{delta_path}'"
+        )
+        try:
+            metadata = _read_delta_log_metadata(delta_path)
+            assert metadata["partitionColumns"] == ["category"]
+        finally:
+            spark.sql("DROP TABLE IF EXISTS delta_interop_partitions")
+
+    def test_sail_write_properties_in_delta_log(self, spark, tmp_path):
+        """Sail creates a Delta table with TBLPROPERTIES and the log records them."""
+        delta_path = tmp_path / "delta_interop_props"
+        spark.sql(
+            f"CREATE TABLE delta_interop_props (id INT) "
+            f"USING DELTA "
+            f"TBLPROPERTIES ('custom.key' = 'custom_value', 'delta.appendOnly' = 'true') "
+            f"LOCATION '{delta_path}'"
+        )
+        try:
+            metadata = _read_delta_log_metadata(delta_path)
+            config = metadata.get("configuration", {})
+            assert config.get("delta.appendOnly") == "true"
+        finally:
+            spark.sql("DROP TABLE IF EXISTS delta_interop_props")
+
+    def test_sail_write_comment_in_delta_log(self, spark, tmp_path):
+        """Sail creates a Delta table with a COMMENT and the log records it."""
+        delta_path = tmp_path / "delta_interop_comment"
+        spark.sql(
+            f"CREATE TABLE delta_interop_comment (id INT) "
+            f"USING DELTA COMMENT 'test table comment' "
+            f"LOCATION '{delta_path}'"
+        )
+        try:
+            metadata = _read_delta_log_metadata(delta_path)
+            assert metadata.get("description") == "test table comment"
+        finally:
+            spark.sql("DROP TABLE IF EXISTS delta_interop_comment")
+
+
+# ---------------------------------------------------------------------------
+# Delta: Delta log → Sail (DataFrameReader)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(is_jvm_spark(), reason="Sail-specific catalog commands")
+class TestDeltaLogToSailReader:
+    """Hand-crafted Delta logs are created; Sail reads data via DataFrameReader."""
+
+    def test_sail_reads_schema_from_delta_log(self, spark, tmp_path):
+        """A Delta log with specific columns is read correctly by Sail."""
+        delta_path = tmp_path / "delta_log_reader_schema"
+        schema_string = json.dumps({
+            "type": "struct",
+            "fields": [
+                {"name": "user_id", "type": "long", "nullable": True, "metadata": {}},
+                {"name": "email", "type": "string", "nullable": False, "metadata": {}},
+            ],
+        })
+        _write_delta_log_with_metadata(delta_path, schema_string=schema_string)
+
+        df = spark.read.format("delta").load(str(delta_path))
+        assert set(df.columns) == {"user_id", "email"}
+        assert df.count() == 0
+
+    def test_sail_reads_partition_columns_from_delta_log(self, spark, tmp_path):
+        """A Delta log with partition columns is read correctly by Sail."""
+        delta_path = tmp_path / "delta_log_reader_partitions"
+        schema_string = json.dumps({
+            "type": "struct",
+            "fields": [
+                {"name": "id", "type": "integer", "nullable": True, "metadata": {}},
+                {"name": "region", "type": "string", "nullable": True, "metadata": {}},
+            ],
+        })
+        _write_delta_log_with_metadata(
+            delta_path,
+            schema_string=schema_string,
+            partition_columns=["region"],
+        )
+
+        df = spark.read.format("delta").load(str(delta_path))
+        assert set(df.columns) == {"id", "region"}
+
+
+# ---------------------------------------------------------------------------
+# Delta: Delta log → Sail (managed table, exercises hydration)
+#
+# These tests create a Delta log externally, then register it as a managed
+# Delta table via CREATE TABLE ... USING DELTA LOCATION. This exercises
+# the full hydration path (hydrate_table_status → load_storage_table_metadata)
+# through SQL and Catalog API against storage metadata written by an
+# external engine.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(is_jvm_spark(), reason="Sail-specific catalog commands")
+class TestDeltaLogToSailHydration:
+    """External Delta log registered as managed table; Sail hydrates metadata from storage."""
+
+    def test_describe_extended_shows_storage_schema(self, spark, tmp_path):
+        """A Delta log created externally; DESCRIBE EXTENDED shows storage-level columns."""
+        delta_path = tmp_path / "delta_hydration_schema"
+        schema_string = json.dumps({
+            "type": "struct",
+            "fields": [
+                {"name": "order_id", "type": "long", "nullable": True, "metadata": {}},
+                {"name": "total", "type": "double", "nullable": True, "metadata": {}},
+            ],
+        })
+        _write_delta_log_with_metadata(delta_path, schema_string=schema_string)
+
+        table_name = "test_hydration_schema"
+        spark.sql(
+            f"CREATE TABLE {table_name} USING DELTA LOCATION '{delta_path}'"
+        )
+        try:
+            rows = spark.sql(f"DESCRIBE EXTENDED {table_name}").collect()
+            col_names = [r.col_name for r in rows if r.col_name and not r.col_name.startswith("#")]
+            assert "order_id" in col_names
+            assert "total" in col_names
+
+            # Verify provider comes from storage metadata
+            metadata = {r.col_name: r.data_type for r in rows}
+            assert metadata.get("Provider") == "delta"
+        finally:
+            spark.sql(f"DROP TABLE IF EXISTS {table_name}")
+
+    def test_describe_extended_shows_partition_columns(self, spark, tmp_path):
+        """A partitioned Delta log; DESCRIBE EXTENDED shows partition info from storage."""
+        delta_path = tmp_path / "delta_hydration_partitions"
+        schema_string = json.dumps({
+            "type": "struct",
+            "fields": [
+                {"name": "id", "type": "integer", "nullable": True, "metadata": {}},
+                {"name": "region", "type": "string", "nullable": True, "metadata": {}},
+            ],
+        })
+        _write_delta_log_with_metadata(
+            delta_path,
+            schema_string=schema_string,
+            partition_columns=["region"],
+        )
+
+        table_name = "test_hydration_partitions"
+        spark.sql(
+            f"CREATE TABLE {table_name} USING DELTA LOCATION '{delta_path}'"
+        )
+        try:
+            rows = spark.sql(f"DESCRIBE EXTENDED {table_name}").collect()
+            col_names = [r.col_name for r in rows if r.col_name and not r.col_name.startswith("#")]
+            assert "region" in col_names
+            assert "id" in col_names
+        finally:
+            spark.sql(f"DROP TABLE IF EXISTS {table_name}")
+
+    def test_show_tblproperties_shows_storage_properties(self, spark, tmp_path):
+        """A Delta log with configuration; SHOW TBLPROPERTIES shows storage-level props."""
+        delta_path = tmp_path / "delta_hydration_props"
+        schema_string = json.dumps({
+            "type": "struct",
+            "fields": [
+                {"name": "id", "type": "integer", "nullable": True, "metadata": {}},
+            ],
+        })
+        _write_delta_log_with_metadata(
+            delta_path,
+            schema_string=schema_string,
+            configuration={"delta.appendOnly": "true", "custom.prop": "value"},
+        )
+
+        table_name = "test_hydration_props"
+        spark.sql(
+            f"CREATE TABLE {table_name} USING DELTA LOCATION '{delta_path}'"
+        )
+        try:
+            rows = spark.sql(f"SHOW TBLPROPERTIES {table_name}").collect()
+            assert len(rows) >= 1
+            props = {r["key"]: r["value"] for r in rows}
+            assert "custom.prop" in props
+            assert props["custom.prop"] == "value"
+        finally:
+            spark.sql(f"DROP TABLE IF EXISTS {table_name}")
+
+    def test_show_table_extended_shows_storage_info(self, spark, tmp_path):
+        """A Delta log with comment; SHOW TABLE EXTENDED shows storage-level information."""
+        delta_path = tmp_path / "delta_hydration_extended"
+        schema_string = json.dumps({
+            "type": "struct",
+            "fields": [
+                {"name": "id", "type": "integer", "nullable": True, "metadata": {}},
+                {"name": "value", "type": "double", "nullable": True, "metadata": {}},
+            ],
+        })
+        _write_delta_log_with_metadata(
+            delta_path,
+            schema_string=schema_string,
+            description="hydrated table comment",
+        )
+
+        table_name = "test_hydration_extended"
+        spark.sql(
+            f"CREATE TABLE {table_name} USING DELTA LOCATION '{delta_path}'"
+        )
+        try:
+            rows = spark.sql(f"SHOW TABLE EXTENDED LIKE '{table_name}'").collect()
+            assert len(rows) >= 1
+            info = rows[0].information
+            assert "Provider: delta" in info
+            assert "Schema: root" in info
+        finally:
+            spark.sql(f"DROP TABLE IF EXISTS {table_name}")
+
+    def test_list_columns_returns_storage_columns(self, spark, tmp_path):
+        """spark.catalog.listColumns() on a managed Delta table returns storage-level columns."""
+        delta_path = tmp_path / "delta_hydration_listcols"
+        schema_string = json.dumps({
+            "type": "struct",
+            "fields": [
+                {"name": "product_id", "type": "long", "nullable": True, "metadata": {}},
+                {"name": "price", "type": "double", "nullable": True, "metadata": {}},
+            ],
+        })
+        _write_delta_log_with_metadata(delta_path, schema_string=schema_string)
+
+        table_name = "test_hydration_listcols"
+        spark.sql(
+            f"CREATE TABLE {table_name} USING DELTA LOCATION '{delta_path}'"
+        )
+        try:
+            columns = spark.catalog.listColumns(table_name)
+            col_names = [c.name for c in columns]
+            assert "product_id" in col_names
+            assert "price" in col_names
+        finally:
+            spark.sql(f"DROP TABLE IF EXISTS {table_name}")


### PR DESCRIPTION
## Summary

Improve Spark catalog metadata compatibility for lakehouse tables by hydrating metadata from storage for Delta and Iceberg-backed tables, and by aligning several catalog command surfaces with Spark behavior.

## What Changed

- add `SHOW TBLPROPERTIES` support to Sail catalog commands
- make `DESCRIBE EXTENDED`, `SHOW TABLE EXTENDED`, and `spark.catalog.listColumns()` use storage-backed metadata for Delta and Iceberg tables when available
- render Spark-compatible metadata surfaces for provider, location, comment, table properties, and partition information, including transformed Iceberg partitions
- redact sensitive property values consistently in metadata output
- qualify explicit relative table `LOCATION` values before catalog and storage use
- fall back to catalog metadata instead of failing read-only metadata commands when an older lakehouse table still has a relative stored location
- preserve bucket-column reporting during Iceberg metadata hydration

## Why

Before this change, Sail catalog metadata surfaces could diverge from the underlying Delta and Iceberg metadata. That caused metadata commands to show incomplete or stale schema and properties compared with what Spark users expect from storage-backed lakehouse tables.

## Scope

Included:
- Spark SQL metadata commands
- Spark catalog column reporting
- Delta and Iceberg storage metadata hydration
- parser and planner support for `SHOW TBLPROPERTIES`

Out of scope:
- adding HMS-backed Iceberg table support
- changing Sail's table lifecycle semantics; Sail still defaults new tables to external tables
- changing managed versus external behavior beyond displaying the stored HMS type consistently