### PR TITLE
fix: support try_make_interval

### DIFF
--- a/crates/sail-execution/src/codec.rs
+++ b/crates/sail-execution/src/codec.rs
@@ -2394,7 +2394,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             "spark_make_dt_interval" | "make_dt_interval" => {
                 Ok(Arc::new(ScalarUDF::from(SparkMakeDtInterval::new())))
             }
-            "spark_make_interval" | "make_interval" => {
+            "spark_make_interval" | "make_interval" | "try_make_interval" => {
                 Ok(Arc::new(ScalarUDF::from(SparkMakeInterval::new())))
             }
             "spark_make_ym_interval" | "make_ym_interval" => {

--- a/crates/sail-plan/src/function/scalar/datetime.rs
+++ b/crates/sail-plan/src/function/scalar/datetime.rs
@@ -1039,7 +1039,7 @@ pub(super) fn list_built_in_datetime_functions() -> Vec<(&'static str, ScalarFun
         ("to_unix_timestamp", F::custom(to_unix_timestamp)),
         ("to_utc_timestamp", F::custom(to_utc_timestamp)),
         ("trunc", F::binary(trunc)),
-        ("try_make_interval", F::unknown("try_make_interval")),
+        ("try_make_interval", F::udf(SparkMakeInterval::new())),
         (
             "try_make_timestamp",
             F::custom(|input| make_timestamp(input, true)),

--- a/crates/sail-spark-connect/tests/gold_data/function/datetime.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/datetime.json
@@ -3142,7 +3142,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: try_make_interval"
+        "success": "ok"
       }
     },
     {
@@ -3164,7 +3164,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: try_make_interval"
+        "success": "ok"
       }
     },
     {
@@ -3186,7 +3186,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: try_make_interval"
+        "success": "ok"
       }
     },
     {
@@ -3208,7 +3208,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: try_make_interval"
+        "success": "ok"
       }
     },
     {


### PR DESCRIPTION
## Summary

- Route `try_make_interval` through the existing `SparkMakeInterval` UDF since this already contains the relevant 'try' logic
- Accept `try_make_interval` in the execution codec as the same interval UDF.
- Update datetime function gold data so the existing `try_make_interval` cases succeed.