### PR TITLE
fix: stale expected_partitions in PythonDataSourceWriteCommitExec causes intermittent write failure

### DIFF
--- a/crates/sail-data-source/src/formats/python/commit_exec.rs
+++ b/crates/sail-data-source/src/formats/python/commit_exec.rs
@@ -364,21 +364,43 @@ mod tests {
     #[test]
     #[expect(clippy::unwrap_used)]
     fn test_with_new_children() {
-        let schema = Arc::new(Schema::new(vec![
+        let data_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
+        let inputs: Vec<Arc<dyn ExecutionPlan>> = (0..4)
+            .map(|_| {
+                Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
+                    data_schema.clone(),
+                )) as Arc<dyn ExecutionPlan>
+            })
+            .collect();
+        let write_exec = Arc::new(PythonDataSourceWriteExec::new(
+            datafusion::physical_plan::union::UnionExec::try_new(inputs).unwrap(),
+            vec![],
+            true,
+        ));
+        let coalesce: Arc<dyn ExecutionPlan> = Arc::new(
+            datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec::new(write_exec),
+        );
+
+        let commit_schema = Arc::new(Schema::new(vec![
             Field::new(COL_PARTITION_ID, DataType::UInt64, false),
             Field::new(COL_COMMIT_MESSAGE, DataType::Binary, true),
             Field::new(COL_ERROR, DataType::Utf8, true),
         ]));
-        let input1 = Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
-            schema.clone(),
+        let exec = Arc::new(PythonDataSourceWriteCommitExec::new(
+            Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
+                commit_schema,
+            )),
+            vec![],
+            2,
         ));
-        let input2 = Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
-            schema.clone(),
-        ));
-        let exec = Arc::new(PythonDataSourceWriteCommitExec::new(input1, vec![], 2));
 
-        let new_exec = exec.clone().with_new_children(vec![input2]).unwrap();
+        let new_exec = exec.clone().with_new_children(vec![coalesce]).unwrap();
         assert!(new_exec.as_any().is::<PythonDataSourceWriteCommitExec>());
+        let new_commit = new_exec
+            .as_any()
+            .downcast_ref::<PythonDataSourceWriteCommitExec>()
+            .unwrap();
+        assert_eq!(new_commit.expected_partitions(), 4,);
     }
 
     #[test]

--- a/crates/sail-data-source/src/formats/python/commit_exec.rs
+++ b/crates/sail-data-source/src/formats/python/commit_exec.rs
@@ -20,22 +20,7 @@ use datafusion_common::{exec_err, internal_err, DataFusionError, Result};
 use futures::StreamExt;
 
 use super::executor::{InProcessExecutor, PythonExecutor};
-use super::write_exec::{
-    PythonDataSourceWriteExec, COL_COMMIT_MESSAGE, COL_ERROR, COL_PARTITION_ID,
-};
-
-/// Walk the plan tree to find the output partition count of `PythonDataSourceWriteExec`.
-fn find_write_exec_partition_count(plan: &dyn ExecutionPlan) -> Option<usize> {
-    if plan.as_any().is::<PythonDataSourceWriteExec>() {
-        return Some(plan.properties().partitioning.partition_count());
-    }
-    for child in plan.children() {
-        if let Some(count) = find_write_exec_partition_count(child.as_ref()) {
-            return Some(count);
-        }
-    }
-    None
-}
+use super::write_exec::{COL_COMMIT_MESSAGE, COL_ERROR, COL_PARTITION_ID};
 
 /// Execution plan for commit/abort in Python datasource write flow.
 #[derive(Debug)]
@@ -130,16 +115,10 @@ impl ExecutionPlan for PythonDataSourceWriteCommitExec {
         if children.len() != 1 {
             return internal_err!("PythonDataSourceWriteCommitExec should have exactly one child");
         }
-        let child = children[0].clone();
-        let Some(expected_partitions) = find_write_exec_partition_count(child.as_ref()) else {
-            return internal_err!(
-                "PythonDataSourceWriteCommitExec: PythonDataSourceWriteExec not found in child plan tree"
-            );
-        };
         Ok(Arc::new(Self::new(
-            child,
+            children[0].clone(),
             self.pickled_writer.clone(),
-            expected_partitions,
+            self.expected_partitions,
         )))
     }
 
