### PR TITLE
fix: type casting issue for `map_entries`

### DIFF
--- a/crates/sail-execution/src/codec.rs
+++ b/crates/sail-execution/src/codec.rs
@@ -166,6 +166,7 @@ use sail_function::scalar::geo::st_geomfromwkb::StGeomFromWKB;
 use sail_function::scalar::hash::spark_murmur3_hash::SparkMurmur3Hash;
 use sail_function::scalar::hash::spark_xxhash64::SparkXxhash64;
 use sail_function::scalar::json::{SparkFromJson, SparkSchemaOfJson, SparkToJson};
+use sail_function::scalar::map::map_entries::SparkMapEntries;
 use sail_function::scalar::map::str_to_map::StrToMap;
 use sail_function::scalar::math::rand_poisson::RandPoisson;
 use sail_function::scalar::math::randn::Randn;
@@ -2313,6 +2314,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             "least" => Ok(Arc::new(ScalarUDF::from(LeastFunc::new()))),
             "levenshtein" => Ok(Arc::new(ScalarUDF::from(Levenshtein::new()))),
             "make_valid_utf8" => Ok(Arc::new(ScalarUDF::from(MakeValidUtf8::new()))),
+            "map_entries" => Ok(Arc::new(ScalarUDF::from(SparkMapEntries::new()))),
             "map_from_arrays" => Ok(Arc::new(ScalarUDF::from(MapFromArrays::new()))),
             "map_from_entries" => Ok(Arc::new(ScalarUDF::from(MapFromEntries::new()))),
             "multi_expr" => Ok(Arc::new(ScalarUDF::from(MultiExpr::new()))),
@@ -2497,6 +2499,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node_inner.is::<StGeomFromWKB>()
             || node_inner.is::<StGeogFromWKB>()
             || node_inner.is::<MakeValidUtf8>()
+            || node_inner.is::<SparkMapEntries>()
             || node_inner.is::<MapFromArrays>()
             || node_inner.is::<MapFromEntries>()
             || node_inner.is::<MultiExpr>()

