### PR TITLE
fix: cast output record batch to match schema in map partitions UDF

### DIFF
--- a/crates/sail-common-datafusion/src/array/record_batch.rs
+++ b/crates/sail-common-datafusion/src/array/record_batch.rs
@@ -15,7 +15,10 @@ use datafusion::arrow::ipc::reader::StreamReader;
 use datafusion::arrow::ipc::writer::StreamWriter;
 use datafusion_common::{DataFusionError, Result};
 
-pub fn cast_record_batch(batch: RecordBatch, schema: SchemaRef) -> Result<RecordBatch> {
+pub fn cast_record_batch_positionally(
+    batch: RecordBatch,
+    schema: SchemaRef,
+) -> Result<RecordBatch> {
     let fields = schema.fields();
     let columns = batch.columns();
     let columns = fields
@@ -36,26 +39,6 @@ pub fn cast_record_batch(batch: RecordBatch, schema: SchemaRef) -> Result<Record
     } else {
         Ok(RecordBatch::try_new(schema, columns)?)
     }
-}
-
-/// Helper function to handle timezone adjustment for timestamp arrays.
-fn adjust_timestamp_timezone<T>(array: &ArrayRef, target_tz: Option<Arc<str>>) -> Result<ArrayRef>
-where
-    T: ArrowTimestampType,
-{
-    let timestamp_array = array
-        .as_any()
-        .downcast_ref::<PrimitiveArray<T>>()
-        .ok_or_else(|| {
-            datafusion_common::DataFusionError::Plan(format!(
-                "Failed to downcast to timestamp array type: {:?}",
-                array.data_type()
-            ))
-        })?;
-
-    Ok(Arc::new(
-        timestamp_array.clone().with_timezone_opt(target_tz),
-    ))
 }
 
 /// Cast a RecordBatch to a target schema with relaxed timezone handling.
@@ -107,6 +90,26 @@ pub fn cast_record_batch_relaxed_tz(
     } else {
         Ok(RecordBatch::try_new(target.clone(), cols)?)
     }
+}
+
+/// Helper function to handle timezone adjustment for timestamp arrays.
+fn adjust_timestamp_timezone<T>(array: &ArrayRef, target_tz: Option<Arc<str>>) -> Result<ArrayRef>
+where
+    T: ArrowTimestampType,
+{
+    let timestamp_array = array
+        .as_any()
+        .downcast_ref::<PrimitiveArray<T>>()
+        .ok_or_else(|| {
+            datafusion_common::DataFusionError::Plan(format!(
+                "Failed to downcast to timestamp array type: {:?}",
+                array.data_type()
+            ))
+        })?;
+
+    Ok(Arc::new(
+        timestamp_array.clone().with_timezone_opt(target_tz),
+    ))
 }
 
 fn cast_array_recursively(src: &ArrayRef, target_type: &DataType) -> Result<ArrayRef> {

--- a/crates/sail-common-datafusion/src/array/record_batch.rs
+++ b/crates/sail-common-datafusion/src/array/record_batch.rs
@@ -27,7 +27,15 @@ pub fn cast_record_batch(batch: RecordBatch, schema: SchemaRef) -> Result<Record
             Ok(column)
         })
         .collect::<Result<Vec<_>>>()?;
-    Ok(RecordBatch::try_new(schema, columns)?)
+    if columns.is_empty() {
+        Ok(RecordBatch::try_new_with_options(
+            schema,
+            columns,
+            &RecordBatchOptions::new().with_row_count(Some(batch.num_rows())),
+        )?)
+    } else {
+        Ok(RecordBatch::try_new(schema, columns)?)
+    }
 }
 
 /// Helper function to handle timezone adjustment for timestamp arrays.

