### PR TITLE
feat: add writer and improve reader for Vortex Python data source

### DIFF
--- a/python/pysail/spark/datasource/vortex.py
+++ b/python/pysail/spark/datasource/vortex.py
@@ -1,7 +1,8 @@
 """Vortex data source for Sail, backed by the ``vortex-data`` Python library.
 
 Supports ``spark.read.format("vortex")`` with filter pushdown and
-zero-copy Arrow RecordBatch yield.
+zero-copy Arrow RecordBatch yield, and ``spark.write.format("vortex")``
+with append, overwrite, error, and ignore modes.
 
 Install the optional dependency before use::
 
@@ -12,7 +13,24 @@ Usage::
     from pysail.spark.datasource.vortex import VortexDataSource
 
     spark.dataSource.register(VortexDataSource)
+
+    # Read a single file
     df = spark.read.format("vortex").option("path", "/data/file.vortex").load()
+
+    # Read a directory recursively
+    df = spark.read.format("vortex").option("path", "/data/").load()
+
+    # Read with a glob pattern
+    df = spark.read.format("vortex").option("path", "/data/*.vortex").load()
+    df = (
+        spark.read.format("vortex").option("path", "/data/**/*.vortex").load()
+    )  # recursive
+
+    # Write with error mode (default)
+    df.write.format("vortex").option("path", "/data/").save()
+
+    # Write with overwrite mode
+    df.write.mode("overwrite").format("vortex").option("path", "/data/").save()
 """
 
 from __future__ import annotations

--- a/python/pysail/spark/datasource/vortex.py
+++ b/python/pysail/spark/datasource/vortex.py
@@ -258,7 +258,7 @@ def _cast_view_types(table: pa.Table) -> pa.Table:
 
 
 def _read_schema(path: str) -> pa.Schema:
-    """Read the Arrow schema from first Vortex file without loading all data."""
+    """Read the Arrow schema from the first Vortex file without loading all data."""
     vortex_files = _get_vortex_files(path)
     vf_path = vortex_files[0]
     try:

--- a/python/pysail/spark/datasource/vortex.py
+++ b/python/pysail/spark/datasource/vortex.py
@@ -381,6 +381,10 @@ class VortexWriter(DataSourceArrowWriter):
         self._staging_dir = os.path.join(self.path, staging_name)
         os.makedirs(self._staging_dir, exist_ok=True)
 
+    def _remove_staging_dir(self) -> None:
+        if self._staging_dir:
+            shutil.rmtree(self._staging_dir, ignore_errors=True)
+
     def write(self, iterator: Iterator[pa.RecordBatch]) -> WriterCommitMessage:
         table = pa.Table.from_batches(iterator, self.schema)
         if table.num_rows == 0:
@@ -409,12 +413,10 @@ class VortexWriter(DataSourceArrowWriter):
             msg = f"Failed to commit to '{self.path}': {e}"
             raise RuntimeError(msg) from e
         finally:
-            shutil.rmtree(self._staging_dir, ignore_errors=True)
+            self._remove_staging_dir()
 
     def abort(self, messages: list[WriterCommitMessage | None]) -> None:  # noqa: ARG002
-        shutil.rmtree(self._staging_dir, ignore_errors=True)
-        if os.path.isdir(self.path) and not os.listdir(self.path):
-            shutil.rmtree(self.path, ignore_errors=True)
+        self._remove_staging_dir()
 
 
 class VortexIgnoreWriter(VortexWriter):

--- a/python/pysail/spark/datasource/vortex.py
+++ b/python/pysail/spark/datasource/vortex.py
@@ -19,6 +19,9 @@ from __future__ import annotations
 
 import glob
 import os
