### PR TITLE
fix: don't fail a pending task while workers are still launching

### DIFF
--- a/crates/sail-execution/src/driver/actor/handler.rs
+++ b/crates/sail-execution/src/driver/actor/handler.rs
@@ -256,15 +256,30 @@ impl DriverActor {
             .get_task_state(&key)
             .is_some_and(|x| matches!(x, TaskState::Created))
         {
-            let message = "task scheduling timeout".to_string();
-            let cause = CommonErrorCause::Execution(message.clone());
-            ctx.send(DriverEvent::UpdateTask {
-                key,
-                status: TaskStatus::Failed,
-                message: Some(message),
-                cause: Some(cause),
-                sequence: None,
-            })
+            // The task has not been assigned to a worker within the launch
+            // timeout. If workers are still launching, the task can be assigned
+            // once one registers (`handle_register_worker` runs pending tasks),
+            // so reschedule the probe instead of failing. This keeps long,
+            // many-stage jobs alive while the worker pool scales between stages.
+            // It cannot loop forever: a pending worker that never registers is
+            // failed at `worker_launch_timeout`, after which there are no pending
+            // workers and the task fails below.
+            if self.worker_pool.has_pending_workers() {
+                ctx.send_with_delay(
+                    DriverEvent::ProbePendingTask { key },
+                    self.options.task_launch_timeout,
+                );
+            } else {
+                let message = "task scheduling timeout".to_string();
+                let cause = CommonErrorCause::Execution(message.clone());
+                ctx.send(DriverEvent::UpdateTask {
+                    key,
+                    status: TaskStatus::Failed,
+                    message: Some(message),
+                    cause: Some(cause),
+                    sequence: None,
+                })
+            }
         }
         ActorAction::Continue
     }

--- a/crates/sail-execution/src/driver/actor/handler.rs
+++ b/crates/sail-execution/src/driver/actor/handler.rs
@@ -264,11 +264,18 @@ impl DriverActor {
             // It cannot loop forever: a pending worker that never registers is
             // failed at `worker_launch_timeout`, after which there are no pending
             // workers and the task fails below.
+            //
+            // Re-probe at `worker_launch_timeout` (capped by `task_launch_timeout`)
+            // rather than a full `task_launch_timeout`: that is the window a
+            // pending worker takes to register or be failed, so once the last
+            // pending worker resolves the task fails promptly instead of waiting
+            // another full launch window.
             if self.worker_pool.has_pending_workers() {
-                ctx.send_with_delay(
-                    DriverEvent::ProbePendingTask { key },
-                    self.options.task_launch_timeout,
-                );
+                let delay = self
+                    .options
+                    .worker_launch_timeout
+                    .min(self.options.task_launch_timeout);
+                ctx.send_with_delay(DriverEvent::ProbePendingTask { key }, delay);
             } else {
                 let message = "task scheduling timeout".to_string();
                 let cause = CommonErrorCause::Execution(message.clone());

--- a/crates/sail-execution/src/driver/worker_pool/core.rs
+++ b/crates/sail-execution/src/driver/worker_pool/core.rs
@@ -173,6 +173,20 @@ impl WorkerPool {
         }
     }
 
+    /// Returns true if any worker is still launching (pending registration).
+    ///
+    /// A task stuck in `Created` should wait for such a worker rather than
+    /// failing with a scheduling timeout: once the worker registers,
+    /// `handle_register_worker` runs the pending tasks and can assign it. A
+    /// worker that never registers is bounded by `worker_launch_timeout`
+    /// (`fail_worker_if_pending`), after which it leaves the `Pending` state, so
+    /// this cannot keep a task alive forever.
+    pub fn has_pending_workers(&self) -> bool {
+        self.workers
+            .values()
+            .any(|worker| matches!(worker.state, WorkerState::Pending))
+    }
+
     fn list_running_workers(&self) -> Vec<WorkerLocation> {
         self.workers
             .iter()


### PR DESCRIPTION
## Problem

A task in `Created` state is failed with `task scheduling timeout` once `cluster.task_launch_timeout_secs` (default 120s) elapses, even when workers are still launching. `handle_probe_pending_task` fails it unconditionally:

```rust
if self.job_scheduler.get_task_state(&key).is_some_and(|x| matches!(x, TaskState::Created)) {
    // fail with "task scheduling timeout"
}
```

For a long, multi-stage job that scales the worker pool between stages, this fails the query mid-run: a stage's tasks get created before the freshly-launched workers register, hit the 120s default, and fail, even though a worker registers moments later and `handle_register_worker` already calls `run_tasks` (which would assign the waiting task).

I hit this consistently running a multi-stage entity-resolution pipeline (block -> score -> dedup -> iterative weakly-connected-components) at 10M and 100M rows on GKE in `kubernetes-cluster` mode. The WCC stage has many substages, each re-provisioning workers; tasks created during a scale-up time out. Raising `task_launch_timeout_secs` is a usable workaround, but the default is brittle for any iterative, many-stage workload.

## Fix

In `handle_probe_pending_task`, if any worker is still `Pending` (launching), reschedule the probe instead of failing. Once a worker registers, the existing `run_tasks` path assigns the waiting task.

This is bounded: a pending worker that never registers is failed at `worker_launch_timeout` (`fail_worker_if_pending`), after which there are no pending workers and the task fails as before. So it cannot keep a task alive indefinitely.

I scoped it deliberately to the launching-worker case (`has_pending_workers`). It could also cover "the pool can still scale up", but I kept it to `Pending` workers for a clearly-bounded change. Happy to widen it if you'd prefer.

## Notes

- I could not run a full local build (heavy dependency tree on my machine), so I leaned on review and CI. Glad to add a driver-actor test if you can point me at the right pattern/harness for this path.
- Related to the lineage-truncation discussion in #482 (same workload); this one is purely the scheduler timing.

Happy to adjust the approach.
