### PR TITLE
fix: render full 2-arg display name for single-arg assert_true

### DIFF
--- a/crates/sail-plan/src/formatter.rs
+++ b/crates/sail-plan/src/formatter.rs
@@ -424,6 +424,14 @@ impl PlanFormatter for SparkPlanFormatter {
     ) -> Result<String> {
         match name.to_lowercase().as_str() {
             "!" | "not" => Ok(format!("(NOT {})", arguments.one()?)),
+            "assert_true" => {
+                let (col, rest) = arguments.at_least_one()?;
+                if let Some(err_msg) = rest.first() {
+                    Ok(format!("assert_true({col}, {err_msg})"))
+                } else {
+                    Ok(format!("assert_true({col}, '{col}' is not true!)"))
+                }
+            }
             "~" => Ok(format!("{name}{}", arguments.one()?)),
             "+" | "-" => {
                 if arguments.len() < 2 {


### PR DESCRIPTION
## Summary

When PySpark calls `sf.assert_true(col)` without an error message, Spark
auto-fills the second argument as `'<predicate-sql>' is not true!` and
includes it in the expression's auto-generated column header. Sail's
runtime already synthesizes the same error message text before lowering
the call to a `CASE WHEN NOT <col> THEN raise_error(msg)` expression, so
runtime behavior was correct. Only the column display name was wrong:

```python
>>> df.select('*', sf.assert_true(df.a < df.b)).show()
+---+---+--------------------------------------------+
|  a|  b|assert_true((a < b), '(a < b)' is not true!)|
+---+---+--------------------------------------------+
|  0|  1|                                        NULL|
+---+---+--------------------------------------------+
```

Before this PR, Sail rendered the header as `assert_true((a < b))`.

The two-argument forms (`assert_true(col, errCol)` and
`assert_true(col, 'error')`) already rendered correctly via the default
dispatcher arm and remain unchanged.

## Change

Add a dedicated `"assert_true"` arm in the
`SparkPlanFormatter::function_call_to_string` dispatcher in
`crates/sail-plan/src/formatter.rs`. For the single-argument form,
synthesize the missing second argument using the same `'<col>' is not true!`
template Spark uses. For the two-argument form, pass through both arguments
verbatim.