+import secrets
+import shutil
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -34,6 +37,7 @@ except ImportError as e:
 try:
     from pyspark.sql.datasource import (
         DataSource,
+        DataSourceArrowWriter,
         DataSourceReader,
         EqualTo,
         GreaterThan,
@@ -46,6 +50,7 @@ try:
         StringContains,
         StringEndsWith,
         StringStartsWith,
+        WriterCommitMessage,
     )
 except ImportError as e:
     msg = (
@@ -62,7 +67,7 @@ if TYPE_CHECKING:
 
 
 # ============================================================================
-# File finding helpers
+# File handling helpers
 # ============================================================================
 
 
@@ -103,6 +108,15 @@ def _get_vortex_files(path: str) -> list[str]:
         raise ValueError(msg)
 
     return sorted(set(vortex_files))
+
+
+def _generate_unique_vortex_path(base_path: str) -> str:
+    """Generates a unique .vortex file path."""
+    while True:
+        file_name = secrets.token_hex(8) + ".vortex"
+        path = os.path.join(base_path, file_name)
+        if not os.path.exists(path):
+            return path
 
 
 # ============================================================================
@@ -321,6 +335,76 @@ class VortexReader(DataSourceReader):
 
 
 # ============================================================================
+# DataSourceWriter
+# ============================================================================
+
+
+@dataclass
+class VortexCommitMessage(WriterCommitMessage):
+    """Commit message returned by the VortexWriter.write"""
+
+    staged_path: str
+
+
+class VortexWriter(DataSourceArrowWriter):
+    """Writer for :class:`VortexDataSource`."""
+
+    def __init__(self, path: str, schema: pa.Schema, mode: str) -> None:
+        self.path = path
+        self.schema = schema
+        self.mode = mode
+        self._init_staging_dir()
+
+    def _init_staging_dir(self) -> None:
+        staging_name = f"._staging_{secrets.token_hex(8)}"
+        self._staging_dir = os.path.join(self.path, staging_name)
+        os.makedirs(self._staging_dir, exist_ok=True)
+
+    def write(self, iterator: Iterator[pa.RecordBatch]) -> WriterCommitMessage:
+        table = pa.Table.from_batches(iterator, self.schema)
+        if table.num_rows == 0:
+            return VortexCommitMessage("")
+
+        staged_path = _generate_unique_vortex_path(self._staging_dir)
+        vortex.io.write(table, staged_path)
+        return VortexCommitMessage(staged_path)
+
+    def commit(self, messages: list[WriterCommitMessage | None]) -> None:
+        staged_files = [m.staged_path for m in messages if m and m.staged_path]
+
+        try:
+            if not staged_files:
+                return
+            if self.mode == "overwrite" and os.path.isdir(self.path):
+                for p in Path(self.path).rglob("*.vortex"):
+                    if p.is_file() and os.path.basename(self._staging_dir) not in p.parts:
+                        p.unlink(missing_ok=True)
+
+            os.makedirs(self.path, exist_ok=True)
+
+            for src in staged_files:
+                shutil.move(src, os.path.join(self.path, os.path.basename(src)))
+        except Exception as e:
+            msg = f"Failed to commit to '{self.path}': {e}"
+            raise RuntimeError(msg) from e
+        finally:
+            shutil.rmtree(self._staging_dir, ignore_errors=True)
+
+    def abort(self, messages: list[WriterCommitMessage | None]) -> None:  # noqa: ARG002
+        shutil.rmtree(self._staging_dir, ignore_errors=True)
+
+
+class VortexIgnoreWriter(VortexWriter):
+    """Writer that no-ops when the path already exists (mode='ignore')."""
+
+    def _init_staging_dir(self) -> None:
+        self._staging_dir = ""
+
+    def write(self, iterator: Iterator[pa.RecordBatch]) -> WriterCommitMessage:  # noqa: ARG002
+        return VortexCommitMessage("")
+
+
+# ============================================================================
 # DataSource
 # ============================================================================
 
@@ -346,6 +430,12 @@ class VortexDataSource(DataSource):
             spark.read.format("vortex").option("path", "/data/**/*.vortex").load()
         )  # recursive
 
+        # Write with error mode (default)
+        df.write.format("vortex").option("path", "/data/").save()
+
+        # Write with overwrite mode
+        df.write.mode("overwrite").format("vortex").option("path", "/data/").save()
+
     Read Mode
     -------
     Path handling:
@@ -369,6 +459,31 @@ class VortexDataSource(DataSource):
     LessThan, LessThanOrEqual, In, Not.
     String predicates (StartsWith, EndsWith, Contains) and null predicates
     (IsNull, IsNotNull) are rejected and applied by Sail post-read.
