### PR TITLE
feat: expose Iceberg planning helpers and commit-table provider seam

### DIFF
--- a/crates/sail-catalog-iceberg/src/lib.rs
+++ b/crates/sail-catalog-iceberg/src/lib.rs
@@ -11,17 +11,23 @@
 // limitations under the License.
 
 #![expect(unused_imports)]
-#![expect(dead_code)]
 #![expect(clippy::all)]
 
 pub mod apis;
-mod models;
+pub mod models;
+mod planning;
 mod provider;
 
-pub use provider::{
-    IcebergRestCatalogProvider, REST_CATALOG_PROP_PREFIX, REST_CATALOG_PROP_URI,
-    REST_CATALOG_PROP_WAREHOUSE,
+pub use planning::{
+    completed_planning_result_from_values, completed_planning_with_id_result_from_values,
+    fetch_scan_tasks_result_from_values,
 };
+pub use provider::{
+    load_table_result_to_status, IcebergRestCatalogProvider, REST_CATALOG_PROP_PREFIX,
+    REST_CATALOG_PROP_URI, REST_CATALOG_PROP_WAREHOUSE,
+};
+
+pub use crate::models::{LoadTableResult, TableMetadata};
 
 #[cfg(test)]
 mod table_update_tests {

--- a/crates/sail-catalog-iceberg/src/planning.rs
+++ b/crates/sail-catalog-iceberg/src/planning.rs
@@ -1,0 +1,173 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sail_catalog::error::{CatalogError, CatalogResult};
+use serde_json::Value;
+
+use crate::models;
+
+pub fn completed_planning_result_from_values(
+    plan_tasks: Vec<String>,
+    file_scan_tasks: Vec<Value>,
+    delete_files: Vec<Value>,
+) -> CatalogResult<models::CompletedPlanningResult> {
+    let mut result = models::CompletedPlanningResult::new(models::PlanStatus::Completed);
+    result.plan_tasks = non_empty(plan_tasks);
+    result.file_scan_tasks = parse_optional_values(file_scan_tasks, "file-scan-tasks")?;
+    result.delete_files = parse_delete_files(delete_files)?;
+    Ok(result)
+}
+
+pub fn completed_planning_with_id_result_from_values(
+    plan_id: Option<String>,
+    plan_tasks: Vec<String>,
+    file_scan_tasks: Vec<Value>,
+    delete_files: Vec<Value>,
+) -> CatalogResult<models::CompletedPlanningWithIdResult> {
+    let mut result = models::CompletedPlanningWithIdResult::new(models::PlanStatus::Completed);
+    result.plan_id = plan_id;
+    result.plan_tasks = non_empty(plan_tasks);
+    result.file_scan_tasks = parse_optional_values(file_scan_tasks, "file-scan-tasks")?;
+    result.delete_files = parse_delete_files(delete_files)?;
+    Ok(result)
+}
+
+pub fn fetch_scan_tasks_result_from_values(
+    plan_tasks: Vec<String>,
+    file_scan_tasks: Vec<Value>,
+    delete_files: Vec<Value>,
+) -> CatalogResult<models::FetchScanTasksResult> {
+    let mut result = models::FetchScanTasksResult::new();
+    result.plan_tasks = non_empty(plan_tasks);
+    result.file_scan_tasks = parse_optional_values(file_scan_tasks, "file-scan-tasks")?;
+    result.delete_files = parse_delete_files(delete_files)?;
+    Ok(result)
+}
+
+fn non_empty<T>(values: Vec<T>) -> Option<Vec<T>> {
+    (!values.is_empty()).then_some(values)
+}
+
+fn parse_optional_values<T: serde::de::DeserializeOwned>(
+    values: Vec<Value>,
+    label: &str,
+) -> CatalogResult<Option<Vec<T>>> {
+    if values.is_empty() {
+        return Ok(None);
+    }
+    serde_json::from_value(Value::Array(values))
+        .map(Some)
+        .map_err(|err| {
+            CatalogError::External(format!("invalid Iceberg REST {label} payload: {err}"))
+        })
+}
+
+fn parse_delete_files(values: Vec<Value>) -> CatalogResult<Option<Vec<models::DeleteFile>>> {
+    if values.is_empty() {
+        return Ok(None);
+    }
+    values
+        .into_iter()
+        .map(parse_delete_file)
+        .collect::<CatalogResult<Vec<_>>>()
+        .map(Some)
+}
+
+fn parse_delete_file(value: Value) -> CatalogResult<models::DeleteFile> {
+    match value.get("content").and_then(Value::as_str) {
+        Some("position-deletes") => serde_json::from_value(value)
+            .map(|file| models::DeleteFile::PositionDeletes(Box::new(file)))
+            .map_err(delete_file_error),
+        Some("equality-deletes") => serde_json::from_value(value)
+            .map(|file| models::DeleteFile::EqualityDeletes(Box::new(file)))
+            .map_err(delete_file_error),
+        Some(content) => Err(CatalogError::External(format!(
+            "invalid Iceberg REST delete-files payload: unsupported content {content}"
+        ))),
+        None => Err(CatalogError::External(
+            "invalid Iceberg REST delete-files payload: missing content".to_string(),
+        )),
+    }
+}
+
+fn delete_file_error(err: serde_json::Error) -> CatalogError {
+    CatalogError::External(format!("invalid Iceberg REST delete-files payload: {err}"))
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn builds_completed_planning_result_from_plan_tokens() {
+        let result = completed_planning_result_from_values(
+            vec!["task-1".to_string(), "task-2".to_string()],
+            Vec::new(),
+            Vec::new(),
+        )
+        .expect("planning result");
+
+        assert_eq!(result.status, models::PlanStatus::Completed);
+        assert_eq!(
+            result.plan_tasks,
+            Some(vec!["task-1".to_string(), "task-2".to_string()])
+        );
+        assert!(result.file_scan_tasks.is_none());
+        assert!(result.delete_files.is_none());
+    }
+
+    #[test]
+    fn builds_fetch_scan_tasks_result_from_concrete_delete_files() {
+        let data_file = json!({
+            "content": "data",
+            "file-path": "file:///tmp/events/data-1.parquet",
+            "file-format": "parquet",
+            "spec-id": 0,
+            "partition": [],
+            "file-size-in-bytes": 100,
+            "record-count": 10
+        });
+        let delete_file = json!({
+            "content": "position-deletes",
+            "file-path": "file:///tmp/events/delete-1.parquet",
+            "file-format": "parquet",
+            "spec-id": 0,
+            "partition": [],
+            "file-size-in-bytes": 50,
+            "record-count": 1
+        });
+
+        let result = fetch_scan_tasks_result_from_values(
+            vec!["child-task".to_string()],
+            vec![json!({
+                "data-file": data_file,
+                "delete-file-references": [0]
+            })],
+            vec![delete_file],
+        )
+        .expect("fetch scan tasks result");
+
+        assert_eq!(result.plan_tasks, Some(vec!["child-task".to_string()]));
+        assert_eq!(result.file_scan_tasks.as_ref().unwrap().len(), 1);
+        assert_eq!(
+            result.file_scan_tasks.as_ref().unwrap()[0].delete_file_references,
+            Some(vec![0])
+        );
+        assert!(matches!(
+            result.delete_files.as_ref().unwrap()[0],
+            models::DeleteFile::PositionDeletes(_)
+        ));
+    }
+}

--- a/crates/sail-catalog-iceberg/src/provider.rs
+++ b/crates/sail-catalog-iceberg/src/provider.rs
@@ -543,241 +543,7 @@ impl IcebergRestCatalogProvider {
         database: &Namespace,
         result: crate::models::LoadTableResult,
     ) -> CatalogResult<TableStatus> {
-        // Table-specific config and storage credentials are access-session state, not
-        // display table properties.
-        // TODO: Preserve unused fields in `TableMetadata` when Sail exposes them.
-        let crate::models::TableMetadata {
-            format_version,
-            table_uuid,
-            location,
-            last_updated_ms,
-            next_row_id,
-            properties,
-            schemas,
-            current_schema_id,
-            last_column_id,
-            partition_specs,
-            default_spec_id,
-            last_partition_id,
-            sort_orders,
-            default_sort_order_id,
-            encryption_keys: _,
-            snapshots: _,
-            refs: _,
-            current_snapshot_id,
-            last_sequence_number,
-            snapshot_log: _,
-            metadata_log: _,
-            statistics,
-            partition_statistics,
-        } = *result.metadata;
-
-        let current_schema =
-            find_by_id_or_last(schemas.as_ref(), current_schema_id, |s| s.schema_id);
-        let default_partition_spec =
-            find_by_id_or_last(partition_specs.as_ref(), default_spec_id, |s| s.spec_id);
-
-        let partition_field_ids: std::collections::HashSet<i32> = default_partition_spec
-            .map(|spec| spec.fields.iter().map(|f| f.source_id).collect())
-            .unwrap_or_default();
-
-        let bucket_field_ids: std::collections::HashSet<i32> = default_partition_spec
-            .map(|spec| {
-                spec.fields
-                    .iter()
-                    .filter(|f| f.transform.trim().to_lowercase().starts_with("bucket"))
-                    .map(|f| f.source_id)
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        let partition_by = match (current_schema, default_partition_spec) {
-            (Some(schema), Some(spec)) => spec
-                .fields
-                .iter()
-                .map(|field| {
-                    let source_column = schema
-                        .fields
-                        .iter()
-                        .find(|f| f.id == field.source_id)
-                        .ok_or_else(|| {
-                            CatalogError::External(format!(
-                                "Partition field source id {} not found in schema",
-                                field.source_id
-                            ))
-                        })?
-                        .name
-                        .clone();
-                    let transform = field.transform.parse().map_err(CatalogError::External)?;
-                    catalog_partition_field_from_iceberg(source_column, transform)
-                        .map_err(CatalogError::External)
-                })
-                .collect::<CatalogResult<Vec<_>>>()?,
-            _ => Vec::new(),
-        };
-
-        let columns = if let Some(schema) = current_schema {
-            let mut cols = Vec::new();
-            for field in &schema.fields {
-                let data_type = iceberg_type_to_arrow(&field.field_type).map_err(|e| {
-                    CatalogError::External(format!(
-                        "Failed to convert Iceberg type to Arrow type for field '{}': {e}",
-                        field.name
-                    ))
-                })?;
-                let field_id = field.id;
-                cols.push(TableColumnStatus {
-                    name: field.name.clone(),
-                    data_type,
-                    nullable: !field.required,
-                    comment: field.doc.clone(),
-                    default: None,
-                    generated_always_as: None,
-                    identity: None,
-                    is_partition: partition_field_ids.contains(&field_id),
-                    is_bucket: bucket_field_ids.contains(&field_id),
-                    is_cluster: false,
-                });
-            }
-            cols
-        } else {
-            Vec::new()
-        };
-
-        let default_sort_order =
-            find_by_id_or_last(sort_orders.as_ref(), default_sort_order_id, |o| {
-                Some(o.order_id)
-            });
-
-        let sort_by: Vec<CatalogTableSort> = default_sort_order
-            .map(|order| {
-                order
-                    .fields
-                    .iter()
-                    .filter_map(|sort_field| {
-                        let field_id = sort_field.source_id;
-                        current_schema.and_then(|schema| {
-                            schema
-                                .fields
-                                .iter()
-                                .find(|f| f.id == field_id)
-                                .map(|field| {
-                                    let ascending = match sort_field.direction {
-                                        crate::models::SortDirection::Asc => true,
-                                        crate::models::SortDirection::Desc => false,
-                                    };
-                                    CatalogTableSort {
-                                        column: field.name.clone(),
-                                        ascending,
-                                    }
-                                })
-                        })
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        let constraints = current_schema
-            .and_then(|schema| {
-                schema.identifier_field_ids.as_ref().and_then(|ids| {
-                    if ids.is_empty() {
-                        None
-                    } else {
-                        let pk_columns: Vec<String> = ids
-                            .iter()
-                            .filter_map(|id| {
-                                schema
-                                    .fields
-                                    .iter()
-                                    .find(|f| f.id == *id)
-                                    .map(|f| f.name.clone())
-                            })
-                            .collect();
-                        if pk_columns.is_empty() {
-                            None
-                        } else {
-                            Some(vec![CatalogTableConstraint::PrimaryKey {
-                                name: None,
-                                columns: pk_columns,
-                            }])
-                        }
-                    }
-                })
-            })
-            .unwrap_or_default();
-
-        let mut properties: HashMap<String, String> = properties.unwrap_or_default();
-
-        let comment = get_property(&properties, "comment");
-
-        if let Some(metadata_location) = result.metadata_location {
-            properties.insert(METADATA_LOCATION_KEY.to_string(), metadata_location);
-        }
-        properties.insert(
-            "metadata.format-version".to_string(),
-            format_version.to_string(),
-        );
-        properties.insert("metadata.table-uuid".to_string(), table_uuid);
-
-        if let Some(v) = last_updated_ms {
-            properties.insert("metadata.last-updated-ms".to_string(), v.to_string());
-        }
-        if let Some(v) = next_row_id {
-            properties.insert("metadata.next-row-id".to_string(), v.to_string());
-        }
-        if let Some(v) = current_schema_id {
-            properties.insert("metadata.current-schema-id".to_string(), v.to_string());
-        }
-        if let Some(v) = last_column_id {
-            properties.insert("metadata.last-column-id".to_string(), v.to_string());
-        }
-        if let Some(v) = default_spec_id {
-            properties.insert("metadata.default-spec-id".to_string(), v.to_string());
-        }
-        if let Some(v) = last_partition_id {
-            properties.insert("metadata.last-partition-id".to_string(), v.to_string());
-        }
-        if let Some(v) = default_sort_order_id {
-            properties.insert("metadata.default-sort-order-id".to_string(), v.to_string());
-        }
-        if let Some(v) = current_snapshot_id {
-            properties.insert("metadata.current-snapshot-id".to_string(), v.to_string());
-        }
-        if let Some(v) = last_sequence_number {
-            properties.insert("metadata.last-sequence-number".to_string(), v.to_string());
-        }
-        if let Some(v) = statistics {
-            properties.insert(
-                "metadata.statistics".to_string(),
-                serde_json::to_string(&v).unwrap_or_default(),
-            );
-        }
-        if let Some(v) = partition_statistics {
-            properties.insert(
-                "metadata.partition-statistics".to_string(),
-                serde_json::to_string(&v).unwrap_or_default(),
-            );
-        }
-
-        let properties: Vec<_> = properties.into_iter().collect();
-
-        Ok(TableStatus {
-            catalog: Some(self.name.clone()),
-            database: database.clone().into(),
-            name: table_name.to_string(),
-            kind: TableKind::Table {
-                columns,
-                comment,
-                constraints,
-                location,
-                format: "iceberg".to_string(),
-                partition_by,
-                sort_by,
-                bucket_by: None,
-                properties,
-                is_external: true,
-            },
-        })
+        load_table_result_to_status(&self.name, table_name, database, result)
     }
 
     fn load_view_result_to_status(
@@ -3471,4 +3237,248 @@ mod tests {
         test_get_database_impl(None).await;
         test_get_database_impl(Some("test")).await;
     }
+}
+
+/// Converts an Iceberg REST API table load result into a catalog `TableStatus`
+/// for an explicitly named catalog. Standalone form of the provider method so
+/// callers (e.g. the LakeCat Sail bridge) can reuse the conversion.
+pub fn load_table_result_to_status(
+    catalog: &str,
+    table_name: &str,
+    database: &Namespace,
+    result: crate::models::LoadTableResult,
+) -> CatalogResult<TableStatus> {
+    // Table-specific config and storage credentials are access-session state, not
+    // display table properties.
+    // TODO: Preserve unused fields in `TableMetadata` when Sail exposes them.
+    let crate::models::TableMetadata {
+        format_version,
+        table_uuid,
+        location,
+        last_updated_ms,
+        next_row_id,
+        properties,
+        schemas,
+        current_schema_id,
+        last_column_id,
+        partition_specs,
+        default_spec_id,
+        last_partition_id,
+        sort_orders,
+        default_sort_order_id,
+        encryption_keys: _,
+        snapshots: _,
+        refs: _,
+        current_snapshot_id,
+        last_sequence_number,
+        snapshot_log: _,
+        metadata_log: _,
+        statistics,
+        partition_statistics,
+    } = *result.metadata;
+
+    let current_schema = find_by_id_or_last(schemas.as_ref(), current_schema_id, |s| s.schema_id);
+    let default_partition_spec =
+        find_by_id_or_last(partition_specs.as_ref(), default_spec_id, |s| s.spec_id);
+
+    let partition_field_ids: std::collections::HashSet<i32> = default_partition_spec
+        .map(|spec| spec.fields.iter().map(|f| f.source_id).collect())
+        .unwrap_or_default();
+
+    let bucket_field_ids: std::collections::HashSet<i32> = default_partition_spec
+        .map(|spec| {
+            spec.fields
+                .iter()
+                .filter(|f| f.transform.trim().to_lowercase().starts_with("bucket"))
+                .map(|f| f.source_id)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let partition_by = match (current_schema, default_partition_spec) {
+        (Some(schema), Some(spec)) => spec
+            .fields
+            .iter()
+            .map(|field| {
+                let source_column = schema
+                    .fields
+                    .iter()
+                    .find(|f| f.id == field.source_id)
+                    .ok_or_else(|| {
+                        CatalogError::External(format!(
+                            "Partition field source id {} not found in schema",
+                            field.source_id
+                        ))
+                    })?
+                    .name
+                    .clone();
+                let transform = field.transform.parse().map_err(CatalogError::External)?;
+                catalog_partition_field_from_iceberg(source_column, transform)
+                    .map_err(CatalogError::External)
+            })
+            .collect::<CatalogResult<Vec<_>>>()?,
+        _ => Vec::new(),
+    };
+
+    let columns = if let Some(schema) = current_schema {
+        let mut cols = Vec::new();
+        for field in &schema.fields {
+            let data_type = iceberg_type_to_arrow(&field.field_type).map_err(|e| {
+                CatalogError::External(format!(
+                    "Failed to convert Iceberg type to Arrow type for field '{}': {e}",
+                    field.name
+                ))
+            })?;
+            let field_id = field.id;
+            cols.push(TableColumnStatus {
+                name: field.name.clone(),
+                data_type,
+                nullable: !field.required,
+                comment: field.doc.clone(),
+                default: None,
+                generated_always_as: None,
+                identity: None,
+                is_partition: partition_field_ids.contains(&field_id),
+                is_bucket: bucket_field_ids.contains(&field_id),
+                is_cluster: false,
+            });
+        }
+        cols
+    } else {
+        Vec::new()
+    };
+
+    let default_sort_order = find_by_id_or_last(sort_orders.as_ref(), default_sort_order_id, |o| {
+        Some(o.order_id)
+    });
+
+    let sort_by: Vec<CatalogTableSort> = default_sort_order
+        .map(|order| {
+            order
+                .fields
+                .iter()
+                .filter_map(|sort_field| {
+                    let field_id = sort_field.source_id;
+                    current_schema.and_then(|schema| {
+                        schema
+                            .fields
+                            .iter()
+                            .find(|f| f.id == field_id)
+                            .map(|field| {
+                                let ascending = match sort_field.direction {
+                                    crate::models::SortDirection::Asc => true,
+                                    crate::models::SortDirection::Desc => false,
+                                };
+                                CatalogTableSort {
+                                    column: field.name.clone(),
+                                    ascending,
+                                }
+                            })
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let constraints = current_schema
+        .and_then(|schema| {
+            schema.identifier_field_ids.as_ref().and_then(|ids| {
+                if ids.is_empty() {
+                    None
+                } else {
+                    let pk_columns: Vec<String> = ids
+                        .iter()
+                        .filter_map(|id| {
+                            schema
+                                .fields
+                                .iter()
+                                .find(|f| f.id == *id)
+                                .map(|f| f.name.clone())
+                        })
+                        .collect();
+                    if pk_columns.is_empty() {
+                        None
+                    } else {
+                        Some(vec![CatalogTableConstraint::PrimaryKey {
+                            name: None,
+                            columns: pk_columns,
+                        }])
+                    }
+                }
+            })
+        })
+        .unwrap_or_default();
+
+    let mut properties: HashMap<String, String> = properties.unwrap_or_default();
+
+    let comment = get_property(&properties, "comment");
+
+    if let Some(metadata_location) = result.metadata_location {
+        properties.insert(METADATA_LOCATION_KEY.to_string(), metadata_location);
+    }
+    properties.insert(
+        "metadata.format-version".to_string(),
+        format_version.to_string(),
+    );
+    properties.insert("metadata.table-uuid".to_string(), table_uuid);
+
+    if let Some(v) = last_updated_ms {
+        properties.insert("metadata.last-updated-ms".to_string(), v.to_string());
+    }
+    if let Some(v) = next_row_id {
+        properties.insert("metadata.next-row-id".to_string(), v.to_string());
+    }
+    if let Some(v) = current_schema_id {
+        properties.insert("metadata.current-schema-id".to_string(), v.to_string());
+    }
+    if let Some(v) = last_column_id {
+        properties.insert("metadata.last-column-id".to_string(), v.to_string());
+    }
+    if let Some(v) = default_spec_id {
+        properties.insert("metadata.default-spec-id".to_string(), v.to_string());
+    }
+    if let Some(v) = last_partition_id {
+        properties.insert("metadata.last-partition-id".to_string(), v.to_string());
+    }
+    if let Some(v) = default_sort_order_id {
+        properties.insert("metadata.default-sort-order-id".to_string(), v.to_string());
+    }
+    if let Some(v) = current_snapshot_id {
+        properties.insert("metadata.current-snapshot-id".to_string(), v.to_string());
+    }
+    if let Some(v) = last_sequence_number {
+        properties.insert("metadata.last-sequence-number".to_string(), v.to_string());
+    }
+    if let Some(v) = statistics {
+        properties.insert(
+            "metadata.statistics".to_string(),
+            serde_json::to_string(&v).unwrap_or_default(),
+        );
+    }
+    if let Some(v) = partition_statistics {
+        properties.insert(
+            "metadata.partition-statistics".to_string(),
+            serde_json::to_string(&v).unwrap_or_default(),
+        );
+    }
+
+    let properties: Vec<_> = properties.into_iter().collect();
+
+    Ok(TableStatus {
+        catalog: Some(catalog.to_string()),
+        database: database.clone().into(),
+        name: table_name.to_string(),
+        kind: TableKind::Table {
+            columns,
+            comment,
+            constraints,
+            location,
+            format: "iceberg".to_string(),
+            partition_by,
+            sort_by,
+            bucket_by: None,
+            properties,
+            is_external: true,
+        },
+    })
 }

--- a/crates/sail-catalog/src/provider/mod.rs
+++ b/crates/sail-catalog/src/provider/mod.rs
@@ -182,6 +182,35 @@ pub trait CatalogProvider: Send + Sync {
         options: AlterTableOptions,
     ) -> CatalogResult<()>;
 
+    /// Commits requirement-guarded updates to a table (Iceberg REST commit-table
+    /// extension). Providers that do not support server-side commit return
+    /// `NotSupported`.
+    async fn commit_table(
+        &self,
+        database: &Namespace,
+        table: &str,
+        options: CommitTableOptions,
+    ) -> CatalogResult<TableStatus> {
+        let _ = (database, table, options);
+        Err(CatalogError::NotSupported(
+            "commit_table is not supported by this catalog provider".to_string(),
+        ))
+    }
+
+    /// Lists historical table commits (Iceberg REST extension). Providers that do
+    /// not track commit history return `NotSupported`.
+    async fn get_table_commits(
+        &self,
+        database: &Namespace,
+        table: &str,
+        options: GetTableCommitsOptions,
+    ) -> CatalogResult<GetTableCommitsResponse> {
+        let _ = (database, table, options);
+        Err(CatalogError::NotSupported(
+            "get_table_commits is not supported by this catalog provider".to_string(),
+        ))
+    }
+
     /// Creates a view in the catalog.
     async fn create_view(
         &self,

--- a/crates/sail-catalog/src/provider/options.rs
+++ b/crates/sail-catalog/src/provider/options.rs
@@ -157,3 +157,41 @@ pub enum AlterTableOptions {
         expression: String,
     },
 }
+
+/// Options for [`CatalogProvider::commit_table`](super::CatalogProvider::commit_table),
+/// the Iceberg REST commit-table extension. `requirements` and `updates` carry the
+/// raw Iceberg REST JSON requirement/update objects.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct CommitTableOptions {
+    pub format: String,
+    pub requirements: Vec<serde_json::Value>,
+    pub updates: Vec<serde_json::Value>,
+}
+
+/// Options for
+/// [`CatalogProvider::get_table_commits`](super::CatalogProvider::get_table_commits).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct GetTableCommitsOptions {
+    pub format: String,
+    pub table_uri: String,
+    pub start_version: i64,
+    pub end_version: Option<i64>,
+}
+
+/// A single historical table-commit descriptor returned by `get_table_commits`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TableCommitInfo {
+    pub version: i64,
+    pub timestamp: i64,
+    pub file_name: String,
+    pub file_size: i64,
+    pub file_modification_timestamp: i64,
+}
+
+/// Response for
+/// [`CatalogProvider::get_table_commits`](super::CatalogProvider::get_table_commits).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct GetTableCommitsResponse {
+    pub latest_table_version: i64,
+    pub commits: Vec<TableCommitInfo>,
+}


### PR DESCRIPTION
## Summary

Surface the Iceberg-REST catalog symbols that a thin external catalog bridge needs,
without forking the generated models:

- **`sail-catalog-iceberg`**: make `models` public; add planning result helpers
  (`planning.rs`: `completed_planning_result_from_values`,
  `completed_planning_with_id_result_from_values`,
  `fetch_scan_tasks_result_from_values`); re-export `LoadTableResult`/`TableMetadata`;
  expose `load_table_result_to_status` as a standalone `pub fn` — the existing
  provider method now delegates to it (its only use of `self` was the catalog name).
- **`sail-catalog`**: add `CommitTableOptions`/`GetTableCommitsOptions`/
  `TableCommitInfo`/`GetTableCommitsResponse`, and
  `CatalogProvider::{commit_table, get_table_commits}` as **default methods that
  return `NotSupported`** — so every existing provider compiles unchanged.

No behavior change for existing providers; this is purely additive surface area.

## Testing

- `cargo check -p sail-catalog -p sail-catalog-iceberg` — clean.
- Existing providers compile via the default trait methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbNyd333y17hMC55Pk4CRk
