### PR TITLE
fix: array_position

### DIFF
--- a/crates/sail-execution/src/codec.rs
+++ b/crates/sail-execution/src/codec.rs
@@ -126,6 +126,7 @@ use sail_function::aggregate::theta_sketch::{
 };
 use sail_function::aggregate::try_avg::TryAvgFunction;
 use sail_function::scalar::array::array_intersect::ArrayIntersect;
+use sail_function::scalar::array::array_position::SparkArrayPosition;
 use sail_function::scalar::array::arrays_zip::ArraysZip;
 use sail_function::scalar::array::spark_array::SparkArray;
 use sail_function::scalar::array::spark_array_compact::SparkArrayCompact;
@@ -2333,6 +2334,9 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             "array_intersect" | "list_intersect" => {
                 Ok(Arc::new(ScalarUDF::from(ArrayIntersect::new())))
             }
+            "spark_array_position" | "array_position" => {
+                Ok(Arc::new(ScalarUDF::from(SparkArrayPosition::new())))
+            }
             "spark_array_compact" => Ok(Arc::new(ScalarUDF::from(SparkArrayCompact::new()))),
             "bitmap_count" => Ok(Arc::new(ScalarUDF::from(BitmapCount::new()))),
             "format_string" => Ok(Arc::new(ScalarUDF::from(FormatStringFunc::new()))),
@@ -2511,6 +2515,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node_inner.is::<ArrayMax>()
             || node_inner.is::<ArrayMin>()
             || node_inner.is::<ArrayIntersect>()
+            || node_inner.is::<SparkArrayPosition>()
             || node_inner.is::<SparkArrayCompact>()
             || node_inner.is::<BitmapCount>()
             || node_inner.is::<FormatStringFunc>()

--- a/crates/sail-function/src/scalar/array/array_position.rs
+++ b/crates/sail-function/src/scalar/array/array_position.rs
@@ -7,13 +7,14 @@ use arrow::array::{
 };
 use arrow::buffer::{NullBuffer, ScalarBuffer};
 use arrow::datatypes::{
-    ArrowPrimitiveType, DataType, Date32Type, Decimal128Type, Float32Type, Float64Type, Int16Type,
-    Int32Type, Int64Type, Int8Type, TimestampMicrosecondType,
+    ArrowPrimitiveType, DataType, Date32Type, Decimal128Type, Field, Float32Type, Float64Type,
+    Int16Type, Int32Type, Int64Type, Int8Type, TimestampMicrosecondType,
 };
 use datafusion::common::{exec_err, DataFusionError, Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::{
-    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
+    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
+use datafusion_expr::type_coercion::binary::comparison_coercion;
 use num::Float;
 
 #[derive(Debug, Hash, Eq, PartialEq)]
@@ -30,7 +31,7 @@ impl Default for SparkArrayPosition {
 impl SparkArrayPosition {
     pub fn new() -> Self {
         Self {
-            signature: Signature::new(TypeSignature::Any(2), Volatility::Immutable),
+            signature: Signature::user_defined(Volatility::Immutable),
         }
     }
 }
@@ -50,6 +51,59 @@ impl ScalarUDFImpl for SparkArrayPosition {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DataFusionResult<ColumnarValue> {
         spark_array_position(&args.args)
+    }
+
+    fn coerce_types(&self, arg_types: &[DataType]) -> DataFusionResult<Vec<DataType>> {
+        if arg_types.len() != 2 {
+            return exec_err!("array_position function takes exactly two arguments");
+        }
+
+        let element_type = &arg_types[1];
+        let (array_type, element_type) = match &arg_types[0] {
+            DataType::List(field)
+            | DataType::ListView(field)
+            | DataType::FixedSizeList(field, _) => {
+                let element_type = coerced_element_type(field.data_type(), element_type)?;
+                (
+                    DataType::List(Arc::new(Field::new_list_field(
+                        element_type.clone(),
+                        field.is_nullable(),
+                    ))),
+                    element_type,
+                )
+            }
+            DataType::LargeList(field) | DataType::LargeListView(field) => {
+                let element_type = coerced_element_type(field.data_type(), element_type)?;
+                (
+                    DataType::LargeList(Arc::new(Field::new_list_field(
+                        element_type.clone(),
+                        field.is_nullable(),
+                    ))),
+                    element_type,
+                )
+            }
+            array_type => {
+                return exec_err!("array_position does not support type '{array_type:?}'");
+            }
+        };
+
+        Ok(vec![array_type, element_type])
+    }
+}
+
+fn coerced_element_type(left: &DataType, right: &DataType) -> DataFusionResult<DataType> {
+    if left == right {
+        Ok(left.clone())
+    } else if left.is_null() {
+        Ok(right.clone())
+    } else if right.is_null() {
+        Ok(left.clone())
+    } else {
+        comparison_coercion(left, right).ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "array_position does not support element types '{left:?}' and '{right:?}'"
+            ))
+        })
     }
 }
 
