### PR TITLE
fix: render Arrow Time as Spark `time(N)` in `data_type_to_simple_string`

### DIFF
--- a/crates/sail-plan/src/formatter.rs
+++ b/crates/sail-plan/src/formatter.rs
@@ -57,14 +57,10 @@ impl PlanFormatter for SparkPlanFormatter {
             DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Ok("string".to_string()),
             DataType::Date32 => Ok("date".to_string()),
             DataType::Date64 => Ok("date64".to_string()),
-            DataType::Time32(time_unit) => Ok(format!(
-                "time32({})",
-                Self::time_unit_to_simple_string(time_unit)
-            )),
-            DataType::Time64(time_unit) => Ok(format!(
-                "time64({})",
-                Self::time_unit_to_simple_string(time_unit)
-            )),
+            DataType::Time32(TimeUnit::Second) => Ok("time(0)".to_string()),
+            DataType::Time32(TimeUnit::Millisecond) => Ok("time(3)".to_string()),
+            DataType::Time64(TimeUnit::Microsecond) => Ok("time(6)".to_string()),
+            DataType::Time64(TimeUnit::Nanosecond) => Ok("time(9)".to_string()),
             DataType::Duration(TimeUnit::Microsecond) => Ok("interval day to second".to_string()),
             DataType::Duration(time_unit) => Ok(format!(
                 "duration({})",
@@ -120,9 +116,9 @@ impl PlanFormatter for SparkPlanFormatter {
             )),
             DataType::RunEndEncoded(_, _)
             | DataType::Decimal32(_, _)
-            | DataType::Decimal64(_, _) => {
-                not_impl_err!("data type: {data_type:?}")
-            }
+            | DataType::Decimal64(_, _)
+            | DataType::Time32(_)
+            | DataType::Time64(_) => not_impl_err!("data type: {data_type:?}"),
         }
     }
 
@@ -978,19 +974,19 @@ mod tests {
 
         assert_eq!(
             formatter.data_type_to_simple_string(&DataType::Time32(TimeUnit::Second))?,
-            "time32(second)"
+            "time(0)"
         );
         assert_eq!(
             formatter.data_type_to_simple_string(&DataType::Time32(TimeUnit::Millisecond))?,
-            "time32(millisecond)"
+            "time(3)"
         );
         assert_eq!(
             formatter.data_type_to_simple_string(&DataType::Time64(TimeUnit::Microsecond))?,
-            "time64(microsecond)"
+            "time(6)"
         );
         assert_eq!(
             formatter.data_type_to_simple_string(&DataType::Time64(TimeUnit::Nanosecond))?,
-            "time64(nanosecond)"
+            "time(9)"
         );
 
         Ok(())

--- a/crates/sail-plan/src/formatter.rs
+++ b/crates/sail-plan/src/formatter.rs
@@ -61,6 +61,14 @@ impl PlanFormatter for SparkPlanFormatter {
             DataType::Time32(TimeUnit::Millisecond) => Ok("time(3)".to_string()),
             DataType::Time64(TimeUnit::Microsecond) => Ok("time(6)".to_string()),
             DataType::Time64(TimeUnit::Nanosecond) => Ok("time(9)".to_string()),
+            DataType::Time32(time_unit) => Ok(format!(
+                "time32({})",
+                Self::time_unit_to_simple_string(time_unit)
+            )),
+            DataType::Time64(time_unit) => Ok(format!(
+                "time64({})",
+                Self::time_unit_to_simple_string(time_unit)
+            )),
             DataType::Duration(TimeUnit::Microsecond) => Ok("interval day to second".to_string()),
             DataType::Duration(time_unit) => Ok(format!(
                 "duration({})",
@@ -116,9 +124,9 @@ impl PlanFormatter for SparkPlanFormatter {
             )),
             DataType::RunEndEncoded(_, _)
             | DataType::Decimal32(_, _)
-            | DataType::Decimal64(_, _)
-            | DataType::Time32(_)
-            | DataType::Time64(_) => not_impl_err!("data type: {data_type:?}"),
+            | DataType::Decimal64(_, _) => {
+                not_impl_err!("data type: {data_type:?}")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

`SparkPlanFormatter::data_type_to_simple_string` rendered Arrow's `Time32` / `Time64` as `time32(<unit>)` / `time64(<unit>)`, while Spark's `TimeType(precision).typeName` produces `time(N)` where N is the fractional-seconds digit count. The mismatch surfaced via `pyspark.sql.functions.typeof`, which the `hour` / `minute` / `second` doctest Example 3s call alongside the arithmetic function on a `cast("time")` column - the typeof cell was the only diverging value but the whole `.show()` frame fails.

This maps Arrow's `TimeUnit` to Spark's precision: `Second` → `time(0)`, `Millisecond` → `time(3)`, `Microsecond` → `time(6)`, `Nanosecond` → `time(9)`. Spark itself caps at precision 6; `time(9)` keeps Arrow's nanosecond variant renderable since the renderer is also reached recursively for nested types (`array<time(6)>` and friends).

The four impossible Arrow combinations (`Time32(Microsecond)`, `Time32(Nanosecond)`, `Time64(Second)`, `Time64(Millisecond)`) join the existing `not_impl_err!` arm next to `RunEndEncoded` / `Decimal32` / `Decimal64`.