### PR TITLE
fix: handle regexp_extract optional capture groups

### DIFF
--- a/crates/sail-execution/src/codec.rs
+++ b/crates/sail-execution/src/codec.rs
@@ -207,7 +207,9 @@ use sail_function::scalar::string::spark_concat_ws::SparkConcatWs;
 use sail_function::scalar::string::spark_encode_decode::{SparkDecode, SparkEncode};
 use sail_function::scalar::string::spark_mask::SparkMask;
 use sail_function::scalar::string::spark_quote::SparkQuote;
-use sail_function::scalar::string::spark_regexp_extract_all::SparkRegexpExtractAll;
+use sail_function::scalar::string::spark_regexp_extract_all::{
+    SparkRegexpExtract, SparkRegexpExtractAll,
+};
 use sail_function::scalar::string::spark_sentences::SparkSentences;
 use sail_function::scalar::string::spark_split::SparkSplit;
 use sail_function::scalar::string::spark_to_binary::{SparkToBinary, SparkTryToBinary};
@@ -2316,6 +2318,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 Ok(Arc::new(ScalarUDF::from(SparkConcat::new())))
             }
             "spark_split" | "split" => Ok(Arc::new(ScalarUDF::from(SparkSplit::new()))),
+            "regexp_extract" => Ok(Arc::new(ScalarUDF::from(SparkRegexpExtract::new()))),
             "regexp_extract_all" => Ok(Arc::new(ScalarUDF::from(SparkRegexpExtractAll::new()))),
             "sentences" => Ok(Arc::new(ScalarUDF::from(SparkSentences::new()))),
             "spark_hex" | "hex" => Ok(Arc::new(ScalarUDF::from(SparkHex::new()))),
@@ -2523,6 +2526,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node_inner.is::<SparkMask>()
             || node_inner.is::<SparkConcatWs>()
             || node_inner.is::<SparkMurmur3Hash>()
+            || node_inner.is::<SparkRegexpExtract>()
             || node_inner.is::<SparkRegexpExtractAll>()
             || node_inner.is::<SparkReverse>()
             || node_inner.is::<SparkSequence>()

--- a/crates/sail-function/src/scalar/string/spark_regexp_extract_all.rs
+++ b/crates/sail-function/src/scalar/string/spark_regexp_extract_all.rs
@@ -18,6 +18,56 @@ use crate::functions_nested_utils::opt_downcast_arg;
 use crate::functions_utils::make_scalar_function;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