@@ -125,6 +179,7 @@ fn generic_array_position<O: OffsetSizeTrait>(
         }
         DataType::Utf8 => position_string::<O, i32>(list_array, offsets, values, element),
         DataType::LargeUtf8 => position_string::<O, i64>(list_array, offsets, values, element),
+        DataType::Utf8View => position_string_view::<O>(list_array, offsets, values, element),
         // Fallback to ScalarValue for complex types (nested arrays, etc.)
         _ => position_fallback::<O>(list_array, offsets, values, element),
     }
@@ -261,6 +316,36 @@ fn position_string<O: OffsetSizeTrait, S: OffsetSizeTrait>(
 ) -> Result<ArrayRef, DataFusionError> {
     let values_typed = values.as_string::<S>();
     let element_typed = element.as_string::<S>();
+    let num_rows = list_array.len();
+    let nulls = combined_nulls(list_array.nulls(), element.nulls());
+    let mut result = vec![0i64; num_rows];
+
+    for (row_index, w) in offsets.windows(2).enumerate() {
+        if nulls.as_ref().is_some_and(|n| n.is_null(row_index)) {
+            continue;
+        }
+        let start = w[0].as_usize();
+        let end = w[1].as_usize();
+        let search_val = element_typed.value(row_index);
+        for i in start..end {
+            if !values_typed.is_null(i) && values_typed.value(i) == search_val {
+                result[row_index] = (i - start + 1) as i64;
+                break;
+            }
+        }
+    }
+
+    Ok(Arc::new(Int64Array::new(ScalarBuffer::from(result), nulls)))
+}
+
+fn position_string_view<O: OffsetSizeTrait>(
+    list_array: &GenericListArray<O>,
+    offsets: &arrow::buffer::OffsetBuffer<O>,
+    values: &ArrayRef,
+    element: &ArrayRef,
+) -> Result<ArrayRef, DataFusionError> {
+    let values_typed = values.as_string_view();
+    let element_typed = element.as_string_view();
     let num_rows = list_array.len();
     let nulls = combined_nulls(list_array.nulls(), element.nulls());
     let mut result = vec![0i64; num_rows];

--- a/crates/sail-function/src/scalar/array/array_position.rs
+++ b/crates/sail-function/src/scalar/array/array_position.rs
@@ -1,0 +1,316 @@
+// [CREDIT]: https://raw.githubusercontent.com/apache/datafusion-comet/c41e4645a92dc3121d62004515f3fb03f1348631/native/spark-expr/src/array_funcs/array_position.rs
+
+use std::sync::Arc;
+
+use arrow::array::{
+    Array, ArrayRef, AsArray, BooleanArray, GenericListArray, Int64Array, OffsetSizeTrait,
+};
+use arrow::buffer::{NullBuffer, ScalarBuffer};
+use arrow::datatypes::{
+    ArrowPrimitiveType, DataType, Date32Type, Decimal128Type, Float32Type, Float64Type, Int16Type,
+    Int32Type, Int64Type, Int8Type, TimestampMicrosecondType,
+};
+use datafusion::common::{exec_err, DataFusionError, Result as DataFusionResult, ScalarValue};
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
+};
+use num::Float;
+
+#[derive(Debug, Hash, Eq, PartialEq)]
+pub struct SparkArrayPosition {
+    signature: Signature,
+}
+
+impl Default for SparkArrayPosition {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SparkArrayPosition {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::new(TypeSignature::Any(2), Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for SparkArrayPosition {
+    fn name(&self) -> &str {
+        "spark_array_position"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
+        Ok(DataType::Int64)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DataFusionResult<ColumnarValue> {
+        spark_array_position(&args.args)
+    }
+}
+
+/// Spark array_position() function that returns the 1-based position of an element in an array.
+/// Returns 0 if the element is not found (Spark behavior differs from DataFusion which returns null).
+fn spark_array_position(args: &[ColumnarValue]) -> Result<ColumnarValue, DataFusionError> {
+    if args.len() != 2 {
+        return exec_err!("array_position function takes exactly two arguments");
+    }
+
+    let len = args
+        .iter()
+        .fold(Option::<usize>::None, |acc, arg| match arg {
+            ColumnarValue::Scalar(_) => acc,
+            ColumnarValue::Array(a) => Some(a.len()),
+        });
+
+    let is_scalar = len.is_none();
+    let arrays = ColumnarValue::values_to_arrays(args)?;
+
+    let result = array_position_inner(&arrays)?;
+
+    if is_scalar {
+        let scalar = ScalarValue::try_from_array(&result, 0)?;
+        Ok(ColumnarValue::Scalar(scalar))
+    } else {
+        Ok(ColumnarValue::Array(result))
+    }
+}
+
+fn array_position_inner(args: &[ArrayRef]) -> Result<ArrayRef, DataFusionError> {
+    let array = &args[0];
+    let element = &args[1];
+
+    match array.data_type() {
+        DataType::List(_) => generic_array_position::<i32>(array, element),
+        DataType::LargeList(_) => generic_array_position::<i64>(array, element),
+        other => exec_err!("array_position does not support type '{other:?}'"),
+    }
+}
+
+/// Searches for an element in a list array using the flat values buffer and offsets directly,
+/// avoiding per-row subarray allocation. Dispatches to typed fast paths by element data type.
+fn generic_array_position<O: OffsetSizeTrait>(
+    array: &ArrayRef,
+    element: &ArrayRef,
+) -> Result<ArrayRef, DataFusionError> {
+    let list_array = array
+        .as_any()
+        .downcast_ref::<GenericListArray<O>>()
+        .ok_or_else(|| DataFusionError::Internal("expected list array".into()))?;
+
+    let values = list_array.values();
+    let offsets = list_array.offsets();
+    let elem_type = values.data_type().clone();
+
+    match &elem_type {
+        DataType::Boolean => position_boolean::<O>(list_array, offsets, values, element),
+        DataType::Int8 => position_primitive::<O, Int8Type>(list_array, offsets, values, element),
+        DataType::Int16 => position_primitive::<O, Int16Type>(list_array, offsets, values, element),
+        DataType::Int32 => position_primitive::<O, Int32Type>(list_array, offsets, values, element),
+        DataType::Int64 => position_primitive::<O, Int64Type>(list_array, offsets, values, element),
+        DataType::Float32 => position_float::<O, Float32Type>(list_array, offsets, values, element),
+        DataType::Float64 => position_float::<O, Float64Type>(list_array, offsets, values, element),
+        DataType::Decimal128(_, _) => {
+            position_primitive::<O, Decimal128Type>(list_array, offsets, values, element)
+        }
+        DataType::Date32 => {
+            position_primitive::<O, Date32Type>(list_array, offsets, values, element)
+        }
+        DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, _) => {
+            position_primitive::<O, TimestampMicrosecondType>(list_array, offsets, values, element)
+        }
+        DataType::Utf8 => position_string::<O, i32>(list_array, offsets, values, element),
+        DataType::LargeUtf8 => position_string::<O, i64>(list_array, offsets, values, element),
+        // Fallback to ScalarValue for complex types (nested arrays, etc.)
+        _ => position_fallback::<O>(list_array, offsets, values, element),
+    }
+}
+
+/// Compute the combined null buffer from list array and element nulls.
+fn combined_nulls(
+    list_array_nulls: Option<&NullBuffer>,
+    element_nulls: Option<&NullBuffer>,
+) -> Option<NullBuffer> {
+    match (list_array_nulls, element_nulls) {
+        (Some(a), Some(b)) => NullBuffer::union(Some(a), Some(b)),
+        (Some(a), None) => Some(a.clone()),
+        (None, Some(b)) => Some(b.clone()),
+        (None, None) => None,
+    }
+}
+
+/// Fast path for primitive types: downcast once, iterate using offsets into the flat buffer.
+fn position_primitive<O: OffsetSizeTrait, T: ArrowPrimitiveType>(
+    list_array: &GenericListArray<O>,
+    offsets: &arrow::buffer::OffsetBuffer<O>,
+    values: &ArrayRef,
+    element: &ArrayRef,
+) -> Result<ArrayRef, DataFusionError>
+where
+    T::Native: PartialEq,
+{
+    let values_typed = values.as_primitive::<T>();
+    let element_typed = element.as_primitive::<T>();
+    let num_rows = list_array.len();
+    let nulls = combined_nulls(list_array.nulls(), element.nulls());
+    let mut result = vec![0i64; num_rows];
+
+    for (row_index, w) in offsets.windows(2).enumerate() {
+        if nulls.as_ref().is_some_and(|n| n.is_null(row_index)) {
+            continue;
+        }
+        let start = w[0].as_usize();
+        let end = w[1].as_usize();
+        let search_val = element_typed.value(row_index);
+        for i in start..end {
+            if !values_typed.is_null(i) && values_typed.value(i) == search_val {
+                result[row_index] = (i - start + 1) as i64;
+                break;
+            }
+        }
+    }
+
+    Ok(Arc::new(Int64Array::new(ScalarBuffer::from(result), nulls)))
+}
+
+/// Float path: same as primitive but treats NaN == NaN (Spark's ordering.equiv() semantics).
+fn position_float<O: OffsetSizeTrait, T: ArrowPrimitiveType>(
+    list_array: &GenericListArray<O>,
+    offsets: &arrow::buffer::OffsetBuffer<O>,
+    values: &ArrayRef,
+    element: &ArrayRef,
+) -> Result<ArrayRef, DataFusionError>
+where
+    T::Native: PartialEq + Float,
+{
+    let values_typed = values.as_primitive::<T>();
+    let element_typed = element.as_primitive::<T>();
+    let num_rows = list_array.len();
+    let nulls = combined_nulls(list_array.nulls(), element.nulls());
+    let mut result = vec![0i64; num_rows];
+
+    for (row_index, w) in offsets.windows(2).enumerate() {
+        if nulls.as_ref().is_some_and(|n| n.is_null(row_index)) {
+            continue;
+        }
+        let start = w[0].as_usize();
+        let end = w[1].as_usize();
+        let search_val = element_typed.value(row_index);
+        let search_is_nan = search_val.is_nan();
+        for i in start..end {
+            if !values_typed.is_null(i) {
+                let v = values_typed.value(i);
+                if (search_is_nan && v.is_nan()) || v == search_val {
+                    result[row_index] = (i - start + 1) as i64;
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(Arc::new(Int64Array::new(ScalarBuffer::from(result), nulls)))
+}
+
+/// Boolean path.
+fn position_boolean<O: OffsetSizeTrait>(
+    list_array: &GenericListArray<O>,
+    offsets: &arrow::buffer::OffsetBuffer<O>,
+    values: &ArrayRef,
+    element: &ArrayRef,
+) -> Result<ArrayRef, DataFusionError> {
+    let values_typed = values
+        .as_any()
+        .downcast_ref::<BooleanArray>()
+        .ok_or_else(|| DataFusionError::Internal("expected boolean array".into()))?;
+    let element_typed = element
+        .as_any()
+        .downcast_ref::<BooleanArray>()
+        .ok_or_else(|| DataFusionError::Internal("expected boolean array".into()))?;
+    let num_rows = list_array.len();
+    let nulls = combined_nulls(list_array.nulls(), element.nulls());
+    let mut result = vec![0i64; num_rows];
+
+    for (row_index, w) in offsets.windows(2).enumerate() {
+        if nulls.as_ref().is_some_and(|n| n.is_null(row_index)) {
+            continue;
+        }
+        let start = w[0].as_usize();
+        let end = w[1].as_usize();
+        let search_val = element_typed.value(row_index);
+        for i in start..end {
+            if !values_typed.is_null(i) && values_typed.value(i) == search_val {
+                result[row_index] = (i - start + 1) as i64;
+                break;
+            }
+        }
+    }
+
+    Ok(Arc::new(Int64Array::new(ScalarBuffer::from(result), nulls)))
+}
+
+/// String path: downcast once, iterate using offsets into the flat string buffer.
+fn position_string<O: OffsetSizeTrait, S: OffsetSizeTrait>(
+    list_array: &GenericListArray<O>,
+    offsets: &arrow::buffer::OffsetBuffer<O>,
+    values: &ArrayRef,
+    element: &ArrayRef,
+) -> Result<ArrayRef, DataFusionError> {
+    let values_typed = values.as_string::<S>();
+    let element_typed = element.as_string::<S>();
+    let num_rows = list_array.len();
+    let nulls = combined_nulls(list_array.nulls(), element.nulls());
+    let mut result = vec![0i64; num_rows];
+
+    for (row_index, w) in offsets.windows(2).enumerate() {
+        if nulls.as_ref().is_some_and(|n| n.is_null(row_index)) {
+            continue;
+        }
+        let start = w[0].as_usize();
+        let end = w[1].as_usize();
+        let search_val = element_typed.value(row_index);
+        for i in start..end {
+            if !values_typed.is_null(i) && values_typed.value(i) == search_val {
+                result[row_index] = (i - start + 1) as i64;
+                break;
+            }
+        }
+    }
+
+    Ok(Arc::new(Int64Array::new(ScalarBuffer::from(result), nulls)))
+}
+
+/// Fallback for complex types (nested arrays, structs, etc.) using ScalarValue comparison.
+fn position_fallback<O: OffsetSizeTrait>(
+    list_array: &GenericListArray<O>,
+    offsets: &arrow::buffer::OffsetBuffer<O>,
+    values: &ArrayRef,
+    element: &ArrayRef,
+) -> Result<ArrayRef, DataFusionError> {
+    let num_rows = list_array.len();
+    let nulls = combined_nulls(list_array.nulls(), element.nulls());
+    let mut result = vec![0i64; num_rows];
+
+    for (row_index, w) in offsets.windows(2).enumerate() {
+        if nulls.as_ref().is_some_and(|n| n.is_null(row_index)) {
+            continue;
+        }
+        let start = w[0].as_usize();
+        let end = w[1].as_usize();
+        let search_scalar = ScalarValue::try_from_array(element, row_index)?;
+        for i in start..end {
+            if !values.is_null(i) {
+                let item_scalar = ScalarValue::try_from_array(values, i)?;
+                if search_scalar == item_scalar {
+                    result[row_index] = (i - start + 1) as i64;
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(Arc::new(Int64Array::new(ScalarBuffer::from(result), nulls)))
+}

--- a/crates/sail-function/src/scalar/array/mod.rs
+++ b/crates/sail-function/src/scalar/array/mod.rs
@@ -1,4 +1,5 @@
 pub mod array_intersect;
+pub mod array_position;
 pub mod arrays_zip;
 pub mod spark_array;
 pub mod spark_array_compact;

--- a/crates/sail-plan/src/function/scalar/array.rs
+++ b/crates/sail-plan/src/function/scalar/array.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::functions::expr_fn::{coalesce, nvl};
 use datafusion::functions_nested::expr_fn;
-use datafusion::functions_nested::position::array_position as datafusion_array_position;
 use datafusion_common::ScalarValue;
 use datafusion_expr::{cast, expr, is_null, lit, not, or, when, ExprSchemable, ScalarUDF};
 use datafusion_functions_nested::make_array::make_array;
@@ -11,6 +10,7 @@ use datafusion_functions_nested::string::ArrayToString;
 use datafusion_spark::function::array::expr_fn as array_fn;
 use sail_common_datafusion::utils::items::ItemTaker;
 use sail_function::scalar::array::array_intersect::ArrayIntersect;
+use sail_function::scalar::array::array_position::SparkArrayPosition;
 use sail_function::scalar::array::arrays_zip::ArraysZip;
 use sail_function::scalar::array::spark_array::SparkArray;
 use sail_function::scalar::array::spark_array_compact::SparkArrayCompact;
@@ -155,23 +155,6 @@ fn array_contains(array: expr::Expr, element: expr::Expr) -> PlanResult<expr::Ex
 
 fn array_contains_all(array: expr::Expr, element: expr::Expr) -> expr::Expr {
     nvl(expr_fn::array_has_all(array, element), lit(false))
-}
-
-fn array_position(array: expr::Expr, element: expr::Expr) -> PlanResult<expr::Expr> {
-    Ok(coalesce(vec![
-        datafusion_array_position(
-            // datafusion panics if from_index > array_len
-            // So if the inner array_len == 0, search in NULL array instead
-            when(
-                expr_fn::cardinality(array.clone()).gt(lit(0)),
-                array.clone(),
-            )
-            .end()?,
-            element,
-            lit(1_i32),
-        ),
-        when(array.clone().is_not_null(), lit(0_i32)).end()?,
-    ]))
 }
 
 fn array_insert(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
@@ -404,7 +387,7 @@ pub(super) fn list_built_in_array_functions() -> Vec<(&'static str, ScalarFuncti
         ("array_join", F::udf(ArrayToString::new())),
         ("array_max", F::udf(ArrayMax::new())),
         ("array_min", F::udf(ArrayMin::new())),
-        ("array_position", F::binary(array_position)),
+        ("array_position", F::udf(SparkArrayPosition::new())),
         ("array_prepend", F::custom(array_prepend)),
         ("array_remove", F::binary(expr_fn::array_remove_all)),
         ("array_repeat", F::custom(array_repeat)),


### PR DESCRIPTION
- Copies implementation from Comet and attributes credit in the code comments.
- Extends Comet implementation to add support for `DataType::Utf8View`.
- Extends Comet implementation to add `coerce_types` for full Spark parity.