### PR TITLE
chore: use `#!/usr/bin/env bash` shebang in shell scripts

### DIFF
--- a/.github/scripts/find-llvm-profdata.sh
+++ b/.github/scripts/find-llvm-profdata.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 SYSROOT=$(rustc +stable --print sysroot)

--- a/.github/scripts/rustc-workspace-wrapper.sh
+++ b/.github/scripts/rustc-workspace-wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 exec "$1" "${@:2}" -C instrument-coverage --cfg coverage

--- a/crates/sail-catalog-iceberg/spec/generate-client.sh
+++ b/crates/sail-catalog-iceberg/spec/generate-client.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -9,8 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/bin/bash
 
 set -euo pipefail
 

--- a/scripts/common-gold-data/report.sh
+++ b/scripts/common-gold-data/report.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo 'pipefail'
 

--- a/scripts/spark-gold-data/bootstrap.sh
+++ b/scripts/spark-gold-data/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo 'pipefail'
 

--- a/scripts/spark-gold-data/bootstrap.sh
+++ b/scripts/spark-gold-data/bootstrap.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -euo 'pipefail'
 

--- a/scripts/spark-tests/build-pyspark.sh
+++ b/scripts/spark-tests/build-pyspark.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo 'pipefail'
 

--- a/scripts/spark-tests/generate-test-report.sh
+++ b/scripts/spark-tests/generate-test-report.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo 'pipefail'
 

--- a/scripts/spark-tests/run-server.sh
+++ b/scripts/spark-tests/run-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo 'pipefail'
 

--- a/scripts/spark-tests/run-tests.sh
+++ b/scripts/spark-tests/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo 'pipefail'
 

--- a/scripts/spark-tests/stop-server.sh
+++ b/scripts/spark-tests/stop-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo 'pipefail'
 

--- a/scripts/spark-tests/wait-for-server.sh
+++ b/scripts/spark-tests/wait-for-server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 for _ in {1..24}; do
   if grpc_health_probe -addr localhost:50051 -connect-timeout 1000ms -rpc-timeout 1000ms; then


### PR DESCRIPTION
Replaces `#!/bin/bash` with `#!/usr/bin/env bash` in all shell scripts, matching `scripts/hadoop/hdfs-init.sh` which already uses this form.

`#!/bin/bash` hardcodes the interpreter path, which is not portable:

- On NixOS, `/bin/bash` does not exist at all.
- On BSDs, Bash is typically installed at `/usr/local/bin/bash`.
- On macOS, `/bin/bash` is the system Bash 3.2 (from 2007, frozen due to GPLv3); the modern Bash from Homebrew lives elsewhere. These scripts use `set -euo pipefail` and other features that benefit from a modern Bash.

`#!/usr/bin/env bash` resolves `bash` from `PATH`, so the script runs with whichever Bash the user/CI actually has installed, while `/usr/bin/env` itself is a stable path on every relevant system.

Additionally, `crates/sail-catalog-iceberg/spec/generate-client.sh` had its shebang on line 13 (after the license header), where it has no effect — a shebang is only honored on line 1. It is now moved to the top of the file.

No behavior change is expected on systems where `/bin/bash` was already the Bash found in `PATH`.