### PR TITLE
feat: remove Kubernetes worker pods on session end

### DIFF
--- a/crates/sail-execution/src/worker_manager/kubernetes.rs
+++ b/crates/sail-execution/src/worker_manager/kubernetes.rs
@@ -7,6 +7,7 @@ use k8s_openapi::api::core::v1::{
 };
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ObjectMeta, OwnerReference};
 use k8s_openapi::{DeepMerge, Resource};
+use kube::api::{DeleteParams, ListParams};
 use kube::Api;
 use rand::distr::Uniform;
 use rand::RngExt;
@@ -101,6 +102,10 @@ impl KubernetesWorkerManager {
             (
                 "app.kubernetes.io/instance".to_string(),
                 format!("{}-{}", self.name, id),
+            ),
+            (
+                "sail.lakesail.com/worker-manager".to_string(),
+                self.name.clone(),
             ),
         ])
     }
@@ -276,6 +281,14 @@ impl WorkerManager for KubernetesWorkerManager {
     }
 
     async fn stop(&self) -> ExecutionResult<()> {
+        self.pods()
+            .await?
+            .delete_collection(
+                &DeleteParams::default(),
+                &ListParams::default()
+                    .labels(&format!("sail.lakesail.com/worker-manager={}", self.name)),
+            )
+            .await?;
         Ok(())
     }
 }
@@ -328,6 +341,10 @@ mod tests {
                 "app.kubernetes.io/instance".to_string(),
                 "test-instance".to_string(),
             ),
+            (
+                "sail.lakesail.com/worker-manager".to_string(),
+                "test-manager".to_string(),
+            ),
         ]);
         labels.extend(default_labels.clone());
 
@@ -355,6 +372,10 @@ mod tests {
         assert_eq!(
             labels.get("app.kubernetes.io/instance"),
             Some(&"test-instance".to_string())
+        );
+        assert_eq!(
+            labels.get("sail.lakesail.com/worker-manager"),
+            Some(&"test-manager".to_string())
         );
     }
 }


### PR DESCRIPTION
This is revisiting the previously reverted PR #1850.

We now always remove Kubernetes worker pods on session end. Configuration for pod cleanup behavior will be added in the near future once we finalize the design.