@@ -364,43 +343,21 @@ mod tests {
     #[test]
     #[expect(clippy::unwrap_used)]
     fn test_with_new_children() {
-        let data_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
-        let inputs: Vec<Arc<dyn ExecutionPlan>> = (0..4)
-            .map(|_| {
-                Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
-                    data_schema.clone(),
-                )) as Arc<dyn ExecutionPlan>
-            })
-            .collect();
-        let write_exec = Arc::new(PythonDataSourceWriteExec::new(
-            datafusion::physical_plan::union::UnionExec::try_new(inputs).unwrap(),
-            vec![],
-            true,
-        ));
-        let coalesce: Arc<dyn ExecutionPlan> = Arc::new(
-            datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec::new(write_exec),
-        );
-
-        let commit_schema = Arc::new(Schema::new(vec![
+        let schema = Arc::new(Schema::new(vec![
             Field::new(COL_PARTITION_ID, DataType::UInt64, false),
             Field::new(COL_COMMIT_MESSAGE, DataType::Binary, true),
             Field::new(COL_ERROR, DataType::Utf8, true),
         ]));
-        let exec = Arc::new(PythonDataSourceWriteCommitExec::new(
-            Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
-                commit_schema,
-            )),
-            vec![],
-            2,
+        let input1 = Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
+            schema.clone(),
         ));
+        let input2 = Arc::new(datafusion::physical_plan::empty::EmptyExec::new(
+            schema.clone(),
+        ));
+        let exec = Arc::new(PythonDataSourceWriteCommitExec::new(input1, vec![], 2));
 
-        let new_exec = exec.clone().with_new_children(vec![coalesce]).unwrap();
+        let new_exec = exec.clone().with_new_children(vec![input2]).unwrap();
         assert!(new_exec.as_any().is::<PythonDataSourceWriteCommitExec>());
-        let new_commit = new_exec
-            .as_any()
-            .downcast_ref::<PythonDataSourceWriteCommitExec>()
-            .unwrap();
-        assert_eq!(new_commit.expected_partitions(), 4,);
     }
 
     #[test]

--- a/crates/sail-data-source/src/formats/python/commit_exec.rs
+++ b/crates/sail-data-source/src/formats/python/commit_exec.rs
@@ -20,7 +20,22 @@ use datafusion_common::{exec_err, internal_err, DataFusionError, Result};
 use futures::StreamExt;
 
 use super::executor::{InProcessExecutor, PythonExecutor};
-use super::write_exec::{COL_COMMIT_MESSAGE, COL_ERROR, COL_PARTITION_ID};
+use super::write_exec::{
+    PythonDataSourceWriteExec, COL_COMMIT_MESSAGE, COL_ERROR, COL_PARTITION_ID,
+};
+
+/// Walk the plan tree to find the output partition count of `PythonDataSourceWriteExec`.
+fn find_write_exec_partition_count(plan: &dyn ExecutionPlan) -> Option<usize> {
+    if plan.as_any().is::<PythonDataSourceWriteExec>() {
+        return Some(plan.properties().partitioning.partition_count());
+    }
+    for child in plan.children() {
+        if let Some(count) = find_write_exec_partition_count(child.as_ref()) {
+            return Some(count);
+        }
+    }
+    None
+}
 
 /// Execution plan for commit/abort in Python datasource write flow.
 #[derive(Debug)]
@@ -115,10 +130,16 @@ impl ExecutionPlan for PythonDataSourceWriteCommitExec {
         if children.len() != 1 {
             return internal_err!("PythonDataSourceWriteCommitExec should have exactly one child");
         }
+        let child = children[0].clone();
+        let Some(expected_partitions) = find_write_exec_partition_count(child.as_ref()) else {
+            return internal_err!(
+                "PythonDataSourceWriteCommitExec: PythonDataSourceWriteExec not found in child plan tree"
+            );
+        };
         Ok(Arc::new(Self::new(
-            children[0].clone(),
+            child,
             self.pickled_writer.clone(),
-            self.expected_partitions,
+            expected_partitions,
         )))
     }
 

--- a/crates/sail-data-source/src/formats/python/write_exec.rs
+++ b/crates/sail-data-source/src/formats/python/write_exec.rs
@@ -128,6 +128,10 @@ impl ExecutionPlan for PythonDataSourceWriteExec {
         &self.properties
     }
 
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        vec![false]
+    }
+
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
         vec![&self.input]
     }


### PR DESCRIPTION
## Problem

Writing to a Python datasource fails intermittently with:

```text
AnalysisException: Invalid partition id 2 in write result (expected < 2)
```

reproducible example (triggers on machines where CPU cores > input partition count):

```python
from pyspark.sql.datasource import DataSource, DataSourceArrowWriter
from collections.abc import Iterator

class NoopWriter(DataSourceArrowWriter):
    def write(self, iterator: Iterator) -> None:
        for _ in iterator:
            pass

class NoopDataSource(DataSource):
    @classmethod
    def name(cls) -> str:
        return "noop"

    def writer(self, schema, overwrite):
        return NoopWriter()

from pysail.spark import SparkConnectServer
from pyspark.sql import SparkSession

server = SparkConnectServer()
server.start()
_, port = server.listening_address
spark = SparkSession.builder.remote(f"sc://localhost:{port}").getOrCreate()
spark.dataSource.register(NoopDataSource)

spark.range(100000).repartition(2).write.mode("overwrite").format("noop").save()

print("successfully written")
```

## Root Cause

`expected_partitions` is captured at plan-creation time in `table_format.rs`. After the optimizer inserts `RepartitionExec` and `CoalescePartitionsExec`, `with_new_children` on `CommitExec` preserves the stale value instead of re-deriving it from the actual `WriteExec` partition count.


## Fix
In `with_new_children`, traverse the new child tree to find `PythonDataSourceWriteExec`'s actual partition count rather than reusing the stale `self.expected_partitions`.


