### PR TITLE
fix: align EXPLAIN EXTENDED, and COST output with Spark

### DIFF
--- a/crates/sail-plan/src/explain.rs
+++ b/crates/sail-plan/src/explain.rs
@@ -82,6 +82,7 @@ pub struct ExplainString {
 
 struct CollectedPlan {
     initial_logical: LogicalPlan,
+    analyzed_logical: LogicalPlan,
     optimized_logical: LogicalPlan,
     physical_plan: Option<Arc<dyn ExecutionPlan>>,
     physical_error: Option<String>,
@@ -91,6 +92,19 @@ struct CollectedPlan {
 impl CollectedPlan {
     fn logical_string(&self, plan: &LogicalPlan, plan_type: PlanType) -> String {
         plan.to_stringified(plan_type).plan.to_string()
+    }
+
+    fn logical_string_with_schema(&self, plan: &LogicalPlan, plan_type: PlanType) -> String {
+        let stringified_logical = self.logical_string(plan, plan_type);
+        let stringified_schema = plan
+            .schema()
+            .inner()
+            .fields()
+            .iter()
+            .map(|f| format!("{}: {}", f.name(), f.data_type()))
+            .collect::<Vec<String>>()
+            .join(", ");
+        format!("{}\n{}", stringified_schema, stringified_logical)
     }
 
     fn physical_string(
@@ -185,7 +199,7 @@ async fn collect_plan_with(
     stringified.push(analyzed_logical.to_stringified(PlanType::FinalAnalyzedLogicalPlan));
 
     let optimized_logical = session_state.optimizer().optimize(
-        analyzed_logical,
+        analyzed_logical.clone(),
         &session_state,
         |optimized_plan, optimizer| {
             let plan_type = PlanType::OptimizedLogicalPlan {
@@ -306,6 +320,7 @@ async fn collect_plan_with(
 
     Ok(CollectedPlan {
         initial_logical,
+        analyzed_logical,
         optimized_logical,
         physical_plan,
         physical_error,
@@ -390,6 +405,8 @@ async fn explain_from_collected(
 
     let logical_simple =
         collected.logical_string(&collected.initial_logical, PlanType::InitialLogicalPlan);
+    let logical_analyzed_schema =
+        collected.logical_string_with_schema(&collected.analyzed_logical, PlanType::FinalAnalyzedLogicalPlan);
     let logical_optimized =
         collected.logical_string(&collected.optimized_logical, PlanType::FinalLogicalPlan);
 
@@ -417,9 +434,8 @@ async fn explain_from_collected(
         }
         ExplainKind::Extended => [
             render_section("Parsed Logical Plan", &logical_simple),
-            // TODO: Spark expects distinct analyzed vs optimized plans
-            // Avoid duplicating the same plan until we can separate.
-            render_section("Analyzed Logical Plan", &logical_optimized),
+            render_section("Analyzed Logical Plan", &logical_analyzed_schema),
+            render_section("Optimized Logical Plan", &logical_optimized),
             render_section(
                 "Physical Plan",
                 if options.analyze {

--- a/crates/sail-plan/src/explain.rs
+++ b/crates/sail-plan/src/explain.rs
@@ -405,8 +405,10 @@ async fn explain_from_collected(
 
     let logical_simple =
         collected.logical_string(&collected.initial_logical, PlanType::InitialLogicalPlan);
-    let logical_analyzed_schema =
-        collected.logical_string_with_schema(&collected.analyzed_logical, PlanType::FinalAnalyzedLogicalPlan);
+    let logical_analyzed_schema = collected.logical_string_with_schema(
+        &collected.analyzed_logical,
+        PlanType::FinalAnalyzedLogicalPlan,
+    );
     let logical_optimized =
         collected.logical_string(&collected.optimized_logical, PlanType::FinalLogicalPlan);
 

--- a/crates/sail-plan/src/explain.rs
+++ b/crates/sail-plan/src/explain.rs
@@ -434,6 +434,7 @@ async fn explain_from_collected(
         }
         ExplainKind::Extended => [
             render_section("Parsed Logical Plan", &logical_simple),
+            // prepend schema to make analyzed plan distinct from optimized plan
             render_section("Analyzed Logical Plan", &logical_analyzed_schema),
             render_section("Optimized Logical Plan", &logical_optimized),
             render_section(

--- a/crates/sail-plan/src/explain.rs
+++ b/crates/sail-plan/src/explain.rs
@@ -467,8 +467,7 @@ async fn explain_from_collected(
         ]
         .join("\n\n"),
         ExplainKind::Cost => [
-            render_section("Parsed Logical Plan", &logical_simple),
-            render_section("Analyzed Logical Plan", &logical_optimized),
+            render_section("Optimized Logical Plan", &logical_optimized),
             // TODO: Spark COST mode shows logical plan + stats; we currently return physical +
             // stats
             render_section(

--- a/crates/sail-sql-analyzer/src/statement.rs
+++ b/crates/sail-sql-analyzer/src/statement.rs
@@ -2026,7 +2026,6 @@ fn from_ast_sort_column(sort: SortColumn) -> SqlResult<spec::SortOrder> {
 
 fn from_ast_explain_format(format: Option<ExplainFormat>) -> SqlResult<spec::ExplainMode> {
     // TODO(spark-compat):
-    //   - EXTENDED: emit Parsed/Analyzed/Optimized Logical Plan sections distinctly.
     //   - COST: match Spark (logical + stats, not physical-with-stats).
     //   - FORMATTED: add outline + node-details sections to mirror Spark.
     //   - CODEGEN: keep "unsupported" notice until DataFusion adds support.

--- a/python/pysail/tests/spark/analyzer/__snapshots__/features/explain.yaml
+++ b/python/pysail/tests/spark/analyzer/__snapshots__/features/explain.yaml
@@ -363,15 +363,7 @@ data:
 name: "test_explain_cost_shows_logical_plans_with_stats"
 data:
   |-
-    == Parsed Logical Plan ==
-    Projection: t.#2 AS #4, sum(t.#3) AS #5
-      Aggregate: groupBy=[[t.#2]], aggr=[[sum(t.#3)]]
-        SubqueryAlias: t
-          Projection: #0 AS #2, #1 AS #3
-            Projection: column1 AS #0, column2 AS #1
-              Values: (Int32(1), Int32(2)), (Int32(1), Int32(3))
-  
-    == Analyzed Logical Plan ==
+    == Optimized Logical Plan ==
     Projection: t.#2 AS #4, sum(t.#3) AS #5
       Aggregate: groupBy=[[t.#2]], aggr=[[sum(CAST(t.#3 AS Int64))]]
         SubqueryAlias: t
@@ -399,6 +391,15 @@ data:
               Values: (Int32(1), Int32(2)), (Int32(1), Int32(3))
   
     == Analyzed Logical Plan ==
+    #4: Int32, #5: Int64
+    Projection: t.#2 AS #4, sum(t.#3) AS #5
+      Aggregate: groupBy=[[t.#2]], aggr=[[sum(CAST(t.#3 AS Int64))]]
+        SubqueryAlias: t
+          Projection: #0 AS #2, #1 AS #3
+            Projection: column1 AS #0, column2 AS #1
+              Values: (Int32(1), Int32(2)), (Int32(1), Int32(3))
+  
+    == Optimized Logical Plan ==
     Projection: t.#2 AS #4, sum(t.#3) AS #5
       Aggregate: groupBy=[[t.#2]], aggr=[[sum(CAST(t.#3 AS Int64))]]
         SubqueryAlias: t

--- a/python/pysail/tests/spark/delta/__snapshots__/features/merge.yaml
+++ b/python/pysail/tests/spark/delta/__snapshots__/features/merge.yaml
@@ -2478,6 +2478,65 @@ data:
                                     Values: (Int32(1), Utf8("s1")), (Int32(1), Utf8("s2"))
   
     == Analyzed Logical Plan ==
+  
+    RowLevelWrite: command=Merge, target=delta_merge_cardinality_skip, format=DELTA, matched=1, not_matched=1, not_matched_by_source=0
+      Union
+        Projection: CASE WHEN __sail_merge_target_row_present IS NULL AND __sail_merge_source_row_present IS NOT NULL THEN __sail_src_id ELSE id END AS id, CASE WHEN __sail_merge_target_row_present IS NOT NULL AND __sail_merge_source_row_present IS NOT NULL THEN __sail_src_value WHEN __sail_merge_target_row_present IS NULL AND __sail_merge_source_row_present IS NOT NULL THEN __sail_src_value ELSE value END AS value, __sail_file_path AS __sail_file_path, CASE WHEN __sail_merge_target_row_present IS NULL THEN Int32(3) WHEN __sail_merge_target_row_present IS NOT NULL AND __sail_merge_source_row_present IS NOT NULL THEN Int32(6) WHEN Boolean(false) THEN Int32(8) WHEN Boolean(false) THEN Int32(5) WHEN Boolean(false) THEN Int32(7) ELSE Int32(0) END AS __sail_operation_type, Int64(NULL) AS __sail_merge_source_metric
+          Filter: __sail_merge_target_row_present IS NOT NULL OR NOT __sail_merge_target_row_present IS NOT NULL AND __sail_merge_source_row_present IS NOT NULL
+            Full Join: id = __sail_src_id
+              Projection: id, value, __sail_file_path, Boolean(true) AS __sail_merge_target_row_present
+                Projection: t.#0 AS id, t.#1 AS value, t.__sail_file_path AS __sail_file_path
+                  SubqueryAlias: t
+                    Projection: delta_merge_cardinality_skip.id AS #0, delta_merge_cardinality_skip.value AS #1, delta_merge_cardinality_skip.__sail_file_path AS __sail_file_path
+                      TableScan: delta_merge_cardinality_skip projection=[id, value, __sail_file_path]
+              Projection: __sail_src_id, __sail_src_value, Boolean(true) AS __sail_merge_source_row_present
+                Projection: s.#2 AS __sail_src_id, s.#3 AS __sail_src_value
+                  SubqueryAlias: s
+                    Projection: src_merge_cardinality_skip.id AS #2, src_merge_cardinality_skip.value AS #3
+                      Projection: src_merge_cardinality_skip.#4 AS id, src_merge_cardinality_skip.#5 AS value
+                        SubqueryAlias: src_merge_cardinality_skip
+                          Projection: src.#2 AS #4, max(src.#3) AS value AS #5
+                            Aggregate: groupBy=[[src.#2]], aggr=[[max(src.#3)]]
+                              SubqueryAlias: src
+                                Projection: #0 AS #2, #1 AS #3
+                                  Projection: column1 AS #0, column2 AS #1
+                                    Values: (Int32(1), Utf8("s1")), (Int32(1), Utf8("s2"))
+        Projection: Int32(NULL) AS id, Utf8(NULL) AS value, Utf8(NULL) AS __sail_file_path, Int32(9) AS __sail_operation_type, __sail_merge_source_metric AS __sail_merge_source_metric
+          Aggregate: groupBy=[[]], aggr=[[count(Int64(1)) AS __sail_merge_source_metric]]
+            Projection: s.#2 AS __sail_src_id, s.#3 AS __sail_src_value
+              SubqueryAlias: s
+                Projection: src_merge_cardinality_skip.id AS #2, src_merge_cardinality_skip.value AS #3
+                  Projection: src_merge_cardinality_skip.#4 AS id, src_merge_cardinality_skip.#5 AS value
+                    SubqueryAlias: src_merge_cardinality_skip
+                      Projection: src.#2 AS #4, max(src.#3) AS value AS #5
+                        Aggregate: groupBy=[[src.#2]], aggr=[[max(src.#3)]]
+                          SubqueryAlias: src
+                            Projection: #0 AS #2, #1 AS #3
+                              Projection: column1 AS #0, column2 AS #1
+                                Values: (Int32(1), Utf8("s1")), (Int32(1), Utf8("s2"))
+      Projection: __sail_file_path AS __sail_file_path
+        Aggregate: groupBy=[[__sail_file_path]], aggr=[[]]
+          Filter: __sail_merge_target_row_present IS NOT NULL AND __sail_merge_source_row_present IS NOT NULL AND id = __sail_src_id
+            Full Join: id = __sail_src_id
+              Projection: id, value, __sail_file_path, Boolean(true) AS __sail_merge_target_row_present
+                Projection: t.#0 AS id, t.#1 AS value, t.__sail_file_path AS __sail_file_path
+                  SubqueryAlias: t
+                    Projection: delta_merge_cardinality_skip.id AS #0, delta_merge_cardinality_skip.value AS #1, delta_merge_cardinality_skip.__sail_file_path AS __sail_file_path
+                      TableScan: delta_merge_cardinality_skip projection=[id, value, __sail_file_path]
+              Projection: __sail_src_id, __sail_src_value, Boolean(true) AS __sail_merge_source_row_present
+                Projection: s.#2 AS __sail_src_id, s.#3 AS __sail_src_value
+                  SubqueryAlias: s
+                    Projection: src_merge_cardinality_skip.id AS #2, src_merge_cardinality_skip.value AS #3
+                      Projection: src_merge_cardinality_skip.#4 AS id, src_merge_cardinality_skip.#5 AS value
+                        SubqueryAlias: src_merge_cardinality_skip
+                          Projection: src.#2 AS #4, max(src.#3) AS value AS #5
+                            Aggregate: groupBy=[[src.#2]], aggr=[[max(src.#3)]]
+                              SubqueryAlias: src
+                                Projection: #0 AS #2, #1 AS #3
+                                  Projection: column1 AS #0, column2 AS #1
+                                    Values: (Int32(1), Utf8("s1")), (Int32(1), Utf8("s2"))
+  
+    == Optimized Logical Plan ==
     RowLevelWrite: command=Merge, target=delta_merge_cardinality_skip, format=DELTA, matched=1, not_matched=1, not_matched_by_source=0
       Union
         Projection: CASE WHEN __common_expr_1 THEN __sail_src_id ELSE id END AS id, CASE WHEN __common_expr_2 THEN __sail_src_value WHEN __common_expr_1 THEN __sail_src_value ELSE value END AS value, __sail_file_path AS __sail_file_path, CASE WHEN __common_expr_3 THEN Int32(3) WHEN __common_expr_2 THEN Int32(6) ELSE Int32(0) END AS __sail_operation_type, Int64(NULL) AS __sail_merge_source_metric
@@ -2659,6 +2718,44 @@ data:
       EmptyRelation: rows=0
   
     == Analyzed Logical Plan ==
+  
+    RowLevelWrite: command=Merge, target=delta_merge_insert_only, format=DELTA, matched=0, not_matched=1, not_matched_by_source=0
+      Union
+        Projection: CASE WHEN Boolean(true) THEN __sail_src_id ELSE CAST(NULL AS Int32) END AS id, CASE WHEN Boolean(true) THEN __sail_src_value ELSE CAST(NULL AS Utf8) END AS value, CASE WHEN Boolean(true) THEN Int32(3) ELSE Int32(4) END AS __sail_operation_type
+          LeftAnti Join: __sail_src_id = id
+            Projection: s.#2 AS __sail_src_id, s.#3 AS __sail_src_value
+              SubqueryAlias: s
+                Projection: src_merge_insert_only.id AS #2, src_merge_insert_only.value AS #3
+                  Projection: src_merge_insert_only.#4 AS id, src_merge_insert_only.#5 AS value
+                    SubqueryAlias: src_merge_insert_only
+                      Projection: src.#2 AS #4, src.#3 AS #5
+                        SubqueryAlias: src
+                          Projection: #0 AS #2, #1 AS #3
+                            Projection: column1 AS #0, column2 AS #1
+                              Values: (Int32(2), Utf8("ignored")), (Int32(3), Utf8("inserted"))
+            Projection: t.#0 AS id, t.#1 AS value, t.__sail_file_path AS __sail_file_path
+              SubqueryAlias: t
+                Projection: delta_merge_insert_only.id AS #0, delta_merge_insert_only.value AS #1, delta_merge_insert_only.__sail_file_path AS __sail_file_path
+                  TableScan: delta_merge_insert_only projection=[id, value, __sail_file_path]
+        Projection: Int32(NULL) AS id, Utf8(NULL) AS value, Int32(4) AS __sail_operation_type
+          LeftSemi Join: __sail_src_id = id
+            Projection: s.#2 AS __sail_src_id, s.#3 AS __sail_src_value
+              SubqueryAlias: s
+                Projection: src_merge_insert_only.id AS #2, src_merge_insert_only.value AS #3
+                  Projection: src_merge_insert_only.#4 AS id, src_merge_insert_only.#5 AS value
+                    SubqueryAlias: src_merge_insert_only
+                      Projection: src.#2 AS #4, src.#3 AS #5
+                        SubqueryAlias: src
+                          Projection: #0 AS #2, #1 AS #3
+                            Projection: column1 AS #0, column2 AS #1
+                              Values: (Int32(2), Utf8("ignored")), (Int32(3), Utf8("inserted"))
+            Projection: t.#0 AS id, t.#1 AS value, t.__sail_file_path AS __sail_file_path
+              SubqueryAlias: t
+                Projection: delta_merge_insert_only.id AS #0, delta_merge_insert_only.value AS #1, delta_merge_insert_only.__sail_file_path AS __sail_file_path
+                  TableScan: delta_merge_insert_only projection=[id, value, __sail_file_path]
+      EmptyRelation: rows=0
+  
+    == Optimized Logical Plan ==
     RowLevelWrite: command=Merge, target=delta_merge_insert_only, format=DELTA, matched=0, not_matched=1, not_matched_by_source=0
       Union
         Projection: __sail_src_id AS id, __sail_src_value AS value, Int32(3) AS __sail_operation_type


### PR DESCRIPTION
## Summary
Updated `explain`'s `extended` and `cost` modes to align more with Spark's behaviour.

## Extended mode
Separated `analyzed logical` and `optimized logical` in the same way Spark does by prepending the output schema of the analyzed logical plan in front of it.

<img width="1108" height="475" alt="Screenshot 2026-06-23 161448" src="https://github.com/user-attachments/assets/ce1ce417-5d20-4088-a6e3-9c8a3ca83814" />

## Cost mode
Updated from `Parsed Logical - Analyzed Logical - Physical (stat) `to `Optimized Logical - Physical (stat)` to align more with Spark's behaviour, which is `Optimized Logical (stat) - Physical`

<img width="1678" height="249" alt="Screenshot 2026-06-23 161526" src="https://github.com/user-attachments/assets/3f9beaa8-cf2a-4579-8239-fe20627319ac" />