--- a/crates/sail-function/src/scalar/map/map_entries.rs
+++ b/crates/sail-function/src/scalar/map/map_entries.rs
@@ -1,0 +1,97 @@
+use std::sync::Arc;
+
+use arrow::array::{Array, ArrayRef, ListArray};
+use arrow::datatypes::{DataType, Field, FieldRef};
+use datafusion_common::cast::as_map_array;
+use datafusion_common::utils::take_function_args;
+use datafusion_common::{exec_err, internal_err, Result};
+use datafusion_expr::{
+    ArrayFunctionSignature, ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl,
+    Signature, TypeSignature, Volatility,
+};
+use datafusion_functions::utils::make_scalar_function;
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct SparkMapEntries {
+    signature: Signature,
+}
+
+impl Default for SparkMapEntries {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SparkMapEntries {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::new(
+                TypeSignature::ArraySignature(ArrayFunctionSignature::MapArray),
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for SparkMapEntries {
+    fn name(&self) -> &str {
+        "map_entries"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        internal_err!("return_field_from_args should be used instead")
+    }
+
+    fn return_field_from_args(&self, args: ReturnFieldArgs) -> Result<FieldRef> {
+        let [map_field] = args.arg_fields else {
+            return exec_err!("map_entries: expected one argument");
+        };
+
+        let DataType::Map(entries_field, _) = map_field.data_type() else {
+            return exec_err!(
+                "map_entries: expected map argument, got {:?}",
+                map_field.data_type()
+            );
+        };
+
+        Ok(Arc::new(Field::new(
+            self.name(),
+            DataType::List(Arc::new(Field::new_list_field(
+                entries_field.data_type().clone(),
+                entries_field.is_nullable(),
+            ))),
+            map_field.is_nullable(),
+        )))
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(map_entries_inner, vec![])(&args.args)
+    }
+}
+
+fn map_entries_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let [map_arg] = take_function_args("map_entries", args)?;
+
+    let map_array = match map_arg.data_type() {
+        DataType::Map(_, _) => as_map_array(&map_arg)?,
+        _ => return exec_err!("map_entries: expected map argument"),
+    };
+
+    let DataType::Map(entries_field, _) = map_arg.data_type() else {
+        unreachable!("map_arg data type was checked above")
+    };
+
+    Ok(Arc::new(ListArray::new(
+        Arc::new(Field::new_list_field(
+            entries_field.data_type().clone(),
+            entries_field.is_nullable(),
+        )),
+        map_array.offsets().clone(),
+        Arc::new(map_array.entries().clone()),
+        map_array.nulls().cloned(),
+    )))
+}

--- a/crates/sail-function/src/scalar/map/mod.rs
+++ b/crates/sail-function/src/scalar/map/mod.rs
@@ -1,2 +1,3 @@
+pub mod map_entries;
 pub mod str_to_map;
 pub mod utils;

--- a/crates/sail-plan/src/function/scalar/map.rs
+++ b/crates/sail-plan/src/function/scalar/map.rs
@@ -3,10 +3,11 @@ use std::sync::Arc;
 use datafusion::arrow::datatypes::{DataType, FieldRef, Fields};
 use datafusion::functions_nested::expr_fn;
 use datafusion_common::ScalarValue;
-use datafusion_expr::{cast, expr, lit, ExprSchemable};
+use datafusion_expr::{cast, expr, lit, ExprSchemable, ScalarUDF};
 use datafusion_spark::function::map::map_from_arrays::MapFromArrays;
 use datafusion_spark::function::map::map_from_entries::MapFromEntries;
 use sail_common_datafusion::utils::items::ItemTaker;
+use sail_function::scalar::map::map_entries::SparkMapEntries;
 use sail_function::scalar::map::str_to_map::StrToMap;
 
 use crate::error::{PlanError, PlanResult};
@@ -74,12 +75,8 @@ fn map_from_entries(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
 }
 
 fn map_entries(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
-    let schema = input.function_context.schema;
     let map = input.arguments.one()?;
-    let value_contains_null = map_value_contains_null(&map.get_type(schema.as_ref())?);
-    let map = cast_map_value_nullability(map, schema, true)?;
-    let expr = expr_fn::map_entries(map);
-    cast_map_entries_value_nullability(expr, schema, value_contains_null)
+    Ok(ScalarUDF::from(SparkMapEntries::new()).call(vec![map]))
 }
 
 fn map_values(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {

--- a/crates/sail-spark-connect/tests/gold_data/function/map.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/map.json
@@ -137,7 +137,7 @@
         }
       },
       "output": {
-        "failure": "error in DataFusion: Optimizer rule 'simplify_expressions' failed\ncaused by\nThis feature is not implemented: Unsupported CAST from List(non-null Struct(\"key\": non-null Int32, \"value\": Utf8)) to List(non-null Struct(\"key\": non-null Int32, \"value\": non-null Utf8))"
+        "success": "ok"
       }
     },
     {

--- a/python/pysail/tests/spark/function/features/map_entries.feature
+++ b/python/pysail/tests/spark/function/features/map_entries.feature
@@ -1,0 +1,14 @@
+Feature: map_entries function
+
+  Rule: Basic usage
+
+    Scenario: map_entries returns entries for a non-nullable map value
+      When query
+        """
+        SELECT
+          map_entries(map(1, 'a', 2, 'b')) AS result,
+          typeof(map_entries(map(1, 'a', 2, 'b'))) AS type
+        """
+      Then query result
+        | result           | type                                |
+        | [{1, a}, {2, b}] | array<struct<key:int,value:string>> |


### PR DESCRIPTION
Review from Codex:

> No findings.
>
> I reviewed `HEAD` (`626fd04a fix: type casting issue for map_entries`) against its parent. The custom `SparkMapEntries` UDF preserves map entry value nullability, is wired into the planner and remote execution codec, and the new BDD coverage exercises the fixed non-null value case.
