### PR TITLE
fix: skip Spark Connect tests for DF ops unavailable in Spark 3.5

### DIFF
--- a/scripts/spark-tests/plugins/spark.py
+++ b/scripts/spark-tests/plugins/spark.py
@@ -389,6 +389,21 @@ SKIPPED_SPARK_TESTS = [
         reason="Not available in Spark Connect until Spark 4",
         spark_major_version_less_than=4,
     ),
+    TestMarker(
+        keywords=["pyspark.sql.dataframe.DataFrame._joinAsOf"],
+        reason="Not available in Spark Connect until Spark 4",
+        spark_major_version_less_than=4,
+    ),
+    TestMarker(
+        keywords=["pyspark.sql.dataframe.DataFrame.checkpoint"],
+        reason="Not available in Spark Connect until Spark 4",
+        spark_major_version_less_than=4,
+    ),
+    TestMarker(
+        keywords=["pyspark.sql.dataframe.DataFrame.localCheckpoint"],
+        reason="Not available in Spark Connect until Spark 4",
+        spark_major_version_less_than=4,
+    ),
 ]
 
 


### PR DESCRIPTION
- Skip Spark Connect tests for `DataFrame._joinAsOf`, `DataFrame.checkpoint`, and `DataFrame.localCheckpoint`
- Scope the skips to Spark versions earlier than 4, where these APIs are not available in Spark Connect