### PR TITLE
fix: regexp_instr ignores the idx argument like Spark

### DIFF
--- a/crates/sail-plan/src/function/scalar/string.rs
+++ b/crates/sail-plan/src/function/scalar/string.rs
@@ -2,7 +2,6 @@ use datafusion::arrow::datatypes::DataType;
 use datafusion::functions::expr_fn;
 use datafusion::functions::regex::expr_fn as regex_fn;
 use datafusion::functions::regex::regexpcount::RegexpCountFunc;
-use datafusion::functions::regex::regexpinstr::RegexpInstrFunc;
 use datafusion_common::{DFSchema, ScalarValue};
 use datafusion_expr::{cast, expr, lit, try_cast, when, ExprSchemable, ScalarUDF};
 use datafusion_functions_nested::expr_fn::array_element;
@@ -36,6 +35,30 @@ use crate::function::scalar::datetime::date_format;
 
 fn regexp_replace(string: expr::Expr, pattern: expr::Expr, replacement: expr::Expr) -> expr::Expr {
     regex_fn::regexp_replace(string, pattern, replacement, Some(lit("g")))
+}
+
+/// Spark's `regexp_instr(str, regexp[, idx])` returns the 1-based position of the
+/// start of the first match, or 0 if there is no match.
+///
+/// Spark accepts an `idx` ("matched group id") argument but, unlike DataFusion's
+/// `regexp_instr` (whose 3rd argument is the search start position), Spark ignores
+/// `idx` for the returned position: it always reports the start of the whole match.
+/// This is confirmed by the PySpark doctest where both `idx = 1` and `idx = 2`
+/// yield `1` even though capture group 1 starts at position 2 and group 2 does not
+/// exist (verified against the Spark JVM, including out-of-range `idx`).
+///
+/// We therefore reuse DataFusion's `regexp_instr` kernel in its 2-argument form and
+/// drop the `idx` argument. Credit: Apache DataFusion (`datafusion::functions::regex`).
+fn regexp_instr(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
+    let mut arguments = input.arguments;
+    // Drop the optional Spark `idx` argument, which does not affect the returned position.
+    let _idx = (arguments.len() == 3).then(|| arguments.pop()).flatten();
+    let (string, pattern) = arguments
+        .two()
+        .map_err(|_| PlanError::invalid("regexp_instr requires 2 or 3 arguments"))?;
+    Ok(regex_fn::regexp_instr(
+        string, pattern, None, None, None, None, None,
+    ))
 }
 
 fn regexp_substr(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
@@ -335,7 +358,7 @@ pub(super) fn list_built_in_string_functions() -> Vec<(&'static str, ScalarFunct
         ("regexp_count", F::udf(RegexpCountFunc::new())),
         ("regexp_extract", F::udf(SparkRegexpExtract::new())),
         ("regexp_extract_all", F::udf(SparkRegexpExtractAll::new())),
-        ("regexp_instr", F::udf(RegexpInstrFunc::new())),
+        ("regexp_instr", F::custom(regexp_instr)),
         ("regexp_replace", F::ternary(regexp_replace)),
         ("regexp_substr", F::custom(regexp_substr)),
         ("repeat", F::binary(expr_fn::repeat)),

--- a/python/pysail/tests/spark/function/features/regexp_instr.feature
+++ b/python/pysail/tests/spark/function/features/regexp_instr.feature
@@ -1,0 +1,101 @@
+Feature: regexp_instr returns the 1-based start position of a regex match
+
+  # Spark's regexp_instr(str, regexp[, idx]) returns the 1-based position of the
+  # start of the first match, or 0 if there is no match. The optional `idx`
+  # ("matched group id") argument is accepted but does NOT change the returned
+  # position: Spark always reports the start of the whole match (unlike
+  # PostgreSQL/Oracle and DataFusion, whose 3rd argument is the search start).
+  # All expected values below were verified against the Spark JVM.
+
+  Rule: Basic position
+
+    Scenario: regexp_instr returns the start of the first match
+      When query
+        """
+        SELECT regexp_instr('1a 2b 14m', '\\d+(a|b|m)') AS result
+        """
+      Then query result
+        | result |
+        | 1      |
+
+    Scenario: regexp_instr reports the position of the first of several matches
+      When query
+        """
+        SELECT regexp_instr('zzz 9q', '\\d+(q)') AS result
+        """
+      Then query result
+        | result |
+        | 5      |
+
+    Scenario: regexp_instr returns 0 when there is no match
+      When query
+        """
+        SELECT regexp_instr('abc', '\\d+') AS result
+        """
+      Then query result
+        | result |
+        | 0      |
+
+  Rule: The idx argument does not affect the returned position
+
+    # idx is the "matched group id" but Spark always returns the start of the
+    # whole match, even when the requested group starts elsewhere or does not
+    # exist. These cases are exactly where the naive mapping to DataFusion's
+    # regexp_instr (3rd arg = search start) diverges.
+
+    Scenario: idx 1 yields the whole-match start
+      When query
+        """
+        SELECT regexp_instr('1a 2b 14m', '\\d+(a|b|m)', 1) AS result
+        """
+      Then query result
+        | result |
+        | 1      |
+
+    Scenario: idx 2 yields the whole-match start, not the group-2 position
+      When query
+        """
+        SELECT regexp_instr('1a 2b 14m', '\\d+(a|b|m)', 2) AS result
+        """
+      Then query result
+        | result |
+        | 1      |
+
+    Scenario: idx is ignored even when the group starts at a different position
+      When query
+        """
+        SELECT regexp_instr('xx1a', '(\\d+)(a)', 2) AS result
+        """
+      Then query result
+        | result |
+        | 3      |
+
+    Scenario: idx is ignored when the match is not at the start of the string
+      When query
+        """
+        SELECT regexp_instr('zzz 9q', '\\d+(q)', 2) AS result
+        """
+      Then query result
+        | result |
+        | 5      |
+
+    Scenario: out-of-range idx does not error and returns the whole-match start
+      When query
+        """
+        SELECT regexp_instr('1a', '(\\d)(a)', 5) AS result
+        """
+      Then query result
+        | result |
+        | 1      |
+
+  Rule: Pattern from a column
+
+    Scenario: regexp_instr with the pattern taken from a column
+      When query
+        """
+        SELECT regexp_instr(str, regexp) AS result
+        FROM VALUES ('1a 2b 14m', '\\d+(a|b|m)') AS t(str, regexp)
+        """
+      Then query result
+        | result |
+        | 1      |


### PR DESCRIPTION
Spark's `regexp_instr(str, regexp[, idx])` returns the 1-based start of the first whole match and ignores `idx` for the returned position, whereas DataFusion's `regexp_instr` treats its 3rd argument as the search start. The direct mapping therefore returned wrong positions (e.g. `idx = 2` searched from position 2 instead of reporting the match start).

Replace the direct `RegexpInstrFunc` mapping with a planner builder that drops the optional `idx` argument and calls DataFusion's `regexp_instr` in its 2-argument form. Add a feature test covering whole-match position, no-match, idx-ignored (including a group at a different position and out-of-range idx), and a column pattern; all expected values verified against the Spark JVM. This fixes the `regexp_instr` doctest in the Spark 3.5.7 suite.