### PR TITLE
fix: validate aggregate/reduce lambda arity

### DIFF
--- a/crates/sail-function/src/scalar/array/spark_array_aggregate.rs
+++ b/crates/sail-function/src/scalar/array/spark_array_aggregate.rs
@@ -323,7 +323,7 @@ fn aggregate_offsets<O: OffsetSizeTrait>(
         return evaluate_finish(finish, acc, number_rows, |arrays| Ok(arrays.to_vec()));
     }
 
-    let row_indices = UInt64Array::from(non_null_rows.clone());
+    let row_indices = UInt64Array::from_iter_values(non_null_rows.iter().copied());
     let acc_param = take_one(&acc, &row_indices)?;
     let finished = evaluate_finish(finish, acc_param, non_null_rows.len(), |arrays| {
         Ok(take_arrays(arrays, &row_indices, None)?)

--- a/crates/sail-function/src/scalar/array/spark_array_aggregate.rs
+++ b/crates/sail-function/src/scalar/array/spark_array_aggregate.rs
@@ -268,9 +268,14 @@ fn aggregate_offsets<O: OffsetSizeTrait>(
         .max()
         .unwrap_or(0);
 
+    // Reused across depth iterations: `number_rows` is the tight upper bound on the
+    // per-depth row count (reached at depth 0), so one allocation up front and a
+    // `clear()` per depth avoids a fresh allocation and growth reallocs per depth.
+    let mut rows = Vec::with_capacity(number_rows);
+    let mut value_indices = Vec::with_capacity(number_rows);
     for depth in 0..max_len {
-        let mut rows = Vec::new();
-        let mut value_indices = Vec::new();
+        rows.clear();
+        value_indices.clear();
         for row in 0..number_rows {
             if is_row_null(nulls, row) {
                 continue;
@@ -286,10 +291,10 @@ fn aggregate_offsets<O: OffsetSizeTrait>(
             continue;
         }
 
-        let row_indices = UInt64Array::from(rows.clone());
-        let value_indices = UInt64Array::from(value_indices);
+        let row_indices = UInt64Array::from_iter_values(rows.iter().copied());
+        let value_index_array = UInt64Array::from_iter_values(value_indices.iter().copied());
         let acc_param = take_one(&acc, &row_indices)?;
-        let value_param = take_one(&values, &value_indices)?;
+        let value_param = take_one(&values, &value_index_array)?;
         let acc_arg = || Ok(Arc::clone(&acc_param));
         let value_arg = || Ok(Arc::clone(&value_param));
         let params: [&dyn Fn() -> Result<ArrayRef>; 2] = if element_first {

--- a/crates/sail-plan/src/function/scalar/lambda.rs
+++ b/crates/sail-plan/src/function/scalar/lambda.rs
@@ -191,13 +191,14 @@ fn forall(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
 fn expect_lambda_arity(role: &str, expr: &expr::Expr, arity: usize) -> PlanResult<()> {
     let expr::Expr::Lambda(lambda) = expr else {
         return Err(PlanError::AnalysisError(format!(
-            "`aggregate` expects a lambda function as the {role} argument"
+            "expects a lambda function as the {role} argument"
         )));
     };
     if lambda.params.len() != arity {
         // Mirrors Spark's `INVALID_LAMBDA_FUNCTION_CALL.NUM_ARGS_MISMATCH` wording.
+        // No function name: `aggregate` and `reduce` share this builder.
         return Err(PlanError::AnalysisError(format!(
-            "Invalid lambda function call. The `aggregate` {role} lambda function expects {arity} arguments, but got {}",
+            "Invalid lambda function call. The {role} lambda function expects {arity} arguments, but got {}",
             lambda.params.len()
         )));
     }

--- a/crates/sail-plan/src/function/scalar/lambda.rs
+++ b/crates/sail-plan/src/function/scalar/lambda.rs
@@ -183,24 +183,27 @@ fn forall(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     )))
 }
 
-/// Validates that a higher-order `aggregate`/`reduce` lambda argument is a lambda
-/// with the exact arity Spark requires. The UDF binding only rejects lambdas with
-/// too many parameters, so a `merge` lambda with fewer than 2 parameters would
-/// otherwise bind silently to a prefix and return a wrong result instead of
-/// erroring like Spark (`INVALID_LAMBDA_FUNCTION_CALL.NUM_ARGS_MISMATCH`).
+/// Enforces the exact lambda arity Spark requires for a higher-order
+/// `aggregate`/`reduce` argument, but only on a direct `Expr::Lambda` match.
+///
+/// The UDF binding only rejects lambdas with too many parameters, so a `merge`
+/// lambda with fewer than 2 parameters would otherwise bind silently to a prefix
+/// and return a wrong result instead of erroring like Spark
+/// (`INVALID_LAMBDA_FUNCTION_CALL.NUM_ARGS_MISMATCH`).
+///
+/// Direct expr matching is unreliable for aliased or otherwise-wrapped lambdas,
+/// so anything that is not a bare `Expr::Lambda` falls back to the lenient path
+/// (no arity check here) until expr matching is improved more broadly.
 fn expect_lambda_arity(role: &str, expr: &expr::Expr, arity: usize) -> PlanResult<()> {
-    let expr::Expr::Lambda(lambda) = expr else {
-        return Err(PlanError::AnalysisError(format!(
-            "expects a lambda function as the {role} argument"
-        )));
-    };
-    if lambda.params.len() != arity {
-        // Mirrors Spark's `INVALID_LAMBDA_FUNCTION_CALL.NUM_ARGS_MISMATCH` wording.
-        // No function name: `aggregate` and `reduce` share this builder.
-        return Err(PlanError::AnalysisError(format!(
-            "Invalid lambda function call. The {role} lambda function expects {arity} arguments, but got {}",
-            lambda.params.len()
-        )));
+    if let expr::Expr::Lambda(lambda) = expr {
+        if lambda.params.len() != arity {
+            // Mirrors Spark's `INVALID_LAMBDA_FUNCTION_CALL.NUM_ARGS_MISMATCH`
+            // wording, naming no function (`aggregate`/`reduce` share this builder).
+            return Err(PlanError::AnalysisError(format!(
+                "Invalid lambda function call. The {role} lambda function expects {arity} arguments, but got {}",
+                lambda.params.len()
+            )));
+        }
     }
     Ok(())
 }

--- a/crates/sail-plan/src/function/scalar/lambda.rs
+++ b/crates/sail-plan/src/function/scalar/lambda.rs
@@ -183,6 +183,27 @@ fn forall(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     )))
 }
 
+/// Validates that a higher-order `aggregate`/`reduce` lambda argument is a lambda
+/// with the exact arity Spark requires. The UDF binding only rejects lambdas with
+/// too many parameters, so a `merge` lambda with fewer than 2 parameters would
+/// otherwise bind silently to a prefix and return a wrong result instead of
+/// erroring like Spark (`INVALID_LAMBDA_FUNCTION_CALL.NUM_ARGS_MISMATCH`).
+fn expect_lambda_arity(role: &str, expr: &expr::Expr, arity: usize) -> PlanResult<()> {
+    let expr::Expr::Lambda(lambda) = expr else {
+        return Err(PlanError::AnalysisError(format!(
+            "`aggregate` expects a lambda function as the {role} argument"
+        )));
+    };
+    if lambda.params.len() != arity {
+        // Mirrors Spark's `INVALID_LAMBDA_FUNCTION_CALL.NUM_ARGS_MISMATCH` wording.
+        return Err(PlanError::AnalysisError(format!(
+            "Invalid lambda function call. The `aggregate` {role} lambda function expects {arity} arguments, but got {}",
+            lambda.params.len()
+        )));
+    }
+    Ok(())
+}
+
 fn aggregate(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     let args = input.arguments;
     let (array, zero, merge, finish) = match args.len() {
@@ -209,6 +230,8 @@ fn aggregate(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
             )));
         }
     };
+    expect_lambda_arity("merge", &merge, 2)?;
+    expect_lambda_arity("finish", &finish, 1)?;
     let (func, merge) = match merge {
         expr::Expr::Lambda(lambda)
             if lambda.params.len() == 2

--- a/python/pysail/data/compatibility/functions/scalar/collection.json
+++ b/python/pysail/data/compatibility/functions/scalar/collection.json
@@ -29,20 +29,17 @@
   {
     "module": "pyspark.sql.functions",
     "function": "exists",
-    "status": "planned",
-    "ref": "https://github.com/lakehq/sail/issues/229"
+    "status": "supported"
   },
   {
     "module": "pyspark.sql.functions",
     "function": "filter",
-    "status": "planned",
-    "ref": "https://github.com/lakehq/sail/issues/229"
+    "status": "supported"
   },
   {
     "module": "pyspark.sql.functions",
     "function": "forall",
-    "status": "planned",
-    "ref": "https://github.com/lakehq/sail/issues/229"
+    "status": "supported"
   },
   {
     "module": "pyspark.sql.functions",
@@ -74,8 +71,7 @@
   {
     "module": "pyspark.sql.functions",
     "function": "transform",
-    "status": "planned",
-    "ref": "https://github.com/lakehq/sail/issues/229"
+    "status": "supported"
   },
   {
     "module": "pyspark.sql.functions",

--- a/python/pysail/tests/spark/function/features/aggregate.feature
+++ b/python/pysail/tests/spark/function/features/aggregate.feature
@@ -1,3 +1,4 @@
+@lambda_hof
 @aggregate
 Feature: aggregate higher-order function
 
@@ -127,3 +128,164 @@ Feature: aggregate higher-order function
       Then query result
         | result |
         | 6      |
+
+    Scenario: reduce applies an explicit finish lambda
+      When query
+        """
+        SELECT reduce(array(1, 2, 3), 0, (acc, x) -> acc + x, acc -> acc * 10) AS result
+        """
+      Then query result
+        | result |
+        | 60     |
+
+    Scenario: reduce merge can reference the element without the accumulator
+      When query
+        """
+        SELECT reduce(array(1, 2, 3), 0, (acc, x) -> x) AS result
+        """
+      Then query result
+        | result |
+        | 3      |
+
+    Scenario: reduce returns NULL for NULL array
+      When query
+        """
+        SELECT reduce(CAST(NULL AS ARRAY<INT>), 0, (acc, x) -> acc + x, acc -> acc * 10) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+  Rule: Float extremes and all-NULL elements propagate through the fold
+
+    Scenario: aggregate propagates positive infinity
+      When query
+        """
+        SELECT aggregate(array(CAST('Infinity' AS DOUBLE), 1.0), CAST(0.0 AS DOUBLE), (acc, x) -> acc + x) AS result
+        """
+      Then query result
+        | result   |
+        | Infinity |
+
+    Scenario: aggregate propagates negative infinity
+      When query
+        """
+        SELECT aggregate(array(CAST('-Infinity' AS DOUBLE), 1.0), CAST(0.0 AS DOUBLE), (acc, x) -> acc + x) AS result
+        """
+      Then query result
+        | result    |
+        | -Infinity |
+
+    Scenario: aggregate propagates NaN
+      When query
+        """
+        SELECT aggregate(array(CAST('NaN' AS DOUBLE), 1.0), CAST(0.0 AS DOUBLE), (acc, x) -> acc + x) AS result
+        """
+      Then query result
+        | result |
+        | NaN    |
+
+    Scenario: aggregate of positive and negative infinity is NaN
+      When query
+        """
+        SELECT aggregate(array(CAST('Infinity' AS DOUBLE), CAST('-Infinity' AS DOUBLE)), CAST(0.0 AS DOUBLE), (acc, x) -> acc + x) AS result
+        """
+      Then query result
+        | result |
+        | NaN    |
+
+    Scenario: aggregate over an all-NULL-element array propagates NULL
+      When query
+        """
+        SELECT aggregate(CAST(array(NULL, NULL) AS ARRAY<INT>), 0, (acc, x) -> acc + x) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: aggregate mixing normal, NULL, infinity and NaN propagates NULL
+      When query
+        """
+        SELECT aggregate(array(1.0, CAST(NULL AS DOUBLE), CAST('Infinity' AS DOUBLE), CAST('NaN' AS DOUBLE)), CAST(0.0 AS DOUBLE), (acc, x) -> acc + x) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: aggregate mixing normal, NULL, infinity and NaN with coalesce yields NaN
+      When query
+        """
+        SELECT aggregate(array(1.0, CAST(NULL AS DOUBLE), CAST('Infinity' AS DOUBLE), CAST('NaN' AS DOUBLE)), CAST(0.0 AS DOUBLE), (acc, x) -> acc + coalesce(x, 0)) AS result
+        """
+      Then query result
+        | result |
+        | NaN    |
+
+    Scenario: aggregate mixing normal, infinity and NaN yields NaN
+      When query
+        """
+        SELECT aggregate(array(1.0, CAST('Infinity' AS DOUBLE), CAST('NaN' AS DOUBLE)), CAST(0.0 AS DOUBLE), (acc, x) -> acc + x) AS result
+        """
+      Then query result
+        | result |
+        | NaN    |
+
+    Scenario: aggregate mixing normal, NULL and infinity with coalesce yields infinity
+      When query
+        """
+        SELECT aggregate(array(1.0, CAST(NULL AS DOUBLE), CAST('Infinity' AS DOUBLE)), CAST(0.0 AS DOUBLE), (acc, x) -> acc + coalesce(x, 0)) AS result
+        """
+      Then query result
+        | result   |
+        | Infinity |
+
+  Rule: ANSI arithmetic inside the merge lambda
+
+    @sail-bug
+    Scenario: integer overflow inside merge errors under ANSI on
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT aggregate(array(2000000000, 2000000000), 0, (acc, x) -> acc + x) AS result
+        """
+      Then query error .*
+
+    Scenario: integer overflow inside merge wraps under ANSI off
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT aggregate(array(2000000000, 2000000000), 0, (acc, x) -> acc + x) AS result
+        """
+      Then query result
+        | result     |
+        | -294967296 |
+
+  Rule: Lambda arity is validated against Spark
+
+    Scenario: aggregate rejects a merge lambda with fewer than 2 parameters
+      When query
+        """
+        SELECT aggregate(array(1, 2, 3), 0, x -> x) AS result
+        """
+      Then query error (?i)lambda function
+
+    Scenario: aggregate rejects a merge lambda with more than 2 parameters
+      When query
+        """
+        SELECT aggregate(array(1, 2, 3), 0, (a, b, c) -> a) AS result
+        """
+      Then query error (?i)lambda function
+
+    Scenario: aggregate rejects a finish lambda with more than 1 parameter
+      When query
+        """
+        SELECT aggregate(array(1, 2, 3), 0, (acc, x) -> acc + x, (a, b) -> a) AS result
+        """
+      Then query error (?i)lambda function
+
+    Scenario: reduce rejects a merge lambda with fewer than 2 parameters
+      When query
+        """
+        SELECT reduce(array(1, 2, 3), 0, acc -> acc + 1) AS result
+        """
+      Then query error (?i)lambda function

--- a/python/pysail/tests/spark/function/features/array_filter.feature
+++ b/python/pysail/tests/spark/function/features/array_filter.feature
@@ -1,3 +1,4 @@
+@lambda_hof
 Feature: array filter with lambda
 
   Rule: Filter array elements using lambda predicates

--- a/python/pysail/tests/spark/function/features/exists.feature
+++ b/python/pysail/tests/spark/function/features/exists.feature
@@ -342,12 +342,3 @@ Feature: exists higher-order function
         SELECT exists(array(1, 2, 3), x -> x + 1) AS result
         """
       Then query error .*
-
-  Rule: Lambda only accepts one parameter
-
-    Scenario: two-parameter lambda is rejected as type error
-      When query
-        """
-        SELECT exists(array(1, 2, 3), (x, i) -> x > i) AS result
-        """
-      Then query error .*

--- a/python/pysail/tests/spark/function/features/exists.feature
+++ b/python/pysail/tests/spark/function/features/exists.feature
@@ -1,3 +1,4 @@
+@lambda_hof
 @exists
 Feature: exists higher-order function
 
@@ -339,5 +340,14 @@ Feature: exists higher-order function
       When query
         """
         SELECT exists(array(1, 2, 3), x -> x + 1) AS result
+        """
+      Then query error .*
+
+  Rule: Lambda only accepts one parameter
+
+    Scenario: two-parameter lambda is rejected as type error
+      When query
+        """
+        SELECT exists(array(1, 2, 3), (x, i) -> x > i) AS result
         """
       Then query error .*

--- a/python/pysail/tests/spark/function/features/forall.feature
+++ b/python/pysail/tests/spark/function/features/forall.feature
@@ -1,3 +1,4 @@
+@lambda_hof
 @forall
 Feature: forall higher-order function
 

--- a/python/pysail/tests/spark/function/features/transform.feature
+++ b/python/pysail/tests/spark/function/features/transform.feature
@@ -1,3 +1,4 @@
+@lambda_hof
 @transform
 Feature: transform higher-order function
 


### PR DESCRIPTION
The merge lambda of `aggregate`/`reduce` requires exactly 2 parameters and the finish lambda exactly 1. The UDF binding only rejects lambdas with too many parameters, so a merge with too few (e.g. `x -> x`) silently bound to a prefix and returned a wrong result instead of erroring like Spark (INVALID_LAMBDA_FUNCTION_CALL.NUM_ARGS_MISMATCH). Add an explicit arity check in the `aggregate` planner builder.

Also:
- mark exists/filter/forall/transform as supported in collection.json
- tag all higher-order-function feature files with @lambda_hof
- expand aggregate.feature with arity, reduce-alias, Inf/NaN/all-NULL and ANSI-overflow (@sail-bug) scenarios, all validated against Spark JVM
- reuse the fold's gather buffers across depth iterations (with_capacity, no per-depth alloc, no clone)