### PR TITLE
fix: support LIKE/ILIKE with ALL/ANY/SOME

### DIFF
--- a/crates/sail-spark-connect/tests/gold_data/expression/like.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/like.json
@@ -6,29 +6,54 @@
         "success": {
           "unresolvedFunction": {
             "functionName": [
-              "ilike"
+              "and"
             ],
             "arguments": [
               {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null,
-                  "isMetadataColumn": false
-                }
-              },
-              {
                 "unresolvedFunction": {
                   "functionName": [
-                    "all"
+                    "ilike"
                   ],
                   "arguments": [
+                    {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "a"
+                        ],
+                        "planId": null,
+                        "isMetadataColumn": false
+                      }
+                    },
                     {
                       "literal": {
                         "utf8": {
                           "value": "Foo%"
                         }
+                      }
+                    }
+                  ],
+                  "namedArguments": [],
+                  "isDistinct": false,
+                  "isUserDefinedFunction": false,
+                  "isInternal": null,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
+                }
+              },
+              {
+                "unresolvedFunction": {
+                  "functionName": [
+                    "ilike"
+                  ],
+                  "arguments": [
+                    {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "a"
+                        ],
+                        "planId": null,
+                        "isMetadataColumn": false
                       }
                     },
                     {
@@ -73,29 +98,54 @@
         "success": {
           "unresolvedFunction": {
             "functionName": [
-              "ilike"
+              "or"
             ],
             "arguments": [
               {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null,
-                  "isMetadataColumn": false
-                }
-              },
-              {
                 "unresolvedFunction": {
                   "functionName": [
-                    "any"
+                    "ilike"
                   ],
                   "arguments": [
+                    {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "a"
+                        ],
+                        "planId": null,
+                        "isMetadataColumn": false
+                      }
+                    },
                     {
                       "literal": {
                         "utf8": {
                           "value": "FOO%"
                         }
+                      }
+                    }
+                  ],
+                  "namedArguments": [],
+                  "isDistinct": false,
+                  "isUserDefinedFunction": false,
+                  "isInternal": null,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
+                }
+              },
+              {
+                "unresolvedFunction": {
+                  "functionName": [
+                    "ilike"
+                  ],
+                  "arguments": [
+                    {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "a"
+                        ],
+                        "planId": null,
+                        "isMetadataColumn": false
                       }
                     },
                     {
@@ -140,29 +190,54 @@
         "success": {
           "unresolvedFunction": {
             "functionName": [
-              "ilike"
+              "or"
             ],
             "arguments": [
               {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null,
-                  "isMetadataColumn": false
-                }
-              },
-              {
                 "unresolvedFunction": {
                   "functionName": [
-                    "some"
+                    "ilike"
                   ],
                   "arguments": [
+                    {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "a"
+                        ],
+                        "planId": null,
+                        "isMetadataColumn": false
+                      }
+                    },
                     {
                       "literal": {
                         "utf8": {
                           "value": "FOO%"
                         }
+                      }
+                    }
+                  ],
+                  "namedArguments": [],
+                  "isDistinct": false,
+                  "isUserDefinedFunction": false,
+                  "isInternal": null,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
+                }
+              },
+              {
+                "unresolvedFunction": {
+                  "functionName": [
+                    "ilike"
+                  ],
+                  "arguments": [
+                    {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "a"
+                        ],
+                        "planId": null,
+                        "isMetadataColumn": false
                       }
                     },
                     {
@@ -346,29 +421,54 @@
         "success": {
           "unresolvedFunction": {
             "functionName": [
-              "like"
+              "and"
             ],
             "arguments": [
               {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null,
-                  "isMetadataColumn": false
-                }
-              },
-              {
                 "unresolvedFunction": {
                   "functionName": [
-                    "all"
+                    "like"
                   ],
                   "arguments": [
+                    {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "a"
+                        ],
+                        "planId": null,
+                        "isMetadataColumn": false
+                      }
+                    },
                     {
                       "literal": {
                         "utf8": {
                           "value": "foo%"
                         }
+                      }
+                    }
+                  ],
+                  "namedArguments": [],
+                  "isDistinct": false,
+                  "isUserDefinedFunction": false,
+                  "isInternal": null,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
+                }
+              },
+              {
+                "unresolvedFunction": {
+                  "functionName": [
+                    "like"
+                  ],
+                  "arguments": [
+                    {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "a"
+                        ],
+                        "planId": null,
+                        "isMetadataColumn": false
                       }
                     },
                     {
@@ -413,29 +513,54 @@
         "success": {
           "unresolvedFunction": {
             "functionName": [
-              "like"
+              "or"
             ],
             "arguments": [
               {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null,
-                  "isMetadataColumn": false
-                }
-              },
-              {
                 "unresolvedFunction": {
                   "functionName": [
-                    "any"
+                    "like"
                   ],
                   "arguments": [
+                    {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "a"
+                        ],
+                        "planId": null,
+                        "isMetadataColumn": false
+                      }
+                    },
                     {
                       "literal": {
                         "utf8": {
                           "value": "foo%"
                         }
+                      }
+                    }
+                  ],
+                  "namedArguments": [],
+                  "isDistinct": false,
+                  "isUserDefinedFunction": false,
+                  "isInternal": null,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
+                }
+              },
+              {
+                "unresolvedFunction": {
+                  "functionName": [
+                    "like"
+                  ],
+                  "arguments": [
+                    {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "a"
+                        ],
+                        "planId": null,
+                        "isMetadataColumn": false
                       }
                     },
                     {
@@ -480,29 +605,54 @@
         "success": {
           "unresolvedFunction": {
             "functionName": [
-              "like"
+              "or"
             ],
             "arguments": [
               {
-                "unresolvedAttribute": {
-                  "name": [
-                    "a"
-                  ],
-                  "planId": null,
-                  "isMetadataColumn": false
-                }
-              },
-              {
                 "unresolvedFunction": {
                   "functionName": [
-                    "some"
+                    "like"
                   ],
                   "arguments": [
+                    {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "a"
+                        ],
+                        "planId": null,
+                        "isMetadataColumn": false
+                      }
+                    },
                     {
                       "literal": {
                         "utf8": {
                           "value": "foo%"
                         }
+                      }
+                    }
+                  ],
+                  "namedArguments": [],
+                  "isDistinct": false,
+                  "isUserDefinedFunction": false,
+                  "isInternal": null,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
+                }
+              },
+              {
+                "unresolvedFunction": {
+                  "functionName": [
+                    "like"
+                  ],
+                  "arguments": [
+                    {
+                      "unresolvedAttribute": {
+                        "name": [
+                          "a"
+                        ],
+                        "planId": null,
+                        "isMetadataColumn": false
                       }
                     },
                     {
@@ -547,35 +697,76 @@
         "success": {
           "unresolvedFunction": {
             "functionName": [
-              "not"
+              "and"
             ],
             "arguments": [
               {
                 "unresolvedFunction": {
                   "functionName": [
-                    "ilike"
+                    "not"
                   ],
                   "arguments": [
                     {
-                      "unresolvedAttribute": {
-                        "name": [
-                          "a"
-                        ],
-                        "planId": null,
-                        "isMetadataColumn": false
-                      }
-                    },
-                    {
                       "unresolvedFunction": {
                         "functionName": [
-                          "all"
+                          "ilike"
                         ],
                         "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
+                            }
+                          },
                           {
                             "literal": {
                               "utf8": {
                                 "value": "foo%"
                               }
+                            }
+                          }
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "isInternal": null,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
+                  ],
+                  "namedArguments": [],
+                  "isDistinct": false,
+                  "isUserDefinedFunction": false,
+                  "isInternal": null,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
+                }
+              },
+              {
+                "unresolvedFunction": {
+                  "functionName": [
+                    "not"
+                  ],
+                  "arguments": [
+                    {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "ilike"
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
                             }
                           },
                           {
@@ -623,35 +814,76 @@
         "success": {
           "unresolvedFunction": {
             "functionName": [
-              "not"
+              "or"
             ],
             "arguments": [
               {
                 "unresolvedFunction": {
                   "functionName": [
-                    "ilike"
+                    "not"
                   ],
                   "arguments": [
                     {
-                      "unresolvedAttribute": {
-                        "name": [
-                          "a"
-                        ],
-                        "planId": null,
-                        "isMetadataColumn": false
-                      }
-                    },
-                    {
                       "unresolvedFunction": {
                         "functionName": [
-                          "any"
+                          "ilike"
                         ],
                         "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
+                            }
+                          },
                           {
                             "literal": {
                               "utf8": {
                                 "value": "foo%"
                               }
+                            }
+                          }
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "isInternal": null,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
+                  ],
+                  "namedArguments": [],
+                  "isDistinct": false,
+                  "isUserDefinedFunction": false,
+                  "isInternal": null,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
+                }
+              },
+              {
+                "unresolvedFunction": {
+                  "functionName": [
+                    "not"
+                  ],
+                  "arguments": [
+                    {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "ilike"
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
                             }
                           },
                           {
@@ -699,35 +931,76 @@
         "success": {
           "unresolvedFunction": {
             "functionName": [
-              "not"
+              "or"
             ],
             "arguments": [
               {
                 "unresolvedFunction": {
                   "functionName": [
-                    "ilike"
+                    "not"
                   ],
                   "arguments": [
                     {
-                      "unresolvedAttribute": {
-                        "name": [
-                          "a"
-                        ],
-                        "planId": null,
-                        "isMetadataColumn": false
-                      }
-                    },
-                    {
                       "unresolvedFunction": {
                         "functionName": [
-                          "some"
+                          "ilike"
                         ],
                         "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
+                            }
+                          },
                           {
                             "literal": {
                               "utf8": {
                                 "value": "foo%"
                               }
+                            }
+                          }
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "isInternal": null,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
+                  ],
+                  "namedArguments": [],
+                  "isDistinct": false,
+                  "isUserDefinedFunction": false,
+                  "isInternal": null,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
+                }
+              },
+              {
+                "unresolvedFunction": {
+                  "functionName": [
+                    "not"
+                  ],
+                  "arguments": [
+                    {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "ilike"
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
                             }
                           },
                           {
@@ -962,35 +1235,76 @@
         "success": {
           "unresolvedFunction": {
             "functionName": [
-              "not"
+              "and"
             ],
             "arguments": [
               {
                 "unresolvedFunction": {
                   "functionName": [
-                    "like"
+                    "not"
                   ],
                   "arguments": [
                     {
-                      "unresolvedAttribute": {
-                        "name": [
-                          "a"
-                        ],
-                        "planId": null,
-                        "isMetadataColumn": false
-                      }
-                    },
-                    {
                       "unresolvedFunction": {
                         "functionName": [
-                          "all"
+                          "like"
                         ],
                         "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
+                            }
+                          },
                           {
                             "literal": {
                               "utf8": {
                                 "value": "foo%"
                               }
+                            }
+                          }
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "isInternal": null,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
+                  ],
+                  "namedArguments": [],
+                  "isDistinct": false,
+                  "isUserDefinedFunction": false,
+                  "isInternal": null,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
+                }
+              },
+              {
+                "unresolvedFunction": {
+                  "functionName": [
+                    "not"
+                  ],
+                  "arguments": [
+                    {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "like"
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
                             }
                           },
                           {
@@ -1038,35 +1352,76 @@
         "success": {
           "unresolvedFunction": {
             "functionName": [
-              "not"
+              "or"
             ],
             "arguments": [
               {
                 "unresolvedFunction": {
                   "functionName": [
-                    "like"
+                    "not"
                   ],
                   "arguments": [
                     {
-                      "unresolvedAttribute": {
-                        "name": [
-                          "a"
-                        ],
-                        "planId": null,
-                        "isMetadataColumn": false
-                      }
-                    },
-                    {
                       "unresolvedFunction": {
                         "functionName": [
-                          "any"
+                          "like"
                         ],
                         "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
+                            }
+                          },
                           {
                             "literal": {
                               "utf8": {
                                 "value": "foo%"
                               }
+                            }
+                          }
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "isInternal": null,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
+                  ],
+                  "namedArguments": [],
+                  "isDistinct": false,
+                  "isUserDefinedFunction": false,
+                  "isInternal": null,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
+                }
+              },
+              {
+                "unresolvedFunction": {
+                  "functionName": [
+                    "not"
+                  ],
+                  "arguments": [
+                    {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "like"
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
                             }
                           },
                           {
@@ -1114,35 +1469,76 @@
         "success": {
           "unresolvedFunction": {
             "functionName": [
-              "not"
+              "or"
             ],
             "arguments": [
               {
                 "unresolvedFunction": {
                   "functionName": [
-                    "like"
+                    "not"
                   ],
                   "arguments": [
                     {
-                      "unresolvedAttribute": {
-                        "name": [
-                          "a"
-                        ],
-                        "planId": null,
-                        "isMetadataColumn": false
-                      }
-                    },
-                    {
                       "unresolvedFunction": {
                         "functionName": [
-                          "some"
+                          "like"
                         ],
                         "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
+                            }
+                          },
                           {
                             "literal": {
                               "utf8": {
                                 "value": "foo%"
                               }
+                            }
+                          }
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "isInternal": null,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    }
+                  ],
+                  "namedArguments": [],
+                  "isDistinct": false,
+                  "isUserDefinedFunction": false,
+                  "isInternal": null,
+                  "ignoreNulls": null,
+                  "filter": null,
+                  "orderBy": null
+                }
+              },
+              {
+                "unresolvedFunction": {
+                  "functionName": [
+                    "not"
+                  ],
+                  "arguments": [
+                    {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "like"
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
                             }
                           },
                           {
@@ -1397,29 +1793,54 @@
               {
                 "unresolvedFunction": {
                   "functionName": [
-                    "ilike"
+                    "and"
                   ],
                   "arguments": [
                     {
-                      "unresolvedAttribute": {
-                        "name": [
-                          "a"
-                        ],
-                        "planId": null,
-                        "isMetadataColumn": false
-                      }
-                    },
-                    {
                       "unresolvedFunction": {
                         "functionName": [
-                          "all"
+                          "ilike"
                         ],
                         "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
+                            }
+                          },
                           {
                             "literal": {
                               "utf8": {
                                 "value": "foO%"
                               }
+                            }
+                          }
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "isInternal": null,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    },
+                    {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "ilike"
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
                             }
                           },
                           {
@@ -1473,29 +1894,54 @@
               {
                 "unresolvedFunction": {
                   "functionName": [
-                    "ilike"
+                    "or"
                   ],
                   "arguments": [
                     {
-                      "unresolvedAttribute": {
-                        "name": [
-                          "a"
-                        ],
-                        "planId": null,
-                        "isMetadataColumn": false
-                      }
-                    },
-                    {
                       "unresolvedFunction": {
                         "functionName": [
-                          "any"
+                          "ilike"
                         ],
                         "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
+                            }
+                          },
                           {
                             "literal": {
                               "utf8": {
                                 "value": "FOO%"
                               }
+                            }
+                          }
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "isInternal": null,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    },
+                    {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "ilike"
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
                             }
                           },
                           {
@@ -1549,29 +1995,54 @@
               {
                 "unresolvedFunction": {
                   "functionName": [
-                    "ilike"
+                    "or"
                   ],
                   "arguments": [
                     {
-                      "unresolvedAttribute": {
-                        "name": [
-                          "a"
-                        ],
-                        "planId": null,
-                        "isMetadataColumn": false
-                      }
-                    },
-                    {
                       "unresolvedFunction": {
                         "functionName": [
-                          "some"
+                          "ilike"
                         ],
                         "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
+                            }
+                          },
                           {
                             "literal": {
                               "utf8": {
                                 "value": "FOO%"
                               }
+                            }
+                          }
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "isInternal": null,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    },
+                    {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "ilike"
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
                             }
                           },
                           {
@@ -1625,29 +2096,54 @@
               {
                 "unresolvedFunction": {
                   "functionName": [
-                    "like"
+                    "and"
                   ],
                   "arguments": [
                     {
-                      "unresolvedAttribute": {
-                        "name": [
-                          "a"
-                        ],
-                        "planId": null,
-                        "isMetadataColumn": false
-                      }
-                    },
-                    {
                       "unresolvedFunction": {
                         "functionName": [
-                          "all"
+                          "like"
                         ],
                         "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
+                            }
+                          },
                           {
                             "literal": {
                               "utf8": {
                                 "value": "foo%"
                               }
+                            }
+                          }
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "isInternal": null,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    },
+                    {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "like"
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
                             }
                           },
                           {
@@ -1701,29 +2197,54 @@
               {
                 "unresolvedFunction": {
                   "functionName": [
-                    "like"
+                    "or"
                   ],
                   "arguments": [
                     {
-                      "unresolvedAttribute": {
-                        "name": [
-                          "a"
-                        ],
-                        "planId": null,
-                        "isMetadataColumn": false
-                      }
-                    },
-                    {
                       "unresolvedFunction": {
                         "functionName": [
-                          "any"
+                          "like"
                         ],
                         "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
+                            }
+                          },
                           {
                             "literal": {
                               "utf8": {
                                 "value": "foo%"
                               }
+                            }
+                          }
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "isInternal": null,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    },
+                    {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "like"
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
                             }
                           },
                           {
@@ -1777,29 +2298,54 @@
               {
                 "unresolvedFunction": {
                   "functionName": [
-                    "like"
+                    "or"
                   ],
                   "arguments": [
                     {
-                      "unresolvedAttribute": {
-                        "name": [
-                          "a"
-                        ],
-                        "planId": null,
-                        "isMetadataColumn": false
-                      }
-                    },
-                    {
                       "unresolvedFunction": {
                         "functionName": [
-                          "some"
+                          "like"
                         ],
                         "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
+                            }
+                          },
                           {
                             "literal": {
                               "utf8": {
                                 "value": "foo%"
                               }
+                            }
+                          }
+                        ],
+                        "namedArguments": [],
+                        "isDistinct": false,
+                        "isUserDefinedFunction": false,
+                        "isInternal": null,
+                        "ignoreNulls": null,
+                        "filter": null,
+                        "orderBy": null
+                      }
+                    },
+                    {
+                      "unresolvedFunction": {
+                        "functionName": [
+                          "like"
+                        ],
+                        "arguments": [
+                          {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
                             }
                           },
                           {

--- a/crates/sail-sql-analyzer/src/expression.rs
+++ b/crates/sail-sql-analyzer/src/expression.rs
@@ -404,56 +404,10 @@ pub fn from_ast_expression(expr: Expr) -> SqlResult<spec::Expr> {
             })
         }
         Expr::Like(expr, not, _, quantifier, pattern, escape) => {
-            let expr = from_ast_expression(*expr)?;
-            let pattern = from_ast_quantified_pattern(quantifier, *pattern)?;
-            let mut arguments = vec![expr, pattern];
-            if let Some(escape) = from_ast_pattern_escape_string(escape)? {
-                arguments.push(spec::Expr::Literal(spec::Literal::Utf8 {
-                    value: Some(escape.to_string()),
-                }))
-            };
-            let expr = spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: spec::ObjectName::bare("like"),
-                arguments,
-                named_arguments: vec![],
-                is_distinct: false,
-                is_user_defined_function: false,
-                is_internal: None,
-                ignore_nulls: None,
-                filter: None,
-                order_by: None,
-            });
-            if not.is_some() {
-                Ok(negated(expr))
-            } else {
-                Ok(expr)
-            }
+            from_ast_like(*expr, not.is_some(), quantifier, *pattern, escape, "like")
         }
         Expr::ILike(expr, not, _, quantifier, pattern, escape) => {
-            let expr = from_ast_expression(*expr)?;
-            let pattern = from_ast_quantified_pattern(quantifier, *pattern)?;
-            let mut arguments = vec![expr, pattern];
-            if let Some(escape) = from_ast_pattern_escape_string(escape)? {
-                arguments.push(spec::Expr::Literal(spec::Literal::Utf8 {
-                    value: Some(escape.to_string()),
-                }));
-            };
-            let expr = spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-                function_name: spec::ObjectName::bare("ilike"),
-                arguments,
-                named_arguments: vec![],
-                is_distinct: false,
-                is_user_defined_function: false,
-                is_internal: None,
-                ignore_nulls: None,
-                filter: None,
-                order_by: None,
-            });
-            if not.is_some() {
-                Ok(negated(expr))
-            } else {
-                Ok(expr)
-            }
+            from_ast_like(*expr, not.is_some(), quantifier, *pattern, escape, "ilike")
         }
         Expr::RLike(expr, not, _, pattern) => {
             let expr = from_ast_expression(*expr)?;
@@ -1012,32 +966,21 @@ pub(crate) fn from_ast_identifier_list(identifiers: IdentList) -> SqlResult<Vec<
     Ok(names.into_items().map(|x| x.value.into()).collect())
 }
 
-fn from_ast_quantified_pattern(
-    quantifier: Option<PatternQuantifier>,
-    pattern: Expr,
-) -> SqlResult<spec::Expr> {
-    let Some(quantifier) = quantifier else {
-        return from_ast_expression(pattern);
-    };
-    let quantifier = match quantifier {
-        PatternQuantifier::All(_) => "all",
-        PatternQuantifier::Any(_) => "any",
-        PatternQuantifier::Some(_) => "some",
-    };
-    let Expr::Atom(AtomExpr::Tuple(_, arguments, _)) = pattern else {
-        return Err(SqlError::invalid("quantified pattern expression"));
-    };
-    let arguments = arguments
-        .into_items()
-        .map(|x| {
-            let NamedExpr { expr, alias: None } = x else {
-                return Err(SqlError::invalid("pattern expression with alias"));
-            };
-            from_ast_expression(expr)
-        })
-        .collect::<SqlResult<Vec<_>>>()?;
-    Ok(spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
-        function_name: spec::ObjectName::bare(quantifier),
+/// Builds a `like`/`ilike` call `function_name(value, pattern [, escape])`.
+fn like_call(
+    function_name: &str,
+    value: spec::Expr,
+    pattern: spec::Expr,
+    escape_char: Option<char>,
+) -> spec::Expr {
+    let mut arguments = vec![value, pattern];
+    if let Some(escape) = escape_char {
+        arguments.push(spec::Expr::Literal(spec::Literal::Utf8 {
+            value: Some(escape.to_string()),
+        }));
+    }
+    spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
+        function_name: spec::ObjectName::bare(function_name),
         arguments,
         named_arguments: vec![],
         is_distinct: false,
@@ -1046,7 +989,87 @@ fn from_ast_quantified_pattern(
         ignore_nulls: None,
         filter: None,
         order_by: None,
+    })
+}
+
+/// Left-associatively combines `terms` with the boolean function `function_name`
+/// (`and` or `or`).
+fn reduce_boolean(
+    function_name: &str,
+    terms: impl IntoIterator<Item = spec::Expr>,
+) -> SqlResult<spec::Expr> {
+    let mut terms = terms.into_iter();
+    let first = terms
+        .next()
+        .ok_or_else(|| SqlError::invalid("quantified pattern requires at least one pattern"))?;
+    Ok(terms.fold(first, |acc, term| {
+        spec::Expr::UnresolvedFunction(spec::UnresolvedFunction {
+            function_name: spec::ObjectName::bare(function_name),
+            arguments: vec![acc, term],
+            named_arguments: vec![],
+            is_distinct: false,
+            is_user_defined_function: false,
+            is_internal: None,
+            ignore_nulls: None,
+            filter: None,
+            order_by: None,
+        })
     }))
+}
+
+/// Resolves a `LIKE`/`ILIKE` predicate, including the quantified
+/// `LIKE ALL/ANY/SOME (...)` forms.
+///
+/// Without a quantifier this is a single `like`/`ilike` call, negated as a whole
+/// when `NOT` is present. With a quantifier the predicate is desugared into a
+/// boolean chain of per-pattern `like`/`ilike` calls, matching Spark's
+/// `LikeAll`/`LikeAny` semantics: `NOT` is pushed into each pattern while the
+/// connective is preserved (`ALL` -> `AND`, `ANY`/`SOME` -> `OR`). For example
+/// `x NOT LIKE ALL (a, b)` becomes `(x NOT LIKE a) AND (x NOT LIKE b)`.
+fn from_ast_like(
+    value: Expr,
+    is_not: bool,
+    quantifier: Option<PatternQuantifier>,
+    pattern: Expr,
+    escape: Option<PatternEscape>,
+    function_name: &str,
+) -> SqlResult<spec::Expr> {
+    let value = from_ast_expression(value)?;
+    let escape_char = from_ast_pattern_escape_string(escape)?;
+
+    let Some(quantifier) = quantifier else {
+        let pattern = from_ast_expression(pattern)?;
+        let expr = like_call(function_name, value, pattern, escape_char);
+        return if is_not { Ok(negated(expr)) } else { Ok(expr) };
+    };
+
+    let connective = match quantifier {
+        PatternQuantifier::All(_) => "and",
+        PatternQuantifier::Any(_) | PatternQuantifier::Some(_) => "or",
+    };
+    // A parenthesized list with multiple patterns parses as a `Tuple`, while a
+    // single pattern `(p)` parses as a plain (grouped) expression.
+    let patterns: Vec<spec::Expr> = match pattern {
+        Expr::Atom(AtomExpr::Tuple(_, items, _)) => items
+            .into_items()
+            .map(|x| {
+                let NamedExpr { expr, alias: None } = x else {
+                    return Err(SqlError::invalid("pattern expression with alias"));
+                };
+                from_ast_expression(expr)
+            })
+            .collect::<SqlResult<Vec<_>>>()?,
+        other => vec![from_ast_expression(other)?],
+    };
+    let terms = patterns.into_iter().map(|pattern| {
+        let term = like_call(function_name, value.clone(), pattern, escape_char);
+        if is_not {
+            negated(term)
+        } else {
+            term
+        }
+    });
+    reduce_boolean(connective, terms)
 }
 
 fn from_ast_pattern_escape_string(escape: Option<PatternEscape>) -> SqlResult<Option<char>> {

--- a/python/pysail/tests/spark/function/features/like_quantifier.feature
+++ b/python/pysail/tests/spark/function/features/like_quantifier.feature
@@ -1,0 +1,204 @@
+Feature: LIKE and ILIKE with ALL/ANY/SOME quantifiers
+
+  Rule: LIKE ALL matches every pattern
+
+    Scenario: like all is true when all patterns match
+      When query
+      """
+      SELECT 'Dan' LIKE ALL ('%an%', '%an') AS result
+      """
+      Then query result
+      | result |
+      | true   |
+
+    Scenario: like all is false when some pattern does not match
+      When query
+      """
+      SELECT 'Evan_W' LIKE ALL ('%an%', '%an') AS result
+      """
+      Then query result
+      | result |
+      | false  |
+
+    Scenario: like all with a single pattern
+      When query
+      """
+      SELECT 'abc' LIKE ALL ('a%') AS result
+      """
+      Then query result
+      | result |
+      | true   |
+
+  Rule: LIKE ANY and LIKE SOME match at least one pattern
+
+    Scenario: like any is true when one pattern matches
+      When query
+      """
+      SELECT 'Dan' LIKE ANY ('%an%', '%xy') AS result
+      """
+      Then query result
+      | result |
+      | true   |
+
+    Scenario: like any is false when no pattern matches
+      When query
+      """
+      SELECT 'John' LIKE ANY ('%an%', '%an') AS result
+      """
+      Then query result
+      | result |
+      | false  |
+
+    Scenario: like some is equivalent to like any
+      When query
+      """
+      SELECT 'Dan' LIKE SOME ('%an%', '%xy') AS result
+      """
+      Then query result
+      | result |
+      | true   |
+
+  Rule: NOT LIKE ALL means the value matches none of the patterns
+
+    Scenario: not like all is true when the value matches no pattern
+      When query
+      """
+      SELECT 'John' NOT LIKE ALL ('%an%', '%an') AS result
+      """
+      Then query result
+      | result |
+      | true   |
+
+    Scenario: not like all is false when the value matches at least one pattern
+      When query
+      """
+      SELECT 'Evan_W' NOT LIKE ALL ('%an%', '%an') AS result
+      """
+      Then query result
+      | result |
+      | false  |
+
+  Rule: NOT LIKE ANY and NOT LIKE SOME mean at least one pattern is not matched
+
+    Scenario: not like any is true when at least one pattern is not matched
+      When query
+      """
+      SELECT 'Evan_W' NOT LIKE ANY ('%an%', '%an') AS result
+      """
+      Then query result
+      | result |
+      | true   |
+
+    Scenario: not like any is false when every pattern matches
+      When query
+      """
+      SELECT 'Dan' NOT LIKE ANY ('%an%', '%an') AS result
+      """
+      Then query result
+      | result |
+      | false  |
+
+    Scenario: not like some is true when at least one pattern is not matched
+      When query
+      """
+      SELECT 'Evan_W' NOT LIKE SOME ('%an%', '%an') AS result
+      """
+      Then query result
+      | result |
+      | true   |
+
+    Scenario: not like some is false when every pattern matches
+      When query
+      """
+      SELECT 'Dan' NOT LIKE SOME ('%an%', '%an') AS result
+      """
+      Then query result
+      | result |
+      | false  |
+
+  Rule: ILIKE quantifiers are case-insensitive
+
+    Scenario: ilike any matches ignoring case
+      When query
+      """
+      SELECT 'JOHN' ILIKE ANY ('%ohn') AS result
+      """
+      Then query result
+      | result |
+      | true   |
+
+    Scenario: like any is case-sensitive
+      When query
+      """
+      SELECT 'JOHN' LIKE ANY ('%ohn') AS result
+      """
+      Then query result
+      | result |
+      | false  |
+
+    Scenario: ilike all matches every pattern ignoring case
+      When query
+      """
+      SELECT 'Spark' ILIKE ALL ('%ARK', 'SP%') AS result
+      """
+      Then query result
+      | result |
+      | true   |
+
+    Scenario: not ilike all matches none ignoring case
+      When query
+      """
+      SELECT 'JOHN' NOT ILIKE ALL ('%xyz%', '%abc%') AS result
+      """
+      Then query result
+      | result |
+      | true   |
+
+  Rule: NULL patterns follow three-valued logic
+
+    Scenario: like all with a matching pattern and a null pattern returns null
+      When query
+      """
+      SELECT 'abc' LIKE ALL ('a%', NULL) AS result
+      """
+      Then query result
+      | result |
+      | NULL   |
+
+    Scenario: like any short-circuits to true past a null pattern
+      When query
+      """
+      SELECT 'abc' LIKE ANY ('a%', NULL) AS result
+      """
+      Then query result
+      | result |
+      | true   |
+
+    Scenario: like any with no match and a null pattern returns null
+      When query
+      """
+      SELECT 'xyz' LIKE ANY ('a%', NULL) AS result
+      """
+      Then query result
+      | result |
+      | NULL   |
+
+  Rule: ESCAPE applies to every pattern in the quantifier
+
+    Scenario: like all with an escaped wildcard
+      When query
+      """
+      SELECT 'a%b' LIKE ALL ('a/%b', 'a%') ESCAPE '/' AS result
+      """
+      Then query result
+      | result |
+      | true   |
+
+    Scenario: like any with an escaped wildcard
+      When query
+      """
+      SELECT 'a%b' LIKE ANY ('a/%b', 'zzz') ESCAPE '/' AS result
+      """
+      Then query result
+      | result |
+      | true   |


### PR DESCRIPTION
fix LIKE/ILIKE ALL/ANY/SOME matching Spark's `LikeAll`/`LikeAny` semantics: `NOT` is pushed into each pattern