### PR TITLE
fix: lowercase startswith/endswith display name from PySpark Column API

### DIFF
--- a/crates/sail-plan/src/formatter.rs
+++ b/crates/sail-plan/src/formatter.rs
@@ -604,7 +604,7 @@ impl PlanFormatter for SparkPlanFormatter {
                 let sep = *list.first().unwrap_or(&"0");
                 Ok(format!("{name}({value}, {sep})"))
             }
-            "startsWith" | "endsWith" => {
+            "startswith" | "endswith" => {
                 let arguments = arguments.join(", ");
                 Ok(format!("{}({arguments})", name.to_lowercase()))
             }


### PR DESCRIPTION
## Summary

The match arm in `SparkPlanFormatter::function_call_to_string` intended to
lowercase the camelCase function name that PySpark's `Column.startswith`
and `Column.endswith` send over Spark Connect was dead code. The match
scrutinee is lowercased on entry (`match name.to_lowercase().as_str()`),
but the arm patterns were spelled `"startsWith" | "endsWith"` and could
never match. The camelCase name then fell through to the default arm and
was rendered verbatim into the column display name.

PySpark's `count_if` Example 2 doctest exercises this path:

```python
>>> df.select(sf.count_if(sf.col('fruit').startswith('a'))).show()
+------------------------------+
|count_if(startswith(fruit, a))|
+------------------------------+
|                             2|
+------------------------------+
```

Before this PR, Sail rendered the header as `count_if(startsWith(fruit, a))`.

The SQL path (`SELECT startswith(...)`) was unaffected because the SQL
parser already passes the function name in lowercase; existing gold-data
assertions in `crates/sail-spark-connect/tests/gold_data/function/string.json`
all originate from SQL queries and exercise only that path.

## Change

Lowercase the arm patterns to `"startswith" | "endswith"` so they actually
match the (already-lowercased) scrutinee. The body's own
`name.to_lowercase()` continues to lowercase the original camelCase `name`
when building the output string.