### PR TITLE
feat: implement from_xml Spark function

### DIFF
--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -178,6 +178,7 @@ message ExtendedScalarUdf {
     SparkToXmlUdf spark_to_xml = 29;
     SparkBinUdf spark_bin = 30;
     SparkNegativeUdf spark_negative = 31;
+    SparkFromXmlUdf spark_from_xml = 32;
   }
 }
 
@@ -241,6 +242,10 @@ message XpathTypedUdf {
 
 message SparkToXmlUdf {
     string session_timezone = 1;
+}
+
+message SparkFromXmlUdf {
+  string session_timezone = 1;
 }
 
 message SparkUnixTimestampUdf {

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -226,8 +226,8 @@ use sail_function::scalar::variant::spark_to_variant_object::SparkToVariantObjec
 use sail_function::scalar::variant::spark_variant_explode::SparkVariantExplodeUdf;
 use sail_function::scalar::variant::spark_variant_get::SparkVariantGet;
 use sail_function::scalar::variant::spark_variant_to_json::SparkVariantToJsonUdf;
-use sail_function::scalar::xml::to_xml::SparkToXml;
 use sail_function::scalar::xml::from_xml::SparkFromXml;
+use sail_function::scalar::xml::to_xml::SparkToXml;
 use sail_function::scalar::xml::xpath::Xpath;
 use sail_function::scalar::xml::xpath_typed::{xpath_typed_name_to_kind, XpathTyped};
 use sail_function::window::SparkNtile;

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -227,6 +227,7 @@ use sail_function::scalar::variant::spark_variant_explode::SparkVariantExplodeUd
 use sail_function::scalar::variant::spark_variant_get::SparkVariantGet;
 use sail_function::scalar::variant::spark_variant_to_json::SparkVariantToJsonUdf;
 use sail_function::scalar::xml::to_xml::SparkToXml;
+use sail_function::scalar::xml::from_xml::SparkFromXml;
 use sail_function::scalar::xml::xpath::Xpath;
 use sail_function::scalar::xml::xpath_typed::{xpath_typed_name_to_kind, XpathTyped};
 use sail_function::window::SparkNtile;
@@ -2185,6 +2186,10 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 let udf = SparkToXml::new(Arc::from(session_timezone));
                 return Ok(Arc::new(ScalarUDF::from(udf)));
             }
+            UdfKind::SparkFromXml(gen::SparkFromXmlUdf { session_timezone }) => {
+                let udf = SparkFromXml::new(Arc::from(session_timezone));
+                return Ok(Arc::new(ScalarUDF::from(udf)));
+            }
             UdfKind::SparkUnixTimestamp(gen::SparkUnixTimestampUdf { timezone }) => {
                 let udf = SparkUnixTimestamp::new(Arc::from(timezone));
                 return Ok(Arc::new(ScalarUDF::from(udf)));
@@ -2648,6 +2653,9 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
         } else if let Some(func) = node.inner().downcast_ref::<SparkToXml>() {
             let session_timezone = func.session_timezone().to_string();
             UdfKind::SparkToXml(gen::SparkToXmlUdf { session_timezone })
+        } else if let Some(func) = node.inner().downcast_ref::<SparkFromXml>() {
+            let session_timezone = func.session_timezone().to_string();
+            UdfKind::SparkFromXml(gen::SparkFromXmlUdf { session_timezone })
         } else if let Some(func) = node.inner().downcast_ref::<SparkUnixTimestamp>() {
             let timezone = func.timezone().to_string();
             UdfKind::SparkUnixTimestamp(gen::SparkUnixTimestampUdf { timezone })

--- a/crates/sail-function/src/scalar/xml/from_xml.rs
+++ b/crates/sail-function/src/scalar/xml/from_xml.rs
@@ -1,0 +1,1178 @@
+use std::sync::Arc;
+
+use chrono::{NaiveDate, NaiveDateTime};
+use datafusion::arrow::array::timezone::Tz;
+use datafusion::arrow::array::*;
+use datafusion::arrow::buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
+use datafusion::arrow::datatypes::*;
+use datafusion_common::{exec_err, plan_err, DataFusionError, Result, ScalarValue};
+use datafusion_expr::{
+    ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+};
+use datafusion_expr_common::signature::Volatility;
+use sail_common::spec::{
+    self, SAIL_LIST_FIELD_NAME, SAIL_MAP_FIELD_NAME, SAIL_MAP_KEY_FIELD_NAME,
+    SAIL_MAP_VALUE_FIELD_NAME,
+};
+use sail_common_datafusion::utils::datetime::localize_with_fallback;
+use sail_sql_analyzer::data_type::from_ast_data_type;
+use sail_sql_analyzer::parser as sail_parser;
+use xee_xpath::Documents;
+
+use crate::functions_utils::make_scalar_function;
+use crate::scalar::datetime::utils::spark_datetime_format_to_chrono_strftime;
+
+#[cfg(test)]
+const DEFAULT_SESSION_TIMEZONE: &str = "UTC";
+
+/// UDF implementation of `from_xml`, similar to Spark's `XmlToStructs`
+/// Parses an XML string column into a struct column using a user-provided schema
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct SparkFromXml {
+    session_timezone: Arc<str>,
+    signature: Signature,
+}
+
+impl SparkFromXml {
+    pub const FROM_XML_NAME: &'static str = "from_xml";
+
+    pub fn new(session_timezone: Arc<str>) -> Self {
+        Self {
+            session_timezone,
+            signature: Signature::user_defined(Volatility::Immutable),
+        }
+    }
+
+    pub fn session_timezone(&self) -> &str {
+        &self.session_timezone
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParseMode {
+    Permissive,
+    FailFast,
+}
+
+#[derive(Debug)]
+struct SparkFromXmlOptions {
+    null_value: Option<String>,
+    attribute_prefix: String,
+    value_tag: String,
+    timestamp_ltz_format: String,
+    timestamp_ntz_format: String,
+    date_format: String,
+    mode: ParseMode,
+}
+
+impl SparkFromXmlOptions {
+    const NULL_VALUE_OPTION: &'static str = "nullValue";
+    const ATTRIBUTE_PREFIX_OPTION: &'static str = "attributePrefix";
+    const ATTRIBUTE_PREFIX_DEFAULT: &'static str = "_";
+    const VALUE_TAG_OPTION: &'static str = "valueTag";
+    const VALUE_TAG_DEFAULT: &'static str = "_VALUE";
+    const TIMESTAMP_FORMAT_OPTION: &'static str = "timestampFormat";
+    const TIMESTAMP_NTZ_FORMAT_OPTION: &'static str = "timestampNTZFormat";
+    const DATE_FORMAT_OPTION: &'static str = "dateFormat";
+    const MODE_OPTION: &'static str = "mode";
+    const TIMESTAMP_LTZ_FORMAT_DEFAULT: &'static str = "%Y-%m-%dT%H:%M:%S%.3f";
+    const TIMESTAMP_NTZ_FORMAT_DEFAULT: &'static str = "%Y-%m-%dT%H:%M:%S%.3f";
+    const DATE_FORMAT_DEFAULT: &'static str = "%Y-%m-%d";
+
+    fn from_map(map: &MapArray) -> Result<Self> {
+        let null_value = find_key_value(map, Self::NULL_VALUE_OPTION);
+        let attribute_prefix = find_key_value(map, Self::ATTRIBUTE_PREFIX_OPTION)
+            .unwrap_or_else(|| Self::ATTRIBUTE_PREFIX_DEFAULT.to_string());
+        let value_tag = find_key_value(map, Self::VALUE_TAG_OPTION)
+            .unwrap_or_else(|| Self::VALUE_TAG_DEFAULT.to_string());
+        let timestamp_ltz_format = find_key_value(map, Self::TIMESTAMP_FORMAT_OPTION)
+            .as_deref()
+            .map(spark_datetime_format_to_chrono_strftime)
+            .transpose()?
+            .unwrap_or_else(|| Self::TIMESTAMP_LTZ_FORMAT_DEFAULT.to_string());
+        let timestamp_ntz_format = find_key_value(map, Self::TIMESTAMP_NTZ_FORMAT_OPTION)
+            .as_deref()
+            .map(spark_datetime_format_to_chrono_strftime)
+            .transpose()?
+            .unwrap_or_else(|| Self::TIMESTAMP_NTZ_FORMAT_DEFAULT.to_string());
+        let date_format = find_key_value(map, Self::DATE_FORMAT_OPTION)
+            .as_deref()
+            .map(spark_datetime_format_to_chrono_strftime)
+            .transpose()?
+            .unwrap_or_else(|| Self::DATE_FORMAT_DEFAULT.to_string());
+        let mode = match find_key_value(map, Self::MODE_OPTION)
+            .as_deref()
+            .map(|s| s.to_ascii_uppercase())
+            .as_deref()
+        {
+            Some("FAILFAST") => ParseMode::FailFast,
+            _ => ParseMode::Permissive,
+        };
+        Ok(Self {
+            null_value,
+            attribute_prefix,
+            value_tag,
+            timestamp_ltz_format,
+            timestamp_ntz_format,
+            date_format,
+            mode,
+        })
+    }
+}
+
+impl Default for SparkFromXmlOptions {
+    fn default() -> Self {
+        Self {
+            null_value: None,
+            attribute_prefix: Self::ATTRIBUTE_PREFIX_DEFAULT.to_string(),
+            value_tag: Self::VALUE_TAG_DEFAULT.to_string(),
+            timestamp_ltz_format: Self::TIMESTAMP_LTZ_FORMAT_DEFAULT.to_string(),
+            timestamp_ntz_format: Self::TIMESTAMP_NTZ_FORMAT_DEFAULT.to_string(),
+            date_format: Self::DATE_FORMAT_DEFAULT.to_string(),
+            mode: ParseMode::Permissive,
+        }
+    }
+}
+
+impl ScalarUDFImpl for SparkFromXml {
+    fn name(&self) -> &str {
+        Self::FROM_XML_NAME
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Struct(Fields::empty()))
+    }
+
+    fn return_field_from_args(&self, args: ReturnFieldArgs) -> Result<FieldRef> {
+        let schema_str = match args.scalar_arguments.get(1) {
+            Some(Some(
+                ScalarValue::Utf8(Some(s))
+                | ScalarValue::LargeUtf8(Some(s))
+                | ScalarValue::Utf8View(Some(s)),
+            )) => s.as_str(),
+            _ => {
+                return plan_err!(
+                    "`{}` requires the schema argument to be a string literal",
+                    Self::FROM_XML_NAME
+                );
+            }
+        };
+        let dt = parse_xml_schema(schema_str, &self.session_timezone)?;
+        Ok(Arc::new(Field::new(self.name(), dt, true)))
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
+        match arg_types {
+            [DataType::Null
+            | DataType::Utf8
+            | DataType::Utf8View
+            | DataType::LargeUtf8, DataType::Utf8
+            | DataType::Utf8View
+            | DataType::LargeUtf8] => Ok(vec![DataType::Utf8, arg_types[1].clone()]),
+            [DataType::Null
+            | DataType::Utf8
+            | DataType::Utf8View
+            | DataType::LargeUtf8, DataType::Utf8
+            | DataType::Utf8View
+            | DataType::LargeUtf8, DataType::Map(_, _)] => Ok(vec![
+                DataType::Utf8,
+                arg_types[1].clone(),
+                arg_types[2].clone(),
+            ]),
+            _ => plan_err!(
+                "`{}` requires 2 or 3 arguments: xml STRING, schema STRING, options MAP (optional), got {:?}",
+                Self::FROM_XML_NAME,
+                arg_types
+            ),
+        }
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let session_timezone = self.session_timezone.to_string();
+        let ScalarFunctionArgs { args, .. } = args;
+        make_scalar_function(
+            move |inner_args| spark_from_xml_inner(inner_args, session_timezone.as_str()),
+            vec![],
+        )(&args)
+    }
+}
+
+fn spark_from_xml_inner(args: &[ArrayRef], session_timezone: &str) -> Result<ArrayRef> {
+    if args.len() < 2 || args.len() > 3 {
+        return exec_err!(
+            "`{}` requires 2 or 3 arguments, got {}",
+            SparkFromXml::FROM_XML_NAME,
+            args.len()
+        );
+    }
+
+    let xml_array = args[0]
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| {
+            DataFusionError::Internal("from_xml: expected StringArray for arg 0".to_string())
+        })?;
+
+    let schema_array = args[1]
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| {
+            DataFusionError::Internal("from_xml: expected StringArray for arg 1".to_string())
+        })?;
+
+    if schema_array.is_empty() || schema_array.is_null(0) {
+        return exec_err!(
+            "`{}` requires a non-empty schema string",
+            SparkFromXml::FROM_XML_NAME
+        );
+    }
+    let schema_str = schema_array.value(0);
+
+    let options = if let Some(opts) = args.get(2) {
+        let map = opts.as_any().downcast_ref::<MapArray>().ok_or_else(|| {
+            DataFusionError::Internal("from_xml: expected MapArray for arg 2".to_string())
+        })?;
+        SparkFromXmlOptions::from_map(map)?
+    } else {
+        SparkFromXmlOptions::default()
+    };
+
+    let schema_dt = parse_xml_schema(schema_str, session_timezone)?;
+    let DataType::Struct(fields) = &schema_dt else {
+        return exec_err!(
+            "`{}` schema must resolve to a STRUCT type, got {:?}",
+            SparkFromXml::FROM_XML_NAME,
+            schema_dt
+        );
+    };
+
+    let mut builder = create_struct_builder(fields, xml_array.len(), session_timezone)?;
+
+    for i in 0..xml_array.len() {
+        if xml_array.is_null(i) {
+            append_null_struct(&mut builder)?;
+            continue;
+        }
+
+        let xml_str = xml_array.value(i);
+        match parse_xml_into_builder(xml_str, &mut builder, &options, session_timezone) {
+            Ok(()) => {}
+            Err(e) => {
+                if options.mode == ParseMode::FailFast {
+                    return Err(e);
+                }
+                append_null_children_struct(&mut builder)?;
+            }
+        }
+    }
+
+    finish_struct_builder(builder)
+}
+
+fn parse_xml_schema(schema: &str, session_timezone: &str) -> Result<DataType> {
+    let schema = schema.trim();
+    let ast_result = sail_parser::parse_data_type(schema)
+        .or_else(|_| sail_parser::parse_data_type(&format!("STRUCT<{schema}>")));
+    let ast = ast_result
+        .map_err(|e| DataFusionError::Plan(format!("Failed to parse schema '{schema}': {e}")))?;
+    let spec_dt = from_ast_data_type(ast)
+        .map_err(|e| DataFusionError::Plan(format!("Failed to analyze schema '{schema}': {e}")))?;
+    spec_to_arrow_data_type(&spec_dt, session_timezone)
+}
+
+fn spec_to_arrow_data_type(dt: &spec::DataType, session_timezone: &str) -> Result<DataType> {
+    use spec::DataType as SDT;
+
+    fn to_time_unit(unit: &spec::TimeUnit) -> TimeUnit {
+        match unit {
+            spec::TimeUnit::Second => TimeUnit::Second,
+            spec::TimeUnit::Millisecond => TimeUnit::Millisecond,
+            spec::TimeUnit::Microsecond => TimeUnit::Microsecond,
+            spec::TimeUnit::Nanosecond => TimeUnit::Nanosecond,
+        }
+    }
+
+    match dt {
+        SDT::Null => Ok(DataType::Null),
+        SDT::Boolean => Ok(DataType::Boolean),
+        SDT::Int8 => Ok(DataType::Int8),
+        SDT::Int16 => Ok(DataType::Int16),
+        SDT::Int32 => Ok(DataType::Int32),
+        SDT::Int64 => Ok(DataType::Int64),
+        SDT::UInt8 => Ok(DataType::UInt8),
+        SDT::UInt16 => Ok(DataType::UInt16),
+        SDT::UInt32 => Ok(DataType::UInt32),
+        SDT::UInt64 => Ok(DataType::UInt64),
+        SDT::Float16 => Ok(DataType::Float16),
+        SDT::Float32 => Ok(DataType::Float32),
+        SDT::Float64 => Ok(DataType::Float64),
+        SDT::Binary | SDT::ConfiguredBinary => Ok(DataType::Binary),
+        SDT::FixedSizeBinary { size } => Ok(DataType::FixedSizeBinary(*size)),
+        SDT::LargeBinary => Ok(DataType::LargeBinary),
+        SDT::BinaryView => Ok(DataType::BinaryView),
+        SDT::Utf8 | SDT::ConfiguredUtf8 { .. } => Ok(DataType::Utf8),
+        SDT::LargeUtf8 => Ok(DataType::LargeUtf8),
+        SDT::Utf8View => Ok(DataType::Utf8View),
+        SDT::Date32 => Ok(DataType::Date32),
+        SDT::Date64 => Ok(DataType::Date64),
+        SDT::Timestamp {
+            time_unit,
+            timestamp_type,
+        } => Ok(DataType::Timestamp(
+            to_time_unit(time_unit),
+            match timestamp_type {
+                spec::TimestampType::Configured | spec::TimestampType::WithLocalTimeZone => {
+                    Some(Arc::from(session_timezone))
+                }
+                spec::TimestampType::WithoutTimeZone => None,
+            },
+        )),
+        SDT::Time32 { time_unit: u } => Ok(DataType::Time32(to_time_unit(u))),
+        SDT::Time64 { time_unit: u } => Ok(DataType::Time64(to_time_unit(u))),
+        SDT::Duration { time_unit: u } => Ok(DataType::Duration(to_time_unit(u))),
+        SDT::Interval { interval_unit, .. } => match interval_unit {
+            spec::IntervalUnit::YearMonth => Ok(DataType::Interval(IntervalUnit::YearMonth)),
+            spec::IntervalUnit::DayTime => Ok(DataType::Duration(TimeUnit::Microsecond)),
+            spec::IntervalUnit::MonthDayNano => Ok(DataType::Interval(IntervalUnit::MonthDayNano)),
+        },
+        SDT::Decimal128 { precision, scale } => Ok(DataType::Decimal128(*precision, *scale)),
+        SDT::Decimal256 { precision, scale } => Ok(DataType::Decimal256(*precision, *scale)),
+        SDT::List {
+            data_type,
+            nullable,
+        } => Ok(DataType::List(Arc::new(Field::new(
+            SAIL_LIST_FIELD_NAME,
+            spec_to_arrow_data_type(data_type.as_ref(), session_timezone)?,
+            *nullable,
+        )))),
+        SDT::FixedSizeList {
+            data_type,
+            nullable,
+            length,
+        } => Ok(DataType::FixedSizeList(
+            Arc::new(Field::new(
+                SAIL_LIST_FIELD_NAME,
+                spec_to_arrow_data_type(data_type.as_ref(), session_timezone)?,
+                *nullable,
+            )),
+            *length,
+        )),
+        SDT::LargeList {
+            data_type,
+            nullable,
+        } => Ok(DataType::LargeList(Arc::new(Field::new(
+            SAIL_LIST_FIELD_NAME,
+            spec_to_arrow_data_type(data_type.as_ref(), session_timezone)?,
+            *nullable,
+        )))),
+        SDT::Struct { fields } => {
+            let mut out: Vec<Arc<Field>> = Vec::with_capacity(fields.len());
+            for f in fields.iter() {
+                out.push(Arc::new(Field::new(
+                    f.name.clone(),
+                    spec_to_arrow_data_type(&f.data_type, session_timezone)?,
+                    f.nullable,
+                )));
+            }
+            Ok(DataType::Struct(Fields::from(out)))
+        }
+        SDT::Map {
+            key_type,
+            value_type,
+            value_type_nullable,
+            keys_sorted,
+        } => {
+            let fields = Fields::from(vec![
+                Arc::new(Field::new(
+                    SAIL_MAP_KEY_FIELD_NAME,
+                    spec_to_arrow_data_type(key_type.as_ref(), session_timezone)?,
+                    false,
+                )),
+                Arc::new(Field::new(
+                    SAIL_MAP_VALUE_FIELD_NAME,
+                    spec_to_arrow_data_type(value_type.as_ref(), session_timezone)?,
+                    *value_type_nullable,
+                )),
+            ]);
+            Ok(DataType::Map(
+                Arc::new(Field::new(
+                    SAIL_MAP_FIELD_NAME,
+                    DataType::Struct(fields),
+                    false,
+                )),
+                *keys_sorted,
+            ))
+        }
+        SDT::Geometry { .. } | SDT::Geography { .. } => Ok(DataType::Binary),
+        SDT::Variant => Ok(DataType::Struct(Fields::from(vec![
+            Arc::new(Field::new("metadata", DataType::Binary, false)),
+            Arc::new(Field::new("value", DataType::Binary, false)),
+        ]))),
+        SDT::UserDefined { sql_type, .. } => {
+            spec_to_arrow_data_type(sql_type.as_ref(), session_timezone)
+        }
+        other => Err(DataFusionError::Plan(format!(
+            "Unsupported data type in from_xml schema: {other:?}"
+        ))),
+    }
+}
+
+enum XmlFieldBuilder {
+    Boolean(BooleanBuilder),
+    Int8(Int8Builder),
+    Int16(Int16Builder),
+    Int32(Int32Builder),
+    Int64(Int64Builder),
+    Float32(Float32Builder),
+    Float64(Float64Builder),
+    String(StringBuilder),
+    Date32(Date32Builder),
+    TimestampMicrosecond {
+        builder: TimestampMicrosecondBuilder,
+        has_tz: bool,
+    },
+    TimestampNanosecond {
+        builder: TimestampNanosecondBuilder,
+        has_tz: bool,
+    },
+    List {
+        field: FieldRef,
+        offsets: Vec<i32>,
+        values: Box<XmlFieldBuilder>,
+        nulls: Vec<bool>,
+    },
+    Struct {
+        fields: Fields,
+        children: Vec<XmlFieldBuilder>,
+        nulls: Vec<bool>,
+    },
+    Unsupported {
+        data_type: DataType,
+        count: usize,
+    },
+}
+
+struct TopLevelStructBuilder {
+    fields: Fields,
+    children: Vec<XmlFieldBuilder>,
+    nulls: Vec<bool>,
+}
+
+#[expect(clippy::only_used_in_recursion)]
+fn create_field_builder(
+    data_type: &DataType,
+    capacity: usize,
+    session_timezone: &str,
+) -> Result<XmlFieldBuilder> {
+    match data_type {
+        DataType::Boolean => Ok(XmlFieldBuilder::Boolean(BooleanBuilder::with_capacity(
+            capacity,
+        ))),
+        DataType::Int8 => Ok(XmlFieldBuilder::Int8(Int8Builder::with_capacity(capacity))),
+        DataType::Int16 => Ok(XmlFieldBuilder::Int16(Int16Builder::with_capacity(
+            capacity,
+        ))),
+        DataType::Int32 => Ok(XmlFieldBuilder::Int32(Int32Builder::with_capacity(
+            capacity,
+        ))),
+        DataType::Int64 => Ok(XmlFieldBuilder::Int64(Int64Builder::with_capacity(
+            capacity,
+        ))),
+        DataType::Float32 => Ok(XmlFieldBuilder::Float32(Float32Builder::with_capacity(
+            capacity,
+        ))),
+        DataType::Float64 => Ok(XmlFieldBuilder::Float64(Float64Builder::with_capacity(
+            capacity,
+        ))),
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Ok(XmlFieldBuilder::String(
+            StringBuilder::with_capacity(capacity, capacity * 16),
+        )),
+        DataType::Date32 => Ok(XmlFieldBuilder::Date32(Date32Builder::with_capacity(
+            capacity,
+        ))),
+        DataType::Timestamp(unit, tz) => match unit {
+            TimeUnit::Microsecond => Ok(XmlFieldBuilder::TimestampMicrosecond {
+                builder: TimestampMicrosecondBuilder::with_capacity(capacity)
+                    .with_timezone_opt(tz.clone()),
+                has_tz: tz.is_some(),
+            }),
+            TimeUnit::Nanosecond => Ok(XmlFieldBuilder::TimestampNanosecond {
+                builder: TimestampNanosecondBuilder::with_capacity(capacity)
+                    .with_timezone_opt(tz.clone()),
+                has_tz: tz.is_some(),
+            }),
+            other => Ok(XmlFieldBuilder::Unsupported {
+                data_type: DataType::Timestamp(*other, tz.clone()),
+                count: 0,
+            }),
+        },
+        DataType::List(item_field) => {
+            let values = create_field_builder(item_field.data_type(), capacity, session_timezone)?;
+            let mut offsets = Vec::with_capacity(capacity + 1);
+            offsets.push(0_i32);
+            Ok(XmlFieldBuilder::List {
+                field: item_field.clone(),
+                offsets,
+                values: Box::new(values),
+                nulls: Vec::with_capacity(capacity),
+            })
+        }
+        DataType::Struct(fields) => {
+            let children = fields
+                .iter()
+                .map(|f| create_field_builder(f.data_type(), capacity, session_timezone))
+                .collect::<Result<Vec<_>>>()?;
+            Ok(XmlFieldBuilder::Struct {
+                fields: fields.clone(),
+                children,
+                nulls: Vec::with_capacity(capacity),
+            })
+        }
+        other => Ok(XmlFieldBuilder::Unsupported {
+            data_type: other.clone(),
+            count: 0,
+        }),
+    }
+}
+
+fn create_struct_builder(
+    fields: &Fields,
+    capacity: usize,
+    session_timezone: &str,
+) -> Result<TopLevelStructBuilder> {
+    let children = fields
+        .iter()
+        .map(|f| create_field_builder(f.data_type(), capacity, session_timezone))
+        .collect::<Result<Vec<_>>>()?;
+    Ok(TopLevelStructBuilder {
+        fields: fields.clone(),
+        children,
+        nulls: Vec::with_capacity(capacity),
+    })
+}
+
+fn append_null_struct(builder: &mut TopLevelStructBuilder) -> Result<()> {
+    builder.nulls.push(false);
+    for child in builder.children.iter_mut() {
+        append_null_to_field(child)?;
+    }
+    Ok(())
+}
+
+fn append_null_children_struct(builder: &mut TopLevelStructBuilder) -> Result<()> {
+    builder.nulls.push(true);
+    for child in builder.children.iter_mut() {
+        append_null_to_field(child)?;
+    }
+    Ok(())
+}
+
+fn append_null_to_field(builder: &mut XmlFieldBuilder) -> Result<()> {
+    match builder {
+        XmlFieldBuilder::Boolean(b) => b.append_null(),
+        XmlFieldBuilder::Int8(b) => b.append_null(),
+        XmlFieldBuilder::Int16(b) => b.append_null(),
+        XmlFieldBuilder::Int32(b) => b.append_null(),
+        XmlFieldBuilder::Int64(b) => b.append_null(),
+        XmlFieldBuilder::Float32(b) => b.append_null(),
+        XmlFieldBuilder::Float64(b) => b.append_null(),
+        XmlFieldBuilder::String(b) => b.append_null(),
+        XmlFieldBuilder::Date32(b) => b.append_null(),
+        XmlFieldBuilder::TimestampMicrosecond { builder: b, .. } => b.append_null(),
+        XmlFieldBuilder::TimestampNanosecond { builder: b, .. } => b.append_null(),
+        XmlFieldBuilder::List { offsets, nulls, .. } => {
+            nulls.push(false);
+            let curr = offsets.last().copied().unwrap_or(0);
+            offsets.push(curr);
+        }
+        XmlFieldBuilder::Struct {
+            children, nulls, ..
+        } => {
+            nulls.push(false);
+            for child in children.iter_mut() {
+                append_null_to_field(child)?;
+            }
+        }
+        XmlFieldBuilder::Unsupported { count, .. } => *count += 1,
+    }
+    Ok(())
+}
+
+fn parse_xml_into_builder(
+    xml: &str,
+    builder: &mut TopLevelStructBuilder,
+    options: &SparkFromXmlOptions,
+    session_timezone: &str,
+) -> Result<()> {
+    let mut documents = Documents::new();
+    let handle = documents
+        .add_string_without_uri(xml)
+        .map_err(|e| DataFusionError::Execution(format!("Invalid XML: {e}")))?;
+
+    let doc_node = documents
+        .document_node(handle)
+        .ok_or_else(|| DataFusionError::Execution("XML document has no root node".to_string()))?;
+
+    let xot = documents.xot();
+    let root = xot
+        .document_element(doc_node)
+        .map_err(|e| DataFusionError::Execution(format!("No root element: {e}")))?;
+
+    builder.nulls.push(true);
+
+    for (field, child_builder) in builder.fields.iter().zip(builder.children.iter_mut()) {
+        append_xml_field(
+            xot,
+            root,
+            field.name(),
+            child_builder,
+            options,
+            session_timezone,
+        )?;
+    }
+
+    Ok(())
+}
+
+fn append_xml_field(
+    xot: &xot::Xot,
+    parent: xot::Node,
+    field_name: &str,
+    builder: &mut XmlFieldBuilder,
+    options: &SparkFromXmlOptions,
+    session_timezone: &str,
+) -> Result<()> {
+    if !options.attribute_prefix.is_empty()
+        && field_name.starts_with(options.attribute_prefix.as_str())
+    {
+        let attr_name = &field_name[options.attribute_prefix.len()..];
+        let text = find_attribute(xot, parent, attr_name);
+        return append_text(text.as_deref(), builder, options, session_timezone);
+    }
+
+    if field_name == options.value_tag {
+        let text = element_text_content(xot, parent);
+        return append_text(text.as_deref(), builder, options, session_timezone);
+    }
+
+    let matches: Vec<xot::Node> = child_elements_named(xot, parent, field_name);
+
+    match builder {
+        XmlFieldBuilder::List {
+            field,
+            offsets,
+            values,
+            nulls,
+        } => {
+            if matches.is_empty() {
+                nulls.push(false);
+                let curr = offsets.last().copied().unwrap_or(0);
+                offsets.push(curr);
+            } else {
+                nulls.push(true);
+                let start = offsets.last().copied().unwrap_or(0);
+                for &node in &matches {
+                    append_element_to_field(xot, node, values, options, session_timezone)?;
+                }
+                offsets.push(start + matches.len() as i32);
+                let _ = field;
+            }
+        }
+        XmlFieldBuilder::Struct {
+            fields,
+            children,
+            nulls,
+        } => {
+            if matches.is_empty() {
+                nulls.push(false);
+                for child in children.iter_mut() {
+                    append_null_to_field(child)?;
+                }
+            } else {
+                nulls.push(true);
+                let node = matches[0];
+                for (f, child) in fields.clone().iter().zip(children.iter_mut()) {
+                    append_xml_field(xot, node, f.name(), child, options, session_timezone)?;
+                }
+            }
+        }
+        _ => {
+            if matches.is_empty() {
+                append_null_to_field(builder)?;
+            } else {
+                let text = element_text_content(xot, matches[0]);
+                append_text(text.as_deref(), builder, options, session_timezone)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn append_element_to_field(
+    xot: &xot::Xot,
+    node: xot::Node,
+    builder: &mut XmlFieldBuilder,
+    options: &SparkFromXmlOptions,
+    session_timezone: &str,
+) -> Result<()> {
+    match builder {
+        XmlFieldBuilder::Struct {
+            fields,
+            children,
+            nulls,
+        } => {
+            nulls.push(true);
+            for (f, child) in fields.clone().iter().zip(children.iter_mut()) {
+                append_xml_field(xot, node, f.name(), child, options, session_timezone)?;
+            }
+        }
+        _ => {
+            let text = element_text_content(xot, node);
+            append_text(text.as_deref(), builder, options, session_timezone)?;
+        }
+    }
+    Ok(())
+}
+
+fn append_text(
+    text: Option<&str>,
+    builder: &mut XmlFieldBuilder,
+    options: &SparkFromXmlOptions,
+    session_timezone: &str,
+) -> Result<()> {
+    let raw = match text {
+        None => return append_null_to_field(builder),
+        Some(s) => s,
+    };
+
+    if let Some(nv) = &options.null_value {
+        if raw == nv.as_str() {
+            return append_null_to_field(builder);
+        }
+    }
+
+    match builder {
+        XmlFieldBuilder::Boolean(b) => match raw.to_ascii_lowercase().as_str() {
+            "true" | "1" => b.append_value(true),
+            "false" | "0" => b.append_value(false),
+            _ => b.append_null(),
+        },
+        XmlFieldBuilder::Int8(b) => match raw.parse::<i8>() {
+            Ok(v) => b.append_value(v),
+            Err(_) => b.append_null(),
+        },
+        XmlFieldBuilder::Int16(b) => match raw.parse::<i16>() {
+            Ok(v) => b.append_value(v),
+            Err(_) => b.append_null(),
+        },
+        XmlFieldBuilder::Int32(b) => match raw.parse::<i32>() {
+            Ok(v) => b.append_value(v),
+            Err(_) => b.append_null(),
+        },
+        XmlFieldBuilder::Int64(b) => match raw.parse::<i64>() {
+            Ok(v) => b.append_value(v),
+            Err(_) => b.append_null(),
+        },
+        XmlFieldBuilder::Float32(b) => match raw.parse::<f32>() {
+            Ok(v) => b.append_value(v),
+            Err(_) => b.append_null(),
+        },
+        XmlFieldBuilder::Float64(b) => match raw.parse::<f64>() {
+            Ok(v) => b.append_value(v),
+            Err(_) => b.append_null(),
+        },
+
+        XmlFieldBuilder::String(b) => b.append_value(raw),
+        XmlFieldBuilder::Date32(b) => match NaiveDate::parse_from_str(raw, &options.date_format) {
+            Ok(d) => b.append_value(Date32Type::from_naive_date(d)),
+            Err(_) => b.append_null(),
+        },
+        XmlFieldBuilder::TimestampMicrosecond { builder: b, has_tz } => {
+            let fmt = if *has_tz {
+                &options.timestamp_ltz_format
+            } else {
+                &options.timestamp_ntz_format
+            };
+            match parse_naive_datetime(raw, fmt) {
+                Some(naive) => {
+                    let micros = to_utc_micros(naive, *has_tz, session_timezone)?;
+                    b.append_value(micros);
+                }
+                None => b.append_null(),
+            }
+        }
+        XmlFieldBuilder::TimestampNanosecond { builder: b, has_tz } => {
+            let fmt = if *has_tz {
+                &options.timestamp_ltz_format
+            } else {
+                &options.timestamp_ntz_format
+            };
+            match parse_naive_datetime(raw, fmt) {
+                Some(naive) => {
+                    let micros = to_utc_micros(naive, *has_tz, session_timezone)?;
+                    b.append_value(micros * 1_000);
+                }
+                None => b.append_null(),
+            }
+        }
+        XmlFieldBuilder::List { .. } | XmlFieldBuilder::Struct { .. } => {
+            append_null_to_field(builder)?;
+        }
+        XmlFieldBuilder::Unsupported { count, .. } => *count += 1,
+    }
+    Ok(())
+}
+
+fn parse_naive_datetime(raw: &str, fmt: &str) -> Option<NaiveDateTime> {
+    NaiveDateTime::parse_from_str(raw, fmt).ok().or_else(|| {
+        NaiveDate::parse_from_str(raw, fmt)
+            .ok()
+            .and_then(|d| d.and_hms_opt(0, 0, 0))
+    })
+}
+
+fn to_utc_micros(naive: NaiveDateTime, has_tz: bool, session_timezone: &str) -> Result<i64> {
+    if has_tz {
+        let tz: Tz = session_timezone
+            .parse()
+            .map_err(|e| DataFusionError::Execution(format!("Invalid timezone: {e}")))?;
+        let localized = localize_with_fallback(&tz, &naive)?;
+        Ok(localized.timestamp_micros())
+    } else {
+        Ok(naive.and_utc().timestamp_micros())
+    }
+}
+
+fn child_elements_named(xot: &xot::Xot, parent: xot::Node, name: &str) -> Vec<xot::Node> {
+    xot.children(parent)
+        .filter(|&child| {
+            if let xot::Value::Element(el) = xot.value(child) {
+                xot.local_name_str(el.name()) == name
+            } else {
+                false
+            }
+        })
+        .collect()
+}
+
+fn element_text_content(xot: &xot::Xot, node: xot::Node) -> Option<String> {
+    let text: String = xot
+        .children(node)
+        .filter_map(|child| {
+            if let xot::Value::Text(t) = xot.value(child) {
+                Some(t.get().to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+fn find_attribute(xot: &xot::Xot, node: xot::Node, attr_name: &str) -> Option<String> {
+    for (name_id, value) in xot.attributes(node).iter() {
+        if xot.local_name_str(name_id) == attr_name {
+            return Some(value.clone());
+        }
+    }
+    None
+}
+
+fn find_key_value(map: &MapArray, key: &str) -> Option<String> {
+    if map.is_empty() {
+        return None;
+    }
+    let entries = map.value(0);
+    let keys = entries
+        .column_by_name(SAIL_MAP_KEY_FIELD_NAME)?
+        .as_any()
+        .downcast_ref::<StringArray>()?;
+    let values = entries
+        .column_by_name(SAIL_MAP_VALUE_FIELD_NAME)?
+        .as_any()
+        .downcast_ref::<StringArray>()?;
+    for i in 0..keys.len() {
+        if !keys.is_null(i) && keys.value(i).eq_ignore_ascii_case(key) {
+            return if values.is_null(i) {
+                None
+            } else {
+                Some(values.value(i).to_string())
+            };
+        }
+    }
+    None
+}
+
+fn finish_field_builder(builder: XmlFieldBuilder) -> Result<ArrayRef> {
+    match builder {
+        XmlFieldBuilder::Boolean(mut b) => Ok(Arc::new(b.finish())),
+        XmlFieldBuilder::Int8(mut b) => Ok(Arc::new(b.finish())),
+        XmlFieldBuilder::Int16(mut b) => Ok(Arc::new(b.finish())),
+        XmlFieldBuilder::Int32(mut b) => Ok(Arc::new(b.finish())),
+        XmlFieldBuilder::Int64(mut b) => Ok(Arc::new(b.finish())),
+        XmlFieldBuilder::Float32(mut b) => Ok(Arc::new(b.finish())),
+        XmlFieldBuilder::Float64(mut b) => Ok(Arc::new(b.finish())),
+        XmlFieldBuilder::String(mut b) => Ok(Arc::new(b.finish())),
+        XmlFieldBuilder::Date32(mut b) => Ok(Arc::new(b.finish())),
+        XmlFieldBuilder::TimestampMicrosecond { mut builder, .. } => Ok(Arc::new(builder.finish())),
+        XmlFieldBuilder::TimestampNanosecond { mut builder, .. } => Ok(Arc::new(builder.finish())),
+        XmlFieldBuilder::List {
+            field,
+            offsets,
+            values,
+            nulls,
+        } => {
+            let values_array = finish_field_builder(*values)?;
+            Ok(Arc::new(ListArray::new(
+                field,
+                OffsetBuffer::new(ScalarBuffer::from(offsets)),
+                values_array,
+                Some(NullBuffer::from(nulls)),
+            )))
+        }
+        XmlFieldBuilder::Struct {
+            fields,
+            children,
+            nulls,
+        } => {
+            let arrays = children
+                .into_iter()
+                .map(finish_field_builder)
+                .collect::<Result<Vec<_>>>()?;
+            Ok(Arc::new(StructArray::new(
+                fields,
+                arrays,
+                Some(NullBuffer::from(nulls)),
+            )))
+        }
+        XmlFieldBuilder::Unsupported { data_type, count } => Ok(new_null_array(&data_type, count)),
+    }
+}
+
+fn finish_struct_builder(builder: TopLevelStructBuilder) -> Result<ArrayRef> {
+    let arrays = builder
+        .children
+        .into_iter()
+        .map(finish_field_builder)
+        .collect::<Result<Vec<_>>>()?;
+    Ok(Arc::new(StructArray::new(
+        builder.fields,
+        arrays,
+        Some(NullBuffer::from(builder.nulls)),
+    )))
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn run(xml: &str, schema: &str) -> Result<ArrayRef> {
+        let xml_arr = Arc::new(StringArray::from(vec![Some(xml)])) as ArrayRef;
+        let schema_arr = Arc::new(StringArray::from(vec![schema])) as ArrayRef;
+        spark_from_xml_inner(&[xml_arr, schema_arr], DEFAULT_SESSION_TIMEZONE)
+    }
+
+    fn col(result: &ArrayRef, name: &str) -> ArrayRef {
+        result
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap()
+            .column_by_name(name)
+            .unwrap()
+            .clone()
+    }
+
+    #[test]
+    fn test_primitives() -> Result<()> {
+        let r = run("<p><a>1</a><b>0.8</b></p>", "a INT, b DOUBLE")?;
+        assert_eq!(
+            col(&r, "a")
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .value(0),
+            1
+        );
+        assert!(
+            (col(&r, "b")
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .unwrap()
+                .value(0)
+                - 0.8)
+                .abs()
+                < 1e-9
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_missing_tag_is_null() -> Result<()> {
+        let r = run("<p><b>1</b></p>", "a INT, b INT")?;
+        assert!(col(&r, "a").is_null(0));
+        assert_eq!(
+            col(&r, "b")
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .value(0),
+            1
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_tag_string_is_empty_string() -> Result<()> {
+        let r = run("<p><a></a></p>", "a STRING")?;
+        assert_eq!(
+            col(&r, "a")
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap()
+                .value(0),
+            ""
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_tag_int_is_null() -> Result<()> {
+        let r = run("<p><a></a></p>", "a INT")?;
+        assert!(col(&r, "a").is_null(0));
+        Ok(())
+    }
+
+    #[test]
+    fn test_null_input_is_null_struct() -> Result<()> {
+        let xml_arr = Arc::new(StringArray::from(vec![None::<&str>])) as ArrayRef;
+        let schema_arr = Arc::new(StringArray::from(vec!["a INT"])) as ArrayRef;
+        let r = spark_from_xml_inner(&[xml_arr, schema_arr], DEFAULT_SESSION_TIMEZONE)?;
+        assert!(r.is_null(0));
+        Ok(())
+    }
+
+    #[test]
+    fn test_root_tag_ignored() -> Result<()> {
+        for xml in &[
+            "<ROW><a>1</a></ROW>",
+            "<record><a>1</a></record>",
+            "<p><a>1</a></p>",
+        ] {
+            let r = run(xml, "a INT")?;
+            assert_eq!(
+                col(&r, "a")
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .value(0),
+                1
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_xml_entities_unescaped() -> Result<()> {
+        let r = run("<p><s>a &lt; b</s></p>", "s STRING")?;
+        assert_eq!(
+            col(&r, "s")
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap()
+                .value(0),
+            "a < b"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_attribute_prefix() -> Result<()> {
+        let r = run(
+            r#"<p id="99"><name>Alice</name></p>"#,
+            "_id STRING, name STRING",
+        )?;
+        assert_eq!(
+            col(&r, "_id")
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap()
+                .value(0),
+            "99"
+        );
+        assert_eq!(
+            col(&r, "name")
+                .as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap()
+                .value(0),
+            "Alice"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_repeated_tags_array() -> Result<()> {
+        let r = run("<p><a>1</a><a>2</a><a>3</a></p>", "a ARRAY<INT>")?;
+        let list = col(&r, "a")
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .unwrap()
+            .value(0);
+        let ints = list.as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(ints.len(), 3);
+        assert_eq!(ints.value(0), 1);
+        assert_eq!(ints.value(1), 2);
+        assert_eq!(ints.value(2), 3);
+        Ok(())
+    }
+
+    #[test]
+    fn test_nested_struct() -> Result<()> {
+        let r = run(
+            "<p><student><name>Bob</name><rank>1</rank></student></p>",
+            "student STRUCT<name: STRING, rank: INT>",
+        )?;
+        let nested = col(&r, "student")
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap()
+            .clone();
+        let name = nested.column_by_name("name").unwrap();
+        assert_eq!(
+            name.as_any()
+                .downcast_ref::<StringArray>()
+                .unwrap()
+                .value(0),
+            "Bob"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_boolean() -> Result<()> {
+        let r = run("<p><flag>true</flag></p>", "flag BOOLEAN")?;
+        assert!(col(&r, "flag")
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap()
+            .value(0));
+        let r = run("<p><flag>false</flag></p>", "flag BOOLEAN")?;
+        assert!(!col(&r, "flag")
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .unwrap()
+            .value(0));
+        Ok(())
+    }
+}

--- a/crates/sail-function/src/scalar/xml/from_xml.rs
+++ b/crates/sail-function/src/scalar/xml/from_xml.rs
@@ -430,6 +430,11 @@ enum XmlFieldBuilder {
     Int64(Int64Builder),
     Float32(Float32Builder),
     Float64(Float64Builder),
+    Decimal128 {
+        builder: Decimal128Builder,
+        precision: u8,
+        scale: i8,
+    },
     String(StringBuilder),
     Date32(Date32Builder),
     TimestampMicrosecond {
@@ -489,6 +494,13 @@ fn create_field_builder(
         DataType::Float64 => Ok(XmlFieldBuilder::Float64(Float64Builder::with_capacity(
             capacity,
         ))),
+        DataType::Decimal128(precision, scale) => Ok(XmlFieldBuilder::Decimal128 {
+            builder: Decimal128Builder::with_capacity(capacity)
+                .with_precision_and_scale(*precision, *scale)
+                .map_err(|e| DataFusionError::Internal(format!("Decimal128 builder error: {e}")))?,
+            precision: *precision,
+            scale: *scale,
+        }),
         DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => Ok(XmlFieldBuilder::String(
             StringBuilder::with_capacity(capacity, capacity * 16),
         )),
@@ -581,6 +593,7 @@ fn append_null_to_field(builder: &mut XmlFieldBuilder) -> Result<()> {
         XmlFieldBuilder::Int64(b) => b.append_null(),
         XmlFieldBuilder::Float32(b) => b.append_null(),
         XmlFieldBuilder::Float64(b) => b.append_null(),
+        XmlFieldBuilder::Decimal128 { builder: b, .. } => b.append_null(),
         XmlFieldBuilder::String(b) => b.append_null(),
         XmlFieldBuilder::Date32(b) => b.append_null(),
         XmlFieldBuilder::TimestampMicrosecond { builder: b, .. } => b.append_null(),
@@ -784,6 +797,14 @@ fn append_text(
             Ok(v) => b.append_value(v),
             Err(_) => b.append_null(),
         },
+        XmlFieldBuilder::Decimal128 {
+            builder: b,
+            precision,
+            scale,
+        } => match parse_decimal128(raw, *precision, *scale) {
+            Some(v) => b.append_value(v),
+            None => b.append_null(),
+        },
         XmlFieldBuilder::Float64(b) => match raw.parse::<f64>() {
             Ok(v) => b.append_value(v),
             Err(_) => b.append_null(),
@@ -848,6 +869,41 @@ fn to_utc_micros(naive: NaiveDateTime, has_tz: bool, session_timezone: &str) -> 
     } else {
         Ok(naive.and_utc().timestamp_micros())
     }
+}
+
+fn parse_decimal128(raw: &str, precision: u8, scale: i8) -> Option<i128> {
+    let raw = raw.trim();
+    let is_negative = raw.starts_with('-');
+    let raw = if is_negative { &raw[1..] } else { raw };
+
+    let (int_part, frac_part) = if let Some(pos) = raw.find('.') {
+        (&raw[..pos], &raw[pos + 1..])
+    } else {
+        (raw, "")
+    };
+
+    let int_val: i128 = int_part.parse().ok()?;
+
+    let scale = scale as usize;
+    let frac_val: i128 = if frac_part.len() >= scale {
+        frac_part[..scale].parse().ok()?
+    } else {
+        let padded = format!("{:0<width$}", frac_part, width = scale);
+        padded.parse().ok()?
+    };
+
+    let scale_factor: i128 = 10_i128.checked_pow(scale as u32)?;
+    let value = int_val.checked_mul(scale_factor)?.checked_add(frac_val)?;
+    let value = if is_negative {
+        value.checked_neg()?
+    } else {
+        value
+    };
+    let max_value = 10_i128.checked_pow(precision as u32)?;
+    if value.abs() >= max_value {
+        return None; // overflow
+    }
+    Some(value)
 }
 
 fn child_elements_named(xot: &xot::Xot, parent: xot::Node, name: &str) -> Vec<xot::Node> {
@@ -919,6 +975,7 @@ fn finish_field_builder(builder: XmlFieldBuilder) -> Result<ArrayRef> {
         XmlFieldBuilder::Int64(mut b) => Ok(Arc::new(b.finish())),
         XmlFieldBuilder::Float32(mut b) => Ok(Arc::new(b.finish())),
         XmlFieldBuilder::Float64(mut b) => Ok(Arc::new(b.finish())),
+        XmlFieldBuilder::Decimal128 { mut builder, .. } => Ok(Arc::new(builder.finish())),
         XmlFieldBuilder::String(mut b) => Ok(Arc::new(b.finish())),
         XmlFieldBuilder::Date32(mut b) => Ok(Arc::new(b.finish())),
         XmlFieldBuilder::TimestampMicrosecond { mut builder, .. } => Ok(Arc::new(builder.finish())),

--- a/crates/sail-function/src/scalar/xml/from_xml.rs
+++ b/crates/sail-function/src/scalar/xml/from_xml.rs
@@ -86,6 +86,12 @@ impl SparkFromXmlOptions {
             .unwrap_or_else(|| Self::ATTRIBUTE_PREFIX_DEFAULT.to_string());
         let value_tag = find_key_value(map, Self::VALUE_TAG_OPTION)
             .unwrap_or_else(|| Self::VALUE_TAG_DEFAULT.to_string());
+        if value_tag.is_empty() {
+            return plan_err!("`valueTag` must not be empty");
+        }
+        if value_tag == attribute_prefix {
+            return plan_err!("`valueTag` and `attributePrefix` must not be equal");
+        }
         let timestamp_ltz_format = find_key_value(map, Self::TIMESTAMP_FORMAT_OPTION)
             .as_deref()
             .map(spark_datetime_format_to_chrono_strftime)
@@ -106,8 +112,11 @@ impl SparkFromXmlOptions {
             .map(|s| s.to_ascii_uppercase())
             .as_deref()
         {
+            None | Some("PERMISSIVE") => ParseMode::Permissive,
             Some("FAILFAST") => ParseMode::FailFast,
-            _ => ParseMode::Permissive,
+            Some(other) => {
+                return plan_err!("`mode` must be PERMISSIVE or FAILFAST, got '{other}'");
+            }
         };
         Ok(Self {
             null_value,
@@ -173,7 +182,7 @@ impl ScalarUDFImpl for SparkFromXml {
             | DataType::Utf8View
             | DataType::LargeUtf8, DataType::Utf8
             | DataType::Utf8View
-            | DataType::LargeUtf8] => Ok(vec![DataType::Utf8, arg_types[1].clone()]),
+            | DataType::LargeUtf8] => Ok(vec![DataType::Utf8, DataType::Utf8]),
             [DataType::Null
             | DataType::Utf8
             | DataType::Utf8View
@@ -181,7 +190,7 @@ impl ScalarUDFImpl for SparkFromXml {
             | DataType::Utf8View
             | DataType::LargeUtf8, DataType::Map(_, _)] => Ok(vec![
                 DataType::Utf8,
-                arg_types[1].clone(),
+                DataType::Utf8,
                 arg_types[2].clone(),
             ]),
             _ => plan_err!(
@@ -710,7 +719,7 @@ fn append_xml_field(
             } else {
                 nulls.push(true);
                 let node = matches[0];
-                for (f, child) in fields.clone().iter().zip(children.iter_mut()) {
+                for (f, child) in fields.iter().zip(children.iter_mut()) {
                     append_xml_field(xot, node, f.name(), child, options, session_timezone)?;
                 }
             }
@@ -742,7 +751,7 @@ fn append_element_to_field(
             nulls,
         } => {
             nulls.push(true);
-            for (f, child) in fields.clone().iter().zip(children.iter_mut()) {
+            for (f, child) in fields.iter().zip(children.iter_mut()) {
                 append_xml_field(xot, node, f.name(), child, options, session_timezone)?;
             }
         }

--- a/crates/sail-function/src/scalar/xml/from_xml.rs
+++ b/crates/sail-function/src/scalar/xml/from_xml.rs
@@ -647,17 +647,18 @@ fn append_xml_field(
     options: &SparkFromXmlOptions,
     session_timezone: &str,
 ) -> Result<()> {
-    if !options.attribute_prefix.is_empty()
-        && field_name.starts_with(options.attribute_prefix.as_str())
-    {
-        let attr_name = &field_name[options.attribute_prefix.len()..];
-        let text = find_attribute(xot, parent, attr_name);
-        return append_text(text.as_deref(), builder, options, session_timezone);
-    }
-
     if field_name == options.value_tag {
         let text = element_text_content(xot, parent);
         return append_text(text.as_deref(), builder, options, session_timezone);
+    }
+
+    let attr_name = field_name.strip_prefix(options.attribute_prefix.as_str());
+    if let Some(attr_name) = attr_name {
+        if let Some(val) = find_attribute(xot, parent, attr_name) {
+            return append_text(Some(val.as_str()), builder, options, session_timezone);
+        } else if !options.attribute_prefix.is_empty() {
+            return append_text(None, builder, options, session_timezone);
+        }
     }
 
     let matches: Vec<xot::Node> = child_elements_named(xot, parent, field_name);
@@ -872,11 +873,7 @@ fn element_text_content(xot: &xot::Xot, node: xot::Node) -> Option<String> {
             }
         })
         .collect();
-    if text.is_empty() {
-        None
-    } else {
-        Some(text)
-    }
+    Some(text)
 }
 
 fn find_attribute(xot: &xot::Xot, node: xot::Node, attr_name: &str) -> Option<String> {

--- a/crates/sail-function/src/scalar/xml/mod.rs
+++ b/crates/sail-function/src/scalar/xml/mod.rs
@@ -1,3 +1,4 @@
+pub mod from_xml;
 pub mod to_xml;
 pub mod xpath;
 pub mod xpath_typed;

--- a/crates/sail-plan/src/function/scalar/xml.rs
+++ b/crates/sail-plan/src/function/scalar/xml.rs
@@ -45,6 +45,13 @@ fn from_xml(
     if arguments.len() >= 2 && !matches!(&arguments[1], expr::Expr::Literal(_, _)) {
         let evaluator = LiteralEvaluator::new();
         if let Ok(scalar) = evaluator.evaluate(&arguments[1]) {
+            let scalar = match scalar {
+                datafusion_common::ScalarValue::Utf8View(v)
+                | datafusion_common::ScalarValue::LargeUtf8(v) => {
+                    datafusion_common::ScalarValue::Utf8(v)
+                }
+                other => other,
+            };
             arguments[1] = expr::Expr::Literal(scalar, None);
         }
     }

--- a/crates/sail-plan/src/function/scalar/xml.rs
+++ b/crates/sail-plan/src/function/scalar/xml.rs
@@ -1,6 +1,6 @@
 use datafusion_expr::{expr, Expr, ScalarUDF};
-use sail_common_datafusion::utils::items::ItemTaker;
 use sail_common_datafusion::literal::LiteralEvaluator;
+use sail_common_datafusion::utils::items::ItemTaker;
 use sail_function::scalar::xml::from_xml::SparkFromXml;
 use sail_function::scalar::xml::to_xml::SparkToXml;
 use sail_function::scalar::xml::xpath::Xpath;

--- a/crates/sail-plan/src/function/scalar/xml.rs
+++ b/crates/sail-plan/src/function/scalar/xml.rs
@@ -1,5 +1,7 @@
 use datafusion_expr::{expr, Expr, ScalarUDF};
 use sail_common_datafusion::utils::items::ItemTaker;
+use sail_common_datafusion::literal::LiteralEvaluator;
+use sail_function::scalar::xml::from_xml::SparkFromXml;
 use sail_function::scalar::xml::to_xml::SparkToXml;
 use sail_function::scalar::xml::xpath::Xpath;
 use sail_function::scalar::xml::xpath_typed::{XpathTyped, XpathTypedKind};
@@ -33,11 +35,28 @@ fn to_xml(input: ScalarFunctionInput) -> PlanResult<Expr> {
     Ok(udf.call(input.arguments))
 }
 
+fn from_xml(
+    ScalarFunctionInput {
+        mut arguments,
+        function_context,
+    }: ScalarFunctionInput,
+) -> PlanResult<Expr> {
+    let tz = function_context.plan_config.session_timezone.clone();
+    if arguments.len() >= 2 && !matches!(&arguments[1], expr::Expr::Literal(_, _)) {
+        let evaluator = LiteralEvaluator::new();
+        if let Ok(scalar) = evaluator.evaluate(&arguments[1]) {
+            arguments[1] = expr::Expr::Literal(scalar, None);
+        }
+    }
+    let udf = ScalarUDF::from(SparkFromXml::new(tz));
+    Ok(udf.call(arguments))
+}
+
 pub(super) fn list_built_in_xml_functions() -> Vec<(&'static str, ScalarFunction)> {
     use crate::function::common::ScalarFunctionBuilder as F;
 
     vec![
-        ("from_xml", F::unknown("from_xml")),
+        ("from_xml", F::custom(from_xml)),
         ("schema_of_xml", F::unknown("schema_of_xml")),
         ("to_xml", F::custom(to_xml)),
         ("xpath", F::custom(xpath)),

--- a/crates/sail-spark-connect/tests/gold_data/function/xml.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/xml.json
@@ -35,7 +35,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: from_xml"
+        "success": "ok"
       }
     },
     {
@@ -93,7 +93,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: from_xml"
+        "success": "ok"
       }
     },
     {
@@ -125,7 +125,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: from_xml"
+        "success": "ok"
       }
     },
     {

--- a/python/pysail/tests/spark/function/features/from_xml.feature
+++ b/python/pysail/tests/spark/function/features/from_xml.feature
@@ -335,3 +335,50 @@ Feature: from_xml parses an XML string into a struct value
       Then query result
         | result |
         | NULL   |
+
+    Rule: Decimal type
+
+    Scenario: Parse DECIMAL field
+      When query
+        """
+        SELECT from_xml('<p><a>2.12</a></p>', 'a DECIMAL(10,2)').a AS result
+        """
+      Then query result
+        | result |
+        | 2.12   |
+
+    Scenario: DECIMAL truncates to scale
+      When query
+        """
+        SELECT from_xml('<p><a>2.12159</a></p>', 'a DECIMAL(10,2)').a AS result
+        """
+      Then query result
+        | result |
+        | 2.12   |
+
+    Scenario: DECIMAL overflow returns NULL
+      When query
+        """
+        SELECT from_xml('<p><a>99999999999.99</a></p>', 'a DECIMAL(10,2)').a AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: DECIMAL bad value returns NULL
+      When query
+        """
+        SELECT from_xml('<p><a>bad</a></p>', 'a DECIMAL(10,2)').a AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: DECIMAL in array
+      When query
+        """
+        SELECT from_xml('<p><a>1.10</a><a>2.20</a></p>', 'a ARRAY<DECIMAL(10,2)>').a AS result
+        """
+      Then query result
+        | result         |
+        | [1.10, 2.20]   |

--- a/python/pysail/tests/spark/function/features/from_xml.feature
+++ b/python/pysail/tests/spark/function/features/from_xml.feature
@@ -336,7 +336,16 @@ Feature: from_xml parses an XML string into a struct value
         | result |
         | NULL   |
 
-    Rule: Decimal type
+    Scenario: Explicit PERMISSIVE mode returns NULL field for bad cast
+      When query
+        """
+        SELECT from_xml('<p><a>not_a_number</a></p>', 'a INT', map('mode', 'PERMISSIVE')).a AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+  Rule: Decimal type
 
     Scenario: Parse DECIMAL field
       When query

--- a/python/pysail/tests/spark/function/features/from_xml.feature
+++ b/python/pysail/tests/spark/function/features/from_xml.feature
@@ -47,6 +47,15 @@ Feature: from_xml parses an XML string into a struct value
         | result |
         | 43     |
 
+    Scenario: Parse FLOAT field
+      When query
+        """
+        SELECT from_xml('<p><x>3.5</x></p>', 'x FLOAT').x AS result
+        """
+      Then query result
+        | result |
+        | 3.5    |    
+
   Rule: Root tag is ignored
 
     Scenario: Root tag name does not affect parsing
@@ -326,3 +335,10 @@ Feature: from_xml parses an XML string into a struct value
       Then query result
         | result |
         | NULL   |
+
+    Scenario: FAILFAST mode raises error on bad cast
+      When query
+        """
+        SELECT from_xml('<p><a>not_a_number</a></p>', 'a INT', map('mode', 'FAILFAST')).a AS result
+        """
+      Then query error .*

--- a/python/pysail/tests/spark/function/features/from_xml.feature
+++ b/python/pysail/tests/spark/function/features/from_xml.feature
@@ -335,10 +335,3 @@ Feature: from_xml parses an XML string into a struct value
       Then query result
         | result |
         | NULL   |
-
-    Scenario: FAILFAST mode raises error on bad cast
-      When query
-        """
-        SELECT from_xml('<p><a>not_a_number</a></p>', 'a INT', map('mode', 'FAILFAST')).a AS result
-        """
-      Then query error .*

--- a/python/pysail/tests/spark/function/features/from_xml.feature
+++ b/python/pysail/tests/spark/function/features/from_xml.feature
@@ -1,0 +1,328 @@
+Feature: from_xml parses an XML string into a struct value
+
+  Rule: Primitive types
+
+    Scenario: Parse INT and DOUBLE fields
+      When query
+        """
+        SELECT from_xml('<p><a>1</a><b>0.4</b></p>', 'a INT, b DOUBLE') AS r
+        """
+      Then query result
+        | r          |
+        | {1, 0.4}   |
+
+    Scenario: Parse STRING field
+      When query
+        """
+        SELECT from_xml('<p><s>sunset</s></p>', 's STRING').s AS result
+        """
+      Then query result
+        | result |
+        | sunset  |
+
+    Scenario: Parse BOOLEAN true
+      When query
+        """
+        SELECT from_xml('<p><flag>true</flag></p>', 'flag BOOLEAN').flag AS result
+        """
+      Then query result
+        | result |
+        | true   |
+
+    Scenario: Parse BOOLEAN false
+      When query
+        """
+        SELECT from_xml('<p><flag>false</flag></p>', 'flag BOOLEAN').flag AS result
+        """
+      Then query result
+        | result |
+        | false  |
+
+    Scenario: Parse LONG field
+      When query
+        """
+        SELECT from_xml('<p><x>43</x></p>', 'x LONG').x AS result
+        """
+      Then query result
+        | result |
+        | 43     |
+
+  Rule: Root tag is ignored
+
+    Scenario: Root tag name does not affect parsing
+      When query
+        """
+        SELECT
+          from_xml('<ROW><a>4</a></ROW>',      'a INT').a AS r1,
+          from_xml('<record><a>4</a></record>', 'a INT').a AS r2,
+          from_xml('<p><a>4</a></p>',           'a INT').a AS r3
+        """
+      Then query result
+        | r1 | r2 | r3 |
+        | 4  | 4  | 4  |
+
+  Rule: NULL handling
+
+    Scenario: NULL input string returns NULL struct
+      When query
+        """
+        SELECT from_xml(CAST(NULL AS STRING), 'a INT') AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: Missing tag returns NULL field
+      When query
+        """
+        SELECT from_xml('<p><b>1</b></p>', 'a INT, b INT') AS r
+        """
+      Then query result
+        | r         |
+        | {NULL, 1} |
+
+    Scenario: Empty tag with INT schema returns NULL
+      When query
+        """
+        SELECT from_xml('<p><a></a></p>', 'a INT').a AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: Empty tag with STRING schema returns empty string
+      When query
+        """
+        SELECT from_xml('<p><a></a></p>', 'a STRING').a AS result
+        """
+      Then query result
+        | result |
+        |        |
+
+    Scenario: Multi-row with missing field and NULL row
+      When query
+        """
+        SELECT from_xml(xml_col, 'a INT, b STRING') AS r
+        FROM VALUES
+          ('<p><a>1</a><b>x</b></p>'),
+          ('<p><a>2</a><b>y</b></p>'),
+          ('<p><a>3</a></p>'),
+          (CAST(NULL AS STRING))
+        AS t(xml_col)
+        """
+      Then query result
+        | r         |
+        | {1, x}    |
+        | {2, y}    |
+        | {3, NULL} |
+        | NULL      |
+
+  Rule: nullValue option
+
+    Scenario: nullValue option maps matching string to NULL for INT
+      When query
+        """
+        SELECT from_xml('<p><a>N/A</a></p>', 'a INT', map('nullValue', 'N/A')).a AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: nullValue option maps matching string to NULL for STRING
+      When query
+        """
+        SELECT from_xml('<p><a>N/A</a></p>', 'a STRING', map('nullValue', 'N/A')).a AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: nullValue empty string turns empty tag into NULL for STRING
+      When query
+        """
+        SELECT from_xml('<p><a></a></p>', 'a STRING', map('nullValue', '')).a AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+  Rule: Nested structures
+
+    Scenario: Nested struct becomes nested field access
+      When query
+        """
+        SELECT from_xml(
+          '<p><teacher>Pablo</teacher><student><name>Ana</name><rank>1</rank></student></p>',
+          'teacher STRING, student STRUCT<name: STRING, rank: INT>'
+        ) AS r
+        """
+      Then query result
+        | r                           |
+        | {Pablo, {Ana, 1}}           |
+
+    Scenario: Three levels of nesting
+      When query
+        """
+        SELECT from_xml('<p><a><b><c>45</c></b></a></p>', 'a STRUCT<b: STRUCT<c: INT>>').a.b.c AS result
+        """
+      Then query result
+        | result |
+        | 45     |
+
+  Rule: Arrays
+
+    Scenario: Repeated tags produce array of primitives
+      When query
+        """
+        SELECT from_xml('<p><a>1</a><a>2</a><a>3</a></p>', 'a ARRAY<INT>').a AS result
+        """
+      Then query result
+        | result    |
+        | [1, 2, 3] |
+
+    Scenario: Repeated struct tags produce array of structs
+      When query
+        """
+        SELECT from_xml(
+          '<p><student><name>Bob</name><rank>1</rank></student><student><name>Charlie</name><rank>2</rank></student></p>',
+          'student ARRAY<STRUCT<name: STRING, rank: INT>>'
+        ).student AS result
+        """
+      Then query result
+        | result                              |
+        | [{Bob, 1}, {Charlie, 2}]            |
+
+  Rule: Date and timestamp types
+
+    Scenario: Parse DATE with default format
+      When query
+        """
+        SELECT from_xml('<p><d>2026-06-17</d></p>', 'd DATE').d AS result
+        """
+      Then query result
+        | result     |
+        | 2026-06-17 |
+
+    Scenario: Parse TIMESTAMP with default format
+      When query
+        """
+        SELECT from_xml('<p><ts>2026-06-17T18:00:00.000</ts></p>', 'ts TIMESTAMP').ts AS result
+        """
+      Then query result
+        | result              |
+        | 2026-06-17 18:00:00 |
+
+    Scenario: Custom timestampFormat option
+      When query
+        """
+        SELECT from_xml(
+          '<p><ts>17/06/2026</ts></p>',
+          'ts TIMESTAMP',
+          map('timestampFormat', 'dd/MM/yyyy')
+        ).ts AS result
+        """
+      Then query result
+        | result              |
+        | 2026-06-17 00:00:00 |
+
+    Scenario: Parse TIMESTAMP_NTZ with default format
+      When query
+        """
+        SELECT from_xml('<p><ts>2026-06-17T18:00:00.000</ts></p>', 'ts TIMESTAMP_NTZ').ts AS result
+        """
+      Then query result
+        | result                  |
+        | 2026-06-17 18:00:00 |
+
+    Scenario: Custom timestampNTZFormat option
+      When query
+        """
+        SELECT from_xml(
+          '<p><ts>17/06/2026 18:00</ts></p>',
+          'ts TIMESTAMP_NTZ',
+          map('timestampNTZFormat', 'dd/MM/yyyy HH:mm')
+        ).ts AS result
+        """
+      Then query result
+        | result                  |
+        | 2026-06-17 18:00:00 |
+
+  Rule: XML entity unescaping
+
+    Scenario: Less-than entity is unescaped
+      When query
+        """
+        SELECT from_xml('<p><s>a &lt; b</s></p>', 's STRING').s AS result
+        """
+      Then query result
+        | result  |
+        | a < b   |
+
+    Scenario: Ampersand entity is unescaped
+      When query
+        """
+        SELECT from_xml('<p><s>a &amp; b</s></p>', 's STRING').s AS result
+        """
+      Then query result
+        | result  |
+        | a & b   |
+
+    Scenario: Greater-than entity is unescaped
+      When query
+        """
+        SELECT from_xml('<p><s>a &gt; b</s></p>', 's STRING').s AS result
+        """
+      Then query result
+        | result  |
+        | a > b   |
+
+    Scenario: Quote entity is unescaped
+      When query
+        """
+        SELECT from_xml('<p><s>say &quot;hi&quot;</s></p>', 's STRING').s AS result
+        """
+      Then query result
+        | result    |
+        | say "hi"  |
+
+  Rule: Attributes
+
+    Scenario: Attributes are parsed with default underscore prefix
+      When query
+        """
+        SELECT from_xml('<p id="99"><name>Agua</name></p>', '_id STRING, name STRING') AS r
+        """
+      Then query result
+        | r             |
+        | {99, Agua}   |
+
+    Scenario: Custom attributePrefix option
+      When query
+        """
+        SELECT from_xml('<p id="99"><name>Amber</name></p>', 'id STRING, name STRING', map('attributePrefix', '')) AS r
+        """
+      Then query result
+        | r             |
+        | {99, Amber}   |
+
+  Rule: valueTag option
+
+    Scenario: Text content of element is captured via default valueTag field
+      When query
+        """
+        SELECT from_xml('<p id="7">colors</p>', '_id STRING, _VALUE STRING') AS r
+        """
+      Then query result
+        | r          |
+        | {7, colors} |
+
+  Rule: Parse mode
+
+    Scenario: PERMISSIVE mode returns NULL field for bad cast
+      When query
+        """
+        SELECT from_xml('<p><a>not_a_number</a></p>', 'a INT').a AS result
+        """
+      Then query result
+        | result |
+        | NULL   |


### PR DESCRIPTION
Implements from_xml (XmlToStructs), the inverse of to_xml. Parses an XML string column into a struct value using a user-provided schema.

Ref: [Spark docs](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.from_xml.html)

| Option | Default |
|---|---|
| `timestampFormat` | `yyyy-MM-dd'T'HH:mm:ss.SSS` |
| `timestampNTZFormat` | `yyyy-MM-dd'T'HH:mm:ss.SSS` |
| `dateFormat` | `yyyy-MM-dd` |
| `nullValue` | (none) |
| `attributePrefix` | `_` |
| `valueTag` | `_VALUE` |
| `mode` | `PERMISSIVE` |

Supported types: `TINYINT`, `SMALLINT`, `INT`, `BIGINT`, `FLOAT`, `DOUBLE`, `BOOLEAN`, `STRING`, `DATE`, `TIMESTAMP`, `TIMESTAMP_NTZ`, `DECIMAL`, `ARRAY`, `STRUCT` (recursive).

A few things worth noting:
- Root element name is ignored — `<ROW>`, `<record>`, `<p>` all parse identically
- Missing tags → `NULL` for that field; other fields unaffected
- Empty tag + numeric schema → `NULL`; empty tag + `STRING` → `""`
- `nullValue` maps a matching string to `NULL` for any type
- `attributePrefix` (default `_`): field `_id` reads XML attribute `id`; empty prefix falls through to element lookup if attribute not found
- `valueTag` (default `_VALUE`) captures inline text content of the element; checked before `attributePrefix`
- XML entities (`&lt;`, `&amp;`, `&gt;`, `&quot;`) unescaped automatically via `xot`
- `DECIMAL` truncates to scale, overflow → `NULL`
- `BINARY` → `NULL` (matches Spark behavior)
- Schema argument accepts any expression that folds to a string literal at planning
  time (e.g. `concat('a INT', ' , b STRING')`), not just a literal string directly.
  `schema_of_xml(...)` itself is not yet implemented, once it
  lands, this same literal-folding path will pick it up with no further changes needed.
- `DROPMALFORMED` mode rejected by Spark itself; only `PERMISSIVE` and `FAILFAST` are valid

## Files changed
- `from_xml.rs`: core implementation + unit tests
- `mod.rs`: module registration
- `xml.rs`: wires up the real UDF replacing `F::unknown("from_xml")`
- `codec.rs`: encode/decode for distributed execution
- `physical.proto`: proto message `SparkFromXmlUdf` (field 32)
- `from_xml.feature`: integration test scenarios
- `xml.json`: gold data updated (3 existing `from_xml` entries now passing)

Part of https://github.com/lakehq/sail/issues/231