### PR TITLE
feat: register timestampdiff Spark function

### DIFF
--- a/crates/sail-plan/src/function/scalar/datetime.rs
+++ b/crates/sail-plan/src/function/scalar/datetime.rs
@@ -814,6 +814,7 @@ pub(super) fn list_built_in_datetime_functions() -> Vec<(&'static str, ScalarFun
                 )
             }),
         ),
+        ("timestampdiff", F::custom(datediff)),
         ("to_date", F::custom(to_date)),
         ("to_time", F::var_arg(to_time)),
         (


### PR DESCRIPTION
## Summary

PySpark's `sf.timestamp_diff(unit, start, end)` is routed by the Spark Connect client to the Catalyst name `timestampdiff` (one word). Sail had no registration under that name, so the PySpark doctest at `pyspark.sql.functions.builtin.timestamp_diff` was failing with `unknown function: timestampdiff`.

The semantics that `timestampdiff(unit, start, end)` needs (unit-keyed `end - start` returning `Int64`) are already implemented in the 3-arg branch of the existing `datediff` handler in [crates/sail-plan/src/function/scalar/datetime.rs:179](https://github.com/lakehq/sail/blob/main/crates/sail-plan/src/function/scalar/datetime.rs#L179). The unit-as-attribute scaffolding in `convert_date_part_argument` already lists `"timestampdiff"`. So the fix is a single registration entry routing the new name at the existing handler.

The failing doctest exercises `YEAR`, `WEEK`, and `DAY`, all covered by the existing dispatch. `MILLISECOND`/`MICROSECOND` are Spark units that are not yet handled by `datediff` and are out of scope here.

## Spec

`TimestampDiff` Catalyst expression: `opt/spark/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala:3842`. `prettyName = "timestampdiff"`, return type `LongType`, computes `end - start` truncated to the requested unit.