+pub struct SparkRegexpExtract {
+    signature: Signature,
+}
+
+impl Default for SparkRegexpExtract {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SparkRegexpExtract {
+    pub const NAME: &'static str = "regexp_extract";
+
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::user_defined(Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for SparkRegexpExtract {
+    fn name(&self) -> &str {
+        Self::NAME
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        coerce_regexp_extract_types(Self::NAME, arg_types)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let ScalarFunctionArgs { mut args, .. } = args;
+        if args.len() == 2 {
+            args.push(ColumnarValue::Scalar(ScalarValue::Int64(Some(1))));
+        }
+        make_scalar_function(
+            regexp_extract_inner,
+            vec![Hint::Pad, Hint::AcceptsSingular, Hint::AcceptsSingular],
+        )(&args)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct SparkRegexpExtractAll {
     signature: Signature,
 }
@@ -55,32 +105,7 @@ impl ScalarUDFImpl for SparkRegexpExtractAll {
     }
 
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
-        let err = || {
-            Err(unsupported_data_types_exec_err(
-                Self::NAME,
-                "Expected (STRING, STRING) or (STRING, STRING, INT)",
-                arg_types,
-            ))
-        };
-
-        let mut res_types = vec![];
-        for i in 0..=1 {
-            res_types.push(match arg_types.get(i) {
-                Some(DataType::Utf8 | DataType::Utf8View | DataType::LargeUtf8) => {
-                    Ok(arg_types[i].clone())
-                }
-                Some(DataType::Null) => Ok(DataType::Utf8),
-                _ => err(),
-            });
-        }
-        if arg_types.len() == 3 {
-            res_types.push(if arg_types[2].is_null() || arg_types[2].is_integer() {
-                Ok(DataType::Int64)
-            } else {
-                err()
-            });
-        }
-        res_types.into_iter().collect::<Result<Vec<_>>>()
+        coerce_regexp_extract_types(Self::NAME, arg_types)
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
@@ -95,6 +120,69 @@ impl ScalarUDFImpl for SparkRegexpExtractAll {
     }
 }
 
+fn regexp_extract_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    match args[0].data_type() {
+        DataType::LargeUtf8 => regexp_extract_downcast::<i64>(args),
+        _ => regexp_extract_downcast::<i32>(args),
+    }
+}
+
+fn regexp_extract_downcast<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let [values_arr, pattern_arr, idx_arr] = take_function_args(SparkRegexpExtract::NAME, args)?;
+    let values = values_arr.as_any().downcast_ref::<GenericStringArray<O>>();
+    let pattern = string_array_like(pattern_arr);
+    let idx = opt_downcast_arg!(idx_arr, Int64Array);
+
+    match (values, pattern.as_deref(), idx.as_ref()) {
+        (Some(values), Some(pattern), Some(idx)) => {
+            let pattern_len = pattern.len_();
+            let idx_len = idx.len();
+
+            let pattern_scalar_opt = (pattern_len == 1 && pattern.is_valid_(0))
+                .then(|| parse_regex(SparkRegexpExtract::NAME, pattern.value_(0)))
+                .transpose()?;
+            let idx_scalar_opt = (idx_len == 1 && idx.is_valid(0)).then(|| idx.value(0));
+            let is_pattern_null = pattern_len == 1 && pattern.is_null_(0);
+            let is_idx_null = idx_len == 1 && idx.is_null(0);
+
+            let mut builder = StringBuilder::new();
+            for i in 0..args[0].len() {
+                let pattern_is_null = if pattern_len == 1 {
+                    is_pattern_null
+                } else {
+                    pattern.is_null_(i)
+                };
+                let idx_is_null = if idx_len == 1 {
+                    is_idx_null
+                } else {
+                    idx.is_null(i)
+                };
+
+                if pattern_is_null || idx_is_null || values.is_null(i) {
+                    builder.append_null();
+                } else {
+                    let re = pattern_scalar_opt.as_ref().map_or_else(
+                        || parse_regex(SparkRegexpExtract::NAME, pattern.value_(i)),
+                        |re| Ok(re.clone()),
+                    )?;
+                    let group_idx = idx_scalar_opt.unwrap_or_else(|| idx.value(i));
+                    builder.append_value(extract_first_match(
+                        SparkRegexpExtract::NAME,
+                        values.value(i),
+                        &re,
+                        group_idx,
+                    )?);
+                }
+            }
+            Ok(Arc::new(builder.finish()))
+        }
+        _ => Err(generic_internal_err(
+            SparkRegexpExtract::NAME,
+            "Could not downcast arguments to arrow arrays",
+        )),
+    }
+}
+
 fn regexp_extract_all_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     match args[0].data_type() {
         DataType::LargeUtf8 => regexp_extract_all_downcast::<i64>(args),
@@ -105,36 +193,16 @@ fn regexp_extract_all_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
 fn regexp_extract_all_downcast<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<ArrayRef> {
     let [values_arr, pattern_arr, idx_arr] = take_function_args(SparkRegexpExtractAll::NAME, args)?;
     let values = values_arr.as_any().downcast_ref::<GenericStringArray<O>>();
-    let pattern = pattern_arr.as_any().downcast_ref::<GenericStringArray<O>>();
+    let pattern = string_array_like(pattern_arr);
     let idx = opt_downcast_arg!(idx_arr, Int64Array);
 
-    // Try the other offset size as fallback for mixed Utf8/LargeUtf8 inputs
-    let pattern_i32_storage;
-    let pattern_i64_storage;
-    let pattern_ref: Option<&dyn StringArrayLike> = match pattern {
-        Some(p) => Some(p),
-        None => {
-            pattern_i32_storage = pattern_arr
-                .as_any()
-                .downcast_ref::<GenericStringArray<i32>>();
-            if let Some(p) = pattern_i32_storage {
-                Some(p as &dyn StringArrayLike)
-            } else {
-                pattern_i64_storage = pattern_arr
-                    .as_any()
-                    .downcast_ref::<GenericStringArray<i64>>();
-                pattern_i64_storage.map(|p| p as &dyn StringArrayLike)
-            }
-        }
-    };
-
-    match (values, pattern_ref, idx.as_ref()) {
+    match (values, pattern.as_deref(), idx.as_ref()) {
         (Some(values), Some(pattern), Some(idx)) => {
             let pattern_len = pattern.len_();
             let idx_len = idx.len();
 
             let pattern_scalar_opt = (pattern_len == 1 && pattern.is_valid_(0))
-                .then(|| parse_regex(pattern.value_(0)))
+                .then(|| parse_regex(SparkRegexpExtractAll::NAME, pattern.value_(0)))
                 .transpose()?;
             let idx_scalar_opt = (idx_len == 1 && idx.is_valid(0)).then(|| idx.value(0));
             let is_pattern_null = pattern_len == 1 && pattern.is_null_(0);
@@ -156,11 +224,17 @@ fn regexp_extract_all_downcast<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<
                 if pattern_is_null || idx_is_null || values.is_null(i) {
                     builder.append_null();
                 } else {
-                    let re = pattern_scalar_opt
-                        .as_ref()
-                        .map_or_else(|| parse_regex(pattern.value_(i)), |re| Ok(re.clone()))?;
+                    let re = pattern_scalar_opt.as_ref().map_or_else(
+                        || parse_regex(SparkRegexpExtractAll::NAME, pattern.value_(i)),
+                        |re| Ok(re.clone()),
+                    )?;
                     let group_idx = idx_scalar_opt.unwrap_or_else(|| idx.value(i));
-                    let matches = extract_all_matches(values.value(i), &re, group_idx)?;
+                    let matches = extract_all_matches(
+                        SparkRegexpExtractAll::NAME,
+                        values.value(i),
+                        &re,
+                        group_idx,
+                    )?;
                     builder.append_value(matches);
                 }
             }
@@ -172,6 +246,46 @@ fn regexp_extract_all_downcast<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<
             "Could not downcast arguments to arrow arrays",
         )),
     }
+}
+
+fn coerce_regexp_extract_types(
+    function_name: &str,
+    arg_types: &[DataType],
+) -> Result<Vec<DataType>> {
+    if !(2..=3).contains(&arg_types.len()) {
+        return Err(unsupported_data_types_exec_err(
+            function_name,
+            "Expected (STRING, STRING) or (STRING, STRING, INT)",
+            arg_types,
+        ));
+    }
+
+    let mut res_types = vec![];
+    for i in 0..=1 {
+        res_types.push(match arg_types.get(i) {
+            Some(DataType::Utf8 | DataType::Utf8View | DataType::LargeUtf8) => {
+                Ok(arg_types[i].clone())
+            }
+            Some(DataType::Null) => Ok(DataType::Utf8),
+            _ => Err(unsupported_data_types_exec_err(
+                function_name,
+                "Expected (STRING, STRING) or (STRING, STRING, INT)",
+                arg_types,
+            )),
+        });
+    }
+    if arg_types.len() == 3 {
+        res_types.push(if arg_types[2].is_null() || arg_types[2].is_integer() {
+            Ok(DataType::Int64)
+        } else {
+            Err(unsupported_data_types_exec_err(
+                function_name,
+                "Expected (STRING, STRING) or (STRING, STRING, INT)",
+                arg_types,
+            ))
+        });
+    }
+    res_types.into_iter().collect::<Result<Vec<_>>>()
 }
 
 trait StringArrayLike {
@@ -196,23 +310,89 @@ impl<O: OffsetSizeTrait> StringArrayLike for GenericStringArray<O> {
     }
 }
 
-fn parse_regex(pattern: &str) -> Result<Regex> {
-    Regex::new(pattern)
-        .map_err(|_| generic_exec_err(SparkRegexpExtractAll::NAME, "Invalid regex pattern"))
+fn string_array_like(array: &ArrayRef) -> Option<Box<dyn StringArrayLike + '_>> {
+    if let Some(array) = array.as_any().downcast_ref::<GenericStringArray<i32>>() {
+        Some(Box::new(array))
+    } else {
+        array
+            .as_any()
+            .downcast_ref::<GenericStringArray<i64>>()
+            .map(|array| Box::new(array) as Box<dyn StringArrayLike>)
+    }
 }
 
-fn extract_all_matches(value: &str, re: &Regex, group_idx: i64) -> Result<Vec<Option<String>>> {
+impl<T: StringArrayLike + ?Sized> StringArrayLike for &T {
+    fn len_(&self) -> usize {
+        (**self).len_()
+    }
+    fn is_valid_(&self, i: usize) -> bool {
+        (**self).is_valid_(i)
+    }
+    fn is_null_(&self, i: usize) -> bool {
+        (**self).is_null_(i)
+    }
+    fn value_(&self, i: usize) -> &str {
+        (**self).value_(i)
+    }
+}
+
+fn parse_regex(function_name: &str, pattern: &str) -> Result<Regex> {
+    Regex::new(pattern).map_err(|_| generic_exec_err(function_name, "Invalid regex pattern"))
+}
+
+fn validate_group_idx(function_name: &str, group_idx: i64) -> Result<usize> {
     if group_idx < 0 {
         return Err(generic_exec_err(
-            SparkRegexpExtractAll::NAME,
+            function_name,
             &format!("The group index must be non-negative, but got {group_idx}"),
         ));
     }
-    let group_idx = group_idx as usize;
+    Ok(group_idx as usize)
+}
+
+fn extract_capture(
+    function_name: &str,
+    caps: &regex::Captures<'_>,
+    group_idx: i64,
+) -> Result<String> {
+    let group_idx = validate_group_idx(function_name, group_idx)?;
+    let max_group_idx = caps.len().saturating_sub(1);
+    if group_idx > max_group_idx {
+        return Err(generic_exec_err(
+            function_name,
+            &format!("Expects group index between 0 and {max_group_idx}, but got {group_idx}"),
+        ));
+    }
+    Ok(caps
+        .get(group_idx)
+        .map(|m| m.as_str())
+        .unwrap_or("")
+        .to_string())
+}
+
+fn extract_first_match(
+    function_name: &str,
+    value: &str,
+    re: &Regex,
+    group_idx: i64,
+) -> Result<String> {
+    validate_group_idx(function_name, group_idx)?;
+    match re.captures(value) {
+        Some(caps) => extract_capture(function_name, &caps, group_idx),
+        None => Ok(String::new()),
+    }
+}
+
+fn extract_all_matches(
+    function_name: &str,
+    value: &str,
+    re: &Regex,
+    group_idx: i64,
+) -> Result<Vec<Option<String>>> {
+    validate_group_idx(function_name, group_idx)?;
     let mut results = Vec::new();
     for caps in re.captures_iter(value) {
-        let matched = caps.get(group_idx).map(|m| m.as_str().to_string());
-        results.push(matched);
+        results.push(Some(extract_capture(function_name, &caps, group_idx)?));
     }
     Ok(results)
 }

--- a/crates/sail-plan/src/function/scalar/string.rs
+++ b/crates/sail-plan/src/function/scalar/string.rs
@@ -21,7 +21,9 @@ use sail_function::scalar::string::spark_concat_ws::SparkConcatWs;
 use sail_function::scalar::string::spark_encode_decode::{SparkDecode, SparkEncode};
 use sail_function::scalar::string::spark_mask::SparkMask;
 use sail_function::scalar::string::spark_quote::SparkQuote;
-use sail_function::scalar::string::spark_regexp_extract_all::SparkRegexpExtractAll;
+use sail_function::scalar::string::spark_regexp_extract_all::{
+    SparkRegexpExtract, SparkRegexpExtractAll,
+};
 use sail_function::scalar::string::spark_sentences::SparkSentences;
 use sail_function::scalar::string::spark_split::SparkSplit;
 use sail_function::scalar::string::spark_to_binary::{SparkToBinary, SparkTryToBinary};
@@ -34,29 +36,6 @@ use crate::function::scalar::datetime::date_format;
 
 fn regexp_replace(string: expr::Expr, pattern: expr::Expr, replacement: expr::Expr) -> expr::Expr {
     regex_fn::regexp_replace(string, pattern, replacement, Some(lit("g")))
-}
-
-fn regexp_extract(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
-    let ScalarFunctionInput { mut arguments, .. } = input;
-    // regexp_extract(str, pattern, idx) - idx defaults to 1
-    let idx = if arguments.len() == 3 {
-        arguments
-            .pop()
-            .ok_or_else(|| PlanError::invalid("regexp_extract requires 2 or 3 arguments"))?
-    } else {
-        lit(1i64)
-    };
-    let (string, pattern) = arguments
-        .two()
-        .map_err(|_| PlanError::invalid("regexp_extract requires 2 or 3 arguments"))?;
-    // Wrap pattern with an outer capture group so idx=0 (entire match) works.
-    // After wrapping, regexp_match returns [entire_match, group1, group2, ...].
-    let wrapped_pattern = expr_fn::concat_ws(lit(""), vec![lit("("), pattern, lit(")")]);
-    let matches = regex_fn::regexp_match(string, wrapped_pattern, None);
-    // array_element is 1-indexed; +1 accounts for the outer group we added.
-    let element = array_element(matches, idx + lit(1i64));
-    // Spark returns "" instead of NULL when no match.
-    Ok(expr_fn::coalesce(vec![element, lit("")]))
 }
 
 fn regexp_substr(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
@@ -354,7 +333,7 @@ pub(super) fn list_built_in_string_functions() -> Vec<(&'static str, ScalarFunct
         ("quote", F::udf(SparkQuote::new())),
         ("randstr", F::udf(Randstr::new())),
         ("regexp_count", F::udf(RegexpCountFunc::new())),
-        ("regexp_extract", F::custom(regexp_extract)),
+        ("regexp_extract", F::udf(SparkRegexpExtract::new())),
         ("regexp_extract_all", F::udf(SparkRegexpExtractAll::new())),
         ("regexp_instr", F::udf(RegexpInstrFunc::new())),
         ("regexp_replace", F::ternary(regexp_replace)),

--- a/python/pysail/tests/spark/function/features/regexp_extract.feature
+++ b/python/pysail/tests/spark/function/features/regexp_extract.feature
@@ -67,6 +67,24 @@ Feature: regexp_extract() extracts regex capture groups from strings
       | result |
       | 15     |
 
+    Scenario: regexp_extract returns empty string for unmatched optional group
+      When query
+      """
+      SELECT regexp_extract('aaaac', '(a+)(b)?(c)', 2) AS result
+      """
+      Then query result
+      | result |
+      |        |
+
+    Scenario: regexp_extract preserves later groups after unmatched optional group
+      When query
+      """
+      SELECT regexp_extract('aaaac', '(a+)(b)?(c)', 3) AS result
+      """
+      Then query result
+      | result |
+      | c      |
+
   Rule: No match and edge cases
 
     Scenario: regexp_extract returns empty string when no match

--- a/python/pysail/tests/spark/function/features/regexp_extract_all.feature
+++ b/python/pysail/tests/spark/function/features/regexp_extract_all.feature
@@ -60,6 +60,15 @@ Feature: regexp_extract_all() extracts all regex capture group matches from stri
       | result |
       | []     |
 
+    Scenario: regexp_extract_all returns empty strings for unmatched optional groups
+      When query
+      """
+      SELECT to_json(regexp_extract_all('aaaac aaabc', r'(a+)(b)?(c)', 2)) AS result
+      """
+      Then query result
+      | result   |
+      | ["","b"] |
+
   Rule: NULL handling
 
     Scenario: regexp_extract_all returns NULL when input is NULL


### PR DESCRIPTION
## Summary
- Add a Spark-compatible `regexp_extract` UDF that preserves optional capture group positions.
- Share capture extraction helpers with `regexp_extract_all` so unmatched optional groups become empty strings instead of shifting or becoming null.
- Register `regexp_extract` through planner and execution codec UDF paths.