### PR TITLE
fix: propagate spark.sql.ansi.enabled to DataFusion session config (enables pmod ANSI errors)

### DIFF
--- a/crates/sail-plan/src/lib.rs
+++ b/crates/sail-plan/src/lib.rs
@@ -31,11 +31,39 @@ pub async fn execute_logical_plan(ctx: &SessionContext, plan: LogicalPlan) -> Re
     Ok(df)
 }
 
+/// Write the current ANSI flag into the DataFusion `SessionContext` so that
+/// upstream UDFs reading `ConfigOptions.execution.enable_ansi_mode` see the
+/// value the client requested via `SET spark.sql.ansi.enabled = …`. No-op if
+/// the flag is already at the target value (avoids needless write-lock churn
+/// on the shared `SessionState`).
+fn sync_ansi_mode_to_ctx(ctx: &SessionContext, ansi: bool) {
+    let current = ctx
+        .state_ref()
+        .read()
+        .config_options()
+        .execution
+        .enable_ansi_mode;
+    if current == ansi {
+        return;
+    }
+    let state_ref = ctx.state_ref();
+    let mut state = state_ref.write();
+    state.config_mut().options_mut().execution.enable_ansi_mode = ansi;
+}
+
 pub async fn resolve_and_execute_plan(
     ctx: &SessionContext,
     config: Arc<PlanConfig>,
     plan: spec::Plan,
 ) -> PlanResult<(Arc<dyn ExecutionPlan>, Vec<StringifiedPlan>)> {
+    // Propagate Sail's `PlanConfig.ansi_mode` (sourced from
+    // `spark.sql.ansi.enabled` via `SparkRuntimeConfig`) into DataFusion's
+    // `SessionConfig.options().execution.enable_ansi_mode`. Upstream
+    // `datafusion_spark` UDFs such as `SparkPmod` / `SparkMod` read the flag
+    // from there at invoke time, so without this sync they always behave as
+    // ANSI=false regardless of what the client SET.
+    sync_ansi_mode_to_ctx(ctx, config.ansi_mode);
+
     let mut info = vec![];
     let resolver = PlanResolver::new(ctx, config);
     let NamedPlan { plan, fields } = resolver.resolve_named_plan(plan).await?;

--- a/python/pysail/tests/spark/function/features/pmod.feature
+++ b/python/pysail/tests/spark/function/features/pmod.feature
@@ -1,0 +1,116 @@
+@pmod
+Feature: pmod (positive modulo) honors ANSI mode and Spark semantics
+
+  # Spark `pmod(a, b)` returns the positive remainder of `a / b` (always in
+  # range `[0, |b|)`), unlike `mod` which preserves the sign of `a`.
+  # Under `spark.sql.ansi.enabled = true`, a zero divisor raises
+  # REMAINDER_BY_ZERO; under ANSI=false it returns NULL.
+  #
+  # Sail delegates to `datafusion_spark::SparkPmod` which reads
+  # `config_options.execution.enable_ansi_mode` at runtime. If the Sail
+  # session never propagates the ANSI flag to that config, the ANSI=true
+  # error path is dead — `pmod(x, 0)` silently returns NULL.
+
+  Rule: Basic behavior — positive remainder regardless of dividend sign
+
+    Scenario: positive dividend
+      When query
+        """
+        SELECT pmod(10, 3) AS result
+        """
+      Then query result
+        | result |
+        | 1      |
+
+    Scenario: negative dividend returns positive remainder
+      When query
+        """
+        SELECT pmod(-7, 3) AS result
+        """
+      Then query result
+        | result |
+        | 2      |
+
+    Scenario: negative divisor — pmod still uses |b| domain
+      When query
+        """
+        SELECT pmod(10, -3) AS result
+        """
+      Then query result
+        | result |
+        | 1      |
+
+    Scenario: exact multiple gives zero
+      When query
+        """
+        SELECT pmod(-15, 5) AS result
+        """
+      Then query result
+        | result |
+        | 0      |
+
+  Rule: NULL operands propagate
+
+    Scenario: NULL dividend returns NULL
+      When query
+        """
+        SELECT pmod(CAST(NULL AS INT), 3) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: NULL divisor returns NULL
+      When query
+        """
+        SELECT pmod(10, CAST(NULL AS INT)) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+  Rule: Divide by zero under ANSI on errors
+
+    Scenario: pmod by 0 errors under ANSI on
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT pmod(10, 0) AS result
+        """
+      Then query error .*
+
+    Scenario: pmod negative dividend by 0 errors under ANSI on
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT pmod(-7, 0) AS result
+        """
+      Then query error .*
+
+  Rule: Divide by zero under ANSI off returns NULL
+
+    Scenario: pmod by 0 returns NULL under ANSI off
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT pmod(10, 0) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: pmod per-row zero divisor nulls only that row
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT pmod(a, b) AS result FROM VALUES
+          (0, 10, 3),
+          (1, -7, 0),
+          (2, 15, 4)
+        AS t(id, a, b) ORDER BY id
+        """
+      Then query result
+        | result |
+        | 1      |
+        | NULL   |
+        | 3      |

--- a/python/pysail/tests/spark/function/features/pmod.feature
+++ b/python/pysail/tests/spark/function/features/pmod.feature
@@ -77,7 +77,7 @@ Feature: pmod (positive modulo) honors ANSI mode and Spark semantics
         """
         SELECT pmod(10, 0) AS result
         """
-      Then query error .*
+      Then query error (?i)by zero
 
     Scenario: pmod negative dividend by 0 errors under ANSI on
       Given config spark.sql.ansi.enabled = true
@@ -85,7 +85,7 @@ Feature: pmod (positive modulo) honors ANSI mode and Spark semantics
         """
         SELECT pmod(-7, 0) AS result
         """
-      Then query error .*
+      Then query error (?i)by zero
 
   Rule: Divide by zero under ANSI off returns NULL
 
@@ -114,3 +114,31 @@ Feature: pmod (positive modulo) honors ANSI mode and Spark semantics
         | 1      |
         | NULL   |
         | 3      |
+
+  Rule: FLOAT/DOUBLE mixed with DECIMAL coerces the result to DOUBLE
+
+    # Spark widens `float`/`double` + `decimal` to DOUBLE, so the result is a
+    # double (e.g. `1.5`), not a decimal. Sail instead widens to DECIMAL, which
+    # changes the result type and — when the double operand is Infinity/NaN —
+    # raises a spurious "cannot cast to Decimal128 ... overflow" error instead
+    # of returning the float result.
+
+    @sail-bug
+    Scenario: double pmod decimal returns a double
+      When query
+        """
+        SELECT pmod(CAST(5.5 AS DOUBLE), 2.0) AS result
+        """
+      Then query result
+        | result |
+        | 1.5    |
+
+    @sail-bug
+    Scenario: infinity double pmod decimal returns NaN not an error
+      When query
+        """
+        SELECT pmod(CAST('Infinity' AS DOUBLE), 2.0) AS result
+        """
+      Then query result
+        | result |
+        | NaN    |


### PR DESCRIPTION
Verified end-to-end: `pmod(x, 0)` now errors with REMAINDER_BY_ZERO under ANSI on (was silently NULL). Same plumbing covers any future `datafusion_spark::*` UDF that reads the flag.