### PR TITLE
fix: tolerate extra deletion vector fields in delta checkpoints & accept json style manifest

### DIFF
--- a/crates/sail-delta-lake/src/delta_log/cleanup.rs
+++ b/crates/sail-delta-lake/src/delta_log/cleanup.rs
@@ -12,7 +12,7 @@ use super::{
     parse_commit_version_from_location, parse_compacted_json_versions_from_location,
     resolve_version_timestamp,
 };
-use crate::kernel::checkpoints::read_checkpoint_main_rows_from_parquet;
+use crate::kernel::checkpoints::read_checkpoint_main_rows_from_checkpoint_file;
 use crate::kernel::snapshot::DeltaSnapshot;
 use crate::spec::{
     checkpoint_path, delta_log_root_path, is_uuid_checkpoint_filename, sidecars_dir_path,
@@ -311,7 +311,9 @@ async fn cleanup_orphaned_sidecars(object_store: Arc<dyn ObjectStore>) -> DeltaR
 
     let mut referenced_sidecars: HashSet<String> = HashSet::new();
     for cp_meta in uuid_checkpoint_metas {
-        match read_checkpoint_main_rows_from_parquet(object_store.clone(), cp_meta.clone()).await {
+        match read_checkpoint_main_rows_from_checkpoint_file(object_store.clone(), cp_meta.clone())
+            .await
+        {
             Ok(rows) => {
                 for row in rows {
                     if let Some(sidecar) = row.sidecar {

--- a/crates/sail-delta-lake/src/delta_log/replay.rs
+++ b/crates/sail-delta-lake/src/delta_log/replay.rs
@@ -14,8 +14,8 @@ use super::{
     ResolvedLogSegment,
 };
 use crate::kernel::checkpoints::{
-    decode_checkpoint_rows, read_checkpoint_main_rows_from_parquet,
-    read_checkpoint_rows_from_parquet, replay_commit_actions_with_compactions,
+    decode_checkpoint_rows, read_checkpoint_main_rows_from_checkpoint_file,
+    read_checkpoint_rows_from_checkpoint_file, replay_commit_actions_with_compactions,
     replay_commit_header_actions_with_compactions, ReconciledCheckpointState,
     ReconciledHeaderState, ReplayedTableState,
 };
@@ -24,12 +24,12 @@ use crate::spec::{
 };
 use crate::storage::LogStore;
 
-async fn read_checkpoint_header_from_parquet(
+async fn read_checkpoint_header_from_checkpoint_file(
     root_store: Arc<dyn ObjectStore>,
     meta: ObjectMeta,
 ) -> DeltaResult<ReconciledHeaderState> {
     if is_json_checkpoint_location(&meta) {
-        let rows = read_checkpoint_main_rows_from_parquet(root_store, meta).await?;
+        let rows = read_checkpoint_main_rows_from_checkpoint_file(root_store, meta).await?;
         let mut state = ReconciledHeaderState::default();
         for row in rows {
             state.apply_checkpoint_row(row)?;
@@ -104,7 +104,7 @@ pub(crate) async fn load_replayed_table_state(
     let store = log_store.object_store(None);
     let mut state = ReconciledCheckpointState::default();
     let start_commit_version = if let Some(cp_meta) = checkpoint {
-        let rows = read_checkpoint_rows_from_parquet(store.clone(), cp_meta).await?;
+        let rows = read_checkpoint_rows_from_checkpoint_file(store.clone(), cp_meta).await?;
         for row in rows {
             state.apply_checkpoint_row(row)?;
         }
@@ -193,7 +193,7 @@ pub(crate) async fn load_replayed_table_header(
             let (mut state, start_commit_version, mut commit_timestamps) = match checkpoint {
                 Some(cp_meta) => {
                     let cp_state =
-                        read_checkpoint_header_from_parquet(store.clone(), cp_meta).await?;
+                        read_checkpoint_header_from_checkpoint_file(store.clone(), cp_meta).await?;
                     let next_v = commit_files
                         .first()
                         .map(|(v, _)| *v)

--- a/crates/sail-delta-lake/src/delta_log/replay.rs
+++ b/crates/sail-delta-lake/src/delta_log/replay.rs
@@ -14,17 +14,29 @@ use super::{
     ResolvedLogSegment,
 };
 use crate::kernel::checkpoints::{
-    decode_checkpoint_rows, read_checkpoint_rows_from_parquet,
-    replay_commit_actions_with_compactions, replay_commit_header_actions_with_compactions,
-    ReconciledCheckpointState, ReconciledHeaderState, ReplayedTableState,
+    decode_checkpoint_rows, read_checkpoint_main_rows_from_parquet,
+    read_checkpoint_rows_from_parquet, replay_commit_actions_with_compactions,
+    replay_commit_header_actions_with_compactions, ReconciledCheckpointState,
+    ReconciledHeaderState, ReplayedTableState,
 };
-use crate::spec::{CheckpointActionRow, DeltaError as DeltaTableError, DeltaResult};
+use crate::spec::{
+    is_json_checkpoint_filename, CheckpointActionRow, DeltaError as DeltaTableError, DeltaResult,
+};
 use crate::storage::LogStore;
 
 async fn read_checkpoint_header_from_parquet(
     root_store: Arc<dyn ObjectStore>,
     meta: ObjectMeta,
 ) -> DeltaResult<ReconciledHeaderState> {
+    if is_json_checkpoint_location(&meta) {
+        let rows = read_checkpoint_main_rows_from_parquet(root_store, meta).await?;
+        let mut state = ReconciledHeaderState::default();
+        for row in rows {
+            state.apply_checkpoint_row(row)?;
+        }
+        return Ok(state);
+    }
+
     let bytes = root_store.get(&meta.location).await?.bytes().await?;
     SpawnedTask::spawn_blocking(move || {
         let builder = ParquetRecordBatchReaderBuilder::try_new(bytes)
@@ -53,6 +65,14 @@ async fn read_checkpoint_header_from_parquet(
     })
     .await
     .map_err(DeltaTableError::generic_err)?
+}
+
+fn is_json_checkpoint_location(meta: &ObjectMeta) -> bool {
+    meta.location
+        .as_ref()
+        .rsplit('/')
+        .next()
+        .is_some_and(is_json_checkpoint_filename)
 }
 
 pub(crate) async fn load_replayed_table_state(

--- a/crates/sail-delta-lake/src/kernel/checkpoint_augment.rs
+++ b/crates/sail-delta-lake/src/kernel/checkpoint_augment.rs
@@ -198,6 +198,10 @@ fn normalize_checkpoint_action_for_decode(
             DeltaTableError::schema(format!("expected {action_name} to be a struct column"))
         })?;
 
+    if !checkpoint_action_needs_normalization(action_struct, &expected_fields) {
+        return Ok(batch);
+    }
+
     let existing: HashMap<&str, ArrayRef> = action_struct
         .fields()
         .iter()
@@ -243,6 +247,24 @@ fn normalize_checkpoint_action_for_decode(
         action_struct.nulls().cloned(),
     )?;
     replace_struct_column(batch, action_idx, action_field, action_name, new_action)
+}
+
+fn checkpoint_action_needs_normalization(
+    action_struct: &StructArray,
+    expected_fields: &[FieldRef],
+) -> bool {
+    let fields = action_struct.fields();
+    if fields.len() != expected_fields.len() {
+        return true;
+    }
+    fields
+        .iter()
+        .zip(expected_fields)
+        .any(|(actual, expected)| {
+            actual.name() != expected.name()
+                || actual.data_type() != expected.data_type()
+                || actual.is_nullable() != expected.is_nullable()
+        })
 }
 
 fn normalize_checkpoint_field_for_decode(

--- a/crates/sail-delta-lake/src/kernel/checkpoint_augment.rs
+++ b/crates/sail-delta-lake/src/kernel/checkpoint_augment.rs
@@ -2,8 +2,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{new_null_array, Array, ArrayRef, StringArray, StructArray};
+use datafusion::arrow::compute::cast;
 use datafusion::arrow::datatypes::{
-    Field, FieldRef, Fields, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef,
+    DataType as ArrowDataType, Field, FieldRef, Fields, Schema as ArrowSchema,
+    SchemaRef as ArrowSchemaRef,
 };
 use datafusion::arrow::json::LineDelimitedWriter;
 use datafusion::arrow::record_batch::RecordBatch;
@@ -12,8 +14,9 @@ use crate::kernel::snapshot::materialize::parse_partition_values_array;
 use crate::schema::make_physical_arrow_schema;
 use crate::spec::fields::{FIELD_NAME_PARTITION_VALUES_PARSED, FIELD_NAME_STATS_PARSED};
 use crate::spec::{
-    add_struct_type, parse_stats_json_array, stats_schema, ColumnMappingMode, ColumnMetadataKey,
-    DeltaError as DeltaTableError, DeltaResult, Metadata, StructField, StructType, TableProperties,
+    add_struct_type, parse_stats_json_array, remove_struct_type, stats_schema, ColumnMappingMode,
+    ColumnMetadataKey, DeltaError as DeltaTableError, DeltaResult, Metadata, StructField,
+    StructType, TableProperties,
 };
 
 pub(crate) struct AddAugmentationConfig {
@@ -166,76 +169,142 @@ impl AddAugmentationConfig {
         }
 
         let new_add = StructArray::try_new(Fields::from(add_fields), add_cols, nulls)?;
-        replace_add_column(batch, add_idx, add_field, new_add)
+        replace_struct_column(batch, add_idx, add_field, "add", new_add)
     }
 }
 
 pub(crate) fn normalize_checkpoint_batch_for_decode(
     batch: &RecordBatch,
 ) -> DeltaResult<RecordBatch> {
+    let batch = normalize_checkpoint_action_for_decode(batch.clone(), "add", add_field_refs()?)?;
+    normalize_checkpoint_action_for_decode(batch, "remove", remove_field_refs()?)
+}
+
+fn normalize_checkpoint_action_for_decode(
+    batch: RecordBatch,
+    action_name: &str,
+    expected_fields: Vec<FieldRef>,
+) -> DeltaResult<RecordBatch> {
     let schema = batch.schema();
-    let (add_idx, add_field) = match schema.column_with_name("add") {
+    let (action_idx, action_field) = match schema.column_with_name(action_name) {
         Some(value) => value,
-        None => return Ok(batch.clone()),
+        None => return Ok(batch),
     };
-    let add_struct = batch
-        .column(add_idx)
+    let action_struct = batch
+        .column(action_idx)
         .as_any()
         .downcast_ref::<StructArray>()
-        .ok_or_else(|| DeltaTableError::schema("expected add to be a struct column"))?;
+        .ok_or_else(|| {
+            DeltaTableError::schema(format!("expected {action_name} to be a struct column"))
+        })?;
 
-    let has_checkpoint_only_add_fields = add_struct.fields().iter().any(|field| {
-        matches!(
-            field.name().as_str(),
-            FIELD_NAME_STATS_PARSED | FIELD_NAME_PARTITION_VALUES_PARSED
-        )
-    });
-    let has_stats = add_struct
+    let existing: HashMap<&str, ArrayRef> = action_struct
         .fields()
         .iter()
-        .any(|field| field.name() == "stats");
-    if !has_checkpoint_only_add_fields && has_stats {
-        return Ok(batch.clone());
-    }
-
-    let existing: HashMap<&str, ArrayRef> = add_struct
-        .fields()
-        .iter()
-        .zip(add_struct.columns())
+        .zip(action_struct.columns())
         .map(|(field, column)| (field.name().as_str(), Arc::clone(column)))
         .collect();
-    let stats_from_parsed = existing
-        .get(FIELD_NAME_STATS_PARSED)
-        .map(|column| {
-            column
-                .as_any()
-                .downcast_ref::<StructArray>()
-                .ok_or_else(|| DeltaTableError::schema("add.stats_parsed must be a struct"))
-                .and_then(stats_parsed_to_json_array)
-        })
-        .transpose()?;
-    let expected_fields = add_field_refs()?;
-    let mut add_cols = Vec::with_capacity(expected_fields.len());
+    let stats_from_parsed = if action_name == "add" {
+        existing
+            .get(FIELD_NAME_STATS_PARSED)
+            .map(|column| {
+                column
+                    .as_any()
+                    .downcast_ref::<StructArray>()
+                    .ok_or_else(|| DeltaTableError::schema("add.stats_parsed must be a struct"))
+                    .and_then(stats_parsed_to_json_array)
+            })
+            .transpose()?
+    } else {
+        None
+    };
+    let mut action_cols = Vec::with_capacity(expected_fields.len());
     for field in &expected_fields {
         if let Some(column) = existing.get(field.name().as_str()) {
-            add_cols.push(Arc::clone(column));
+            action_cols.push(normalize_checkpoint_field_for_decode(
+                field,
+                column,
+                action_struct.len(),
+            )?);
         } else if field.name() == "stats" {
-            add_cols.push(
+            action_cols.push(
                 stats_from_parsed
                     .clone()
-                    .unwrap_or_else(|| new_null_array(field.data_type(), add_struct.len())),
+                    .unwrap_or_else(|| new_null_array(field.data_type(), action_struct.len())),
             );
         } else {
-            add_cols.push(new_null_array(field.data_type(), add_struct.len()));
+            action_cols.push(new_null_array(field.data_type(), action_struct.len()));
         }
     }
 
-    let new_add = StructArray::try_new(
+    let new_action = StructArray::try_new(
         Fields::from(expected_fields),
-        add_cols,
-        add_struct.nulls().cloned(),
+        action_cols,
+        action_struct.nulls().cloned(),
     )?;
-    replace_add_column(batch.clone(), add_idx, add_field, new_add)
+    replace_struct_column(batch, action_idx, action_field, action_name, new_action)
+}
+
+fn normalize_checkpoint_field_for_decode(
+    expected_field: &Field,
+    column: &ArrayRef,
+    len: usize,
+) -> DeltaResult<ArrayRef> {
+    let column = if expected_field.name() == "deletionVector" {
+        normalize_deletion_vector_for_decode(expected_field, column, len)
+    } else {
+        Ok(Arc::clone(column))
+    }?;
+    if column.data_type() == expected_field.data_type() {
+        Ok(column)
+    } else {
+        Ok(cast(column.as_ref(), expected_field.data_type())?)
+    }
+}
+
+fn normalize_deletion_vector_for_decode(
+    expected_field: &Field,
+    column: &ArrayRef,
+    len: usize,
+) -> DeltaResult<ArrayRef> {
+    let ArrowDataType::Struct(expected_fields) = expected_field.data_type() else {
+        return Err(DeltaTableError::schema(
+            "expected deletionVector schema to be a struct",
+        ));
+    };
+    if matches!(column.data_type(), ArrowDataType::Null) {
+        return Ok(new_null_array(expected_field.data_type(), len));
+    }
+    let deletion_vector = column
+        .as_any()
+        .downcast_ref::<StructArray>()
+        .ok_or_else(|| DeltaTableError::schema("deletionVector must be a struct"))?;
+
+    let existing: HashMap<&str, ArrayRef> = deletion_vector
+        .fields()
+        .iter()
+        .zip(deletion_vector.columns())
+        .map(|(field, column)| (field.name().as_str(), Arc::clone(column)))
+        .collect();
+
+    let mut columns = Vec::with_capacity(expected_fields.len());
+    for field in expected_fields {
+        let column = existing
+            .get(field.name().as_str())
+            .cloned()
+            .unwrap_or_else(|| new_null_array(field.data_type(), len));
+        if column.data_type() == field.data_type() {
+            columns.push(column);
+        } else {
+            columns.push(cast(column.as_ref(), field.data_type())?);
+        }
+    }
+
+    Ok(Arc::new(StructArray::try_new(
+        expected_fields.clone(),
+        columns,
+        deletion_vector.nulls().cloned(),
+    )?))
 }
 
 fn stats_parsed_to_json_array(stats_parsed: &StructArray) -> DeltaResult<ArrayRef> {
@@ -291,35 +360,44 @@ fn effective_column_mapping_mode(
 }
 
 fn add_field_refs() -> DeltaResult<Vec<FieldRef>> {
-    add_struct_type()
+    struct_field_refs(add_struct_type(), "add")
+}
+
+fn remove_field_refs() -> DeltaResult<Vec<FieldRef>> {
+    struct_field_refs(remove_struct_type(), "remove")
+}
+
+fn struct_field_refs(schema: StructType, action_name: &str) -> DeltaResult<Vec<FieldRef>> {
+    schema
         .fields()
         .map(|field| {
             Field::try_from(field)
                 .map(|field| Arc::new(field) as FieldRef)
                 .map_err(|err| {
                     DeltaTableError::schema(format!(
-                        "add schema should convert to Arrow for checkpoint decode: {err}"
+                        "{action_name} schema should convert to Arrow for checkpoint decode: {err}"
                     ))
                 })
         })
         .collect()
 }
 
-fn replace_add_column(
+fn replace_struct_column(
     batch: RecordBatch,
-    add_idx: usize,
-    add_field: &Field,
-    new_add: StructArray,
+    column_idx: usize,
+    original_field: &Field,
+    column_name: &str,
+    new_struct: StructArray,
 ) -> DeltaResult<RecordBatch> {
     let schema = batch.schema();
     let mut out_fields: Vec<FieldRef> = schema.fields().iter().cloned().collect();
-    out_fields[add_idx] = Arc::new(Field::new(
-        "add",
-        new_add.data_type().clone(),
-        add_field.is_nullable(),
+    out_fields[column_idx] = Arc::new(Field::new(
+        column_name,
+        new_struct.data_type().clone(),
+        original_field.is_nullable(),
     ));
     let mut out_cols = batch.columns().to_vec();
-    out_cols[add_idx] = Arc::new(new_add);
+    out_cols[column_idx] = Arc::new(new_struct);
     Ok(RecordBatch::try_new(
         Arc::new(ArrowSchema::new(out_fields)),
         out_cols,

--- a/crates/sail-delta-lake/src/kernel/checkpoints.rs
+++ b/crates/sail-delta-lake/src/kernel/checkpoints.rs
@@ -1305,8 +1305,10 @@ mod tests {
     use std::sync::Arc;
 
     use chrono::DateTime;
-    use datafusion::arrow::array::StructArray;
-    use datafusion::arrow::datatypes::DataType as ArrowDataType;
+    use datafusion::arrow::array::{Array, ArrayRef, Int64Array, StructArray};
+    use datafusion::arrow::datatypes::{
+        DataType as ArrowDataType, Field, FieldRef, Fields, Schema as ArrowSchema,
+    };
     use datafusion::arrow::record_batch::RecordBatch;
     use object_store::memory::InMemory;
     use object_store::path::Path;
@@ -1363,6 +1365,86 @@ mod tests {
             e_tag: None,
             version: None,
         })
+    }
+
+    fn widen_deletion_vector_for_test(
+        batch: RecordBatch,
+        action_name: &str,
+    ) -> DeltaResult<RecordBatch> {
+        let schema = batch.schema();
+        let (action_idx, action_field) = schema
+            .column_with_name(action_name)
+            .ok_or_else(|| DeltaTableError::schema(format!("{action_name} column missing")))?;
+        let action = batch
+            .column(action_idx)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .ok_or_else(|| DeltaTableError::schema(format!("{action_name} must be a struct")))?;
+        let dv_idx = action
+            .fields()
+            .iter()
+            .position(|field| field.name() == "deletionVector")
+            .ok_or_else(|| {
+                DeltaTableError::schema(format!("{action_name}.deletionVector field missing"))
+            })?;
+        let deletion_vector = action
+            .column(dv_idx)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .ok_or_else(|| DeltaTableError::schema("deletionVector must be a struct"))?;
+
+        let mut dv_fields: Vec<FieldRef> = deletion_vector
+            .fields()
+            .iter()
+            .map(|field| {
+                Arc::new(Field::new(
+                    field.name().clone(),
+                    field.data_type().clone(),
+                    true,
+                )) as FieldRef
+            })
+            .collect();
+        let mut dv_columns = deletion_vector.columns().to_vec();
+        dv_fields.push(Arc::new(Field::new(
+            "maxRowIndex",
+            ArrowDataType::Int64,
+            true,
+        )));
+        dv_columns.push(
+            Arc::new(Int64Array::from(vec![Some(999_i64); deletion_vector.len()])) as ArrayRef,
+        );
+        let widened_dv = StructArray::try_new(
+            Fields::from(dv_fields),
+            dv_columns,
+            deletion_vector.nulls().cloned(),
+        )?;
+
+        let mut action_fields: Vec<FieldRef> = action.fields().iter().cloned().collect();
+        action_fields[dv_idx] = Arc::new(Field::new(
+            "deletionVector",
+            widened_dv.data_type().clone(),
+            true,
+        ));
+        let mut action_columns = action.columns().to_vec();
+        action_columns[dv_idx] = Arc::new(widened_dv);
+        let widened_action = StructArray::try_new(
+            Fields::from(action_fields),
+            action_columns,
+            action.nulls().cloned(),
+        )?;
+
+        let mut out_fields: Vec<FieldRef> = schema.fields().iter().cloned().collect();
+        out_fields[action_idx] = Arc::new(Field::new(
+            action_name,
+            widened_action.data_type().clone(),
+            action_field.is_nullable(),
+        ));
+        let mut out_columns = batch.columns().to_vec();
+        out_columns[action_idx] = Arc::new(widened_action);
+        Ok(RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(out_fields)),
+            out_columns,
+        )?)
     }
 
     async fn put_commit(
@@ -1552,6 +1634,74 @@ mod tests {
             Some("{\"numRecords\":1}")
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn checkpoint_decode_ignores_spark_extra_deletion_vector_fields() -> DeltaResult<()> {
+        let deletion_vector = DeletionVectorDescriptor {
+            storage_type: StorageType::Inline,
+            path_or_inline_dv: "encoded-dv".to_string(),
+            offset: Some(12),
+            size_in_bytes: 34,
+            cardinality: 56,
+        };
+        let rows = vec![
+            CheckpointActionRow {
+                add: Some(Add {
+                    path: "part-001.parquet".to_string(),
+                    partition_values: HashMap::new(),
+                    size: 10,
+                    modification_time: 20,
+                    data_change: true,
+                    stats: None,
+                    tags: None,
+                    deletion_vector: Some(deletion_vector.clone()),
+                    base_row_id: None,
+                    default_row_commit_version: None,
+                    clustering_provider: None,
+                    commit_version: None,
+                    commit_timestamp: None,
+                }),
+                ..Default::default()
+            },
+            CheckpointActionRow {
+                remove: Some(Remove {
+                    path: "part-001.parquet".to_string(),
+                    data_change: true,
+                    deletion_timestamp: Some(30),
+                    extended_file_metadata: Some(true),
+                    partition_values: Some(HashMap::new()),
+                    size: Some(10),
+                    stats: None,
+                    tags: None,
+                    deletion_vector: Some(deletion_vector.clone()),
+                    base_row_id: None,
+                    default_row_commit_version: None,
+                }),
+                ..Default::default()
+            },
+        ];
+
+        let batch = encode_rows_for_test(&rows)?;
+        let batch = widen_deletion_vector_for_test(batch, "add")?;
+        let batch = widen_deletion_vector_for_test(batch, "remove")?;
+        let decoded = decode_checkpoint_rows(&batch)?;
+
+        assert_eq!(
+            decoded
+                .first()
+                .and_then(|row| row.add.as_ref())
+                .and_then(|add| add.deletion_vector.as_ref()),
+            Some(&deletion_vector)
+        );
+        assert_eq!(
+            decoded
+                .get(1)
+                .and_then(|row| row.remove.as_ref())
+                .and_then(|remove| remove.deletion_vector.as_ref()),
+            Some(&deletion_vector)
+        );
         Ok(())
     }
 

--- a/crates/sail-delta-lake/src/kernel/checkpoints.rs
+++ b/crates/sail-delta-lake/src/kernel/checkpoints.rs
@@ -21,6 +21,7 @@
 use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::sync::Arc;
 
+use bytes::Bytes;
 use chrono::Utc;
 use datafusion::arrow::datatypes::{DataType as ArrowDataType, FieldRef};
 use datafusion::arrow::record_batch::RecordBatch;
@@ -45,10 +46,10 @@ use crate::kernel::checkpoint_augment::{
 };
 use crate::kernel::log_segment::ReplayedTableHeader;
 use crate::spec::{
-    checkpoint_path, last_checkpoint_path, sidecar_file_path, uuid_checkpoint_path, Action, Add,
-    CheckpointActionRow, CheckpointMetadata, DeltaError as DeltaTableError, DeltaResult,
-    DomainMetadata, LastCheckpointHint, Metadata, Protocol, Remove, Sidecar, TableFeature,
-    TableProperties, Transaction,
+    checkpoint_path, is_json_checkpoint_filename, last_checkpoint_path, sidecar_file_path,
+    uuid_checkpoint_path, Action, Add, CheckpointActionRow, CheckpointMetadata,
+    DeltaError as DeltaTableError, DeltaResult, DomainMetadata, LastCheckpointHint, Metadata,
+    Protocol, Remove, Sidecar, TableFeature, TableProperties, Transaction,
 };
 use crate::storage::{get_actions, LogStore};
 
@@ -852,16 +853,31 @@ pub(crate) async fn replay_commit_actions(
     Ok(commit_timestamps)
 }
 
-/// Read only the main checkpoint parquet file (without loading sidecars).
+/// Read only the main checkpoint file (without loading sidecars).
 /// Useful when callers only need non-file actions (protocol, metadata, sidecar
 /// descriptors, etc.) — for example during sidecar garbage collection.
 pub(crate) async fn read_checkpoint_main_rows_from_parquet(
     root_store: std::sync::Arc<dyn ObjectStore>,
     meta: ObjectMeta,
 ) -> DeltaResult<Vec<CheckpointActionRow>> {
-    let main_bytes = root_store.get(&meta.location).await?.bytes().await?;
+    let version = parse_checkpoint_version_from_location(&meta.location).ok_or_else(|| {
+        DeltaTableError::generic(format!(
+            "checkpoint path does not contain a parseable version: {}",
+            meta.location
+        ))
+    })?;
+    let bytes = root_store.get(&meta.location).await?.bytes().await?;
+    if meta
+        .location
+        .as_ref()
+        .rsplit('/')
+        .next()
+        .is_some_and(is_json_checkpoint_filename)
+    {
+        return decode_checkpoint_json_rows(version, &bytes);
+    }
     SpawnedTask::spawn_blocking(move || {
-        let mut batches = ParquetRecordBatchReaderBuilder::try_new(main_bytes)
+        let mut batches = ParquetRecordBatchReaderBuilder::try_new(bytes)
             .map_err(DeltaTableError::generic_err)?
             .build()
             .map_err(DeltaTableError::generic_err)?;
@@ -911,6 +927,63 @@ pub(crate) async fn read_checkpoint_rows_from_parquet(
     }
 
     Ok(rows)
+}
+
+fn decode_checkpoint_json_rows(
+    version: i64,
+    bytes: &Bytes,
+) -> DeltaResult<Vec<CheckpointActionRow>> {
+    let actions = get_actions(version, bytes)?;
+    let mut rows = Vec::with_capacity(actions.len());
+    for action in actions {
+        if let Some(row) = checkpoint_row_from_action(action)? {
+            rows.push(row);
+        }
+    }
+    Ok(rows)
+}
+
+fn checkpoint_row_from_action(action: Action) -> DeltaResult<Option<CheckpointActionRow>> {
+    let row = match action {
+        Action::Add(add) => CheckpointActionRow {
+            add: Some(add),
+            ..Default::default()
+        },
+        Action::Remove(remove) => CheckpointActionRow {
+            remove: Some(remove),
+            ..Default::default()
+        },
+        Action::Metadata(metadata) => CheckpointActionRow {
+            metadata: Some(metadata),
+            ..Default::default()
+        },
+        Action::Protocol(protocol) => CheckpointActionRow {
+            protocol: Some(protocol),
+            ..Default::default()
+        },
+        Action::Txn(txn) => CheckpointActionRow {
+            txn: Some(txn),
+            ..Default::default()
+        },
+        Action::DomainMetadata(domain_metadata) => CheckpointActionRow {
+            domain_metadata: Some(domain_metadata),
+            ..Default::default()
+        },
+        Action::CheckpointMetadata(checkpoint_metadata) => CheckpointActionRow {
+            checkpoint_metadata: Some(checkpoint_metadata),
+            ..Default::default()
+        },
+        Action::Sidecar(sidecar) => CheckpointActionRow {
+            sidecar: Some(sidecar),
+            ..Default::default()
+        },
+        Action::CommitInfo(_) | Action::Cdc(_) => {
+            return Err(DeltaTableError::generic(
+                "V2 checkpoint JSON must not contain commitInfo or cdc actions",
+            ));
+        }
+    };
+    Ok(Some(row))
 }
 
 pub(crate) async fn replay_commit_header_actions(
@@ -1313,17 +1386,22 @@ mod tests {
     use object_store::memory::InMemory;
     use object_store::path::Path;
     use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt};
+    use parquet::arrow::async_writer::ParquetObjectWriter;
+    use parquet::arrow::AsyncArrowWriter;
 
     use super::{
         checkpoint_fields, decode_checkpoint_rows, encode_checkpoint_rows,
-        replay_commit_header_actions, ReconciledCheckpointState, ReconciledHeaderState,
+        read_checkpoint_rows_from_parquet, replay_commit_header_actions, ReconciledCheckpointState,
+        ReconciledHeaderState,
     };
-    use crate::kernel::checkpoint_augment::AddAugmentationConfig;
+    use crate::kernel::checkpoint_augment::{
+        normalize_checkpoint_batch_for_decode, AddAugmentationConfig,
+    };
     use crate::spec::{
-        Action, Add, CheckpointActionRow, CheckpointMetadata, CommitInfo, DataType,
-        DeletionVectorDescriptor, DeltaError as DeltaTableError, DeltaResult, DomainMetadata,
-        Metadata, Protocol, Remove, Sidecar, StorageType, StructField, StructType, TableFeature,
-        Transaction,
+        sidecar_file_path, Action, Add, CheckpointActionRow, CheckpointMetadata, CommitInfo,
+        DataType, DeletionVectorDescriptor, DeltaError as DeltaTableError, DeltaResult,
+        DomainMetadata, Metadata, Protocol, Remove, Sidecar, StorageType, StructField, StructType,
+        TableFeature, Transaction,
     };
 
     fn encode_rows_for_test(rows: &Vec<CheckpointActionRow>) -> DeltaResult<RecordBatch> {
@@ -1468,6 +1546,22 @@ mod tests {
         Ok(())
     }
 
+    async fn put_parquet_batch(
+        store: Arc<dyn ObjectStore>,
+        path: Path,
+        batch: RecordBatch,
+    ) -> DeltaResult<()> {
+        let writer = ParquetObjectWriter::new(store, path);
+        let mut writer = AsyncArrowWriter::try_new(writer, batch.schema(), None)
+            .map_err(DeltaTableError::generic_err)?;
+        writer
+            .write(&batch)
+            .await
+            .map_err(DeltaTableError::generic_err)?;
+        let _ = writer.close().await.map_err(DeltaTableError::generic_err)?;
+        Ok(())
+    }
+
     #[test]
     fn checkpoint_row_roundtrip_preserves_add_path() -> DeltaResult<()> {
         let rows = vec![CheckpointActionRow {
@@ -1498,6 +1592,62 @@ mod tests {
                 .map(|add| add.path.as_str()),
             Some("part-000.parquet")
         );
+        Ok(())
+    }
+
+    #[test]
+    fn checkpoint_decode_normalization_keeps_matching_batch_on_fast_path() -> DeltaResult<()> {
+        let rows = vec![
+            CheckpointActionRow {
+                add: Some(Add {
+                    path: "part-000.parquet".to_string(),
+                    partition_values: HashMap::new(),
+                    size: 10,
+                    modification_time: 20,
+                    data_change: true,
+                    stats: None,
+                    tags: None,
+                    deletion_vector: None,
+                    base_row_id: None,
+                    default_row_commit_version: None,
+                    clustering_provider: None,
+                    commit_version: None,
+                    commit_timestamp: None,
+                }),
+                ..Default::default()
+            },
+            CheckpointActionRow {
+                remove: Some(Remove {
+                    path: "part-001.parquet".to_string(),
+                    data_change: true,
+                    deletion_timestamp: Some(30),
+                    extended_file_metadata: Some(true),
+                    partition_values: Some(HashMap::new()),
+                    size: Some(10),
+                    stats: None,
+                    tags: None,
+                    deletion_vector: None,
+                    base_row_id: None,
+                    default_row_commit_version: None,
+                }),
+                ..Default::default()
+            },
+        ];
+        let batch =
+            encode_rows_with_properties(&rows, [("delta.checkpoint.writeStatsAsStruct", "false")])?;
+        let normalized_once = normalize_checkpoint_batch_for_decode(&batch)?;
+        let normalized = normalize_checkpoint_batch_for_decode(&normalized_once)?;
+
+        let original_schema = normalized_once.schema();
+        let normalized_schema = normalized.schema();
+        assert!(Arc::ptr_eq(&original_schema, &normalized_schema));
+        assert_eq!(normalized_once.num_columns(), normalized.num_columns());
+        for index in 0..normalized_once.num_columns() {
+            assert!(Arc::ptr_eq(
+                normalized_once.column(index),
+                normalized.column(index)
+            ));
+        }
         Ok(())
     }
 
@@ -1800,6 +1950,84 @@ mod tests {
                 )])),
             })
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn spark_style_json_v2_checkpoint_loads_sidecar_actions() -> DeltaResult<()> {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let metadata = test_metadata([("delta.checkpointPolicy", "v2")])?;
+        let protocol = Protocol::new(
+            3,
+            7,
+            Some(vec![TableFeature::V2Checkpoint]),
+            Some(vec![TableFeature::V2Checkpoint]),
+        );
+        let add = Add {
+            path: "part-000.parquet".to_string(),
+            partition_values: HashMap::new(),
+            size: 10,
+            modification_time: 20,
+            data_change: true,
+            stats: None,
+            tags: None,
+            deletion_vector: None,
+            base_row_id: None,
+            default_row_commit_version: None,
+            clustering_provider: None,
+            commit_version: None,
+            commit_timestamp: None,
+        };
+
+        let sidecar_filename =
+            "00000000000000000002.checkpoint.0000000001.0000000001.bbf4d2d5-b626-41f8-854f-63b5e397ad82.parquet";
+        let sidecar_batch = encode_rows_for_test(&vec![CheckpointActionRow {
+            add: Some(add.clone()),
+            ..Default::default()
+        }])?;
+        put_parquet_batch(
+            store.clone(),
+            sidecar_file_path(sidecar_filename),
+            sidecar_batch,
+        )
+        .await?;
+
+        let checkpoint_path = Path::from(
+            "_delta_log/00000000000000000002.checkpoint.c13805b3-8c9f-45f0-b1e4-a16b695fc042.json",
+        );
+        let actions = [
+            Action::CheckpointMetadata(CheckpointMetadata {
+                version: 2,
+                tags: None,
+            }),
+            Action::Sidecar(Sidecar {
+                path: sidecar_filename.to_string(),
+                size_in_bytes: 1,
+                modification_time: 2,
+                tags: None,
+            }),
+            Action::Protocol(protocol.clone()),
+            Action::Metadata(metadata.clone()),
+        ];
+        let mut bytes = Vec::new();
+        for (index, action) in actions.iter().enumerate() {
+            if index > 0 {
+                bytes.push(b'\n');
+            }
+            serde_json::to_writer(&mut bytes, action)?;
+        }
+        store.put(&checkpoint_path, bytes.into()).await?;
+
+        let meta = store.head(&checkpoint_path).await?;
+        let rows = read_checkpoint_rows_from_parquet(store, meta).await?;
+        let mut state = ReconciledCheckpointState::default();
+        for row in rows {
+            state.apply_checkpoint_row(row)?;
+        }
+
+        assert_eq!(state.protocol.as_ref(), Some(&protocol));
+        assert_eq!(state.metadata.as_ref(), Some(&metadata));
+        assert!(state.adds.values().any(|entry| entry == &add));
         Ok(())
     }
 

--- a/crates/sail-delta-lake/src/kernel/checkpoints.rs
+++ b/crates/sail-delta-lake/src/kernel/checkpoints.rs
@@ -581,7 +581,7 @@ impl<'a> CheckpointManager<'a> {
 
         let mut state = ReconciledCheckpointState::default();
         let start_commit_version = if let Some((cp_ver, cp_meta)) = checkpoint_entries.pop() {
-            let rows = read_checkpoint_rows_from_parquet(store.clone(), cp_meta).await?;
+            let rows = read_checkpoint_rows_from_checkpoint_file(store.clone(), cp_meta).await?;
             for row in rows {
                 state.apply_checkpoint_row(row)?;
             }
@@ -856,7 +856,7 @@ pub(crate) async fn replay_commit_actions(
 /// Read only the main checkpoint file (without loading sidecars).
 /// Useful when callers only need non-file actions (protocol, metadata, sidecar
 /// descriptors, etc.) — for example during sidecar garbage collection.
-pub(crate) async fn read_checkpoint_main_rows_from_parquet(
+pub(crate) async fn read_checkpoint_main_rows_from_checkpoint_file(
     root_store: std::sync::Arc<dyn ObjectStore>,
     meta: ObjectMeta,
 ) -> DeltaResult<Vec<CheckpointActionRow>> {
@@ -893,11 +893,11 @@ pub(crate) async fn read_checkpoint_main_rows_from_parquet(
     .map_err(DeltaTableError::generic_err)?
 }
 
-pub(crate) async fn read_checkpoint_rows_from_parquet(
+pub(crate) async fn read_checkpoint_rows_from_checkpoint_file(
     root_store: std::sync::Arc<dyn ObjectStore>,
     meta: ObjectMeta,
 ) -> DeltaResult<Vec<CheckpointActionRow>> {
-    let mut rows = read_checkpoint_main_rows_from_parquet(root_store.clone(), meta).await?;
+    let mut rows = read_checkpoint_main_rows_from_checkpoint_file(root_store.clone(), meta).await?;
 
     // Collect sidecar descriptors from V2 checkpoint rows and load add/remove
     // payload from the referenced sidecar parquet files.
@@ -1391,8 +1391,8 @@ mod tests {
 
     use super::{
         checkpoint_fields, decode_checkpoint_rows, encode_checkpoint_rows,
-        read_checkpoint_rows_from_parquet, replay_commit_header_actions, ReconciledCheckpointState,
-        ReconciledHeaderState,
+        read_checkpoint_rows_from_checkpoint_file, replay_commit_header_actions,
+        ReconciledCheckpointState, ReconciledHeaderState,
     };
     use crate::kernel::checkpoint_augment::{
         normalize_checkpoint_batch_for_decode, AddAugmentationConfig,
@@ -2019,7 +2019,7 @@ mod tests {
         store.put(&checkpoint_path, bytes.into()).await?;
 
         let meta = store.head(&checkpoint_path).await?;
-        let rows = read_checkpoint_rows_from_parquet(store, meta).await?;
+        let rows = read_checkpoint_rows_from_checkpoint_file(store, meta).await?;
         let mut state = ReconciledCheckpointState::default();
         for row in rows {
             state.apply_checkpoint_row(row)?;

--- a/crates/sail-delta-lake/src/kernel/log_segment.rs
+++ b/crates/sail-delta-lake/src/kernel/log_segment.rs
@@ -12,7 +12,7 @@
 
 pub(crate) use crate::delta_log::ReplayedTableHeader;
 use crate::delta_log::{list_log_files, read_last_checkpoint_version_from_store};
-use crate::kernel::checkpoints::read_checkpoint_main_rows_from_parquet;
+use crate::kernel::checkpoints::read_checkpoint_main_rows_from_checkpoint_file;
 use crate::spec::{is_uuid_checkpoint_filename, DeltaResult};
 
 /// The minimal set of Delta log files needed to reconstruct table state up to a given version.
@@ -72,7 +72,7 @@ pub async fn list_log_segment_files(
 
         // Only UUID-named checkpoints (V2) can contain sidecar references.
         if is_uuid_checkpoint_filename(&filename) {
-            let rows = read_checkpoint_main_rows_from_parquet(store, meta).await?;
+            let rows = read_checkpoint_main_rows_from_checkpoint_file(store, meta).await?;
             for row in &rows {
                 if let Some(ref sidecar) = row.sidecar {
                     sidecar_files.push(format!("_sidecars/{}", sidecar.path));

--- a/crates/sail-delta-lake/src/spec/log.rs
+++ b/crates/sail-delta-lake/src/spec/log.rs
@@ -60,7 +60,14 @@ pub fn sidecars_dir_path() -> Path {
 }
 
 pub fn sidecar_file_path(sidecar_filename: &str) -> Path {
-    Path::from(format!("{DELTA_LOG_DIR}/{SIDECARS_DIR}/{sidecar_filename}"))
+    let path = sidecar_filename.trim_start_matches(DELIMITER);
+    if path.starts_with(&format!("{DELTA_LOG_DIR}{DELIMITER}")) {
+        Path::from(path)
+    } else if path.starts_with(&format!("{SIDECARS_DIR}{DELIMITER}")) {
+        Path::from(format!("{DELTA_LOG_DIR}{DELIMITER}{path}"))
+    } else {
+        Path::from(format!("{DELTA_LOG_DIR}/{SIDECARS_DIR}/{path}"))
+    }
 }
 
 pub fn uuid_checkpoint_path(version: i64, uuid: &Uuid) -> Path {
@@ -102,8 +109,10 @@ pub fn parse_checkpoint_version(filename: &str) -> Option<i64> {
     // Handles three checkpoint naming schemes:
     // 1. Classic: `{version:020}.checkpoint.parquet`
     // 2. Multi-part: `{version:020}.checkpoint.{part:010}.{total:010}.parquet`
-    // 3. UUID-named V2: `{version:020}.checkpoint.{uuid}.parquet`
-    if !filename.contains(".checkpoint") || !filename.ends_with(".parquet") {
+    // 3. UUID-named V2: `{version:020}.checkpoint.{uuid}.{json|parquet}`
+    if !filename.contains(".checkpoint")
+        || !(filename.ends_with(".parquet") || filename.ends_with(".json"))
+    {
         return None;
     }
     parse_version_prefix(filename)
@@ -111,12 +120,14 @@ pub fn parse_checkpoint_version(filename: &str) -> Option<i64> {
 
 /// Returns `true` if the checkpoint filename uses the UUID-named V2 naming scheme.
 pub fn is_uuid_checkpoint_filename(filename: &str) -> bool {
-    // UUID-named: `{version:020}.checkpoint.{uuid}.parquet`
-    // The UUID part is 36 chars (8-4-4-4-12), total = 20 + 12 + 36 + 8 = 76
-    // Pattern: 20 digits + ".checkpoint." + 36 UUID + ".parquet"
-    if filename.len() != 76 || !filename.ends_with(".parquet") {
+    // UUID-named: `{version:020}.checkpoint.{uuid}.{json|parquet}`.
+    let extension_len = if filename.ends_with(".parquet") {
+        ".parquet".len()
+    } else if filename.ends_with(".json") {
+        ".json".len()
+    } else {
         return false;
-    }
+    };
     if parse_version_prefix(filename).is_none() {
         return false;
     }
@@ -126,8 +137,17 @@ pub fn is_uuid_checkpoint_filename(filename: &str) -> bool {
     if !rest.starts_with(".checkpoint.") {
         return false;
     }
-    let uuid_part = &rest[12..48]; // 36-char UUID
+    let uuid_start = ".checkpoint.".len();
+    if rest.len() != uuid_start + 36 + extension_len {
+        return false;
+    }
+    let uuid_part = &rest[uuid_start..uuid_start + 36];
     Uuid::parse_str(uuid_part).is_ok()
+}
+
+/// Returns `true` if the filename is a UUID-named V2 JSON checkpoint manifest.
+pub fn is_json_checkpoint_filename(filename: &str) -> bool {
+    is_uuid_checkpoint_filename(filename) && filename.ends_with(".json")
 }
 
 /// Parses a compacted JSON filename and returns the (start_version, end_version) pair.
@@ -203,6 +223,52 @@ mod tests {
     fn parse_compacted_json_rejects_checkpoint() {
         let filename = "00000000000000000004.checkpoint.parquet";
         assert_eq!(parse_compacted_json_versions(filename), None);
+    }
+
+    #[test]
+    fn parse_checkpoint_version_accepts_v2_json_checkpoint() {
+        assert_eq!(
+            parse_checkpoint_version(
+                "00000000000000000002.checkpoint.c13805b3-8c9f-45f0-b1e4-a16b695fc042.json"
+            ),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn is_uuid_checkpoint_accepts_json_and_parquet_extensions() {
+        assert!(is_uuid_checkpoint_filename(
+            "00000000000000000002.checkpoint.c13805b3-8c9f-45f0-b1e4-a16b695fc042.json"
+        ));
+        assert!(is_uuid_checkpoint_filename(
+            "00000000000000000002.checkpoint.c13805b3-8c9f-45f0-b1e4-a16b695fc042.parquet"
+        ));
+        assert!(!is_uuid_checkpoint_filename(
+            "00000000000000000002.checkpoint.0000000001.0000000001.parquet"
+        ));
+    }
+
+    #[test]
+    fn is_json_checkpoint_only_accepts_uuid_json_checkpoint() {
+        assert!(is_json_checkpoint_filename(
+            "00000000000000000002.checkpoint.c13805b3-8c9f-45f0-b1e4-a16b695fc042.json"
+        ));
+        assert!(!is_json_checkpoint_filename(
+            "00000000000000000002.checkpoint.c13805b3-8c9f-45f0-b1e4-a16b695fc042.parquet"
+        ));
+        assert!(!is_json_checkpoint_filename("00000000000000000002.json"));
+    }
+
+    #[test]
+    fn sidecar_file_path_accepts_filename_or_relative_sidecar_path() {
+        assert_eq!(
+            sidecar_file_path("part.parquet").as_ref(),
+            "_delta_log/_sidecars/part.parquet"
+        );
+        assert_eq!(
+            sidecar_file_path("_sidecars/part.parquet").as_ref(),
+            "_delta_log/_sidecars/part.parquet"
+        );
     }
 
     #[test]

--- a/crates/sail-delta-lake/src/spec/mod.rs
+++ b/crates/sail-delta-lake/src/spec/mod.rs
@@ -28,10 +28,10 @@ pub use error::{CommitConflictError, DeltaError, DeltaResult, TransactionError};
 pub use log::{
     checkpoint_path, checksum_path, commit_path, compacted_json_path, delta_log_file_path,
     delta_log_prefix_path, delta_log_root_path, is_compacted_json_filename,
-    is_uuid_checkpoint_filename, last_checkpoint_path, parse_checkpoint_version,
-    parse_checksum_version, parse_commit_version, parse_compacted_json_versions,
-    parse_version_prefix, sidecar_file_path, sidecars_dir_path, temp_commit_path,
-    uuid_checkpoint_path, DELTA_LOG_DIR, LAST_CHECKPOINT_FILE, SIDECARS_DIR,
+    is_json_checkpoint_filename, is_uuid_checkpoint_filename, last_checkpoint_path,
+    parse_checkpoint_version, parse_checksum_version, parse_commit_version,
+    parse_compacted_json_versions, parse_version_prefix, sidecar_file_path, sidecars_dir_path,
+    temp_commit_path, uuid_checkpoint_path, DELTA_LOG_DIR, LAST_CHECKPOINT_FILE, SIDECARS_DIR,
 };
 pub use metadata::{Format, Metadata};
 pub use operation::{DeltaOperation, MergePredicate, SaveMode};


### PR DESCRIPTION
#1965 
Since none of both are recorded in the delta protocol, we can consider later how to better perform end-to-end verification. 