### PR TITLE
fix: fixing create() table for Nessie, adding test for it

### DIFF
--- a/crates/sail-catalog-iceberg/src/provider.rs
+++ b/crates/sail-catalog-iceberg/src/provider.rs
@@ -125,9 +125,9 @@ impl IcebergRestCatalogProvider {
                     .await?;
 
                 let uri = if let Some(uri) = config.overrides.remove(REST_CATALOG_PROP_URI) {
-                    uri
+                    uri.trim_end_matches('/').to_string()
                 } else {
-                    self.catalog_config.uri.clone()
+                    self.catalog_config.uri.trim_end_matches('/').to_string()
                 };
 
                 let mut props = config.defaults;
@@ -817,7 +817,7 @@ impl CatalogProvider for IcebergRestCatalogProvider {
             schema: Box::new(schema),
             partition_spec,
             write_order,
-            stage_create: None,
+            stage_create: Some(false),
             properties: if props.is_empty() { None } else { Some(props) },
         };
 

--- a/python/pysail/tests/spark/catalog_integration/iceberg_rest/conftest.py
+++ b/python/pysail/tests/spark/catalog_integration/iceberg_rest/conftest.py
@@ -1,7 +1,7 @@
 """Pytest fixtures for Iceberg REST catalog integration tests.
 
-Uses SeaweedFS for S3-compatible storage and the Apache Iceberg REST fixture
-as the catalog server.
+Uses SeaweedFS for S3-compatible storage and Iceberg REST-compatible catalog
+servers.
 """
 
 from __future__ import annotations
@@ -149,6 +149,58 @@ def iceberg_spark(iceberg_rest_endpoint: str) -> Generator[SparkSession, None, N
     catalog_config = f'[{{name="sail", type="iceberg-rest", uri="{iceberg_rest_endpoint}"}}]'
     server, remote, saved_env = start_sail_server(catalog_list=catalog_config)
     spark = create_spark_session(remote, "iceberg_rest_catalog_test")
+    yield spark
+    with contextlib.suppress(Exception):
+        spark.stop()
+    stop_sail_server(server, saved_env)
+
+
+@pytest.fixture(scope="module")
+def nessie_container(
+    docker_network: Network,
+    seaweedfs_container: DockerContainer,  # noqa: ARG001
+    seaweedfs_internal_endpoint: str,
+    _create_s3_bucket: None,
+) -> Generator[DockerContainer, None, None]:
+    """Start a Nessie server with Iceberg REST enabled."""
+    container = (
+        DockerContainer("ghcr.io/projectnessie/nessie:0.107.5")
+        .with_exposed_ports(19120)
+        .with_env("NESSIE_CATALOG_DEFAULT_WAREHOUSE", "warehouse")
+        .with_env("NESSIE_CATALOG_WAREHOUSES_WAREHOUSE_LOCATION", "s3://icebergdata/nessie")
+        .with_env("NESSIE_CATALOG_SERVICE_S3_DEFAULT_OPTIONS_ENDPOINT", seaweedfs_internal_endpoint)
+        .with_env("NESSIE_CATALOG_SERVICE_S3_DEFAULT_OPTIONS_REGION", "us-east-1")
+        .with_env("NESSIE_CATALOG_SERVICE_S3_DEFAULT_OPTIONS_PATH_STYLE_ACCESS", "true")
+        .with_env("NESSIE_CATALOG_SERVICE_S3_DEFAULT_OPTIONS_AUTH_TYPE", "STATIC")
+        .with_env(
+            "NESSIE_CATALOG_SERVICE_S3_DEFAULT_OPTIONS_ACCESS_KEY",
+            "urn:nessie-secret:quarkus:nessie.catalog.secrets.s3default",
+        )
+        .with_env("NESSIE_CATALOG_SECRETS_S3DEFAULT_NAME", "admin")
+        .with_env("NESSIE_CATALOG_SECRETS_S3DEFAULT_SECRET", "password")
+        .with_network(docker_network)
+        .with_network_aliases("nessie")
+    )
+    container.start()
+    wait_for_logs(container, "Nessie 0.107.5", timeout=120)
+    yield container
+    container.stop()
+
+
+@pytest.fixture(scope="module")
+def nessie_iceberg_rest_endpoint(nessie_container: DockerContainer) -> str:
+    """Host-accessible Nessie Iceberg REST catalog endpoint."""
+    host = nessie_container.get_container_host_ip()
+    port = nessie_container.get_exposed_port(19120)
+    return f"http://{host}:{port}/iceberg"
+
+
+@pytest.fixture(scope="module")
+def nessie_spark(nessie_iceberg_rest_endpoint: str) -> Generator[SparkSession, None, None]:
+    """Start Sail server with Nessie as the Iceberg REST catalog."""
+    catalog_config = f'[{{name="sail", type="iceberg-rest", uri="{nessie_iceberg_rest_endpoint}"}}]'
+    server, remote, saved_env = start_sail_server(catalog_list=catalog_config)
+    spark = create_spark_session(remote, "nessie_iceberg_rest_catalog_test")
     yield spark
     with contextlib.suppress(Exception):
         spark.stop()

--- a/python/pysail/tests/spark/catalog_integration/iceberg_rest/test_nessie.py
+++ b/python/pysail/tests/spark/catalog_integration/iceberg_rest/test_nessie.py
@@ -1,0 +1,27 @@
+"""Nessie-backed Iceberg REST catalog integration tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyspark.sql import SparkSession
+
+
+def test_create_table_with_nessie_catalog(nessie_spark: SparkSession) -> None:
+    """Create a table through Nessie's Iceberg REST endpoint."""
+    namespace = "nessie_create_table"
+    table = f"{namespace}.t1"
+
+    try:
+        nessie_spark.sql(f"CREATE DATABASE IF NOT EXISTS {namespace}").collect()
+        nessie_spark.sql(f"CREATE TABLE {table} (id INT) USING iceberg").collect()
+
+        rows = nessie_spark.sql(f"SHOW TABLES IN {namespace} LIKE 't1'").collect()
+
+        assert len(rows) == 1
+        assert rows[0].database == namespace
+        assert rows[0].tableName == "t1"
+        assert rows[0].isTemporary is False
+    finally:
+        nessie_spark.sql(f"DROP DATABASE IF EXISTS {namespace} CASCADE").collect()


### PR DESCRIPTION
fix: always set stage-create for Iceberg REST create, and add a test for it

When using Nessie for an Iceberg provider, I found that it insists on the stage-create parameter being present.  It should be set to false, but present.  Codex and I have also discovered extraneous trailing slashes that could be trimmed.  The integration test is also added.