### PR TITLE
feat: initial support for named window clause in SQL

### DIFF
--- a/crates/sail-common/src/spec/plan.rs
+++ b/crates/sail-common/src/spec/plan.rs
@@ -9,7 +9,7 @@ use crate::spec::expression::{
     SortOrder,
 };
 use crate::spec::literal::Literal;
-use crate::spec::{DataType, FunctionDefinition, Identifier};
+use crate::spec::{DataType, FunctionDefinition, Identifier, Window};
 
 /// Unresolved logical plan node for Sail.
 /// As a starting point, the definition matches the structure of the `Relation` message
@@ -256,6 +256,10 @@ pub enum QueryNode {
         input: Box<QueryPlan>,
         recursive: bool,
         ctes: Vec<(Identifier, QueryPlan)>,
+    },
+    NamedWindows {
+        input: Box<QueryPlan>,
+        windows: Vec<(Identifier, Window)>,
     },
     /// A relation that wraps a root plan with referenced subquery plans.
     WithRelations {

--- a/crates/sail-plan/src/error.rs
+++ b/crates/sail-plan/src/error.rs
@@ -67,6 +67,10 @@ impl PlanError {
     pub fn internal(message: impl Into<String>) -> Self {
         PlanError::InternalError(message.into())
     }
+
+    pub fn analysis(message: impl Into<String>) -> Self {
+        PlanError::AnalysisError(message.into())
+    }
 }
 
 impl From<CommonError> for PlanError {

--- a/crates/sail-plan/src/resolver/expression/window.rs
+++ b/crates/sail-plan/src/resolver/expression/window.rs
@@ -10,7 +10,7 @@ use datafusion_expr::{
     expr, AggregateUDF, ExprSchemable, WindowFrame, WindowFrameBound, WindowFrameUnits,
 };
 use sail_catalog::manager::CatalogManager;
-use sail_common::spec;
+use sail_common::spec::{self};
 use sail_common_datafusion::extension::SessionExtensionAccessor;
 use sail_common_datafusion::literal::LiteralEvaluator;
 use sail_common_datafusion::session::plan::PlanService;
@@ -35,6 +35,14 @@ impl PlanResolver<'_> {
         schema: &DFSchemaRef,
         state: &mut PlanResolverState,
     ) -> PlanResult<NamedExpr> {
+        let window = match window {
+            spec::Window::Named(name) => state
+                .get_window(name.as_ref())
+                .ok_or_else(|| PlanError::invalid(format!("undefined window: {}", name.as_ref())))?
+                .clone(),
+            w => w,
+        };
+
         let spec::Window::Unnamed {
             cluster_by,
             partition_by,
@@ -42,7 +50,7 @@ impl PlanResolver<'_> {
             frame,
         } = window
         else {
-            return Err(PlanError::todo("named window"));
+            return Err(PlanError::analysis("named windows in window expressions"));
         };
         if !cluster_by.is_empty() {
             return Err(PlanError::unsupported(

--- a/crates/sail-plan/src/resolver/expression/window.rs
+++ b/crates/sail-plan/src/resolver/expression/window.rs
@@ -38,7 +38,7 @@ impl PlanResolver<'_> {
         let window = match window {
             spec::Window::Named(name) => state
                 .get_window(name.as_ref())
-                .ok_or_else(|| PlanError::invalid(format!("undefined window: {}", name.as_ref())))?
+                .ok_or_else(|| PlanError::analysis(format!("undefined window: {}", name.as_ref())))?
                 .clone(),
             w => w,
         };

--- a/crates/sail-plan/src/resolver/query/mod.rs
+++ b/crates/sail-plan/src/resolver/query/mod.rs
@@ -31,6 +31,7 @@ mod time_travel;
 mod udf;
 mod udtf;
 mod values;
+mod window;
 mod with_relations;
 
 impl PlanResolver<'_> {
@@ -355,6 +356,9 @@ impl PlanResolver<'_> {
             } => {
                 self.resolve_query_lateral_join(*left, *right, join_condition, join_type, state)
                     .await?
+            }
+            QueryNode::NamedWindows { input, windows } => {
+                self.resolve_named_windows(*input, windows, state).await?
             }
         };
         self.verify_query_plan(&plan, state)?;

--- a/crates/sail-plan/src/resolver/query/window.rs
+++ b/crates/sail-plan/src/resolver/query/window.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use datafusion_expr::LogicalPlan;
 use sail_common::spec::{self, Identifier};
 
@@ -12,19 +14,23 @@ impl PlanResolver<'_> {
         window: Vec<(Identifier, spec::Window)>,
         state: &mut PlanResolverState,
     ) -> PlanResult<LogicalPlan> {
+        let mut windows: HashMap<String, spec::Window> = HashMap::new();
         for (name, w) in window {
-            if state.get_window(name.as_ref()).is_some() {
-                return Err(PlanError::AnalysisError(format!(
+            if windows.get(name.as_ref()).is_some() {
+                return Err(PlanError::analysis(format!(
                     "Name {} is used more than once in WINDOW clause",
                     name.as_ref()
                 )));
             } else {
-                state.insert_window(name.into(), w);
+                windows.insert(name.into(), w);
             }
         }
+
+        let old_windows = state.set_windows(windows);
         let input = self
             .resolve_query_plan_with_hidden_fields(input, state)
             .await?;
+        let _ = state.set_windows(old_windows);
         Ok(input)
     }
 }

--- a/crates/sail-plan/src/resolver/query/window.rs
+++ b/crates/sail-plan/src/resolver/query/window.rs
@@ -1,0 +1,30 @@
+use datafusion_expr::LogicalPlan;
+use sail_common::spec::{self, Identifier};
+
+use crate::error::{PlanError, PlanResult};
+use crate::resolver::state::PlanResolverState;
+use crate::resolver::PlanResolver;
+
+impl PlanResolver<'_> {
+    pub(super) async fn resolve_named_windows(
+        &self,
+        input: spec::QueryPlan,
+        window: Vec<(Identifier, spec::Window)>,
+        state: &mut PlanResolverState,
+    ) -> PlanResult<LogicalPlan> {
+        for (name, w) in window {
+            if state.get_window(name.as_ref()).is_some() {
+                return Err(PlanError::AnalysisError(format!(
+                    "Name {} is used more than once in WINDOW clause",
+                    name.as_ref()
+                )));
+            } else {
+                state.insert_window(name.into(), w);
+            }
+        }
+        let input = self
+            .resolve_query_plan_with_hidden_fields(input, state)
+            .await?;
+        Ok(input)
+    }
+}

--- a/crates/sail-plan/src/resolver/query/window.rs
+++ b/crates/sail-plan/src/resolver/query/window.rs
@@ -16,7 +16,7 @@ impl PlanResolver<'_> {
     ) -> PlanResult<LogicalPlan> {
         let mut windows: HashMap<String, spec::Window> = HashMap::new();
         for (name, w) in window {
-            if windows.get(name.as_ref()).is_some() {
+            if windows.contains_key(name.as_ref()) {
                 return Err(PlanError::analysis(format!(
                     "Name {} is used more than once in WINDOW clause",
                     name.as_ref()

--- a/crates/sail-plan/src/resolver/state.rs
+++ b/crates/sail-plan/src/resolver/state.rs
@@ -249,8 +249,11 @@ impl PlanResolverState {
         ConfigScope::new(self)
     }
 
-    pub fn insert_window(&mut self, name: String, window: spec::Window) {
-        self.windows.insert(name, window);
+    pub fn set_windows(
+        &mut self,
+        windows: HashMap<String, spec::Window>,
+    ) -> HashMap<String, spec::Window> {
+        std::mem::replace(&mut self.windows, windows)
     }
 
     pub fn get_window(&self, name: &str) -> Option<&spec::Window> {

--- a/crates/sail-plan/src/resolver/state.rs
+++ b/crates/sail-plan/src/resolver/state.rs
@@ -85,6 +85,8 @@ pub(super) struct PlanResolverState {
     /// Positional parameter values available for IDENTIFIER clause evaluation.
     /// Set alongside `param_values` when resolving a `WithParameters` query node.
     positional_param_values: Vec<ScalarValue>,
+    /// The named windows defined in the current query, keyed by window name.
+    windows: HashMap<String, spec::Window>,
 }
 
 impl Default for PlanResolverState {
@@ -105,6 +107,7 @@ impl PlanResolverState {
             config: PlanResolverStateConfig::default(),
             param_values: HashMap::new(),
             positional_param_values: Vec::new(),
+            windows: HashMap::new(),
         }
     }
 
@@ -244,6 +247,14 @@ impl PlanResolverState {
 
     pub fn enter_config_scope(&mut self) -> ConfigScope<'_> {
         ConfigScope::new(self)
+    }
+
+    pub fn insert_window(&mut self, name: String, window: spec::Window) {
+        self.windows.insert(name, window);
+    }
+
+    pub fn get_window(&self, name: &str) -> Option<&spec::Window> {
+        self.windows.get(name)
     }
 
     // TODO:

--- a/crates/sail-spark-connect/src/service/plan_analyzer.rs
+++ b/crates/sail-spark-connect/src/service/plan_analyzer.rs
@@ -294,6 +294,7 @@ fn is_streaming_query_node(node: &spec::QueryNode) -> bool {
         spec::QueryNode::Parse(p) => is_streaming_query_plan(&p.input),
         spec::QueryNode::WithWatermark(w) => is_streaming_query_plan(&w.input),
         spec::QueryNode::ApplyInPandasWithState(a) => is_streaming_query_plan(&a.input),
+        spec::QueryNode::NamedWindows { input, windows: _ } => is_streaming_query_plan(input),
         // multiple inputs
         spec::QueryNode::Join(j) => {
             is_streaming_query_plan(&j.left) || is_streaming_query_plan(&j.right)

--- a/crates/sail-spark-connect/tests/gold_data/plan/plan_order_by.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/plan_order_by.json
@@ -502,35 +502,118 @@
       "output": {
         "success": {
           "query": {
-            "project": {
+            "namedWindows": {
               "input": {
-                "read": {
-                  "namedTable": {
-                    "name": [
-                      "t"
-                    ],
-                    "temporal": null,
-                    "sample": null,
-                    "options": []
+                "project": {
+                  "input": {
+                    "read": {
+                      "namedTable": {
+                        "name": [
+                          "t"
+                        ],
+                        "temporal": null,
+                        "sample": null,
+                        "options": []
+                      },
+                      "isStreaming": false
+                    },
+                    "planId": null
                   },
-                  "isStreaming": false
+                  "expressions": [
+                    {
+                      "unresolvedStar": {
+                        "target": null,
+                        "planId": null,
+                        "wildcardOptions": {
+                          "ilikePattern": null,
+                          "excludeColumns": null,
+                          "exceptColumns": null,
+                          "replaceColumns": null,
+                          "renameColumns": null
+                        }
+                      }
+                    }
+                  ]
                 },
                 "planId": null
               },
-              "expressions": [
-                {
-                  "unresolvedStar": {
-                    "target": null,
-                    "planId": null,
-                    "wildcardOptions": {
-                      "ilikePattern": null,
-                      "excludeColumns": null,
-                      "exceptColumns": null,
-                      "replaceColumns": null,
-                      "renameColumns": null
+              "windows": [
+                [
+                  "w1",
+                  {
+                    "unnamed": {
+                      "clusterBy": [],
+                      "partitionBy": [
+                        {
+                          "unresolvedAttribute": {
+                            "name": [
+                              "a"
+                            ],
+                            "planId": null,
+                            "isMetadataColumn": false
+                          }
+                        },
+                        {
+                          "unresolvedAttribute": {
+                            "name": [
+                              "b"
+                            ],
+                            "planId": null,
+                            "isMetadataColumn": false
+                          }
+                        }
+                      ],
+                      "orderBy": [
+                        {
+                          "child": {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "c"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
+                            }
+                          },
+                          "direction": "unspecified",
+                          "nullOrdering": "unspecified"
+                        }
+                      ],
+                      "frame": {
+                        "frameType": "row",
+                        "lower": {
+                          "preceding": {
+                            "literal": {
+                              "int32": {
+                                "value": 1
+                              }
+                            }
+                          }
+                        },
+                        "upper": {
+                          "following": {
+                            "literal": {
+                              "int32": {
+                                "value": 1
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
-                }
+                ],
+                [
+                  "w2",
+                  {
+                    "named": "w1"
+                  }
+                ],
+                [
+                  "w3",
+                  {
+                    "named": "w1"
+                  }
+                ]
               ]
             },
             "planId": null
@@ -804,82 +887,7 @@
       "output": {
         "success": {
           "query": {
-            "sort": {
-              "input": {
-                "project": {
-                  "input": {
-                    "read": {
-                      "namedTable": {
-                        "name": [
-                          "t"
-                        ],
-                        "temporal": null,
-                        "sample": null,
-                        "options": []
-                      },
-                      "isStreaming": false
-                    },
-                    "planId": null
-                  },
-                  "expressions": [
-                    {
-                      "unresolvedStar": {
-                        "target": null,
-                        "planId": null,
-                        "wildcardOptions": {
-                          "ilikePattern": null,
-                          "excludeColumns": null,
-                          "exceptColumns": null,
-                          "replaceColumns": null,
-                          "renameColumns": null
-                        }
-                      }
-                    }
-                  ]
-                },
-                "planId": null
-              },
-              "order": [
-                {
-                  "child": {
-                    "unresolvedAttribute": {
-                      "name": [
-                        "a"
-                      ],
-                      "planId": null,
-                      "isMetadataColumn": false
-                    }
-                  },
-                  "direction": "unspecified",
-                  "nullOrdering": "unspecified"
-                },
-                {
-                  "child": {
-                    "unresolvedAttribute": {
-                      "name": [
-                        "b"
-                      ],
-                      "planId": null,
-                      "isMetadataColumn": false
-                    }
-                  },
-                  "direction": "descending",
-                  "nullOrdering": "unspecified"
-                }
-              ],
-              "isGlobal": true
-            },
-            "planId": null
-          }
-        }
-      }
-    },
-    {
-      "input": "select * from t order by a, b desc window w1 as () limit 10",
-      "output": {
-        "success": {
-          "query": {
-            "limit": {
+            "namedWindows": {
               "input": {
                 "sort": {
                   "input": {
@@ -948,14 +956,125 @@
                 },
                 "planId": null
               },
-              "skip": null,
-              "limit": {
-                "literal": {
-                  "int32": {
-                    "value": 10
+              "windows": [
+                [
+                  "w1",
+                  {
+                    "unnamed": {
+                      "clusterBy": [],
+                      "partitionBy": [],
+                      "orderBy": [],
+                      "frame": null
+                    }
                   }
-                }
-              }
+                ]
+              ]
+            },
+            "planId": null
+          }
+        }
+      }
+    },
+    {
+      "input": "select * from t order by a, b desc window w1 as () limit 10",
+      "output": {
+        "success": {
+          "query": {
+            "namedWindows": {
+              "input": {
+                "limit": {
+                  "input": {
+                    "sort": {
+                      "input": {
+                        "project": {
+                          "input": {
+                            "read": {
+                              "namedTable": {
+                                "name": [
+                                  "t"
+                                ],
+                                "temporal": null,
+                                "sample": null,
+                                "options": []
+                              },
+                              "isStreaming": false
+                            },
+                            "planId": null
+                          },
+                          "expressions": [
+                            {
+                              "unresolvedStar": {
+                                "target": null,
+                                "planId": null,
+                                "wildcardOptions": {
+                                  "ilikePattern": null,
+                                  "excludeColumns": null,
+                                  "exceptColumns": null,
+                                  "replaceColumns": null,
+                                  "renameColumns": null
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "planId": null
+                      },
+                      "order": [
+                        {
+                          "child": {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
+                            }
+                          },
+                          "direction": "unspecified",
+                          "nullOrdering": "unspecified"
+                        },
+                        {
+                          "child": {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "b"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
+                            }
+                          },
+                          "direction": "descending",
+                          "nullOrdering": "unspecified"
+                        }
+                      ],
+                      "isGlobal": true
+                    },
+                    "planId": null
+                  },
+                  "skip": null,
+                  "limit": {
+                    "literal": {
+                      "int32": {
+                        "value": 10
+                      }
+                    }
+                  }
+                },
+                "planId": null
+              },
+              "windows": [
+                [
+                  "w1",
+                  {
+                    "unnamed": {
+                      "clusterBy": [],
+                      "partitionBy": [],
+                      "orderBy": [],
+                      "frame": null
+                    }
+                  }
+                ]
+              ]
             },
             "planId": null
           }
@@ -1130,82 +1249,7 @@
       "output": {
         "success": {
           "query": {
-            "sort": {
-              "input": {
-                "project": {
-                  "input": {
-                    "read": {
-                      "namedTable": {
-                        "name": [
-                          "t"
-                        ],
-                        "temporal": null,
-                        "sample": null,
-                        "options": []
-                      },
-                      "isStreaming": false
-                    },
-                    "planId": null
-                  },
-                  "expressions": [
-                    {
-                      "unresolvedStar": {
-                        "target": null,
-                        "planId": null,
-                        "wildcardOptions": {
-                          "ilikePattern": null,
-                          "excludeColumns": null,
-                          "exceptColumns": null,
-                          "replaceColumns": null,
-                          "renameColumns": null
-                        }
-                      }
-                    }
-                  ]
-                },
-                "planId": null
-              },
-              "order": [
-                {
-                  "child": {
-                    "unresolvedAttribute": {
-                      "name": [
-                        "a"
-                      ],
-                      "planId": null,
-                      "isMetadataColumn": false
-                    }
-                  },
-                  "direction": "unspecified",
-                  "nullOrdering": "unspecified"
-                },
-                {
-                  "child": {
-                    "unresolvedAttribute": {
-                      "name": [
-                        "b"
-                      ],
-                      "planId": null,
-                      "isMetadataColumn": false
-                    }
-                  },
-                  "direction": "descending",
-                  "nullOrdering": "unspecified"
-                }
-              ],
-              "isGlobal": false
-            },
-            "planId": null
-          }
-        }
-      }
-    },
-    {
-      "input": "select * from t sort by a, b desc window w1 as () limit 10",
-      "output": {
-        "success": {
-          "query": {
-            "limit": {
+            "namedWindows": {
               "input": {
                 "sort": {
                   "input": {
@@ -1274,14 +1318,125 @@
                 },
                 "planId": null
               },
-              "skip": null,
-              "limit": {
-                "literal": {
-                  "int32": {
-                    "value": 10
+              "windows": [
+                [
+                  "w1",
+                  {
+                    "unnamed": {
+                      "clusterBy": [],
+                      "partitionBy": [],
+                      "orderBy": [],
+                      "frame": null
+                    }
                   }
-                }
-              }
+                ]
+              ]
+            },
+            "planId": null
+          }
+        }
+      }
+    },
+    {
+      "input": "select * from t sort by a, b desc window w1 as () limit 10",
+      "output": {
+        "success": {
+          "query": {
+            "namedWindows": {
+              "input": {
+                "limit": {
+                  "input": {
+                    "sort": {
+                      "input": {
+                        "project": {
+                          "input": {
+                            "read": {
+                              "namedTable": {
+                                "name": [
+                                  "t"
+                                ],
+                                "temporal": null,
+                                "sample": null,
+                                "options": []
+                              },
+                              "isStreaming": false
+                            },
+                            "planId": null
+                          },
+                          "expressions": [
+                            {
+                              "unresolvedStar": {
+                                "target": null,
+                                "planId": null,
+                                "wildcardOptions": {
+                                  "ilikePattern": null,
+                                  "excludeColumns": null,
+                                  "exceptColumns": null,
+                                  "replaceColumns": null,
+                                  "renameColumns": null
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "planId": null
+                      },
+                      "order": [
+                        {
+                          "child": {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "a"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
+                            }
+                          },
+                          "direction": "unspecified",
+                          "nullOrdering": "unspecified"
+                        },
+                        {
+                          "child": {
+                            "unresolvedAttribute": {
+                              "name": [
+                                "b"
+                              ],
+                              "planId": null,
+                              "isMetadataColumn": false
+                            }
+                          },
+                          "direction": "descending",
+                          "nullOrdering": "unspecified"
+                        }
+                      ],
+                      "isGlobal": false
+                    },
+                    "planId": null
+                  },
+                  "skip": null,
+                  "limit": {
+                    "literal": {
+                      "int32": {
+                        "value": 10
+                      }
+                    }
+                  }
+                },
+                "planId": null
+              },
+              "windows": [
+                [
+                  "w1",
+                  {
+                    "unnamed": {
+                      "clusterBy": [],
+                      "partitionBy": [],
+                      "orderBy": [],
+                      "frame": null
+                    }
+                  }
+                ]
+              ]
             },
             "planId": null
           }

--- a/crates/sail-spark-connect/tests/gold_data/plan/plan_select.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/plan_select.json
@@ -4532,48 +4532,7 @@
       "output": {
         "success": {
           "query": {
-            "project": {
-              "input": {
-                "read": {
-                  "namedTable": {
-                    "name": [
-                      "t"
-                    ],
-                    "temporal": null,
-                    "sample": null,
-                    "options": []
-                  },
-                  "isStreaming": false
-                },
-                "planId": null
-              },
-              "expressions": [
-                {
-                  "unresolvedStar": {
-                    "target": null,
-                    "planId": null,
-                    "wildcardOptions": {
-                      "ilikePattern": null,
-                      "excludeColumns": null,
-                      "exceptColumns": null,
-                      "replaceColumns": null,
-                      "renameColumns": null
-                    }
-                  }
-                }
-              ]
-            },
-            "planId": null
-          }
-        }
-      }
-    },
-    {
-      "input": "select * from t window w1 as () limit 10",
-      "output": {
-        "success": {
-          "query": {
-            "limit": {
+            "namedWindows": {
               "input": {
                 "project": {
                   "input": {
@@ -4608,14 +4567,91 @@
                 },
                 "planId": null
               },
-              "skip": null,
-              "limit": {
-                "literal": {
-                  "int32": {
-                    "value": 10
+              "windows": [
+                [
+                  "w1",
+                  {
+                    "unnamed": {
+                      "clusterBy": [],
+                      "partitionBy": [],
+                      "orderBy": [],
+                      "frame": null
+                    }
                   }
-                }
-              }
+                ]
+              ]
+            },
+            "planId": null
+          }
+        }
+      }
+    },
+    {
+      "input": "select * from t window w1 as () limit 10",
+      "output": {
+        "success": {
+          "query": {
+            "namedWindows": {
+              "input": {
+                "limit": {
+                  "input": {
+                    "project": {
+                      "input": {
+                        "read": {
+                          "namedTable": {
+                            "name": [
+                              "t"
+                            ],
+                            "temporal": null,
+                            "sample": null,
+                            "options": []
+                          },
+                          "isStreaming": false
+                        },
+                        "planId": null
+                      },
+                      "expressions": [
+                        {
+                          "unresolvedStar": {
+                            "target": null,
+                            "planId": null,
+                            "wildcardOptions": {
+                              "ilikePattern": null,
+                              "excludeColumns": null,
+                              "exceptColumns": null,
+                              "replaceColumns": null,
+                              "renameColumns": null
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "planId": null
+                  },
+                  "skip": null,
+                  "limit": {
+                    "literal": {
+                      "int32": {
+                        "value": 10
+                      }
+                    }
+                  }
+                },
+                "planId": null
+              },
+              "windows": [
+                [
+                  "w1",
+                  {
+                    "unnamed": {
+                      "clusterBy": [],
+                      "partitionBy": [],
+                      "orderBy": [],
+                      "frame": null
+                    }
+                  }
+                ]
+              ]
             },
             "planId": null
           }

--- a/crates/sail-sql-analyzer/src/expression.rs
+++ b/crates/sail-sql-analyzer/src/expression.rs
@@ -1,6 +1,6 @@
 use std::iter::once;
 
-use sail_common::spec;
+use sail_common::spec::{self, Window};
 use sail_sql_parser::ast::expression::{
     AtomExpr, BinaryOperator, CaseElse, CaseWhen, DuplicateTreatment, Expr, FilterClause,
     FunctionArgument, FunctionArgumentList, FunctionExpr, GroupingExpr, GroupingSet,
@@ -1053,48 +1053,9 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
             });
             if let Some(over_clause) = over_clause {
                 let OverClause { over: _, window } = over_clause;
-                let window = match window {
-                    WindowSpec::Named(x) => spec::Window::Named(x.value.into()),
-                    WindowSpec::Unnamed {
-                        left: _,
-                        modifiers,
-                        window_frame,
-                        right: _,
-                    } => {
-                        let WindowModifiers {
-                            cluster_by,
-                            partition_by,
-                            order_by,
-                        } = modifiers.try_into()?;
-                        let cluster_by = cluster_by
-                            .unwrap_or_default()
-                            .into_iter()
-                            .map(from_ast_expression)
-                            .collect::<SqlResult<Vec<_>>>()?;
-                        let partition_by = partition_by
-                            .unwrap_or_default()
-                            .into_iter()
-                            .map(from_ast_expression)
-                            .collect::<SqlResult<Vec<_>>>()?;
-                        let order_by = order_by
-                            .unwrap_or_default()
-                            .into_iter()
-                            .map(from_ast_order_by)
-                            .collect::<SqlResult<Vec<_>>>()?;
-                        let frame = window_frame
-                            .map(|f| from_ast_window_frame(*f))
-                            .transpose()?;
-                        spec::Window::Unnamed {
-                            cluster_by,
-                            partition_by,
-                            order_by,
-                            frame,
-                        }
-                    }
-                };
                 Ok(spec::Expr::Window {
                     window_function: Box::new(function),
-                    window,
+                    window: from_ast_window(window)?,
                 })
             } else {
                 Ok(function)
@@ -1219,5 +1180,47 @@ fn from_ast_pattern_escape_string(escape: Option<PatternEscape>) -> SqlResult<Op
         _ => Err(SqlError::invalid(format!(
             "invalid escape character: {value}"
         ))),
+    }
+}
+
+pub(crate) fn from_ast_window(window: WindowSpec) -> SqlResult<spec::Window> {
+    match window {
+        WindowSpec::Named(x) => Ok(spec::Window::Named(x.value.into())),
+        WindowSpec::Unnamed {
+            left: _,
+            modifiers,
+            window_frame,
+            right: _,
+        } => {
+            let WindowModifiers {
+                cluster_by,
+                partition_by,
+                order_by,
+            } = modifiers.try_into()?;
+            let cluster_by = cluster_by
+                .unwrap_or_default()
+                .into_iter()
+                .map(from_ast_expression)
+                .collect::<SqlResult<Vec<_>>>()?;
+            let partition_by = partition_by
+                .unwrap_or_default()
+                .into_iter()
+                .map(from_ast_expression)
+                .collect::<SqlResult<Vec<_>>>()?;
+            let order_by = order_by
+                .unwrap_or_default()
+                .into_iter()
+                .map(from_ast_order_by)
+                .collect::<SqlResult<Vec<_>>>()?;
+            let frame = window_frame
+                .map(|f| from_ast_window_frame(*f))
+                .transpose()?;
+            Ok(spec::Window::Unnamed {
+                cluster_by,
+                partition_by,
+                order_by,
+                frame,
+            })
+        }
     }
 }

--- a/crates/sail-sql-analyzer/src/expression.rs
+++ b/crates/sail-sql-analyzer/src/expression.rs
@@ -1,6 +1,6 @@
 use std::iter::once;
 
-use sail_common::spec::{self, Window};
+use sail_common::spec::{self};
 use sail_sql_parser::ast::expression::{
     AtomExpr, BinaryOperator, CaseElse, CaseWhen, DuplicateTreatment, Expr, FilterClause,
     FunctionArgument, FunctionArgumentList, FunctionExpr, GroupingExpr, GroupingSet,

--- a/crates/sail-sql-analyzer/src/query.rs
+++ b/crates/sail-sql-analyzer/src/query.rs
@@ -20,7 +20,7 @@ use crate::error::{SqlError, SqlResult};
 use crate::expression::{
     expr_with_default_column_values, from_ast_expression, from_ast_function_arguments,
     from_ast_grouping_expression, from_ast_identifier_list, from_ast_object_name,
-    from_ast_order_by,
+    from_ast_order_by, from_ast_window,
 };
 
 #[derive(Default)]
@@ -136,7 +136,7 @@ pub(crate) fn from_ast_query(query: Query) -> SqlResult<spec::QueryPlan> {
         distribute_by,
         offset,
         limit,
-        window: _, // TODO: support window
+        window,
     } = modifiers.try_into()?;
 
     if cluster_by.is_some() {
@@ -193,6 +193,11 @@ pub(crate) fn from_ast_query(query: Query) -> SqlResult<spec::QueryPlan> {
             })
         }
     };
+
+    let plan = spec::QueryPlan::new(spec::QueryNode::NamedWindows {
+        input: Box::new(plan),
+        windows: from_ast_named_windows(window)?,
+    });
 
     if let Some(WithClause {
         with: _,
@@ -802,6 +807,19 @@ pub fn from_ast_with(
                 columns,
             });
             Ok((name, plan))
+        })
+        .collect::<SqlResult<Vec<_>>>()
+}
+
+pub fn from_ast_named_windows(
+    windows: Vec<NamedWindow>,
+) -> SqlResult<Vec<(spec::Identifier, spec::Window)>> {
+    windows
+        .into_iter()
+        .map(|window| {
+            let name = spec::Identifier::from(window.name.value);
+            let window = from_ast_window(window.window)?;
+            Ok((name, window))
         })
         .collect::<SqlResult<Vec<_>>>()
 }

--- a/crates/sail-sql-analyzer/src/query.rs
+++ b/crates/sail-sql-analyzer/src/query.rs
@@ -31,7 +31,7 @@ struct QueryModifiers {
     distribute_by: Option<Vec<Expr>>,
     offset: Option<Expr>,
     limit: Option<LimitValue>,
-    window: Vec<NamedWindow>,
+    window: Option<Vec<NamedWindow>>,
 }
 
 impl TryFrom<Vec<QueryModifier>> for QueryModifiers {
@@ -42,7 +42,13 @@ impl TryFrom<Vec<QueryModifier>> for QueryModifiers {
         for modifier in value {
             match modifier {
                 QueryModifier::Window(WindowClause { window: _, items }) => {
-                    output.window.extend(items.into_items())
+                    if output
+                        .window
+                        .replace(items.into_items().collect())
+                        .is_some()
+                    {
+                        return Err(SqlError::invalid("duplicated WINDOW clause"));
+                    }
                 }
                 QueryModifier::OrderBy(OrderByClause { order_by: _, items }) => {
                     if output
@@ -194,10 +200,14 @@ pub(crate) fn from_ast_query(query: Query) -> SqlResult<spec::QueryPlan> {
         }
     };
 
-    let plan = spec::QueryPlan::new(spec::QueryNode::NamedWindows {
-        input: Box::new(plan),
-        windows: from_ast_named_windows(window)?,
-    });
+    let plan = if let Some(w) = window {
+        spec::QueryPlan::new(spec::QueryNode::NamedWindows {
+            input: Box::new(plan),
+            windows: from_ast_named_windows(w)?,
+        })
+    } else {
+        plan
+    };
 
     if let Some(WithClause {
         with: _,

--- a/python/pysail/tests/spark/test_basic.py
+++ b/python/pysail/tests/spark/test_basic.py
@@ -395,6 +395,14 @@ def test_sql_named_window_clause(spark, df_view):
         pd.DataFrame({"min": [1, 1]}, dtype="int32"),
     )
 
+    with pytest.raises(Exception, match=r"Name w is used more than once in WINDOW clause"):
+        spark.sql(
+            f"SELECT min(a) OVER w AS min FROM {df_view} WINDOW w AS (ORDER BY a), w AS (ORDER BY a)"
+        ).toPandas()  # noqa: S608
+
+    with pytest.raises(Exception, match=r"undefined window"):
+        spark.sql(f"SELECT min(a) OVER w AS min FROM {df_view}").toPandas()  # noqa: S608
+
 
 @pytest.mark.skipif(is_jvm_spark(), reason="Sail only")
 def test_sql_parameters(spark):

--- a/python/pysail/tests/spark/test_basic.py
+++ b/python/pysail/tests/spark/test_basic.py
@@ -397,8 +397,8 @@ def test_sql_named_window_clause(spark, df_view):
 
     with pytest.raises(Exception, match=r"Name w is used more than once in WINDOW clause"):
         spark.sql(
-            f"SELECT min(a) OVER w AS min FROM {df_view} WINDOW w AS (ORDER BY a), w AS (ORDER BY a)"
-        ).toPandas()  # noqa: S608
+            f"SELECT min(a) OVER w AS min FROM {df_view} WINDOW w AS (ORDER BY a), w AS (ORDER BY a)"  #noqa: S608
+        ).toPandas()
 
     with pytest.raises(Exception, match=r"undefined window"):
         spark.sql(f"SELECT min(a) OVER w AS min FROM {df_view}").toPandas()  # noqa: S608

--- a/python/pysail/tests/spark/test_basic.py
+++ b/python/pysail/tests/spark/test_basic.py
@@ -397,7 +397,7 @@ def test_sql_named_window_clause(spark, df_view):
 
     with pytest.raises(Exception, match=r"Name w is used more than once in WINDOW clause"):
         spark.sql(
-            f"SELECT min(a) OVER w AS min FROM {df_view} WINDOW w AS (ORDER BY a), w AS (ORDER BY a)"  #noqa: S608
+            f"SELECT min(a) OVER w AS min FROM {df_view} WINDOW w AS (ORDER BY a), w AS (ORDER BY a)"  # noqa: S608
         ).toPandas()
 
     with pytest.raises(Exception, match=r"undefined window"):

--- a/python/pysail/tests/spark/test_basic.py
+++ b/python/pysail/tests/spark/test_basic.py
@@ -389,6 +389,13 @@ def test_sql_with_clause(spark, df, df_view):
     )
 
 
+def test_sql_named_window_clause(spark, df_view):
+    assert_frame_equal(
+        spark.sql(f"SELECT min(a) OVER w AS min FROM {df_view} WINDOW w AS (ORDER BY a)").toPandas(),
+        pd.DataFrame({"min": [1, 1]}, dtype="int32"),
+    )
+
+
 @pytest.mark.skipif(is_jvm_spark(), reason="Sail only")
 def test_sql_parameters(spark):
     actual = spark.sql("SELECT 1 AS text WHERE $1 > 'a'", ["b"]).toPandas()

--- a/python/pysail/tests/spark/test_basic.py
+++ b/python/pysail/tests/spark/test_basic.py
@@ -391,7 +391,7 @@ def test_sql_with_clause(spark, df, df_view):
 
 def test_sql_named_window_clause(spark, df_view):
     assert_frame_equal(
-        spark.sql(f"SELECT min(a) OVER w AS min FROM {df_view} WINDOW w AS (ORDER BY a)").toPandas(),
+        spark.sql(f"SELECT min(a) OVER w AS min FROM {df_view} WINDOW w AS (ORDER BY a)").toPandas(),  # noqa: S608
         pd.DataFrame({"min": [1, 1]}, dtype="int32"),
     )
 


### PR DESCRIPTION
# Initial support for named window in SQL

## Context

https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-window.html
https://docs.databricks.com/gcp/en/sql/language-manual/sql-ref-syntax-qry-select-named-window

Currently sail already supports unnamed window expressions, and they work correctly. This PR provides initial support for named window in the SQL query. It's currently a syntactic sugar over the existing unnamed window expression, but we can decide  to do something smarter later on with better optimization techniques. 

## Example

Examples and setups are copied from Databricks doc,

### Setup

```sql
CREATE TABLE employees (name STRING, dept STRING, salary INT, age INT);

INSERT INTO employees
('Lisa', 'Sales', 10000, 35),
('Evan', 'Sales', 32000, 38),
('Fred', 'Engineering', 21000, 28),
('Alex', 'Sales', 30000, 33),
('Tom', 'Engineering', 23000, 33),
('Jane', 'Marketing', 29000, 28),
('Jeff', 'Marketing', 35000, 38),
('Paul', 'Engineering', 29000, 23),
('Chloe', 'Engineering', 23000, 25); 
```

### Test Query

```sql
SELECT 
    round(avg(age) OVER win, 1) AS salary,
    round(avg(salary) OVER win, 1) AS avgsalary,
    min(salary) OVER win AS minsalary,
    max(salary) OVER win AS maxsalary,
    count(1) OVER win AS numEmps
FROM employees
WINDOW win AS (
    ORDER BY age
    ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING
);
```

```
SELECT sum(salary) OVER w FROM employees
    WINDOW w AS (ORDER BY salary), w AS (ORDER BY age);
```

### Before

```
    raise convert_exception(
    ...<5 lines>...
    ) from None
pyspark.errors.exceptions.connect.UnsupportedOperationException: named window
```

### After

```
+------+---------+---------+---------+-------+
|salary|avgsalary|minsalary|maxsalary|numEmps|
+------+---------+---------+---------+-------+
|  25.3|  27000.0|    23000|    29000|      3|
|  26.0|  25500.0|    21000|    29000|      4|
|  27.4|  26400.0|    21000|    30000|      5|
|  29.4|  25200.0|    21000|    30000|      5|
|  31.4|  22600.0|    10000|    30000|      5|
|  33.4|  23800.0|    10000|    35000|      5|
|  35.4|  26000.0|    10000|    35000|      5|
|  36.0|  25000.0|    10000|    35000|      4|
|  37.0|  25666.7|    10000|    35000|      3|
+------+---------+---------+---------+-------+
```

```
pyspark.errors.exceptions.connect.AnalysisException: Name w is used more than once in WINDOW clause
```

### Expected Result

25.3    27000.0 23000   29000   3
26.0    25500.0 21000   29000   4
27.4    25000.0 21000   29000   5
29.4    25200.0 21000   30000   5
31.4    22600.0 10000   30000   5
33.4    23800.0 10000   35000   5
35.4    26000.0 10000   35000   5
36.0    26750.0 10000   35000   4
37.0    25666.7 10000   35000   3