--- a/crates/sail-common-datafusion/src/array/record_batch.rs
+++ b/crates/sail-common-datafusion/src/array/record_batch.rs
@@ -31,7 +31,7 @@ pub fn cast_record_batch(batch: RecordBatch, schema: SchemaRef) -> Result<Record
         Ok(RecordBatch::try_new_with_options(
             schema,
             columns,
-            &RecordBatchOptions::new().with_row_count(Some(batch.num_rows())),
+            &RecordBatchOptions::default().with_row_count(Some(batch.num_rows())),
         )?)
     } else {
         Ok(RecordBatch::try_new(schema, columns)?)
@@ -98,7 +98,15 @@ pub fn cast_record_batch_relaxed_tz(
         cols.push(casted);
     }
 
-    Ok(RecordBatch::try_new(target.clone(), cols)?)
+    if cols.is_empty() {
+        Ok(RecordBatch::try_new_with_options(
+            target.clone(),
+            cols,
+            &RecordBatchOptions::default().with_row_count(Some(batch.num_rows())),
+        )?)
+    } else {
+        Ok(RecordBatch::try_new(target.clone(), cols)?)
+    }
 }
 
 fn cast_array_recursively(src: &ArrayRef, target_type: &DataType) -> Result<ArrayRef> {

--- a/crates/sail-plan/src/resolver/query/misc.rs
+++ b/crates/sail-plan/src/resolver/query/misc.rs
@@ -6,7 +6,9 @@ use datafusion_common::{DFSchema, DFSchemaRef, ParamValues};
 use datafusion_expr::{EmptyRelation, Extension, LogicalPlan, UNNAMED_TABLE};
 use log::warn;
 use sail_common::spec;
-use sail_common_datafusion::array::record_batch::{cast_record_batch, read_record_batches};
+use sail_common_datafusion::array::record_batch::{
+    cast_record_batch_positionally, read_record_batches,
+};
 use sail_common_datafusion::literal::LiteralEvaluator;
 use sail_logical_plan::range::RangeNode;
 
@@ -119,7 +121,7 @@ impl PlanResolver<'_> {
             let schema = Arc::new(self.resolve_schema(schema, state)?);
             let batches = batches
                 .into_iter()
-                .map(|b| Ok(cast_record_batch(b, schema.clone())?))
+                .map(|b| Ok(cast_record_batch_positionally(b, schema.clone())?))
                 .collect::<PlanResult<_>>()?;
             (schema, batches)
         } else if let [batch, ..] = batches.as_slice() {

--- a/crates/sail-python-udf/src/stream.rs
+++ b/crates/sail-python-udf/src/stream.rs
@@ -12,7 +12,7 @@ use futures::{Stream, StreamExt};
 use pyo3::exceptions::{PyRuntimeError, PyStopIteration};
 use pyo3::prelude::PyAnyMethods;
 use pyo3::{pyclass, pymethods, IntoPyObject, Py, PyAny, PyRef, PyRefMut, PyResult, Python};
-use sail_common_datafusion::array::record_batch::record_batch_with_schema;
+use sail_common_datafusion::array::record_batch::cast_record_batch_positionally;
 use tokio::runtime::Handle;
 use tokio::select;
 use tokio::sync::{mpsc, oneshot};
@@ -165,7 +165,9 @@ impl PyMapStream {
                 .detach(|| {
                     let batch = batch
                         .map_err(|e| DataFusionError::External(e.into()))
-                        .and_then(|x| record_batch_with_schema(x, &output_schema));
+                        .and_then(|x| {
+                            cast_record_batch_positionally(x, Arc::clone(&output_schema))
+                        });
                     sender.blocking_send(batch)
                 })
                 .is_err()


### PR DESCRIPTION
Matches JVM Spark, columns are matched positionally, names are ignored.
```
>>> df = spark.range(5)
... schema = StructType([
...   StructField("a", LongType(), True),
...   StructField("b", LongType(), True),
...   StructField("c", LongType(), True),
... ])
... def wrong_names(batches):
...   for batch in batches:
...       n = len(batch)
...       yield pa.record_batch({
...           "y": pa.array([1] * n, type=pa.int64()),
...           "z": pa.array([0] * n, type=pa.int64()),
...           "x": pa.array([2] * n, type=pa.int64()),
...       })
...
>>> out = df.mapInArrow(wrong_names, schema)
... out.show()
...
+---+---+---+
|  a|  b|  c|
+---+---+---+
|  1|  0|  2|
|  1|  0|  2|
|  1|  0|  2|
|  1|  0|  2|
|  1|  0|  2|
+---+---+---+

>>>
>>> df = spark.range(5)
... schema = StructType([
...   StructField("a", LongType(), True),
...   StructField("b", LongType(), True),
...   StructField("c", LongType(), True),
... ])
... def wrong_names(batches):
...   for batch in batches:
...       n = len(batch)
...       yield pa.record_batch({
...           "z": pa.array([0] * n, type=pa.int64()),
...           "y": pa.array([1] * n, type=pa.int64()),
...           "x": pa.array([2] * n, type=pa.int64()),
...       })
...
>>> out = df.mapInArrow(wrong_names, schema)
... out.show()
...
+---+---+---+
|  a|  b|  c|
+---+---+---+
|  0|  1|  2|
|  0|  1|  2|
|  0|  1|  2|
|  0|  1|  2|
|  0|  1|  2|
+---+---+---+
```