### PR TITLE
Skip Spark collation doctest

### DIFF
--- a/scripts/spark-tests/plugins/spark.py
+++ b/scripts/spark-tests/plugins/spark.py
@@ -340,6 +340,13 @@ SKIPPED_SPARK_TESTS = [
         keywords=["pyspark.sql.functions.java_method"],
         reason="JVM-dependent test",
     ),
+    TestMarker(
+        keywords=["pyspark.sql.functions.builtin.collation"],
+        reason=(
+            "Spark string types carry collation metadata, but DataFusion/Arrow string types used by Sail do not "
+            "model Spark-style collations"
+        ),
+    ),
     # We skip all the streaming tests since some of them are slow,
     # and some of them test behaviors that are tied to the specific JVM implementation
     # of Spark Structured Streaming.


### PR DESCRIPTION
## What this change does

Skips the PySpark `pyspark.sql.functions.builtin.collation` doctest in the Spark parity runner.

| Before | After |
| --- | --- |
| Spark 4.1.1 parity runs collected the `collation` doctest and Sail failed it with `UnsupportedOperationException('function: collation')`. | The same doctest is collected and skipped with a reason that names the missing collation model. |

The targeted local run selected only this doctest and reported it as skipped:

```text
1 skipped, 494 deselected
SKIPPED [1] .../pyspark/sql/functions/builtin.py: Spark string types carry collation metadata, but DataFusion/Arrow string types used by Sail do not model Spark-style collations
```

## Implementation rationale

This doctest is exercising a Spark type-system feature, not just a missing scalar function. In Spark, string expressions have a `StringType` that carries a collation id. `collation(expr)` reads that metadata from the expression type and returns the fully qualified collation name, such as `SYSTEM.BUILTIN.UTF8_BINARY`.

Sail's execution path is backed by DataFusion/Arrow string types. Those types distinguish string storage/layout variants like `Utf8`, `LargeUtf8`, and `Utf8View`, but they do not currently model Spark-style string comparison collations. Implementing `collation(col)` as a hardcoded `SYSTEM.BUILTIN.UTF8_BINARY` result would make this one doctest pass while implying that Sail understands non-default Spark collations too.

Principles used here:

- **Do not fake semantic support.** A skip is more accurate than a partial implementation that only reports the default collation and silently papers over non-default cases.
- **Keep the parity signal narrow.** The marker targets only `pyspark.sql.functions.builtin.collation`, so the rest of the PySpark function doctests still run normally.

## Code summary

- Adds a `TestMarker` entry for `pyspark.sql.functions.builtin.collation` in the Spark pytest plugin.
- Uses a skip reason that explains the Spark collation metadata gap against the current DataFusion/Arrow-backed type model.