+
+    Write Mode
+    ----------
+    Writes one ``.vortex`` file per Spark partition into the target directory.
+    Uses a two-phase commit: partitions write to a staging directory first,
+    the driver moves files to the final path only after all partitions succeed.
+
+    Supported Write Options:
+
+    +--------+----------+-----------------------------------------------+
+    | Option | Required | Description                                   |
+    +========+==========+===============================================+
+    | path   | Yes      | Target directory to write ``.vortex`` files   |
+    +--------+----------+-----------------------------------------------+
+    | mode   | No       | Write mode (see below). Defaults to           |
+    |        |          | ``error`` if not set.                        |
+    +--------+----------+-----------------------------------------------+
+
+    Supported write modes:
+
+    - **append**: Adds new ``.vortex`` files to the target directory.
+    - **overwrite**: Deletes existing ``.vortex`` files in the target
+      directory before writing new ones.
+    - **error**: Raises ``RuntimeError`` if the target directory already exists.
+    - **ignore**: Skips the write entirely if the target directory already exists.
     """
 
     @classmethod
@@ -390,3 +505,16 @@ class VortexDataSource(DataSource):
     def reader(self, schema: pa.Schema) -> VortexReader:  # noqa: ARG002
         path = self._validate_options()
         return VortexReader(path)
+
+    def writer(self, schema: pa.Schema, overwrite: bool) -> VortexWriter:  # noqa: FBT001
+        path = self._validate_options()
+        mode = self.options.get("mode") or ("overwrite" if overwrite else "error")
+
+        path_exists = os.path.isdir(path)
+        if mode == "error" and path_exists:
+            msg = f"Path '{path}' already exists. Use mode='overwrite' to replace or mode='append' to add to it."
+            raise RuntimeError(msg)
+        if mode == "ignore" and path_exists:
+            return VortexIgnoreWriter(path, schema, mode)
+
+        return VortexWriter(path, schema, mode)

--- a/python/pysail/spark/datasource/vortex.py
+++ b/python/pysail/spark/datasource/vortex.py
@@ -91,6 +91,9 @@ def _get_vortex_files(path: str) -> list[str]:
         vortex_files.append(path)
     elif os.path.isdir(path):
         for p in Path(path).rglob("*"):
+            # skip hidden files and files inside hidden directories
+            if any(part.startswith(("_", ".")) for part in p.parts):
+                continue
             if p.is_file():
                 f = str(p)
                 if not f.endswith(".vortex"):

--- a/python/pysail/spark/datasource/vortex.py
+++ b/python/pysail/spark/datasource/vortex.py
@@ -395,6 +395,8 @@ class VortexWriter(DataSourceArrowWriter):
 
     def abort(self, messages: list[WriterCommitMessage | None]) -> None:  # noqa: ARG002
         shutil.rmtree(self._staging_dir, ignore_errors=True)
+        if os.path.isdir(self.path) and not os.listdir(self.path):
+            shutil.rmtree(self.path, ignore_errors=True)
 
 
 class VortexIgnoreWriter(VortexWriter):

--- a/python/pysail/spark/datasource/vortex.py
+++ b/python/pysail/spark/datasource/vortex.py
@@ -17,6 +17,9 @@ Usage::
 
 from __future__ import annotations
 
+import glob
+import os
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pyarrow as pa
@@ -56,6 +59,51 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from pyspark.sql.datasource import Filter
+
+
+# ============================================================================
+# File finding helpers
+# ============================================================================
+
+
+def _get_vortex_files(path: str) -> list[str]:
+    """Resolve a path into a sorted list of Vortex files.
+
+    Path handling:
+    - File:         Returns [path] directly if it's a Vortex file.
+    - Directory:    Recursively collects all files; raises ValueError
+                    if any non-Vortex file is found, otherwise returns all.
+    - Glob pattern: If pattern targets Vortex (ends with ``.vortex``), expands
+                    the pattern, collects matching Vortex files and returns them;
+                    non-Vortex files are silently skipped.
+    """
+    vortex_files: list[str] = []
+
+    if os.path.isfile(path):
+        if not path.endswith(".vortex"):
+            msg = f"Path is not a Vortex file: '{path}'"
+            raise ValueError(msg)
+        vortex_files.append(path)
+    elif os.path.isdir(path):
+        for p in Path(path).rglob("*"):
+            if p.is_file():
+                f = str(p)
+                if not f.endswith(".vortex"):
+                    msg = f"Path contains non-Vortex file(s): '{path}'"
+                    raise ValueError(msg)
+                vortex_files.append(f)
+    else:
+        is_vortex_pattern = path.endswith(".vortex")
+        if is_vortex_pattern:
+            matched = glob.glob(path, recursive=True)
+            vortex_files.extend([m for m in matched if os.path.isfile(m) and m.endswith(".vortex")])
+
+    if not vortex_files:
+        msg = f"No Vortex files found in the specified path: '{path}'"
+        raise ValueError(msg)
+
+    return sorted(set(vortex_files))
+
 
 # ============================================================================
 # Filter helpers
@@ -193,15 +241,17 @@ def _cast_view_types(table: pa.Table) -> pa.Table:
 
 
 def _read_schema(path: str) -> pa.Schema:
-    """Read the Arrow schema from a Vortex file without loading all data."""
+    """Read the Arrow schema from first Vortex file without loading all data."""
+    vortex_files = _get_vortex_files(path)
+    vf_path = vortex_files[0]
     try:
-        vf = vortex.open(path)
+        vf = vortex.open(vf_path)
     except Exception as e:
-        msg = f"Failed to open Vortex file: {path!r}. Error: {e}"
+        msg = f"Failed to open Vortex file: {vf_path!r}. Error: {e}"
         raise RuntimeError(msg) from e
     first = next(iter(vf.scan()), None)
     if first is None:
-        msg = f"Cannot infer schema from empty Vortex file: {path!r}"
+        msg = f"Cannot infer schema from empty Vortex file: {vf_path!r}"
         raise ValueError(msg)
     return _normalize_schema(first.to_arrow_table().schema)
 
@@ -212,10 +262,10 @@ def _read_schema(path: str) -> pa.Schema:
 
 
 class VortexPartition(InputPartition):
-    """A single Vortex file partition."""
+    """Partition, one per Vortex file."""
 
-    def __init__(self, path: str) -> None:
-        super().__init__(0)  # partition index; single-file source always uses 0
+    def __init__(self, index: int, path: str) -> None:
+        super().__init__(index)  # partition index
         self.path = path
 
 
@@ -244,7 +294,8 @@ class VortexReader(DataSourceReader):
         return iter(rejected)
 
     def partitions(self) -> list[InputPartition]:
-        return [VortexPartition(self.path)]
+        vortex_files = _get_vortex_files(self.path)
+        return [VortexPartition(index, vf_path) for index, vf_path in enumerate(vortex_files)]
 
     def read(self, partition: InputPartition) -> Iterator[pa.RecordBatch]:
         if not isinstance(partition, VortexPartition):
@@ -282,14 +333,36 @@ class VortexDataSource(DataSource):
         from pysail.spark.datasource.vortex import VortexDataSource
 
         spark.dataSource.register(VortexDataSource)
+
+        # Read a single file
         df = spark.read.format("vortex").option("path", "/data/file.vortex").load()
 
-    Supported options:
+        # Read a directory recursively
+        df = spark.read.format("vortex").option("path", "/data/").load()
+
+        # Read with a glob pattern
+        df = spark.read.format("vortex").option("path", "/data/*.vortex").load()
+        df = (
+            spark.read.format("vortex").option("path", "/data/**/*.vortex").load()
+        )  # recursive
+
+    Read Mode
+    -------
+    Path handling:
+
+    - **File**: Must be a Vortex file. Raises ``ValueError`` otherwise.
+    - **Directory**: Recursively collects all files beneath the directory.
+      Raises ``ValueError`` if any non-Vortex file is encountered.
+    - **Glob pattern**: Only patterns ending with ``.vortex`` are expanded;
+    non-Vortex matches are silently skipped.
+
+    Supported Options:
 
     +--------+----------+------------------------------------------+
     | Option | Required | Description                              |
     +========+==========+==========================================+
-    | path   | Yes      | Path to the Vortex file (.vortex)        |
+    | path   | Yes      | Path to read: file, directory, or        |
+    |        |          | glob pattern ending with ``.vortex``     |
     +--------+----------+------------------------------------------+
 
     Supported filter pushdown: EqualTo, GreaterThan, GreaterThanOrEqual,

--- a/python/pysail/spark/datasource/vortex.py
+++ b/python/pysail/spark/datasource/vortex.py
@@ -92,7 +92,7 @@ def _get_vortex_files(path: str) -> list[str]:
     elif os.path.isdir(path):
         for p in Path(path).rglob("*"):
             # skip hidden files and files inside hidden directories
-            if any(part.startswith(("_", ".")) for part in p.parts):
+            if any(part.startswith(("_", ".")) for part in p.parts[len(Path(path).parts):]):
                 continue
             if p.is_file():
                 f = str(p)

--- a/python/pysail/spark/datasource/vortex.py
+++ b/python/pysail/spark/datasource/vortex.py
@@ -92,7 +92,7 @@ def _get_vortex_files(path: str) -> list[str]:
     elif os.path.isdir(path):
         for p in Path(path).rglob("*"):
             # skip hidden files and files inside hidden directories
-            if any(part.startswith(("_", ".")) for part in p.parts[len(Path(path).parts):]):
+            if any(part.startswith(("_", ".")) for part in p.parts[len(Path(path).parts) :]):
                 continue
             if p.is_file():
                 f = str(p)

--- a/python/pysail/tests/spark/datasource/test_vortex.py
+++ b/python/pysail/tests/spark/datasource/test_vortex.py
@@ -6,6 +6,8 @@ All tests are skipped if ``vortex-data`` is not available.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 import pyarrow as pa
 import pytest
 
@@ -20,6 +22,12 @@ try:
     import vortex
 except ImportError:
     pytest.skip("vortex-data not installed", allow_module_level=True)
+
+
+def safe_sort_key(row):
+    if isinstance(row, Mapping):
+        return tuple((v is not None, v) for _, v in sorted(row.items()))
+    return tuple((v is not None, v) for v in row)
 
 
 @pytest.fixture
@@ -38,6 +46,23 @@ def vtx_file(tmp_path):
 
 
 @pytest.fixture
+def nested_vtx_file(tmp_path):
+    """Create a temporary Vortex file inside nested subdirectories."""
+    table = pa.table(
+        {
+            "id": pa.array([1, 2, 3, 4, 5], type=pa.int64()),
+            "name": pa.array(["alice", "bob", "carol", "dave", "eve"], type=pa.string()),
+            "score": pa.array([90.5, 85.0, 92.3, 78.1, 88.7], type=pa.float64()),
+        }
+    )
+    parent_dir = tmp_path / "sub_dir_1" / "sub_dir_2"
+    parent_dir.mkdir(parents=True, exist_ok=True)
+    path = str(parent_dir / "test.vortex")
+    vortex.io.write(table, path)
+    return tmp_path, path
+
+
+@pytest.fixture
 def vtx_file_with_nulls(tmp_path):
     """Create a Vortex file with null values."""
     table = pa.table(
@@ -51,6 +76,18 @@ def vtx_file_with_nulls(tmp_path):
     return path
 
 
+@pytest.fixture
+def other_df(spark):
+    """A different DataFrame from sample_df with the same schema."""
+    table = pa.table(
+        {
+            "col1": pa.array(["alice", "carol"], type=pa.string()),
+            "col2": pa.array([1, 2], type=pa.int64()),
+        }
+    )
+    return spark.createDataFrame(table)
+
+
 @pytest.fixture(autouse=True)
 def _register_vortex(spark):
     """Register VortexDataSource for all tests."""
@@ -62,6 +99,70 @@ def _register_vortex(spark):
 def test_vortex_read_all_rows(spark, vtx_file):
     df = spark.read.format("vortex").option("path", vtx_file).load()
     assert df.count() == 5  # noqa: PLR2004
+
+
+def test_vortex_read_all_rows_from_nested_directory(spark, nested_vtx_file):
+    vtx_directory = nested_vtx_file[0]
+    df = spark.read.format("vortex").option("path", vtx_directory).load()
+    assert df.count() == 5  # noqa: PLR2004
+
+
+def test_vortex_read_all_rows_using_glob_pattern(spark, nested_vtx_file):
+    vtx_pattern = f"{nested_vtx_file[0]}/**/*.vortex"
+    df = spark.read.format("vortex").option("path", vtx_pattern).load()
+    assert df.count() == 5  # noqa: PLR2004
+
+
+def test_vortex_write_basic(spark, sample_df, tmp_path):
+    path = str(tmp_path / "vortex_write_basic")
+    sample_df.write.format("vortex").option("path", path).save()
+    read_df = spark.read.format("vortex").option("path", path).load()
+    assert sample_df.count() == read_df.count()
+    assert sample_df.schema == read_df.schema
+    assert sorted(sample_df.collect(), key=safe_sort_key) == sorted(read_df.collect(), key=safe_sort_key)
+
+
+def test_vortex_write_error_mode(spark, sample_df, other_df, tmp_path):
+    path = str(tmp_path / "vortex_write_error_mode")
+    sample_df.write.format("vortex").option("path", path).save()
+    with pytest.raises(
+        Exception, match=f"Path '{path}' already exists. Use mode='overwrite' to replace or mode='append' to add to it."
+    ):
+        other_df.write.format("vortex").option("path", path).save()
+    read_df = spark.read.format("vortex").option("path", path).load()
+    assert sample_df.count() == read_df.count()
+    assert sample_df.schema == read_df.schema
+    assert sorted(sample_df.collect(), key=safe_sort_key) == sorted(read_df.collect(), key=safe_sort_key)
+
+
+def test_vortex_write_ignore_mode(spark, sample_df, other_df, tmp_path):
+    path = str(tmp_path / "vortex_write_ignore_mode")
+    sample_df.write.format("vortex").option("path", path).save()
+    other_df.write.mode("ignore").format("vortex").option("path", path).save()
+    read_df = spark.read.format("vortex").option("path", path).load()
+    assert sample_df.count() == read_df.count()
+    assert sample_df.schema == read_df.schema
+    assert sorted(sample_df.collect(), key=safe_sort_key) == sorted(read_df.collect(), key=safe_sort_key)
+
+
+def test_vortex_write_overwrite_mode(spark, sample_df, other_df, tmp_path):
+    path = str(tmp_path / "vortex_write_overwrite_mode")
+    sample_df.write.format("vortex").option("path", path).save()
+    other_df.write.mode("overwrite").format("vortex").option("path", path).save()
+    read_df = spark.read.format("vortex").option("path", path).load()
+    assert other_df.count() == read_df.count()
+    assert other_df.schema == read_df.schema
+    assert sorted(other_df.collect(), key=safe_sort_key) == sorted(read_df.collect(), key=safe_sort_key)
+
+
+def test_vortex_write_append_mode(spark, sample_df, tmp_path):
+    path = str(tmp_path / "vortex_write_append_mode")
+    sample_df.write.format("vortex").option("path", path).save()
+    sample_df.write.mode("append").format("vortex").option("path", path).save()
+    read_df = spark.read.format("vortex").option("path", path).load()
+    assert sample_df.count() * 2 == read_df.count()
+    assert sample_df.schema == read_df.schema
+    assert sorted(sample_df.collect() * 2, key=safe_sort_key) == sorted(read_df.collect(), key=safe_sort_key)
 
 
 def test_vortex_read_schema(spark, vtx_file):
@@ -166,7 +267,7 @@ def test_vortex_missing_path_option(spark):
 
 def test_vortex_nonexistent_file(spark, tmp_path):
     path = str(tmp_path / "nonexistent.vortex")
-    with pytest.raises(Exception, match="Failed to open Vortex file"):
+    with pytest.raises(Exception, match=f"No Vortex files found in the specified path: '{path}'"):
         spark.read.format("vortex").option("path", path).load().collect()
 
 


### PR DESCRIPTION
## Summary  
Issue: https://github.com/lakehq/sail/issues/1281

This PR extends the Vortex Python DataSource in two areas: **write support** and **improved path handling for reads**.

---

### Writer 

Adds a `VortexDataWriter` implementation that allows Spark DataFrames to be written as Vortex files:

- Writes one `.vortex` file per Spark partition into the target directory
- Uses a **two-phase commit**: partitions write to a staging directory first, and the driver moves files to the final path only after all partitions succeed — this avoids leaving partial output on failure
- Supports four write modes via `.mode(...)`:
  - `error` (default) — raises `RuntimeError` if the target directory already exists
  - `overwrite` — deletes existing `.vortex` files before writing
  - `append` — adds new files alongside existing ones
  - `ignore` — skips the write entirely if the target already exists

**Usage:**
```python
df.write.format("vortex").option("path", "/data/").save()
df.write.mode("overwrite").format("vortex").option("path", "/data/").save()
```

---

### Reader improvements

The `path` option now accepts three forms instead of just a single file path:

| Form | Behaviour |
|---|---|
| Single file | Must be a `.vortex` file, raises `ValueError` otherwise |
| Directory | Recursively collects all files beneath it; raises `ValueError` if any non-Vortex file is encountered |
| Glob pattern | Only patterns ending in `.vortex` are expanded; non-Vortex matches are silently skipped |

**Usage:**
```python
spark.read.format("vortex").option("path", "/data/file.vortex").load()  # file
spark.read.format("vortex").option("path", "/data/").load()             # directory
spark.read.format("vortex").option("path", "/data/*.vortex").load()     # glob
spark.read.format("vortex").option("path", "/data/**/*.vortex").load()  # recursive glob
```

---
## Tests

`tests/spark/datasource/test_vortex.py` is updated, covering new changes.

