### PR TITLE
test: round percentile output and tag plan-snapshot scenarios sail-only

### DIFF
--- a/python/pysail/tests/spark/function/features/abs.feature
+++ b/python/pysail/tests/spark/function/features/abs.feature
@@ -755,6 +755,7 @@ Feature: abs comprehensive tests
         | 5      |
         | 5      |
 
+  @sail-only
   Rule: simplify rewrite shape
     # Locks the simplify hook's dispatch (Int8/Int16/Int32/Int64/Interval/Duration
     # stay in SparkAbs invoke for ANSI handling; floats/decimals/null delegate

--- a/python/pysail/tests/spark/function/features/ceil_floor_preimage.feature
+++ b/python/pysail/tests/spark/function/features/ceil_floor_preimage.feature
@@ -384,6 +384,7 @@ Feature: ceil() / floor() — preimage hook (filter pushdown)
         """
       Then query plan matches snapshot
 
+  @sail-only
   Rule: Simplify + preimage interaction — ceil(ceil(x)) chains correctly
 
     Scenario: ceil(ceil(x)) collapses to ceil(x) then preimage applies

--- a/python/pysail/tests/spark/function/features/percentile_window.feature
+++ b/python/pysail/tests/spark/function/features/percentile_window.feature
@@ -197,8 +197,8 @@ Feature: percentile() window function computes running percentiles
       SELECT
         category,
         value,
-        percentile(value, 0.5) OVER (PARTITION BY category ORDER BY value) AS p50,
-        percentile(value, 0.9) OVER (PARTITION BY category ORDER BY value) AS p90
+        ROUND(percentile(value, 0.5) OVER (PARTITION BY category ORDER BY value), 6) AS p50,
+        ROUND(percentile(value, 0.9) OVER (PARTITION BY category ORDER BY value), 6) AS p90
       FROM (VALUES
         ('A', 1), ('A', 2), ('A', 3), ('A', 4), ('A', 5),
         ('B', 10), ('B', 20), ('B', 30)


### PR DESCRIPTION
Round percentile_window output (IEEE-754 drift vs Spark) and mark the abs /
ceil_floor_preimage EXPLAIN scenarios @sail-only (Sail-specific physical plan).