### PR TITLE
feat: improve catalog providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7445,6 +7445,7 @@ version = "0.6.4"
 dependencies = [
  "arrow",
  "async-trait",
+ "log",
  "percent-encoding",
  "reqwest",
  "sail-catalog",
@@ -7482,6 +7483,7 @@ dependencies = [
  "sail-catalog-unity",
  "sail-common-datafusion",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7475,12 +7475,12 @@ dependencies = [
 name = "sail-catalog-onelake"
 version = "0.6.4"
 dependencies = [
- "arrow",
  "async-trait",
- "reqwest",
+ "object_store",
  "sail-catalog",
+ "sail-catalog-iceberg",
+ "sail-catalog-unity",
  "sail-common-datafusion",
- "serde",
  "tokio",
 ]
 

--- a/crates/sail-catalog-iceberg/Cargo.toml
+++ b/crates/sail-catalog-iceberg/Cargo.toml
@@ -33,6 +33,7 @@ serde_json = { workspace = true }
 serde_with = { workspace = true }
 uuid = { workspace = true }
 tokio = { workspace = true }
+log = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/sail-catalog-iceberg/src/lib.rs
+++ b/crates/sail-catalog-iceberg/src/lib.rs
@@ -19,8 +19,8 @@ mod models;
 mod provider;
 
 pub use provider::{
-    IcebergRestCatalogProvider, REST_CATALOG_PROP_PREFIX, REST_CATALOG_PROP_URI,
-    REST_CATALOG_PROP_WAREHOUSE,
+    IcebergRestCatalogOptions, IcebergRestCatalogProvider, REST_CATALOG_PROP_PREFIX,
+    REST_CATALOG_PROP_URI, REST_CATALOG_PROP_WAREHOUSE,
 };
 
 #[cfg(test)]

--- a/crates/sail-catalog-iceberg/src/lib.rs
+++ b/crates/sail-catalog-iceberg/src/lib.rs
@@ -39,42 +39,116 @@ mod table_update_tests {
             "updates": [{"action": "set-properties", "updates": {"k": "v"}}]
         }))
         .expect("set-properties commit must deserialize");
+        assert_eq!(request.requirements.len(), 1);
+        assert!(matches!(
+            &request.requirements[0],
+            models::TableRequirement::AssertTableUuid { uuid }
+                if uuid == "11111111-1111-1111-1111-111111111111"
+        ));
         assert_eq!(request.updates.len(), 1);
         assert!(matches!(
-            request.updates[0],
-            models::TableUpdate::SetPropertiesUpdate {}
+            &request.updates[0],
+            models::TableUpdate::SetPropertiesUpdate { updates }
+                if updates.get("k").map(String::as_str) == Some("v")
         ));
+    }
+
+    #[test]
+    fn commit_table_request_preserves_ref_snapshot_requirement() {
+        let request = models::CommitTableRequest::new(
+            vec![models::TableRequirement::AssertRefSnapshotId {
+                r#ref: "main".to_string(),
+                snapshot_id: None,
+            }],
+            vec![models::TableUpdate::SetSnapshotRefUpdate {
+                ref_name: "main".to_string(),
+                r#type: models::set_snapshot_ref_update::Type::Branch,
+                snapshot_id: 123,
+                max_ref_age_ms: None,
+                max_snapshot_age_ms: None,
+                min_snapshots_to_keep: None,
+            }],
+        );
+        let value = serde_json::to_value(request).expect("commit request must serialize");
+        assert_eq!(
+            value["requirements"][0],
+            serde_json::json!({
+                "type": "assert-ref-snapshot-id",
+                "ref": "main",
+                "snapshot-id": null
+            })
+        );
+        assert_eq!(
+            value["updates"][0],
+            serde_json::json!({
+                "action": "set-snapshot-ref",
+                "ref-name": "main",
+                "type": "branch",
+                "snapshot-id": 123
+            })
+        );
     }
 
     #[test]
     fn table_update_discriminates_on_action() {
         let cases = [
-            ("assign-uuid", "AssignUuidUpdate"),
-            ("add-snapshot", "AddSnapshotUpdate"),
-            ("set-location", "SetLocationUpdate"),
-            ("remove-properties", "RemovePropertiesUpdate"),
-            ("upgrade-format-version", "UpgradeFormatVersionUpdate"),
+            serde_json::json!({"action": "assign-uuid", "uuid": "table-uuid"}),
+            serde_json::json!({"action": "set-location", "location": "s3://bucket/table"}),
+            serde_json::json!({"action": "remove-properties", "removals": ["k"]}),
+            serde_json::json!({"action": "set-properties", "updates": {"k": "v"}}),
+            serde_json::json!({"action": "upgrade-format-version", "format-version": 2}),
         ];
-        for (action, _name) in cases {
+        for input in cases {
             let update: models::TableUpdate =
-                serde_json::from_value(serde_json::json!({"action": action}))
-                    .unwrap_or_else(|err| panic!("action {action} must deserialize: {err}"));
-            // Round-trips back to the same tagged action.
+                serde_json::from_value(input.clone()).unwrap_or_else(|err| {
+                    panic!("update {input} must deserialize and preserve fields: {err}")
+                });
             let value = serde_json::to_value(&update).unwrap();
-            assert_eq!(value["action"], serde_json::json!(action));
+            assert_eq!(value, input);
         }
     }
 
     #[test]
-    fn view_update_accepts_set_properties() {
+    fn commit_view_request_preserves_requirements_and_updates() {
         let request: models::CommitViewRequest = serde_json::from_value(serde_json::json!({
+            "requirements": [{"type": "assert-view-uuid", "uuid": "22222222-2222-2222-2222-222222222222"}],
             "updates": [{"action": "set-properties", "updates": {"k": "v"}}]
         }))
         .expect("view set-properties commit must deserialize");
+        let requirement = request
+            .requirements
+            .as_ref()
+            .expect("view requirements must deserialize");
         assert!(matches!(
-            request.updates[0],
-            models::ViewUpdate::SetPropertiesUpdate {}
+            &requirement[0],
+            models::ViewRequirement::AssertViewUuid { uuid }
+                if uuid == "22222222-2222-2222-2222-222222222222"
         ));
+        assert!(matches!(
+            &request.updates[0],
+            models::ViewUpdate::SetPropertiesUpdate { updates }
+                if updates.get("k").map(String::as_str) == Some("v")
+        ));
+    }
+
+    #[test]
+    fn view_update_discriminates_on_action() {
+        let cases = [
+            serde_json::json!({"action": "assign-uuid", "uuid": "view-uuid"}),
+            serde_json::json!({"action": "set-current-view-version", "view-version-id": 7}),
+            serde_json::json!({"action": "set-location", "location": "s3://bucket/view"}),
+            serde_json::json!({"action": "remove-properties", "removals": ["k"]}),
+            serde_json::json!({"action": "set-properties", "updates": {"k": "v"}}),
+            serde_json::json!({"action": "upgrade-format-version", "format-version": 1}),
+        ];
+        for input in cases {
+            let update: models::ViewUpdate =
+                serde_json::from_value(input.clone()).unwrap_or_else(|err| {
+                    panic!("view update {input} must deserialize and preserve fields: {err}")
+                });
+            let value = serde_json::to_value(&update).unwrap();
+            assert_eq!(value, input);
+        }
     }
 
     #[test]
@@ -82,5 +156,9 @@ mod table_update_tests {
         let result: Result<models::TableUpdate, _> =
             serde_json::from_value(serde_json::json!({"action": "not-a-real-update"}));
         assert!(result.is_err(), "unknown action must not deserialize");
+
+        let result: Result<models::ViewUpdate, _> =
+            serde_json::from_value(serde_json::json!({"action": "not-a-real-update"}));
+        assert!(result.is_err(), "unknown view action must not deserialize");
     }
 }

--- a/crates/sail-catalog-iceberg/src/models/assert_ref_snapshot_id.rs
+++ b/crates/sail-catalog-iceberg/src/models/assert_ref_snapshot_id.rs
@@ -32,12 +32,12 @@ pub struct AssertRefSnapshotId {
     #[serde(rename = "ref")]
     pub r#ref: String,
     #[serde(rename = "snapshot-id")]
-    pub snapshot_id: i64,
+    pub snapshot_id: Option<i64>,
 }
 
 impl AssertRefSnapshotId {
     /// The table branch or tag identified by the requirement's `ref` must reference the requirement's `snapshot-id`. The `snapshot-id` field is required in this object, but in the case of a `null` the ref must not already exist.
-    pub fn new(r#ref: String, snapshot_id: i64) -> AssertRefSnapshotId {
+    pub fn new(r#ref: String, snapshot_id: Option<i64>) -> AssertRefSnapshotId {
         AssertRefSnapshotId {
             r#type: None,
             r#ref,

--- a/crates/sail-catalog-iceberg/src/models/mod.rs
+++ b/crates/sail-catalog-iceberg/src/models/mod.rs
@@ -252,6 +252,8 @@ pub mod view_history_entry;
 pub use self::view_history_entry::ViewHistoryEntry;
 pub mod view_metadata;
 pub use self::view_metadata::ViewMetadata;
+pub mod view_requirement;
+pub use self::view_requirement::ViewRequirement;
 pub mod view_update;
 pub use self::view_update::ViewUpdate;
 pub mod view_version;

--- a/crates/sail-catalog-iceberg/src/models/table_requirement.rs
+++ b/crates/sail-catalog-iceberg/src/models/table_requirement.rs
@@ -30,19 +30,39 @@ pub enum TableRequirement {
     #[serde(rename = "assert-create")]
     AssertCreate {},
     #[serde(rename = "assert-current-schema-id")]
-    AssertCurrentSchemaId {},
+    AssertCurrentSchemaId {
+        #[serde(rename = "current-schema-id")]
+        current_schema_id: i32,
+    },
     #[serde(rename = "assert-default-sort-order-id")]
-    AssertDefaultSortOrderId {},
+    AssertDefaultSortOrderId {
+        #[serde(rename = "default-sort-order-id")]
+        default_sort_order_id: i64,
+    },
     #[serde(rename = "assert-default-spec-id")]
-    AssertDefaultSpecId {},
+    AssertDefaultSpecId {
+        #[serde(rename = "default-spec-id")]
+        default_spec_id: i32,
+    },
     #[serde(rename = "assert-last-assigned-field-id")]
-    AssertLastAssignedFieldId {},
+    AssertLastAssignedFieldId {
+        #[serde(rename = "last-assigned-field-id")]
+        last_assigned_field_id: i32,
+    },
     #[serde(rename = "assert-last-assigned-partition-id")]
-    AssertLastAssignedPartitionId {},
+    AssertLastAssignedPartitionId {
+        #[serde(rename = "last-assigned-partition-id")]
+        last_assigned_partition_id: i32,
+    },
     #[serde(rename = "assert-ref-snapshot-id")]
-    AssertRefSnapshotId {},
+    AssertRefSnapshotId {
+        #[serde(rename = "ref")]
+        r#ref: String,
+        #[serde(rename = "snapshot-id")]
+        snapshot_id: Option<i64>,
+    },
     #[serde(rename = "assert-table-uuid")]
-    AssertTableUuid {},
+    AssertTableUuid { uuid: String },
 }
 
 impl Default for TableRequirement {

--- a/crates/sail-catalog-iceberg/src/models/table_update.rs
+++ b/crates/sail-catalog-iceberg/src/models/table_update.rs
@@ -28,51 +28,135 @@ use crate::models;
 #[serde(tag = "action")]
 pub enum TableUpdate {
     #[serde(rename = "add-encryption-key")]
-    AddEncryptionKeyUpdate {},
+    AddEncryptionKeyUpdate {
+        #[serde(rename = "encryption-key")]
+        encryption_key: Box<models::EncryptedKey>,
+    },
     #[serde(rename = "add-schema")]
-    AddSchemaUpdate {},
+    AddSchemaUpdate {
+        #[serde(rename = "schema")]
+        schema: Box<models::Schema>,
+        #[serde(rename = "last-column-id", skip_serializing_if = "Option::is_none")]
+        last_column_id: Option<i32>,
+    },
     #[serde(rename = "add-snapshot")]
-    AddSnapshotUpdate {},
+    AddSnapshotUpdate {
+        #[serde(rename = "snapshot")]
+        snapshot: Box<models::Snapshot>,
+    },
     #[serde(rename = "add-sort-order")]
-    AddSortOrderUpdate {},
+    AddSortOrderUpdate {
+        #[serde(rename = "sort-order")]
+        sort_order: Box<models::SortOrder>,
+    },
     #[serde(rename = "add-spec")]
-    AddPartitionSpecUpdate {},
+    AddPartitionSpecUpdate {
+        #[serde(rename = "spec")]
+        spec: Box<models::PartitionSpec>,
+    },
     #[serde(rename = "assign-uuid")]
-    AssignUuidUpdate {},
+    AssignUuidUpdate { uuid: String },
     #[serde(rename = "remove-encryption-key")]
-    RemoveEncryptionKeyUpdate {},
+    RemoveEncryptionKeyUpdate {
+        #[serde(rename = "key-id")]
+        key_id: String,
+    },
     #[serde(rename = "remove-partition-specs")]
-    RemovePartitionSpecsUpdate {},
+    RemovePartitionSpecsUpdate {
+        #[serde(rename = "spec-ids")]
+        spec_ids: Vec<i32>,
+    },
+    #[serde(rename = "remove-partition-statistics")]
+    RemovePartitionStatisticsUpdate {
+        #[serde(rename = "snapshot-id")]
+        snapshot_id: i64,
+    },
     #[serde(rename = "remove-properties")]
-    RemovePropertiesUpdate {},
+    RemovePropertiesUpdate { removals: Vec<String> },
     #[serde(rename = "remove-schemas")]
-    RemoveSchemasUpdate {},
+    RemoveSchemasUpdate {
+        #[serde(rename = "schema-ids")]
+        schema_ids: Vec<i32>,
+    },
     #[serde(rename = "remove-snapshot-ref")]
-    RemoveSnapshotRefUpdate {},
+    RemoveSnapshotRefUpdate {
+        #[serde(rename = "ref-name")]
+        ref_name: String,
+    },
     #[serde(rename = "remove-snapshots")]
-    RemoveSnapshotsUpdate {},
+    RemoveSnapshotsUpdate {
+        #[serde(rename = "snapshot-ids")]
+        snapshot_ids: Vec<i64>,
+    },
     #[serde(rename = "remove-statistics")]
-    RemoveStatisticsUpdate {},
+    RemoveStatisticsUpdate {
+        #[serde(rename = "snapshot-id")]
+        snapshot_id: i64,
+    },
     #[serde(rename = "set-current-schema")]
-    SetCurrentSchemaUpdate {},
+    SetCurrentSchemaUpdate {
+        #[serde(rename = "schema-id")]
+        schema_id: i32,
+    },
     #[serde(rename = "set-default-sort-order")]
-    SetDefaultSortOrderUpdate {},
+    SetDefaultSortOrderUpdate {
+        #[serde(rename = "sort-order-id")]
+        sort_order_id: i64,
+    },
     #[serde(rename = "set-default-spec")]
-    SetDefaultSpecUpdate {},
+    SetDefaultSpecUpdate {
+        #[serde(rename = "spec-id")]
+        spec_id: i32,
+    },
     #[serde(rename = "set-location")]
-    SetLocationUpdate {},
+    SetLocationUpdate { location: String },
+    #[serde(rename = "set-partition-statistics")]
+    SetPartitionStatisticsUpdate {
+        #[serde(rename = "partition-statistics")]
+        partition_statistics: Box<models::PartitionStatisticsFile>,
+    },
     #[serde(rename = "set-properties")]
-    SetPropertiesUpdate {},
+    SetPropertiesUpdate {
+        updates: std::collections::HashMap<String, String>,
+    },
     #[serde(rename = "set-snapshot-ref")]
-    SetSnapshotRefUpdate {},
+    SetSnapshotRefUpdate {
+        #[serde(rename = "ref-name")]
+        ref_name: String,
+        #[serde(rename = "type")]
+        r#type: models::set_snapshot_ref_update::Type,
+        #[serde(rename = "snapshot-id")]
+        snapshot_id: i64,
+        #[serde(rename = "max-ref-age-ms", skip_serializing_if = "Option::is_none")]
+        max_ref_age_ms: Option<i64>,
+        #[serde(
+            rename = "max-snapshot-age-ms",
+            skip_serializing_if = "Option::is_none"
+        )]
+        max_snapshot_age_ms: Option<i64>,
+        #[serde(
+            rename = "min-snapshots-to-keep",
+            skip_serializing_if = "Option::is_none"
+        )]
+        min_snapshots_to_keep: Option<i32>,
+    },
     #[serde(rename = "set-statistics")]
-    SetStatisticsUpdate {},
+    SetStatisticsUpdate {
+        #[serde(rename = "snapshot-id", skip_serializing_if = "Option::is_none")]
+        snapshot_id: Option<i64>,
+        statistics: Box<models::StatisticsFile>,
+    },
     #[serde(rename = "upgrade-format-version")]
-    UpgradeFormatVersionUpdate {},
+    UpgradeFormatVersionUpdate {
+        #[serde(rename = "format-version")]
+        format_version: i32,
+    },
 }
 
 impl Default for TableUpdate {
     fn default() -> Self {
-        Self::AddEncryptionKeyUpdate {}
+        Self::SetPropertiesUpdate {
+            updates: Default::default(),
+        }
     }
 }

--- a/crates/sail-catalog-iceberg/src/models/view_requirement.rs
+++ b/crates/sail-catalog-iceberg/src/models/view_requirement.rs
@@ -22,25 +22,17 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::models;
-
-#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
-pub struct CommitViewRequest {
-    /// View identifier to update
-    #[serde(rename = "identifier", skip_serializing_if = "Option::is_none")]
-    pub identifier: Option<Box<models::TableIdentifier>>,
-    #[serde(rename = "requirements", skip_serializing_if = "Option::is_none")]
-    pub requirements: Option<Vec<models::ViewRequirement>>,
-    #[serde(rename = "updates")]
-    pub updates: Vec<models::ViewUpdate>,
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum ViewRequirement {
+    #[serde(rename = "assert-view-uuid")]
+    AssertViewUuid { uuid: String },
 }
 
-impl CommitViewRequest {
-    pub fn new(updates: Vec<models::ViewUpdate>) -> CommitViewRequest {
-        CommitViewRequest {
-            identifier: None,
-            requirements: None,
-            updates,
+impl Default for ViewRequirement {
+    fn default() -> Self {
+        Self::AssertViewUuid {
+            uuid: Default::default(),
         }
     }
 }

--- a/crates/sail-catalog-iceberg/src/models/view_update.rs
+++ b/crates/sail-catalog-iceberg/src/models/view_update.rs
@@ -28,25 +28,43 @@ use crate::models;
 #[serde(tag = "action")]
 pub enum ViewUpdate {
     #[serde(rename = "add-schema")]
-    AddSchemaUpdate {},
+    AddSchemaUpdate {
+        #[serde(rename = "schema")]
+        schema: Box<models::Schema>,
+        #[serde(rename = "last-column-id", skip_serializing_if = "Option::is_none")]
+        last_column_id: Option<i32>,
+    },
     #[serde(rename = "add-view-version")]
-    AddViewVersionUpdate {},
+    AddViewVersionUpdate {
+        #[serde(rename = "view-version")]
+        view_version: Box<models::ViewVersion>,
+    },
     #[serde(rename = "assign-uuid")]
-    AssignUuidUpdate {},
+    AssignUuidUpdate { uuid: String },
     #[serde(rename = "remove-properties")]
-    RemovePropertiesUpdate {},
+    RemovePropertiesUpdate { removals: Vec<String> },
     #[serde(rename = "set-current-view-version")]
-    SetCurrentViewVersionUpdate {},
+    SetCurrentViewVersionUpdate {
+        #[serde(rename = "view-version-id")]
+        view_version_id: i32,
+    },
     #[serde(rename = "set-location")]
-    SetLocationUpdate {},
+    SetLocationUpdate { location: String },
     #[serde(rename = "set-properties")]
-    SetPropertiesUpdate {},
+    SetPropertiesUpdate {
+        updates: std::collections::HashMap<String, String>,
+    },
     #[serde(rename = "upgrade-format-version")]
-    UpgradeFormatVersionUpdate {},
+    UpgradeFormatVersionUpdate {
+        #[serde(rename = "format-version")]
+        format_version: i32,
+    },
 }
 
 impl Default for ViewUpdate {
     fn default() -> Self {
-        Self::AddSchemaUpdate {}
+        Self::SetPropertiesUpdate {
+            updates: Default::default(),
+        }
     }
 }

--- a/crates/sail-catalog-iceberg/src/provider.rs
+++ b/crates/sail-catalog-iceberg/src/provider.rs
@@ -10,11 +10,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::sync::Arc;
 
 use percent_encoding::percent_decode_str;
+use sail_catalog::credentials::CatalogCredentials;
 use sail_catalog::error::{CatalogError, CatalogObject, CatalogResult};
 use sail_catalog::lakehouse::{
     BeginTableAccessRequest, LakehouseCapability, LakehouseCommitOutcome, LakehouseCommitRequest,
@@ -59,165 +61,35 @@ const REST_REMOTE_SIGNING_ENABLED_KEY: &str = "s3.remote-signing-enabled";
 //  - https://iceberg.apache.org/docs/nightly/configuration/#catalog-properties
 //  - https://iceberg.apache.org/docs/nightly/spark-configuration/
 #[derive(Clone, Debug)]
-pub struct RestCatalogConfig {
-    uri: String,
-    warehouse: Option<String>,
-    props: HashMap<String, String>,
+pub struct CatalogConfig<'a> {
+    properties: Cow<'a, HashMap<String, String>>,
 }
 
-/// Provider for Apache Iceberg REST Catalog.
-pub struct IcebergRestCatalogProvider {
-    name: String,
-    catalog_config: RestCatalogConfig,
-    merged_catalog_config: OnceCell<RestCatalogConfig>,
-    client: OnceCell<ApiClient>,
-}
-
-impl IcebergRestCatalogProvider {
-    fn normalize_catalog_props(props: HashMap<String, String>) -> HashMap<String, String> {
-        props
-            .into_iter()
-            .map(|(key, value)| {
-                let key = if Self::is_namespace_separator_key(&key) {
-                    REST_CATALOG_PROP_NAMESPACE_SEPARATOR.to_string()
-                } else {
-                    key
-                };
-                (key, value)
-            })
-            .collect()
+impl CatalogConfig<'_> {
+    fn uri(&self) -> Option<String> {
+        self.properties
+            .get(REST_CATALOG_PROP_URI)
+            .cloned()
+            .map(|value| value.trim_end_matches('/').to_string())
+            .filter(|value| !value.is_empty())
     }
 
-    fn catalog_prefix(catalog_config: &RestCatalogConfig) -> Option<&str> {
-        catalog_config
-            .props
+    fn warehouse(&self) -> Option<String> {
+        self.properties
+            .get(REST_CATALOG_PROP_WAREHOUSE)
+            .map(|value| value.trim_end_matches('/').to_string())
+    }
+
+    fn prefix(&self) -> Option<&str> {
+        self.properties
             .get(REST_CATALOG_PROP_PREFIX)
             .map(|value| value.trim())
             .filter(|value| !value.is_empty())
     }
 
-    fn is_namespace_separator_key(key: &str) -> bool {
-        matches!(
-            key.trim().to_ascii_lowercase().as_str(),
-            "namespace-separator" | "namespaceseparator" | "namespace_separator"
-        )
-    }
-
-    pub fn new(name: String, props: HashMap<String, String>) -> Self {
-        let catalog_config = RestCatalogConfig {
-            uri: props
-                .get(REST_CATALOG_PROP_URI)
-                .cloned()
-                .unwrap_or(Configuration::new().base_path),
-            warehouse: props.get(REST_CATALOG_PROP_WAREHOUSE).cloned(),
-            props: Self::normalize_catalog_props(
-                props
-                    .into_iter()
-                    .filter(|(k, _)| k != REST_CATALOG_PROP_URI && k != REST_CATALOG_PROP_WAREHOUSE)
-                    .collect(),
-            ),
-        };
-
-        Self {
-            name,
-            catalog_config,
-            merged_catalog_config: OnceCell::new(),
-            client: OnceCell::new(),
-        }
-    }
-
-    fn init_client_config(
-        &self,
-        catalog_config: &RestCatalogConfig,
-    ) -> CatalogResult<Configuration> {
-        let mut client_config = Configuration::new();
-        client_config.user_agent = Some("Sail".to_string());
-        client_config.base_path = catalog_config.uri.to_string();
-        for (key, value) in &catalog_config.props {
-            // TODO: `basic_auth` and `api_key` are not used anything in the API yet.
-            //  We may need to support them in the future.
-            match key.as_str() {
-                "oauth-access-token" => {
-                    client_config.oauth_access_token = Some(value.to_string());
-                }
-                "bearer-access-token" => {
-                    client_config.bearer_access_token = Some(value.to_string());
-                }
-                _ => {}
-            }
-        }
-        Ok(client_config)
-    }
-
-    fn init_client(&self, catalog_config: &RestCatalogConfig) -> CatalogResult<ApiClient> {
-        Ok(ApiClient::new(Arc::new(
-            self.init_client_config(catalog_config)?,
-        )))
-    }
-
-    async fn load_catalog_config(
-        &self,
-        client: &ApiClient,
-        warehouse: Option<&str>,
-    ) -> CatalogResult<crate::models::CatalogConfig> {
-        let config = client
-            .configuration_api_api()
-            .get_config(warehouse)
-            .await
-            .map_err(|e| CatalogError::External(format!("Failed to load config: {e}")))?;
-        Ok(config)
-    }
-
-    // Merge the `RestCatalogConfig` with the a [`CatalogConfig`] (fetched from the REST server).
-    // Then initialize the `ApiClient` with the merged config.
-    // This only happens once, then the result is cached.
-    async fn load_client_and_merged_config(
-        &self,
-    ) -> CatalogResult<(&ApiClient, &RestCatalogConfig)> {
-        let merged_catalog_config = self
-            .merged_catalog_config
-            .get_or_try_init(|| async {
-                let temp_client = self.init_client(&self.catalog_config)?;
-                let config = self
-                    .load_catalog_config(&temp_client, self.catalog_config.warehouse.as_deref())
-                    .await?;
-
-                let mut overrides = Self::normalize_catalog_props(config.overrides);
-                let mut client_props = self.catalog_config.props.clone();
-                if let Some(warehouse) = &self.catalog_config.warehouse {
-                    client_props.insert(REST_CATALOG_PROP_WAREHOUSE.to_string(), warehouse.clone());
-                }
-
-                let uri = if let Some(uri) = overrides.remove(REST_CATALOG_PROP_URI) {
-                    uri.trim_end_matches('/').to_string()
-                } else {
-                    self.catalog_config.uri.trim_end_matches('/').to_string()
-                };
-
-                let mut props = Self::normalize_catalog_props(config.defaults);
-                props.extend(client_props);
-                props.extend(overrides);
-                let warehouse = props.get(REST_CATALOG_PROP_WAREHOUSE).cloned();
-
-                Ok::<_, CatalogError>(RestCatalogConfig {
-                    uri,
-                    warehouse,
-                    props,
-                })
-            })
-            .await?;
-
-        let client = self
-            .client
-            .get_or_try_init(|| async { self.init_client(merged_catalog_config) })
-            .await?;
-
-        Ok((client, merged_catalog_config))
-    }
-
-    fn namespace_separator(catalog_config: &RestCatalogConfig) -> CatalogResult<String> {
-        let separator = catalog_config
-            .props
+    fn namespace_separator(&self) -> CatalogResult<String> {
+        let separator = self
+            .properties
             .get(REST_CATALOG_PROP_NAMESPACE_SEPARATOR)
             .map(|value| value.trim());
 
@@ -235,11 +107,8 @@ impl IcebergRestCatalogProvider {
     }
 
     /// Converts a `Namespace` into a string representation for the REST API URL.
-    fn namespace_string(
-        catalog_config: &RestCatalogConfig,
-        database: &Namespace,
-    ) -> CatalogResult<String> {
-        let separator = Self::namespace_separator(catalog_config)?;
+    fn namespace_string(&self, database: &Namespace) -> CatalogResult<String> {
+        let separator = self.namespace_separator()?;
         let mut result = database.head.to_string();
         for s in &database.tail {
             result.push_str(&separator);
@@ -247,29 +116,128 @@ impl IcebergRestCatalogProvider {
         }
         Ok(result)
     }
+}
 
-    async fn load_table_result_with(
+#[derive(Debug, Clone)]
+pub struct IcebergRestCatalogOptions {
+    pub credentials: Arc<dyn CatalogCredentials>,
+    pub properties: HashMap<String, String>,
+    pub user_agent: Option<String>,
+}
+
+/// Provider for Apache Iceberg REST Catalog.
+pub struct IcebergRestCatalogProvider {
+    name: String,
+    options: IcebergRestCatalogOptions,
+    resolved_catalog_config: OnceCell<CatalogConfig<'static>>,
+}
+
+impl IcebergRestCatalogProvider {
+    pub fn new(name: String, options: IcebergRestCatalogOptions) -> Self {
+        Self {
+            name,
+            options,
+            resolved_catalog_config: OnceCell::new(),
+        }
+    }
+
+    async fn configuration(
+        catalog_config: &CatalogConfig<'_>,
+        credentials: &Arc<dyn CatalogCredentials>,
+        user_agent: Option<String>,
+    ) -> CatalogResult<Configuration> {
+        let mut client_config = Configuration::new();
+        client_config.user_agent = user_agent;
+        client_config.base_path = catalog_config.uri().ok_or_else(|| {
+            CatalogError::InvalidArgument(format!(
+                "Iceberg REST catalog property '{REST_CATALOG_PROP_URI}' is required"
+            ))
+        })?;
+        if let Some(credential) = credentials.retrieve().await? {
+            client_config.bearer_access_token = Some(credential);
+        }
+        Ok(client_config)
+    }
+
+    async fn bootstrap_client(&self) -> CatalogResult<ApiClient> {
+        let catalog_config = CatalogConfig {
+            properties: Cow::Borrowed(&self.options.properties),
+        };
+        Ok(ApiClient::new(Arc::new(
+            Self::configuration(
+                &catalog_config,
+                &self.options.credentials,
+                self.options.user_agent.clone(),
+            )
+            .await?,
+        )))
+    }
+
+    async fn client(&self) -> CatalogResult<ApiClient> {
+        let catalog_config = self.resolved_catalog_config().await?;
+        Ok(ApiClient::new(Arc::new(
+            Self::configuration(
+                catalog_config,
+                &self.options.credentials,
+                self.options.user_agent.clone(),
+            )
+            .await?,
+        )))
+    }
+
+    // Merge the local catalog config with the [`crate::models::CatalogConfig`] fetched from the REST server.
+    // This only happens once, then the result is cached.
+    async fn resolved_catalog_config(&self) -> CatalogResult<&CatalogConfig<'static>> {
+        self.resolved_catalog_config
+            .get_or_try_init(|| async {
+                let client = self.bootstrap_client().await?;
+                let catalog_config = CatalogConfig {
+                    properties: Cow::Borrowed(&self.options.properties),
+                };
+                let warehouse = catalog_config.warehouse();
+                let config = client
+                    .configuration_api_api()
+                    .get_config(warehouse.as_deref())
+                    .await
+                    .map_err(|e| CatalogError::External(format!("Failed to load config: {e}")))?;
+
+                let mut properties = config
+                    .defaults
+                    .into_iter()
+                    .filter(|(key, _)| key != REST_CATALOG_PROP_URI)
+                    .collect::<HashMap<_, _>>();
+                properties.extend(self.options.properties.clone());
+                properties.extend(config.overrides);
+
+                Ok::<_, CatalogError>(CatalogConfig {
+                    properties: Cow::Owned(properties),
+                })
+            })
+            .await
+    }
+
+    async fn load_table_result(
         &self,
-        client: &ApiClient,
-        catalog_config: &RestCatalogConfig,
         database: &Namespace,
         table: &str,
         access_delegation: Option<&str>,
     ) -> CatalogResult<crate::models::LoadTableResult> {
+        let client = self.client().await?;
+        let catalog_config = self.resolved_catalog_config().await?;
         client
             .catalog_api_api()
             .load_table(
-                &Self::namespace_string(catalog_config, database)?,
+                &catalog_config.namespace_string(database)?,
                 table,
                 access_delegation,
                 None,
                 None,
-                Self::catalog_prefix(catalog_config),
+                catalog_config.prefix(),
             )
             .await
             .map_err(|e| match e {
                 apis::Error::ResponseError(apis::ResponseContent { status, .. })
-                    if status == 404 =>
+                    if status == reqwest::StatusCode::NOT_FOUND =>
                 {
                     CatalogError::NotFound(
                         CatalogObject::Table,
@@ -283,124 +251,9 @@ impl IcebergRestCatalogProvider {
                 _ => CatalogError::External(format!(
                     "Failed to load table {}.{}: {e}",
                     quote_namespace_if_needed(database),
-                    quote_name_if_needed(table),
+                    quote_name_if_needed(table)
                 )),
             })
-    }
-
-    async fn load_table_result(
-        &self,
-        database: &Namespace,
-        table: &str,
-    ) -> CatalogResult<crate::models::LoadTableResult> {
-        let (client, catalog_config) = self.load_client_and_merged_config().await?;
-        self.load_table_result_with(client, catalog_config, database, table, None)
-            .await
-    }
-
-    async fn commit_table_request(
-        &self,
-        database: &Namespace,
-        table: &str,
-        format: &str,
-        requirements: Vec<serde_json::Value>,
-        updates: Vec<serde_json::Value>,
-    ) -> CatalogResult<crate::models::CommitTableResponse> {
-        if !format.eq_ignore_ascii_case("iceberg") {
-            return Err(CatalogError::NotSupported(format!(
-                "Iceberg REST catalog cannot commit '{format}' tables",
-            )));
-        }
-
-        let (_client, catalog_config) = self.load_client_and_merged_config().await?;
-        let client_config = self.init_client_config(catalog_config)?;
-        let namespace = Self::namespace_string(catalog_config, database)?;
-        let prefix = catalog_config
-            .props
-            .get(REST_CATALOG_PROP_PREFIX)
-            .map(|prefix| format!("/{}", crate::apis::urlencode(prefix)))
-            .unwrap_or_default();
-        let uri = format!(
-            "{}/v1{prefix}/namespaces/{namespace}/tables/{table}",
-            client_config.base_path,
-            namespace = crate::apis::urlencode(namespace),
-            table = crate::apis::urlencode(table)
-        );
-        let body = serde_json::json!({
-            "identifier": {
-                "namespace": Vec::<String>::from(database.clone()),
-                "name": table,
-            },
-            "requirements": requirements,
-            "updates": updates,
-        });
-
-        let mut request = client_config.client.post(uri);
-        if let Some(user_agent) = client_config.user_agent {
-            request = request.header(reqwest::header::USER_AGENT, user_agent);
-        }
-        if let Some(token) = client_config.oauth_access_token {
-            request = request.bearer_auth(token);
-        }
-        if let Some(token) = client_config.bearer_access_token {
-            request = request.bearer_auth(token);
-        }
-
-        let response = request
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| CatalogError::External(format!("Failed to commit table: {e}")))?;
-        let status = response.status();
-        let content = response
-            .text()
-            .await
-            .map_err(|e| CatalogError::External(format!("Failed to read commit response: {e}")))?;
-
-        if status.is_success() {
-            serde_json::from_str(&content).map_err(|e| {
-                CatalogError::External(format!("Failed to parse commit response: {e}"))
-            })
-        } else if status == reqwest::StatusCode::NOT_FOUND {
-            Err(CatalogError::NotFound(
-                CatalogObject::Table,
-                format!(
-                    "{}.{}",
-                    quote_namespace_if_needed(database),
-                    quote_name_if_needed(table)
-                ),
-            ))
-        } else if status == reqwest::StatusCode::CONFLICT {
-            Err(CatalogError::Conflict(format!(
-                "Iceberg REST catalog commit conflict for {}.{}: {content}",
-                quote_namespace_if_needed(database),
-                quote_name_if_needed(table)
-            )))
-        } else if status == reqwest::StatusCode::UNAUTHORIZED {
-            Err(CatalogError::Unauthorized(format!(
-                "Iceberg REST catalog commit unauthorized for {}.{}: {content}",
-                quote_namespace_if_needed(database),
-                quote_name_if_needed(table)
-            )))
-        } else if status == reqwest::StatusCode::FORBIDDEN {
-            Err(CatalogError::Forbidden(format!(
-                "Iceberg REST catalog commit forbidden for {}.{}: {content}",
-                quote_namespace_if_needed(database),
-                quote_name_if_needed(table)
-            )))
-        } else if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-            Err(CatalogError::RateLimited(format!(
-                "Iceberg REST catalog commit rate limited for {}.{}: {content}",
-                quote_namespace_if_needed(database),
-                quote_name_if_needed(table)
-            )))
-        } else {
-            Err(CatalogError::External(format!(
-                "Failed to commit Iceberg table {}.{}: status {status}: {content}",
-                quote_namespace_if_needed(database),
-                quote_name_if_needed(table)
-            )))
-        }
     }
 
     fn normalize_scan_planning_mode(value: &str) -> CatalogResult<String> {
@@ -415,22 +268,30 @@ impl IcebergRestCatalogProvider {
 
     fn effective_scan_planning_mode(
         table_config: Option<&HashMap<String, String>>,
-        catalog_config: &RestCatalogConfig,
+        catalog_config: &CatalogConfig<'_>,
     ) -> CatalogResult<Option<String>> {
         table_config
             .and_then(|config| config.get(REST_TABLE_SCAN_PLANNING_MODE_KEY))
-            .or_else(|| catalog_config.props.get(REST_TABLE_SCAN_PLANNING_MODE_KEY))
+            .or_else(|| {
+                catalog_config
+                    .properties
+                    .get(REST_TABLE_SCAN_PLANNING_MODE_KEY)
+            })
             .map(|value| Self::normalize_scan_planning_mode(value))
             .transpose()
     }
 
     fn remote_signing_enabled(
         table_config: Option<&HashMap<String, String>>,
-        catalog_config: &RestCatalogConfig,
+        catalog_config: &CatalogConfig<'_>,
     ) -> bool {
         table_config
             .and_then(|config| config.get(REST_REMOTE_SIGNING_ENABLED_KEY))
-            .or_else(|| catalog_config.props.get(REST_REMOTE_SIGNING_ENABLED_KEY))
+            .or_else(|| {
+                catalog_config
+                    .properties
+                    .get(REST_REMOTE_SIGNING_ENABLED_KEY)
+            })
             .map(|value| value.eq_ignore_ascii_case("true"))
             .unwrap_or(false)
     }
@@ -445,7 +306,7 @@ impl IcebergRestCatalogProvider {
     }
 
     fn rest_table_session_fingerprint(
-        &self,
+        catalog: &str,
         database: &Namespace,
         table: &str,
         scan_planning_mode: Option<&str>,
@@ -453,7 +314,7 @@ impl IcebergRestCatalogProvider {
         result: &crate::models::LoadTableResult,
     ) -> String {
         let mut hasher = DefaultHasher::new();
-        self.name.hash(&mut hasher);
+        catalog.hash(&mut hasher);
         Vec::<String>::from(database.clone()).hash(&mut hasher);
         table.hash(&mut hasher);
         result.metadata_location.hash(&mut hasher);
@@ -480,17 +341,18 @@ impl IcebergRestCatalogProvider {
     }
 
     fn rest_table_session_ref(
-        &self,
+        catalog: &str,
         database: &Namespace,
         table: &str,
-        catalog_config: &RestCatalogConfig,
+        catalog_config: &CatalogConfig<'_>,
         result: &crate::models::LoadTableResult,
     ) -> CatalogResult<IcebergRestTableSessionRef> {
         let config = result.config.as_ref();
         let credentials = result.storage_credentials.as_deref();
         let scan_planning_mode = Self::effective_scan_planning_mode(config, catalog_config)?;
         let remote_signing_enabled = Self::remote_signing_enabled(config, catalog_config);
-        let fingerprint = self.rest_table_session_fingerprint(
+        let fingerprint = Self::rest_table_session_fingerprint(
+            catalog,
             database,
             table,
             scan_planning_mode.as_deref(),
@@ -508,13 +370,14 @@ impl IcebergRestCatalogProvider {
     }
 
     fn validate_create_table_access_session_requirements(
-        &self,
+        catalog: &str,
         database: &Namespace,
         table: &str,
-        catalog_config: &RestCatalogConfig,
+        catalog_config: &CatalogConfig<'_>,
         result: &crate::models::LoadTableResult,
     ) -> CatalogResult<()> {
-        let rest_session = self.rest_table_session_ref(database, table, catalog_config, result)?;
+        let rest_session =
+            Self::rest_table_session_ref(catalog, database, table, catalog_config, result)?;
         let mut requirements = Vec::new();
         if rest_session.scan_planning_mode.as_deref() == Some("server") {
             requirements.push("server-side scan planning");
@@ -538,9 +401,9 @@ impl IcebergRestCatalogProvider {
 
     /// Converts an Iceberg REST API table load result into a catalog `TableStatus`.
     fn load_table_result_to_status(
-        &self,
-        table_name: &str,
+        catalog: &str,
         database: &Namespace,
+        table: &str,
         result: crate::models::LoadTableResult,
     ) -> CatalogResult<TableStatus> {
         // Table-specific config and storage credentials are access-session state, not
@@ -762,9 +625,9 @@ impl IcebergRestCatalogProvider {
         let properties: Vec<_> = properties.into_iter().collect();
 
         Ok(TableStatus {
-            catalog: Some(self.name.clone()),
+            catalog: Some(catalog.to_string()),
             database: database.clone().into(),
-            name: table_name.to_string(),
+            name: table.to_string(),
             kind: TableKind::Table {
                 columns,
                 comment,
@@ -781,9 +644,9 @@ impl IcebergRestCatalogProvider {
     }
 
     fn load_view_result_to_status(
-        &self,
-        view_name: &str,
+        catalog: &str,
         database: &Namespace,
+        view: &str,
         result: crate::models::LoadViewResult,
     ) -> CatalogResult<TableStatus> {
         // TODO: Do we want to do anything with:
@@ -866,9 +729,9 @@ impl IcebergRestCatalogProvider {
         let properties: Vec<_> = properties.into_iter().collect();
 
         Ok(TableStatus {
-            catalog: Some(self.name.clone()),
+            catalog: Some(catalog.to_string()),
             database: database.clone().into(),
-            name: view_name.to_string(),
+            name: view.to_string(),
             kind: TableKind::View {
                 definition,
                 columns,
@@ -897,7 +760,8 @@ impl CatalogProvider for IcebergRestCatalogProvider {
         database: &Namespace,
         options: CreateDatabaseOptions,
     ) -> CatalogResult<DatabaseStatus> {
-        let (client, catalog_config) = self.load_client_and_merged_config().await?;
+        let catalog_config = self.resolved_catalog_config().await?;
+        let client = self.client().await?;
 
         let CreateDatabaseOptions {
             if_not_exists,
@@ -921,7 +785,7 @@ impl CatalogProvider for IcebergRestCatalogProvider {
 
         let result = client
             .catalog_api_api()
-            .create_namespace(request, Self::catalog_prefix(catalog_config))
+            .create_namespace(request, catalog_config.prefix())
             .await;
 
         match result {
@@ -946,7 +810,7 @@ impl CatalogProvider for IcebergRestCatalogProvider {
                 })
             }
             Err(apis::Error::ResponseError(apis::ResponseContent { status, .. }))
-                if status == 409 && if_not_exists =>
+                if status == reqwest::StatusCode::CONFLICT && if_not_exists =>
             {
                 self.get_database(database).await
             }
@@ -957,16 +821,17 @@ impl CatalogProvider for IcebergRestCatalogProvider {
     }
 
     async fn get_database(&self, database: &Namespace) -> CatalogResult<DatabaseStatus> {
-        let (client, catalog_config) = self.load_client_and_merged_config().await?;
-        let namespace = Self::namespace_string(catalog_config, database)?;
+        let catalog_config = self.resolved_catalog_config().await?;
+        let client = self.client().await?;
+        let namespace = catalog_config.namespace_string(database)?;
 
         let result = client
             .catalog_api_api()
-            .load_namespace_metadata(&namespace, Self::catalog_prefix(catalog_config))
+            .load_namespace_metadata(&namespace, catalog_config.prefix())
             .await
             .map_err(|e| match e {
                 apis::Error::ResponseError(apis::ResponseContent { status, .. }) => {
-                    if status == 404 {
+                    if status == reqwest::StatusCode::NOT_FOUND {
                         CatalogError::NotFound(
                             CatalogObject::Namespace,
                             quote_namespace_if_needed(database),
@@ -1007,19 +872,15 @@ impl CatalogProvider for IcebergRestCatalogProvider {
         &self,
         prefix: Option<&Namespace>,
     ) -> CatalogResult<Vec<DatabaseStatus>> {
-        let (client, catalog_config) = self.load_client_and_merged_config().await?;
+        let catalog_config = self.resolved_catalog_config().await?;
+        let client = self.client().await?;
         let parent = prefix
-            .map(|namespace| Self::namespace_string(catalog_config, namespace))
+            .map(|namespace| catalog_config.namespace_string(namespace))
             .transpose()?;
 
         let result = client
             .catalog_api_api()
-            .list_namespaces(
-                None,
-                None,
-                parent.as_deref(),
-                Self::catalog_prefix(catalog_config),
-            )
+            .list_namespaces(None, None, parent.as_deref(), catalog_config.prefix())
             .await
             .map_err(|e| CatalogError::External(format!("Failed to list namespaces: {e}")))?;
 
@@ -1042,14 +903,15 @@ impl CatalogProvider for IcebergRestCatalogProvider {
         database: &Namespace,
         options: DropDatabaseOptions,
     ) -> CatalogResult<()> {
-        let (client, catalog_config) = self.load_client_and_merged_config().await?;
+        let catalog_config = self.resolved_catalog_config().await?;
+        let client = self.client().await?;
 
         let DropDatabaseOptions { if_exists, cascade } = options;
 
         if cascade {
             // For CASCADE, first drop all tables and views in the namespace before dropping the namespace.
-            let prefix = Self::catalog_prefix(catalog_config);
-            let ns_string = Self::namespace_string(catalog_config, database)?;
+            let prefix = catalog_config.prefix();
+            let ns_string = catalog_config.namespace_string(database)?;
             let tables_result = client
                 .catalog_api_api()
                 .list_tables(&ns_string, None, None, prefix)
@@ -1079,14 +941,14 @@ impl CatalogProvider for IcebergRestCatalogProvider {
         match client
             .catalog_api_api()
             .drop_namespace(
-                &Self::namespace_string(catalog_config, database)?,
-                Self::catalog_prefix(catalog_config),
+                &catalog_config.namespace_string(database)?,
+                catalog_config.prefix(),
             )
             .await
         {
             Ok(_) => Ok(()),
             Err(apis::Error::ResponseError(apis::ResponseContent { status, .. }))
-                if status == 404 && if_exists =>
+                if status == reqwest::StatusCode::NOT_FOUND && if_exists =>
             {
                 Ok(())
             }
@@ -1123,7 +985,8 @@ impl CatalogProvider for IcebergRestCatalogProvider {
             )));
         }
 
-        let (client, catalog_config) = self.load_client_and_merged_config().await?;
+        let catalog_config = self.resolved_catalog_config().await?;
+        let client = self.client().await?;
 
         if mode.ignore_if_exists() {
             if let Ok(existing) = self.get_table(database, table).await {
@@ -1195,40 +1058,42 @@ impl CatalogProvider for IcebergRestCatalogProvider {
         let result = client
             .catalog_api_api()
             .create_table(
-                &Self::namespace_string(catalog_config, database)?,
+                &catalog_config.namespace_string(database)?,
                 request,
                 None,
-                Self::catalog_prefix(catalog_config),
+                catalog_config.prefix(),
             )
             .await
             .map_err(|e| CatalogError::External(format!("Failed to create table: {e}")))?;
 
         if is_write_precondition {
-            self.validate_create_table_access_session_requirements(
+            Self::validate_create_table_access_session_requirements(
+                &self.name,
                 database,
                 table,
                 catalog_config,
                 &result,
             )?;
         }
-        self.load_table_result_to_status(table, database, result)
+        Self::load_table_result_to_status(&self.name, database, table, result)
     }
 
     async fn get_table(&self, database: &Namespace, table: &str) -> CatalogResult<TableStatus> {
-        let result = self.load_table_result(database, table).await?;
-        self.load_table_result_to_status(table, database, result)
+        let result = self.load_table_result(database, table, None).await?;
+        Self::load_table_result_to_status(&self.name, database, table, result)
     }
 
     async fn list_tables(&self, database: &Namespace) -> CatalogResult<Vec<TableStatus>> {
-        let (client, catalog_config) = self.load_client_and_merged_config().await?;
+        let catalog_config = self.resolved_catalog_config().await?;
+        let client = self.client().await?;
 
         let result = client
             .catalog_api_api()
             .list_tables(
-                &Self::namespace_string(catalog_config, database)?,
+                &catalog_config.namespace_string(database)?,
                 None,
                 None,
-                Self::catalog_prefix(catalog_config),
+                catalog_config.prefix(),
             )
             .await
             .map_err(|e| CatalogError::External(format!("Failed to list tables: {e}")))?;
@@ -1263,21 +1128,22 @@ impl CatalogProvider for IcebergRestCatalogProvider {
         table: &str,
         options: DropTableOptions,
     ) -> CatalogResult<()> {
-        let (client, catalog_config) = self.load_client_and_merged_config().await?;
+        let catalog_config = self.resolved_catalog_config().await?;
+        let client = self.client().await?;
         let DropTableOptions { if_exists, purge } = options;
         match client
             .catalog_api_api()
             .drop_table(
-                &Self::namespace_string(catalog_config, database)?,
+                &catalog_config.namespace_string(database)?,
                 table,
                 Some(purge),
-                Self::catalog_prefix(catalog_config),
+                catalog_config.prefix(),
             )
             .await
         {
             Ok(_) => Ok(()),
             Err(apis::Error::ResponseError(apis::ResponseContent { status, .. }))
-                if status == 404 && if_exists =>
+                if status == reqwest::StatusCode::NOT_FOUND && if_exists =>
             {
                 Ok(())
             }
@@ -1309,9 +1175,95 @@ impl CatalogProvider for IcebergRestCatalogProvider {
             updates,
             payload,
         } = request;
-        let response = self
-            .commit_table_request(database, table, &format, requirements, updates)
-            .await?;
+        if !format.eq_ignore_ascii_case("iceberg") {
+            return Err(CatalogError::NotSupported(format!(
+                "Iceberg REST catalog cannot commit '{format}' tables",
+            )));
+        }
+
+        let catalog_config = self.resolved_catalog_config().await?;
+        let client = self.client().await?;
+        let namespace = catalog_config.namespace_string(database)?;
+        let requirements = requirements
+            .into_iter()
+            .map(serde_json::from_value)
+            .collect::<Result<Vec<crate::models::TableRequirement>, _>>()
+            .map_err(|e| {
+                CatalogError::External(format!(
+                    "Failed to parse Iceberg REST commit requirements: {e}"
+                ))
+            })?;
+        let updates = updates
+            .into_iter()
+            .map(serde_json::from_value)
+            .collect::<Result<Vec<crate::models::TableUpdate>, _>>()
+            .map_err(|e| {
+                CatalogError::External(format!("Failed to parse Iceberg REST commit updates: {e}"))
+            })?;
+        let request = crate::models::CommitTableRequest {
+            identifier: Some(Box::new(crate::models::TableIdentifier::new(
+                Vec::<String>::from(database.clone()),
+                table.to_string(),
+            ))),
+            requirements,
+            updates,
+        };
+        let response = client
+            .catalog_api_api()
+            .update_table(&namespace, table, request, catalog_config.prefix())
+            .await
+            .map_err(|e| match e {
+                apis::Error::ResponseError(apis::ResponseContent {
+                    status, content: _, ..
+                }) if status == reqwest::StatusCode::NOT_FOUND => CatalogError::NotFound(
+                    CatalogObject::Table,
+                    format!(
+                        "{}.{}",
+                        quote_namespace_if_needed(database),
+                        quote_name_if_needed(table)
+                    ),
+                ),
+                apis::Error::ResponseError(apis::ResponseContent {
+                    status, content, ..
+                }) if status == reqwest::StatusCode::CONFLICT => CatalogError::Conflict(format!(
+                    "Iceberg REST catalog commit conflict for {}.{}: {content}",
+                    quote_namespace_if_needed(database),
+                    quote_name_if_needed(table)
+                )),
+                apis::Error::ResponseError(apis::ResponseContent {
+                    status, content, ..
+                }) if status == reqwest::StatusCode::UNAUTHORIZED => {
+                    CatalogError::Unauthorized(format!(
+                        "Iceberg REST catalog commit unauthorized for {}.{}: {content}",
+                        quote_namespace_if_needed(database),
+                        quote_name_if_needed(table)
+                    ))
+                }
+                apis::Error::ResponseError(apis::ResponseContent {
+                    status, content, ..
+                }) if status == reqwest::StatusCode::FORBIDDEN => CatalogError::Forbidden(format!(
+                    "Iceberg REST catalog commit forbidden for {}.{}: {content}",
+                    quote_namespace_if_needed(database),
+                    quote_name_if_needed(table)
+                )),
+                apis::Error::ResponseError(apis::ResponseContent {
+                    status, content, ..
+                }) if status == reqwest::StatusCode::TOO_MANY_REQUESTS => {
+                    CatalogError::RateLimited(format!(
+                        "Iceberg REST catalog commit rate limited for {}.{}: {content}",
+                        quote_namespace_if_needed(database),
+                        quote_name_if_needed(table)
+                    ))
+                }
+                apis::Error::ResponseError(apis::ResponseContent {
+                    status, content, ..
+                }) => CatalogError::External(format!(
+                    "Failed to commit Iceberg table {}.{}: status {status}: {content}",
+                    quote_namespace_if_needed(database),
+                    quote_name_if_needed(table)
+                )),
+                e => CatalogError::External(format!("Failed to commit table: {e}")),
+            })?;
         let payload = match payload {
             Some(payload) => Some(payload),
             None => Some(serde_json::to_value(response).map_err(|e| {
@@ -1331,11 +1283,9 @@ impl CatalogProvider for IcebergRestCatalogProvider {
             mut context,
             purpose: _,
         } = request;
-        let (client, catalog_config) = self.load_client_and_merged_config().await?;
+        let catalog_config = self.resolved_catalog_config().await?;
         let result = self
-            .load_table_result_with(
-                client,
-                catalog_config,
+            .load_table_result(
                 database,
                 table,
                 Some(REST_ACCESS_DELEGATION_VENDED_CREDENTIALS),
@@ -1343,7 +1293,8 @@ impl CatalogProvider for IcebergRestCatalogProvider {
             .await?;
         // TODO: Convert preserved REST table-session credentials into operation-scoped
         // FileIO/object-store access instead of only fingerprinting the session.
-        let rest_session = self.rest_table_session_ref(database, table, catalog_config, &result)?;
+        let rest_session =
+            Self::rest_table_session_ref(&self.name, database, table, catalog_config, &result)?;
         if rest_session.scan_planning_mode.as_deref() == Some("server") {
             context.scan = ScanAuthority::IcebergRestServerSide;
         } else {
@@ -1380,7 +1331,8 @@ impl CatalogProvider for IcebergRestCatalogProvider {
         view: &str,
         options: CreateViewOptions,
     ) -> CatalogResult<TableStatus> {
-        let (client, catalog_config) = self.load_client_and_merged_config().await?;
+        let catalog_config = self.resolved_catalog_config().await?;
+        let client = self.client().await?;
 
         let CreateViewOptions {
             columns,
@@ -1496,29 +1448,30 @@ impl CatalogProvider for IcebergRestCatalogProvider {
         let result = client
             .catalog_api_api()
             .create_view(
-                &Self::namespace_string(catalog_config, database)?,
+                &catalog_config.namespace_string(database)?,
                 request,
-                Self::catalog_prefix(catalog_config),
+                catalog_config.prefix(),
             )
             .await
             .map_err(|e| CatalogError::External(format!("Failed to create view: {e}")))?;
 
-        self.load_view_result_to_status(view, database, result)
+        Self::load_view_result_to_status(&self.name, database, view, result)
     }
 
     async fn get_view(&self, database: &Namespace, view: &str) -> CatalogResult<TableStatus> {
-        let (client, catalog_config) = self.load_client_and_merged_config().await?;
+        let catalog_config = self.resolved_catalog_config().await?;
+        let client = self.client().await?;
         let result = client
             .catalog_api_api()
             .load_view(
-                &Self::namespace_string(catalog_config, database)?,
+                &catalog_config.namespace_string(database)?,
                 view,
-                Self::catalog_prefix(catalog_config),
+                catalog_config.prefix(),
             )
             .await
             .map_err(|e| match e {
                 apis::Error::ResponseError(apis::ResponseContent { status, .. })
-                    if status == 404 =>
+                    if status == reqwest::StatusCode::NOT_FOUND =>
                 {
                     CatalogError::NotFound(
                         CatalogObject::View,
@@ -1535,19 +1488,20 @@ impl CatalogProvider for IcebergRestCatalogProvider {
                     quote_name_if_needed(view)
                 )),
             })?;
-        self.load_view_result_to_status(view, database, result)
+        Self::load_view_result_to_status(&self.name, database, view, result)
     }
 
     async fn list_views(&self, database: &Namespace) -> CatalogResult<Vec<TableStatus>> {
-        let (client, catalog_config) = self.load_client_and_merged_config().await?;
+        let catalog_config = self.resolved_catalog_config().await?;
+        let client = self.client().await?;
 
         let result = client
             .catalog_api_api()
             .list_views(
-                &Self::namespace_string(catalog_config, database)?,
+                &catalog_config.namespace_string(database)?,
                 None,
                 None,
-                Self::catalog_prefix(catalog_config),
+                catalog_config.prefix(),
             )
             .await
             .map_err(|e| CatalogError::External(format!("Failed to list views: {e}")))?;
@@ -1576,20 +1530,21 @@ impl CatalogProvider for IcebergRestCatalogProvider {
         view: &str,
         options: DropViewOptions,
     ) -> CatalogResult<()> {
-        let (client, catalog_config) = self.load_client_and_merged_config().await?;
+        let catalog_config = self.resolved_catalog_config().await?;
+        let client = self.client().await?;
         let DropViewOptions { if_exists } = options;
         match client
             .catalog_api_api()
             .drop_view(
-                &Self::namespace_string(catalog_config, database)?,
+                &catalog_config.namespace_string(database)?,
                 view,
-                Self::catalog_prefix(catalog_config),
+                catalog_config.prefix(),
             )
             .await
         {
             Ok(_) => Ok(()),
             Err(apis::Error::ResponseError(apis::ResponseContent { status, .. }))
-                if status == 404 && if_exists =>
+                if status == reqwest::StatusCode::NOT_FOUND && if_exists =>
             {
                 Ok(())
             }
@@ -1957,6 +1912,7 @@ fn parse_unary_sort_transform(
 #[cfg(test)]
 mod tests {
     use arrow::datatypes::DataType;
+    use sail_catalog::credentials::EmptyCatalogCredentials;
     use sail_catalog::lakehouse::TableAccessPurpose;
     use sail_common_datafusion::catalog::{
         CatalogProviderId, CatalogTableIdentity, CommitAuthority, LakehouseAuthority,
@@ -1991,7 +1947,8 @@ mod tests {
 
             let name_str = name.unwrap_or("");
             let props = HashMap::from([(REST_CATALOG_PROP_URI.to_string(), server.uri())]);
-            let catalog = IcebergRestCatalogProvider::new(name_str.to_string(), props);
+            let catalog =
+                IcebergRestCatalogProvider::new(name_str.to_string(), test_options(props));
 
             Self {
                 name: name_str.to_string(),
@@ -2040,6 +1997,14 @@ mod tests {
                 })))
                 .mount(&self.server)
                 .await;
+        }
+    }
+
+    fn test_options(properties: HashMap<String, String>) -> IcebergRestCatalogOptions {
+        IcebergRestCatalogOptions {
+            credentials: Arc::new(EmptyCatalogCredentials),
+            properties,
+            user_agent: Some("Sail".to_string()),
         }
     }
 
@@ -2112,7 +2077,7 @@ mod tests {
         mut client_props: HashMap<String, String>,
         overrides: HashMap<String, String>,
         expected_config_warehouse: Option<&str>,
-    ) -> RestCatalogConfig {
+    ) -> CatalogConfig<'static> {
         let server = MockServer::start().await;
         let response = ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "defaults": defaults,
@@ -2141,32 +2106,11 @@ mod tests {
             .entry(REST_CATALOG_PROP_URI.to_string())
             .or_insert_with(|| server.uri());
 
-        let catalog = IcebergRestCatalogProvider::new("test".to_string(), client_props);
+        let catalog =
+            IcebergRestCatalogProvider::new("test".to_string(), test_options(client_props));
 
-        let (_, config) = catalog.load_client_and_merged_config().await.unwrap();
+        let config = catalog.resolved_catalog_config().await.unwrap();
         config.clone()
-    }
-
-    #[test]
-    fn test_namespace_separator_aliases_are_canonicalized() {
-        for alias in [
-            "namespace_separator",
-            "namespace-separator",
-            "namespaceSeparator",
-            "namespaceseparator",
-        ] {
-            let props = IcebergRestCatalogProvider::normalize_catalog_props(HashMap::from([(
-                alias.to_string(),
-                "::".to_string(),
-            )]));
-
-            assert_eq!(
-                props
-                    .get(REST_CATALOG_PROP_NAMESPACE_SEPARATOR)
-                    .map(String::as_str),
-                Some("::")
-            );
-        }
     }
 
     #[tokio::test]
@@ -2180,7 +2124,10 @@ mod tests {
             None,
         )
         .await;
-        assert_eq!(config.props.get(&key).map(String::as_str), Some("defaults"));
+        assert_eq!(
+            config.properties.get(&key).map(String::as_str),
+            Some("defaults")
+        );
 
         let config = load_merged_test_config(
             HashMap::from([(key.clone(), "defaults".to_string())]),
@@ -2189,7 +2136,10 @@ mod tests {
             None,
         )
         .await;
-        assert_eq!(config.props.get(&key).map(String::as_str), Some("client"));
+        assert_eq!(
+            config.properties.get(&key).map(String::as_str),
+            Some("client")
+        );
 
         let config = load_merged_test_config(
             HashMap::from([(key.clone(), "defaults".to_string())]),
@@ -2199,7 +2149,7 @@ mod tests {
         )
         .await;
         assert_eq!(
-            config.props.get(&key).map(String::as_str),
+            config.properties.get(&key).map(String::as_str),
             Some("overrides")
         );
     }
@@ -2216,7 +2166,7 @@ mod tests {
             None,
         )
         .await;
-        assert_ne!(config.uri, "http://default.example");
+        assert_ne!(config.uri().as_deref(), Some("http://default.example"));
 
         let config = load_merged_test_config(
             HashMap::new(),
@@ -2228,14 +2178,14 @@ mod tests {
             None,
         )
         .await;
-        assert_eq!(config.uri, "http://server.example");
+        assert_eq!(config.uri().as_deref(), Some("http://server.example"));
     }
 
     #[tokio::test]
     async fn test_warehouse_merge_matrix() {
         let config =
             load_merged_test_config(HashMap::new(), HashMap::new(), HashMap::new(), None).await;
-        assert_eq!(config.warehouse, None);
+        assert_eq!(config.warehouse(), None);
 
         let config = load_merged_test_config(
             HashMap::from([(
@@ -2247,7 +2197,10 @@ mod tests {
             None,
         )
         .await;
-        assert_eq!(config.warehouse.as_deref(), Some("s3://default/warehouse"));
+        assert_eq!(
+            config.warehouse().as_deref(),
+            Some("s3://default/warehouse")
+        );
 
         let config = load_merged_test_config(
             HashMap::from([(
@@ -2262,7 +2215,7 @@ mod tests {
             Some("s3://client/warehouse"),
         )
         .await;
-        assert_eq!(config.warehouse.as_deref(), Some("s3://client/warehouse"));
+        assert_eq!(config.warehouse().as_deref(), Some("s3://client/warehouse"));
 
         let config = load_merged_test_config(
             HashMap::from([(
@@ -2280,14 +2233,14 @@ mod tests {
             Some("s3://client/warehouse"),
         )
         .await;
-        assert_eq!(config.warehouse.as_deref(), Some("s3://server/warehouse"));
+        assert_eq!(config.warehouse().as_deref(), Some("s3://server/warehouse"));
     }
 
     #[tokio::test]
     async fn test_prefix_merge_matrix() {
         let config =
             load_merged_test_config(HashMap::new(), HashMap::new(), HashMap::new(), None).await;
-        assert_eq!(IcebergRestCatalogProvider::catalog_prefix(&config), None);
+        assert_eq!(config.prefix(), None);
 
         let config = load_merged_test_config(
             HashMap::from([(
@@ -2299,10 +2252,7 @@ mod tests {
             None,
         )
         .await;
-        assert_eq!(
-            IcebergRestCatalogProvider::catalog_prefix(&config),
-            Some("default_prefix")
-        );
+        assert_eq!(config.prefix(), Some("default_prefix"));
 
         let config = load_merged_test_config(
             HashMap::from([(
@@ -2317,10 +2267,7 @@ mod tests {
             None,
         )
         .await;
-        assert_eq!(
-            IcebergRestCatalogProvider::catalog_prefix(&config),
-            Some("client_prefix")
-        );
+        assert_eq!(config.prefix(), Some("client_prefix"));
 
         let config = load_merged_test_config(
             HashMap::from([(
@@ -2338,10 +2285,7 @@ mod tests {
             None,
         )
         .await;
-        assert_eq!(
-            IcebergRestCatalogProvider::catalog_prefix(&config),
-            Some("server_prefix")
-        );
+        assert_eq!(config.prefix(), Some("server_prefix"));
 
         let config = load_merged_test_config(
             HashMap::new(),
@@ -2353,7 +2297,7 @@ mod tests {
             None,
         )
         .await;
-        assert_eq!(IcebergRestCatalogProvider::catalog_prefix(&config), None);
+        assert_eq!(config.prefix(), None);
     }
 
     #[tokio::test]
@@ -2364,7 +2308,7 @@ mod tests {
         let config =
             load_merged_test_config(HashMap::new(), HashMap::new(), HashMap::new(), None).await;
         assert_eq!(
-            IcebergRestCatalogProvider::namespace_string(&config, &namespace).unwrap(),
+            config.namespace_string(&namespace).unwrap(),
             "accounting\x1Ftax"
         );
 
@@ -2379,7 +2323,7 @@ mod tests {
         )
         .await;
         assert_eq!(
-            IcebergRestCatalogProvider::namespace_string(&config, &namespace).unwrap(),
+            config.namespace_string(&namespace).unwrap(),
             "accounting/tax"
         );
 
@@ -2394,8 +2338,8 @@ mod tests {
         )
         .await;
         assert_eq!(
-            IcebergRestCatalogProvider::namespace_string(&config, &namespace).unwrap(),
-            "accounting::tax"
+            config.namespace_string(&namespace).unwrap(),
+            "accounting/tax"
         );
 
         let config = load_merged_test_config(
@@ -2412,7 +2356,7 @@ mod tests {
         )
         .await;
         assert_eq!(
-            IcebergRestCatalogProvider::namespace_string(&config, &namespace).unwrap(),
+            config.namespace_string(&namespace).unwrap(),
             "accounting|tax"
         );
 
@@ -2430,7 +2374,7 @@ mod tests {
         )
         .await;
         assert_eq!(
-            IcebergRestCatalogProvider::namespace_string(&config, &namespace).unwrap(),
+            config.namespace_string(&namespace).unwrap(),
             "accounting\x1Ftax"
         );
     }

--- a/crates/sail-catalog-iceberg/src/provider.rs
+++ b/crates/sail-catalog-iceberg/src/provider.rs
@@ -415,6 +415,14 @@ impl IcebergRestCatalogProvider {
         table: &str,
         result: crate::models::LoadTableResult,
     ) -> CatalogResult<TableStatus> {
+        log::trace!(
+            "Iceberg REST table load result: catalog={}, database={:?}, table={}, metadata.location={:?}, metadata-location={:?}",
+            catalog,
+            database,
+            table,
+            result.metadata.location,
+            result.metadata_location,
+        );
         // Table-specific config and storage credentials are access-session state, not
         // display table properties.
         // TODO: Preserve unused fields in `TableMetadata` when Sail exposes them.
@@ -1480,6 +1488,15 @@ impl CatalogProvider for IcebergRestCatalogProvider {
             .await
             .map_err(|e| match e {
                 apis::Error::ResponseError(apis::ResponseContent { status, .. })
+                    if matches!(
+                        status,
+                        reqwest::StatusCode::METHOD_NOT_ALLOWED
+                            | reqwest::StatusCode::NOT_IMPLEMENTED
+                    ) =>
+                {
+                    CatalogError::NotSupported("get view".to_string())
+                }
+                apis::Error::ResponseError(apis::ResponseContent { status, .. })
                     if status == reqwest::StatusCode::NOT_FOUND =>
                 {
                     CatalogError::NotFound(
@@ -1513,7 +1530,26 @@ impl CatalogProvider for IcebergRestCatalogProvider {
                 catalog_config.prefix(),
             )
             .await
-            .map_err(|e| CatalogError::External(format!("Failed to list views: {e}")))?;
+            .map_err(|e| match e {
+                apis::Error::ResponseError(apis::ResponseContent { status, .. })
+                    if matches!(status, reqwest::StatusCode::NOT_FOUND) =>
+                {
+                    CatalogError::NotFound(
+                        CatalogObject::Namespace,
+                        quote_namespace_if_needed(database),
+                    )
+                }
+                apis::Error::ResponseError(apis::ResponseContent { status, .. })
+                    if matches!(
+                        status,
+                        reqwest::StatusCode::METHOD_NOT_ALLOWED
+                            | reqwest::StatusCode::NOT_IMPLEMENTED
+                    ) =>
+                {
+                    CatalogError::NotSupported("list views".to_string())
+                }
+                _ => CatalogError::External(format!("Failed to list views: {e}")),
+            })?;
         let catalog = &self.name;
         Ok(result
             .identifiers
@@ -1563,11 +1599,7 @@ impl CatalogProvider for IcebergRestCatalogProvider {
 }
 
 /// Finds an item by ID, falling back to the last item if not found or no ID is provided.
-fn find_by_id_or_last<'a, T, F>(
-    items: Option<&'a Vec<T>>,
-    id: Option<i32>,
-    get_id: F,
-) -> Option<&'a T>
+fn find_by_id_or_last<T, F>(items: Option<&Vec<T>>, id: Option<i32>, get_id: F) -> Option<&T>
 where
     F: Fn(&T) -> Option<i32>,
 {
@@ -2575,6 +2607,22 @@ mod tests {
         test_list_views_impl(Some("test")).await;
     }
 
+    #[tokio::test]
+    async fn test_list_views_unsupported_endpoint() {
+        let ctx = TestContext::new(None).await;
+
+        Mock::given(method("GET"))
+            .and(path(ctx.path("/namespaces/ns1/views")))
+            .respond_with(ResponseTemplate::new(405))
+            .mount(&ctx.server)
+            .await;
+
+        let namespace = Namespace::try_from(vec!["ns1".to_string()]).unwrap();
+        let error = ctx.catalog.list_views(&namespace).await.unwrap_err();
+
+        assert!(matches!(error, CatalogError::NotSupported(_)));
+    }
+
     async fn test_drop_database_impl(name: Option<&str>) {
         let ctx = TestContext::new(name).await;
 
@@ -3191,6 +3239,22 @@ mod tests {
     async fn test_get_view() {
         test_get_view_impl(None).await;
         test_get_view_impl(Some("test")).await;
+    }
+
+    #[tokio::test]
+    async fn test_get_view_unsupported_endpoint() {
+        let ctx = TestContext::new(None).await;
+
+        Mock::given(method("GET"))
+            .and(path(ctx.path("/namespaces/db1/views/view1")))
+            .respond_with(ResponseTemplate::new(501))
+            .mount(&ctx.server)
+            .await;
+
+        let namespace = Namespace::try_from(vec!["db1".to_string()]).unwrap();
+        let error = ctx.catalog.get_view(&namespace, "view1").await.unwrap_err();
+
+        assert!(matches!(error, CatalogError::NotSupported(_)));
     }
 
     async fn test_create_database_impl(name: Option<&str>) {

--- a/crates/sail-catalog-iceberg/src/provider.rs
+++ b/crates/sail-catalog-iceberg/src/provider.rs
@@ -2340,7 +2340,7 @@ mod tests {
                 REST_CATALOG_PROP_NAMESPACE_SEPARATOR.to_string(),
                 "/".to_string(),
             )]),
-            HashMap::from([("namespace_separator".to_string(), "%3A%3A".to_string())]),
+            HashMap::from([]),
             HashMap::new(),
             None,
         )
@@ -2355,7 +2355,7 @@ mod tests {
                 REST_CATALOG_PROP_NAMESPACE_SEPARATOR.to_string(),
                 "/".to_string(),
             )]),
-            HashMap::from([("namespace_separator".to_string(), "::".to_string())]),
+            HashMap::from([]),
             HashMap::from([(
                 REST_CATALOG_PROP_NAMESPACE_SEPARATOR.to_string(),
                 "%7C".to_string(),
@@ -2373,7 +2373,7 @@ mod tests {
                 REST_CATALOG_PROP_NAMESPACE_SEPARATOR.to_string(),
                 "/".to_string(),
             )]),
-            HashMap::from([("namespace_separator".to_string(), "::".to_string())]),
+            HashMap::from([]),
             HashMap::from([(
                 REST_CATALOG_PROP_NAMESPACE_SEPARATOR.to_string(),
                 " ".to_string(),

--- a/crates/sail-catalog-iceberg/src/provider.rs
+++ b/crates/sail-catalog-iceberg/src/provider.rs
@@ -129,6 +129,7 @@ pub struct IcebergRestCatalogOptions {
 pub struct IcebergRestCatalogProvider {
     name: String,
     options: IcebergRestCatalogOptions,
+    http_client: reqwest::Client,
     resolved_catalog_config: OnceCell<CatalogConfig<'static>>,
 }
 
@@ -137,6 +138,7 @@ impl IcebergRestCatalogProvider {
         Self {
             name,
             options,
+            http_client: reqwest::Client::new(),
             resolved_catalog_config: OnceCell::new(),
         }
     }
@@ -145,14 +147,22 @@ impl IcebergRestCatalogProvider {
         catalog_config: &CatalogConfig<'_>,
         credentials: &Arc<dyn CatalogCredentials>,
         user_agent: Option<String>,
+        http_client: reqwest::Client,
     ) -> CatalogResult<Configuration> {
-        let mut client_config = Configuration::new();
-        client_config.user_agent = user_agent;
-        client_config.base_path = catalog_config.uri().ok_or_else(|| {
+        let base_path = catalog_config.uri().ok_or_else(|| {
             CatalogError::InvalidArgument(format!(
                 "Iceberg REST catalog property '{REST_CATALOG_PROP_URI}' is required"
             ))
         })?;
+        let mut client_config = Configuration {
+            base_path,
+            user_agent,
+            client: http_client,
+            basic_auth: None,
+            oauth_access_token: None,
+            bearer_access_token: None,
+            api_key: None,
+        };
         if let Some(credential) = credentials.retrieve().await? {
             client_config.bearer_access_token = Some(credential);
         }
@@ -168,6 +178,7 @@ impl IcebergRestCatalogProvider {
                 &catalog_config,
                 &self.options.credentials,
                 self.options.user_agent.clone(),
+                self.http_client.clone(),
             )
             .await?,
         )))
@@ -180,6 +191,7 @@ impl IcebergRestCatalogProvider {
                 catalog_config,
                 &self.options.credentials,
                 self.options.user_agent.clone(),
+                self.http_client.clone(),
             )
             .await?,
         )))

--- a/crates/sail-catalog-iceberg/src/provider.rs
+++ b/crates/sail-catalog-iceberg/src/provider.rs
@@ -29,6 +29,7 @@ use sail_catalog::provider::{
     PartitionTransform,
 };
 use sail_catalog::utils::{get_property, quote_name_if_needed, quote_namespace_if_needed};
+use sail_common::http::SAIL_USER_AGENT;
 use sail_common_datafusion::catalog::managed::METADATA_LOCATION_KEY;
 use sail_common_datafusion::catalog::{
     CapabilityFingerprint, CatalogTableBucketBy, CatalogTableConstraint, CatalogTableSort,
@@ -122,7 +123,6 @@ impl CatalogConfig<'_> {
 pub struct IcebergRestCatalogOptions {
     pub credentials: Arc<dyn CatalogCredentials>,
     pub properties: HashMap<String, String>,
-    pub user_agent: Option<String>,
 }
 
 /// Provider for Apache Iceberg REST Catalog.
@@ -146,7 +146,6 @@ impl IcebergRestCatalogProvider {
     async fn configuration(
         catalog_config: &CatalogConfig<'_>,
         credentials: &Arc<dyn CatalogCredentials>,
-        user_agent: Option<String>,
         http_client: reqwest::Client,
     ) -> CatalogResult<Configuration> {
         let base_path = catalog_config.uri().ok_or_else(|| {
@@ -156,7 +155,7 @@ impl IcebergRestCatalogProvider {
         })?;
         let mut client_config = Configuration {
             base_path,
-            user_agent,
+            user_agent: Some(SAIL_USER_AGENT.to_string()),
             client: http_client,
             basic_auth: None,
             oauth_access_token: None,
@@ -177,7 +176,6 @@ impl IcebergRestCatalogProvider {
             Self::configuration(
                 &catalog_config,
                 &self.options.credentials,
-                self.options.user_agent.clone(),
                 self.http_client.clone(),
             )
             .await?,
@@ -190,7 +188,6 @@ impl IcebergRestCatalogProvider {
             Self::configuration(
                 catalog_config,
                 &self.options.credentials,
-                self.options.user_agent.clone(),
                 self.http_client.clone(),
             )
             .await?,
@@ -2016,7 +2013,6 @@ mod tests {
         IcebergRestCatalogOptions {
             credentials: Arc::new(EmptyCatalogCredentials),
             properties,
-            user_agent: Some("Sail".to_string()),
         }
     }
 

--- a/crates/sail-catalog-iceberg/tests/rest_integration_test.rs
+++ b/crates/sail-catalog-iceberg/tests/rest_integration_test.rs
@@ -13,15 +13,19 @@
 #![expect(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use arrow::datatypes::DataType;
+use sail_catalog::credentials::EmptyCatalogCredentials;
 use sail_catalog::provider::{
     CatalogPartitionField, CatalogProvider, CreateDatabaseOptions, CreateTableColumnOptions,
     CreateTableMode, CreateTableOptions, CreateViewColumnOptions, CreateViewOptions,
     DropDatabaseOptions, DropTableOptions, DropViewOptions, Namespace, PartitionTransform,
     RuntimeAwareCatalogProvider,
 };
-use sail_catalog_iceberg::{IcebergRestCatalogProvider, REST_CATALOG_PROP_URI};
+use sail_catalog_iceberg::{
+    IcebergRestCatalogOptions, IcebergRestCatalogProvider, REST_CATALOG_PROP_URI,
+};
 use sail_common::runtime::RuntimeHandle;
 use sail_common_datafusion::catalog::{
     CatalogTableConstraint, CatalogTableSort, TableColumnStatus, TableKind,
@@ -108,7 +112,14 @@ async fn setup_catalog(
     let catalog = RuntimeAwareCatalogProvider::try_new(
         || {
             let props = HashMap::from([(REST_CATALOG_PROP_URI.to_string(), rest_url)]);
-            let provider = IcebergRestCatalogProvider::new("test".to_string(), props);
+            let provider = IcebergRestCatalogProvider::new(
+                "test".to_string(),
+                IcebergRestCatalogOptions {
+                    credentials: Arc::new(EmptyCatalogCredentials),
+                    properties: props,
+                    user_agent: Some("Sail".to_string()),
+                },
+            );
             Ok(provider)
         },
         runtime.io().clone(),

--- a/crates/sail-catalog-iceberg/tests/rest_integration_test.rs
+++ b/crates/sail-catalog-iceberg/tests/rest_integration_test.rs
@@ -117,7 +117,6 @@ async fn setup_catalog(
                 IcebergRestCatalogOptions {
                     credentials: Arc::new(EmptyCatalogCredentials),
                     properties: props,
-                    user_agent: Some("Sail".to_string()),
                 },
             );
             Ok(provider)

--- a/crates/sail-catalog-onelake/Cargo.toml
+++ b/crates/sail-catalog-onelake/Cargo.toml
@@ -15,3 +15,4 @@ sail-catalog-unity = { path = "../sail-catalog-unity" }
 async-trait = { workspace = true }
 object_store = { workspace = true }
 tokio = { workspace = true }
+url = { workspace = true }

--- a/crates/sail-catalog-onelake/Cargo.toml
+++ b/crates/sail-catalog-onelake/Cargo.toml
@@ -9,9 +9,9 @@ workspace = true
 [dependencies]
 sail-common-datafusion = { path = "../sail-common-datafusion" }
 sail-catalog = { path = "../sail-catalog" }
+sail-catalog-iceberg = { path = "../sail-catalog-iceberg" }
+sail-catalog-unity = { path = "../sail-catalog-unity" }
 
-arrow = { workspace = true }
 async-trait = { workspace = true }
-reqwest = { workspace = true }
-serde = { workspace = true }
+object_store = { workspace = true }
 tokio = { workspace = true }

--- a/crates/sail-catalog-onelake/src/credentials.rs
+++ b/crates/sail-catalog-onelake/src/credentials.rs
@@ -1,0 +1,63 @@
+use object_store::azure::{AzureCredential, AzureCredentialProvider, MicrosoftAzureBuilder};
+use sail_catalog::credentials::CatalogCredentials;
+use sail_catalog::error::{CatalogError, CatalogResult};
+use tokio::sync::OnceCell;
+
+#[derive(Debug)]
+pub enum OneLakeCredentials {
+    Static {
+        bearer_token: String,
+    },
+    Dynamic {
+        workspace: String,
+        provider: OnceCell<AzureCredentialProvider>,
+    },
+}
+
+#[async_trait::async_trait]
+impl CatalogCredentials for OneLakeCredentials {
+    async fn retrieve(&self) -> CatalogResult<Option<String>> {
+        match self {
+            Self::Static { bearer_token } => Ok(Some(bearer_token.clone())),
+            Self::Dynamic {
+                workspace,
+                provider,
+            } => {
+                let provider = provider
+                    .get_or_try_init(|| async {
+                        let mut builder = MicrosoftAzureBuilder::from_env()
+                            .with_account("onelake")
+                            .with_container_name(workspace)
+                            .with_use_fabric_endpoint(true);
+
+                        if std::env::var("AZURE_STORAGE_TOKEN").is_err() {
+                            if let Ok(token) = std::env::var("AZURE_ACCESS_TOKEN") {
+                                builder = builder.with_bearer_token_authorization(token);
+                            }
+                        }
+
+                        let store = builder.build().map_err(|e| {
+                            CatalogError::External(format!(
+                                "Failed to build OneLake Azure credential provider: {e}"
+                            ))
+                        })?;
+                        Ok::<AzureCredentialProvider, CatalogError>(store.credentials().clone())
+                    })
+                    .await?;
+
+                let credential = provider.get_credential().await.map_err(|e| {
+                    CatalogError::External(format!("Failed to get OneLake token: {e}"))
+                })?;
+
+                match credential.as_ref() {
+                    AzureCredential::BearerToken(token) => Ok(Some(token.clone())),
+                    AzureCredential::AccessKey(_) | AzureCredential::SASToken(_) => {
+                        Err(CatalogError::External(
+                            "OneLake catalog requires Microsoft Entra bearer token authentication; Azure access keys and SAS tokens are not supported".to_string(),
+                        ))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/sail-catalog-onelake/src/lib.rs
+++ b/crates/sail-catalog-onelake/src/lib.rs
@@ -1,3 +1,5 @@
+mod credentials;
 mod provider;
 
-pub use provider::OneLakeCatalogProvider;
+pub use credentials::OneLakeCredentials;
+pub use provider::{OneLakeApiKind, OneLakeCatalogProvider};

--- a/crates/sail-catalog-onelake/src/provider.rs
+++ b/crates/sail-catalog-onelake/src/provider.rs
@@ -84,7 +84,6 @@ impl OneLakeCatalogProvider {
                         default_catalog: catalog_name,
                         uri,
                         credentials,
-                        user_agent: Some("Sail".to_string()),
                         quote_object_name: false,
                     },
                 )?)
@@ -100,7 +99,6 @@ impl OneLakeCatalogProvider {
                     IcebergRestCatalogOptions {
                         credentials,
                         properties,
-                        user_agent: Some("Sail".to_string()),
                     },
                 ))
             }

--- a/crates/sail-catalog-onelake/src/provider.rs
+++ b/crates/sail-catalog-onelake/src/provider.rs
@@ -21,6 +21,7 @@ use sail_catalog_iceberg::{
 use sail_catalog_unity::{UnityCatalogOptions, UnityCatalogProvider};
 use sail_common_datafusion::catalog::{DatabaseStatus, TableKind, TableStatus};
 use tokio::sync::OnceCell;
+use url::Url;
 
 use crate::credentials::OneLakeCredentials;
 
@@ -39,7 +40,7 @@ pub struct OneLakeCatalogConfig {
     #[expect(unused)]
     pub workspace: String,
     pub item_name: String,
-    pub item_type: String,
+    pub item_type: Option<String>,
     pub api: OneLakeApiKind,
 }
 
@@ -58,7 +59,7 @@ impl OneLakeCatalogProvider {
         name: String,
         workspace: String,
         item_name: String,
-        item_type: String,
+        item_type: Option<String>,
         api: OneLakeApiKind,
         bearer_token: Option<String>,
     ) -> CatalogResult<Self> {
@@ -70,14 +71,16 @@ impl OneLakeCatalogProvider {
             },
         };
         let credentials = Arc::new(credentials) as Arc<dyn CatalogCredentials>;
-        let item_path = format!("{workspace}/{item_name}.{item_type}");
+        // `<workspace>/<item>.<type>` for friendly names, or
+        // `<workspaceId>/<itemId>`(no type segment) for GUIDs
+        let item_path = onelake_item_path(&workspace, &item_name, item_type.as_deref());
         let inner: Arc<dyn CatalogProvider> = match api {
             OneLakeApiKind::Delta => {
                 let uri = format!(
                     "{}/{}/api/2.1/unity-catalog",
                     ONE_LAKE_DELTA_ENDPOINT, item_path
                 );
-                let catalog_name = format!("{item_name}.{item_type}");
+                let catalog_name = onelake_catalog_name(&item_name, item_type.as_deref());
                 Arc::new(UnityCatalogProvider::new(
                     name.clone(),
                     UnityCatalogOptions {
@@ -117,12 +120,28 @@ impl OneLakeCatalogProvider {
     }
 
     fn catalog_name(&self) -> String {
-        format!("{}.{}", self.config.item_name, self.config.item_type)
+        onelake_catalog_name(&self.config.item_name, self.config.item_type.as_deref())
     }
 
     fn normalize_database_status(&self, mut status: DatabaseStatus) -> DatabaseStatus {
         if matches!(self.config.api, OneLakeApiKind::Delta) {
             status.database = self.normalize_delta_database(status.database);
+        }
+        // OneLake's Iceberg REST API returns the namespace `location` as a workspace-relative
+        // path (e.g. `workspace/item.Type/Tables/schema`). `resolve_default_table_location` then
+        // seems to append the table name and hand the result to the Iceberg writer, which seems
+        // to reject any non-absolute location, so convert it to an absolute `abfss://` URL.
+        if let Some(location) = status.location.take() {
+            status.location = Some(normalize_onelake_location(&location).unwrap_or(location));
+        }
+        // Keep the mirrored `location` table property consistent with the field above
+        // (DESCRIBE DATABASE EXTENDED surfaces both).
+        for (key, value) in status.properties.iter_mut() {
+            if key.eq_ignore_ascii_case("location") {
+                if let Some(abfss) = normalize_onelake_location(value) {
+                    *value = abfss;
+                }
+            }
         }
         status
     }
@@ -132,7 +151,7 @@ impl OneLakeCatalogProvider {
             status.database = self.normalize_delta_database(status.database);
             if let TableKind::Table { location, .. } = &mut status.kind {
                 if let Some(url) = location.take() {
-                    *location = Some(convert_to_abfss_url(&url).unwrap_or(url));
+                    *location = Some(normalize_onelake_location(&url).unwrap_or(url));
                 }
             }
         }
@@ -162,16 +181,48 @@ impl OneLakeCatalogProvider {
     }
 }
 
-/// Converts OneLake https:// URL to abfss:// URL for Delta Lake access.
-/// From: https://onelake.dfs.fabric.microsoft.com/workspace/item.ItemType/Tables/schema/table
-/// To:   abfss://workspace@onelake.dfs.fabric.microsoft.com/item.ItemType/Tables/schema/table
-fn convert_to_abfss_url(https_url: &str) -> Option<String> {
-    let url = https_url.strip_prefix("https://onelake.dfs.fabric.microsoft.com/")?;
-    let (workspace, rest) = url.split_once('/')?;
-    Some(format!(
-        "abfss://{}@onelake.dfs.fabric.microsoft.com/{}",
-        workspace, rest
-    ))
+// OneLake reports locations in different forms depending on the API:
+// - Delta (Unity) returns an absolute `https://` URL:
+//   From: https://onelake.dfs.fabric.microsoft.com/workspace/item.ItemType/Tables/schema/table
+//   To:   abfss://workspace@onelake.dfs.fabric.microsoft.com/item.ItemType/Tables/schema/table
+// - Iceberg (REST) returns the namespace `location` as a workspace-relative path:
+//   From: workspace/item.ItemType/Tables/schema
+//   To:   abfss://workspace@onelake.dfs.fabric.microsoft.com/item.ItemType/Tables/schema
+fn normalize_onelake_location(location: &str) -> Option<String> {
+    let trimmed = location.trim();
+    let relative =
+        if let Some(rest) = trimmed.strip_prefix("https://onelake.dfs.fabric.microsoft.com/") {
+            // OneLake `https://` form.
+            rest
+        } else if Url::parse(trimmed)
+            .ok()
+            .is_some_and(|url| url.scheme().len() > 1)
+        {
+            // Already absolute with another scheme (e.g., `abfss://`, `file://`, ...).
+            return None;
+        } else {
+            // Workspace-relative form (Iceberg namespace location).
+            trimmed
+        };
+    let (workspace, rest) = relative.split_once('/')?;
+    (!workspace.is_empty() && !rest.is_empty())
+        .then(|| format!("abfss://{workspace}@onelake.dfs.fabric.microsoft.com/{rest}"))
+}
+
+// `<workspace>/<item>.<type>` for friendly names, or `<workspaceId>/<itemId>` for GUIDs.
+fn onelake_item_path(workspace: &str, item_name: &str, item_type: Option<&str>) -> String {
+    match item_type {
+        Some(item_type) => format!("{workspace}/{item_name}.{item_type}"),
+        None => format!("{workspace}/{item_name}"),
+    }
+}
+
+// `<item>.<type>` for friendly names, or `<itemId>` for GUIDs.
+fn onelake_catalog_name(item_name: &str, item_type: Option<&str>) -> String {
+    match item_type {
+        Some(item_type) => format!("{item_name}.{item_type}"),
+        None => item_name.to_string(),
+    }
 }
 
 #[async_trait::async_trait]
@@ -352,5 +403,39 @@ impl CatalogProvider for OneLakeCatalogProvider {
         options: DropViewOptions,
     ) -> CatalogResult<()> {
         self.inner.drop_view(database, view, options).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_onelake_location;
+
+    #[test]
+    fn normalize_onelake_location_handles_each_form() {
+        // Iceberg: workspace-relative namespace location -> abfss (the reported bug).
+        assert_eq!(
+            normalize_onelake_location("OneLake_LakeSail_Testing/LakeSail.Lakehouse/Tables/dbo")
+                .as_deref(),
+            Some("abfss://OneLake_LakeSail_Testing@onelake.dfs.fabric.microsoft.com/LakeSail.Lakehouse/Tables/dbo"),
+        );
+        // Delta/Unity: absolute https OneLake URL -> abfss (unchanged from before).
+        assert_eq!(
+            normalize_onelake_location(
+                "https://onelake.dfs.fabric.microsoft.com/ws/item.Lakehouse/Tables/dbo/t",
+            )
+            .as_deref(),
+            Some("abfss://ws@onelake.dfs.fabric.microsoft.com/item.Lakehouse/Tables/dbo/t"),
+        );
+        // Already absolute -> None so the caller keeps the original (never double-convert).
+        assert_eq!(
+            normalize_onelake_location("abfss://ws@onelake.dfs.fabric.microsoft.com/x"),
+            None,
+        );
+        assert_eq!(normalize_onelake_location("s3://bucket/x"), None);
+        // Single-slash scheme: `Url::parse` should detect it.
+        assert_eq!(normalize_onelake_location("file:/tmp/onelake"), None);
+        // Degenerate inputs -> no conversion.
+        assert_eq!(normalize_onelake_location("single-segment"), None);
+        assert_eq!(normalize_onelake_location("ws/"), None);
     }
 }

--- a/crates/sail-catalog-onelake/src/provider.rs
+++ b/crates/sail-catalog-onelake/src/provider.rs
@@ -1,62 +1,170 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
-use reqwest::Client;
-use sail_catalog::error::{CatalogError, CatalogObject, CatalogResult};
-use sail_catalog::provider::{
-    AlterTableOptions, CatalogProvider, CreateDatabaseOptions, CreateTableOptions,
-    CreateViewOptions, DropDatabaseOptions, DropTableOptions, DropViewOptions, Namespace,
+use sail_catalog::credentials::CatalogCredentials;
+use sail_catalog::error::CatalogResult;
+use sail_catalog::lakehouse::{
+    BeginTableAccessRequest, DeltaRatifiedCommitRequest, DeltaRatifiedCommitResponse,
+    LakehouseCapability, LakehouseCommitOutcome, LakehouseCommitRequest, LakehouseCreatePlan,
+    LakehouseCreateRequest, LakehouseResolvedTable, LakehouseScanPlanningRequest,
+    LakehouseScanPlanningResponse, ResolveLakehouseTableRequest, TableAccessSession,
 };
-use sail_catalog::utils::quote_namespace_if_needed;
-use sail_common_datafusion::catalog::{DatabaseStatus, TableColumnStatus, TableKind, TableStatus};
-use serde::Deserialize;
+use sail_catalog::provider::{
+    AlterTableOptions, CatalogProvider, CreateDatabaseOptions, CreateTableMetadataRequirement,
+    CreateTableOptions, CreateViewOptions, DropDatabaseOptions, DropTableOptions, DropViewOptions,
+    Namespace,
+};
+use sail_catalog_iceberg::{
+    IcebergRestCatalogOptions, IcebergRestCatalogProvider, REST_CATALOG_PROP_PREFIX,
+    REST_CATALOG_PROP_URI, REST_CATALOG_PROP_WAREHOUSE,
+};
+use sail_catalog_unity::{UnityCatalogOptions, UnityCatalogProvider};
+use sail_common_datafusion::catalog::{DatabaseStatus, TableKind, TableStatus};
 use tokio::sync::OnceCell;
 
-const ONELAKE_TABLE_API_BASE: &str = "https://onelake.table.fabric.microsoft.com/delta";
+use crate::credentials::OneLakeCredentials;
 
-/// Fetches Azure access token using Azure CLI
-async fn get_azure_cli_token() -> CatalogResult<String> {
-    // On Windows, az is a batch file (.cmd) and must be run through cmd.exe
-    // See: https://doc.rust-lang.org/nightly/std/process/struct.Command.html
-    let (program, extra_args): (&str, &[&str]) = if cfg!(target_os = "windows") {
-        ("cmd", &["/C", "az"])
-    } else {
-        ("az", &[])
-    };
-
-    let output = tokio::process::Command::new(program)
-        .args(extra_args)
-        .args([
-            "account",
-            "get-access-token",
-            "--resource",
-            "https://storage.azure.com/",
-            "--query",
-            "accessToken",
-            "-o",
-            "tsv",
-        ])
-        .output()
-        .await
-        .map_err(|e| CatalogError::External(format!("Failed to run az cli: {e}")))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(CatalogError::External(format!(
-            "Azure CLI failed: {stderr}"
-        )));
-    }
-
-    let token = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if token.is_empty() {
-        return Err(CatalogError::External(
-            "Azure CLI returned empty token".to_string(),
-        ));
-    }
-
-    Ok(token)
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum OneLakeApiKind {
+    Delta,
+    Iceberg,
 }
 
-/// Converts OneLake https:// URL to abfss:// URL for Delta Lake access
+const ONE_LAKE_DELTA_ENDPOINT: &str = "https://onelake.table.fabric.microsoft.com/delta";
+const ONE_LAKE_ICEBERG_ENDPOINT: &str = "https://onelake.table.fabric.microsoft.com/iceberg";
+
+/// Configuration for OneLake catalog.
+#[derive(Debug, Clone)]
+pub struct OneLakeCatalogConfig {
+    #[expect(unused)]
+    pub workspace: String,
+    pub item_name: String,
+    pub item_type: String,
+    pub api: OneLakeApiKind,
+}
+
+/// Provider for Microsoft Fabric OneLake catalog.
+///
+/// This catalog uses the OneLake Table APIs and delegates protocol-specific catalog
+/// behavior to the Iceberg REST or Unity Catalog providers.
+pub struct OneLakeCatalogProvider {
+    name: String,
+    config: OneLakeCatalogConfig,
+    inner: Arc<dyn CatalogProvider>,
+}
+
+impl OneLakeCatalogProvider {
+    pub fn new(
+        name: String,
+        workspace: String,
+        item_name: String,
+        item_type: String,
+        api: OneLakeApiKind,
+        bearer_token: Option<String>,
+    ) -> CatalogResult<Self> {
+        let credentials = match bearer_token {
+            Some(bearer_token) => OneLakeCredentials::Static { bearer_token },
+            None => OneLakeCredentials::Dynamic {
+                workspace: workspace.clone(),
+                provider: OnceCell::new(),
+            },
+        };
+        let credentials = Arc::new(credentials) as Arc<dyn CatalogCredentials>;
+        let item_path = format!("{workspace}/{item_name}.{item_type}");
+        let inner: Arc<dyn CatalogProvider> = match api {
+            OneLakeApiKind::Delta => {
+                let uri = format!(
+                    "{}/{}/api/2.1/unity-catalog",
+                    ONE_LAKE_DELTA_ENDPOINT, item_path
+                );
+                let catalog_name = format!("{item_name}.{item_type}");
+                Arc::new(UnityCatalogProvider::new(
+                    name.clone(),
+                    UnityCatalogOptions {
+                        default_catalog: catalog_name,
+                        uri,
+                        credentials,
+                        user_agent: Some("Sail".to_string()),
+                        quote_object_name: false,
+                    },
+                )?)
+            }
+            OneLakeApiKind::Iceberg => {
+                let uri = ONE_LAKE_ICEBERG_ENDPOINT.to_string();
+                let mut properties = HashMap::new();
+                properties.insert(REST_CATALOG_PROP_URI.to_string(), uri);
+                properties.insert(REST_CATALOG_PROP_WAREHOUSE.to_string(), item_path.clone());
+                properties.insert(REST_CATALOG_PROP_PREFIX.to_string(), item_path);
+                Arc::new(IcebergRestCatalogProvider::new(
+                    name.clone(),
+                    IcebergRestCatalogOptions {
+                        credentials,
+                        properties,
+                        user_agent: Some("Sail".to_string()),
+                    },
+                ))
+            }
+        };
+
+        Ok(Self {
+            name,
+            config: OneLakeCatalogConfig {
+                workspace,
+                item_name,
+                item_type,
+                api,
+            },
+            inner,
+        })
+    }
+
+    fn catalog_name(&self) -> String {
+        format!("{}.{}", self.config.item_name, self.config.item_type)
+    }
+
+    fn normalize_database_status(&self, mut status: DatabaseStatus) -> DatabaseStatus {
+        if matches!(self.config.api, OneLakeApiKind::Delta) {
+            status.database = self.normalize_delta_database(status.database);
+        }
+        status
+    }
+
+    fn normalize_table_status(&self, mut status: TableStatus) -> TableStatus {
+        if matches!(self.config.api, OneLakeApiKind::Delta) {
+            status.database = self.normalize_delta_database(status.database);
+            if let TableKind::Table { location, .. } = &mut status.kind {
+                if let Some(url) = location.take() {
+                    *location = Some(convert_to_abfss_url(&url).unwrap_or(url));
+                }
+            }
+        }
+        status
+    }
+
+    fn normalize_delta_database(&self, database: Vec<String>) -> Vec<String> {
+        if database.first().is_some_and(|x| x == &self.catalog_name()) {
+            database.into_iter().skip(1).collect()
+        } else {
+            database
+        }
+    }
+
+    fn normalize_database_statuses(&self, statuses: Vec<DatabaseStatus>) -> Vec<DatabaseStatus> {
+        statuses
+            .into_iter()
+            .map(|status| self.normalize_database_status(status))
+            .collect()
+    }
+
+    fn normalize_table_statuses(&self, statuses: Vec<TableStatus>) -> Vec<TableStatus> {
+        statuses
+            .into_iter()
+            .map(|status| self.normalize_table_status(status))
+            .collect()
+    }
+}
+
+/// Converts OneLake https:// URL to abfss:// URL for Delta Lake access.
 /// From: https://onelake.dfs.fabric.microsoft.com/workspace/item.ItemType/Tables/schema/table
 /// To:   abfss://workspace@onelake.dfs.fabric.microsoft.com/item.ItemType/Tables/schema/table
 fn convert_to_abfss_url(https_url: &str) -> Option<String> {
@@ -68,261 +176,6 @@ fn convert_to_abfss_url(https_url: &str) -> Option<String> {
     ))
 }
 
-/// Response from list schemas API
-#[derive(Debug, Deserialize)]
-struct ListSchemasResponse {
-    schemas: Vec<SchemaInfo>,
-}
-
-#[derive(Debug, Deserialize)]
-struct SchemaInfo {
-    name: Option<String>,
-    #[expect(dead_code)]
-    catalog_name: Option<String>,
-    comment: Option<String>,
-}
-
-/// Response from list tables API
-#[derive(Debug, Deserialize)]
-struct ListTablesResponse {
-    tables: Vec<TableInfo>,
-}
-
-#[derive(Debug, Deserialize)]
-struct TableInfo {
-    name: Option<String>,
-    #[expect(dead_code)]
-    catalog_name: Option<String>,
-    schema_name: Option<String>,
-    #[expect(dead_code)]
-    table_type: Option<String>,
-    data_source_format: Option<String>,
-    storage_location: Option<String>,
-    columns: Option<Vec<ColumnInfo>>,
-    comment: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ColumnInfo {
-    name: Option<String>,
-    type_name: Option<String>,
-    type_text: Option<String>,
-    nullable: Option<bool>,
-    comment: Option<String>,
-}
-
-/// Configuration for OneLake catalog
-#[derive(Debug, Clone)]
-pub struct OneLakeCatalogConfig {
-    pub workspace: String,
-    pub item_name: String,
-    pub item_type: String,
-    pub bearer_token: Option<String>,
-}
-
-/// Provider for Microsoft Fabric OneLake catalog.
-///
-/// This catalog uses the OneLake Table APIs to list schemas and tables,
-/// and returns Delta table locations that can be read/written via abfss://.
-pub struct OneLakeCatalogProvider {
-    name: String,
-    config: OneLakeCatalogConfig,
-    client: OnceCell<Arc<Client>>,
-}
-
-impl OneLakeCatalogProvider {
-    pub fn new(
-        name: String,
-        workspace: String,
-        item_name: String,
-        item_type: String,
-        bearer_token: Option<String>,
-    ) -> Self {
-        Self {
-            name,
-            config: OneLakeCatalogConfig {
-                workspace,
-                item_name,
-                item_type,
-                bearer_token,
-            },
-            client: OnceCell::new(),
-        }
-    }
-
-    fn base_url(&self) -> String {
-        format!(
-            "{}/{}/{}.{}",
-            ONELAKE_TABLE_API_BASE,
-            self.config.workspace,
-            self.config.item_name,
-            self.config.item_type
-        )
-    }
-
-    fn schema_name(database: &Namespace) -> CatalogResult<String> {
-        if database.tail.is_empty() {
-            Ok(database.head.to_string())
-        } else {
-            Err(CatalogError::InvalidArgument(format!(
-                "OneLake catalog does not support multi-level namespaces: {}",
-                quote_namespace_if_needed(database)
-            )))
-        }
-    }
-
-    fn catalog_name(&self) -> String {
-        format!("{}.{}", self.config.item_name, self.config.item_type)
-    }
-
-    async fn get_client(&self) -> CatalogResult<&Arc<Client>> {
-        self.client
-            .get_or_try_init(|| async {
-                // Priority: 1) config token, 2) env var, 3) Azure CLI
-                let token = if let Some(token) = &self.config.bearer_token {
-                    token.clone()
-                } else if let Ok(token) = std::env::var("AZURE_STORAGE_TOKEN") {
-                    token
-                } else if let Ok(token) = std::env::var("AZURE_ACCESS_TOKEN") {
-                    token
-                } else {
-                    // Fall back to Azure CLI
-                    get_azure_cli_token().await?
-                };
-
-                let mut headers = reqwest::header::HeaderMap::new();
-                let header_value = reqwest::header::HeaderValue::from_str(&format!(
-                    "Bearer {token}"
-                ))
-                .map_err(|e| CatalogError::External(format!("Invalid bearer token: {e}")))?;
-                headers.insert(reqwest::header::AUTHORIZATION, header_value);
-
-                let client = Client::builder()
-                    .default_headers(headers)
-                    .build()
-                    .map_err(|e| {
-                        CatalogError::External(format!("Failed to build HTTP client: {e}"))
-                    })?;
-
-                Ok(Arc::new(client))
-            })
-            .await
-    }
-
-    fn schema_info_to_database_status(&self, info: SchemaInfo) -> DatabaseStatus {
-        let schema_name = info.name.unwrap_or_else(|| "dbo".to_string());
-        DatabaseStatus {
-            catalog: self.name.clone(),
-            database: vec![schema_name],
-            comment: info.comment,
-            location: None,
-            properties: vec![],
-        }
-    }
-
-    fn table_info_to_table_status(&self, info: TableInfo) -> CatalogResult<TableStatus> {
-        let name = info.name.unwrap_or_default();
-        let schema_name = info.schema_name.unwrap_or_else(|| "dbo".to_string());
-        let format = info
-            .data_source_format
-            .map(|f| f.to_lowercase())
-            .unwrap_or_else(|| "delta".to_string());
-
-        // Convert https:// URL to abfss:// for Delta Lake access
-        let location = info
-            .storage_location
-            .and_then(|url| convert_to_abfss_url(&url).or(Some(url)));
-
-        let columns = info
-            .columns
-            .unwrap_or_default()
-            .into_iter()
-            .map(|col| {
-                // Prefer type_name over type_text (OneLake API often returns type_text as null)
-                let type_str = col
-                    .type_name
-                    .or(col.type_text)
-                    .unwrap_or_else(|| "string".to_string());
-                let data_type = parse_type_text(&type_str);
-                TableColumnStatus {
-                    name: col.name.unwrap_or_default(),
-                    data_type,
-                    nullable: col.nullable.unwrap_or(true),
-                    comment: col.comment,
-                    default: None,
-                    generated_always_as: None,
-                    identity: None,
-                    is_partition: false,
-                    is_bucket: false,
-                    is_cluster: false,
-                }
-            })
-            .collect();
-
-        Ok(TableStatus {
-            catalog: Some(self.name.clone()),
-            database: vec![schema_name],
-            name,
-            kind: TableKind::Table {
-                columns,
-                comment: info.comment,
-                constraints: vec![],
-                location,
-                format,
-                partition_by: vec![],
-                sort_by: vec![],
-                bucket_by: None,
-                properties: vec![],
-                is_external: true,
-            },
-        })
-    }
-}
-
-/// Simple type text parser - converts Unity Catalog type strings to Arrow DataType
-// TODO: Add support for complex types (array, map, struct) if OneLake returns them in JSON format.
-fn parse_type_text(type_text: &str) -> arrow::datatypes::DataType {
-    use arrow::datatypes::DataType;
-
-    let lower = type_text.to_lowercase();
-
-    // Handle decimal(precision, scale) format
-    if lower.starts_with("decimal") {
-        if let Some(params) = lower
-            .strip_prefix("decimal(")
-            .and_then(|s| s.strip_suffix(')'))
-        {
-            let parts: Vec<&str> = params.split(',').collect();
-            if parts.len() == 2 {
-                if let (Ok(precision), Ok(scale)) =
-                    (parts[0].trim().parse::<u8>(), parts[1].trim().parse::<i8>())
-                {
-                    return DataType::Decimal128(precision, scale);
-                }
-            }
-        }
-        // Default decimal if parsing fails
-        return DataType::Decimal128(38, 18);
-    }
-
-    match lower.as_str() {
-        "boolean" | "bool" => DataType::Boolean,
-        "byte" | "tinyint" => DataType::Int8,
-        "short" | "smallint" => DataType::Int16,
-        "int" | "integer" => DataType::Int32,
-        "long" | "bigint" => DataType::Int64,
-        "float" | "real" => DataType::Float32,
-        "double" => DataType::Float64,
-        "string" | "varchar" | "text" => DataType::Utf8,
-        "binary" => DataType::Binary,
-        "date" => DataType::Date32,
-        "timestamp" | "timestamp_ntz" => {
-            DataType::Timestamp(arrow::datatypes::TimeUnit::Microsecond, None)
-        }
-        _ => DataType::Utf8, // Default to string for unknown types
-    }
-}
-
 #[async_trait::async_trait]
 impl CatalogProvider for OneLakeCatalogProvider {
     fn get_name(&self) -> &str {
@@ -331,238 +184,175 @@ impl CatalogProvider for OneLakeCatalogProvider {
 
     async fn create_database(
         &self,
-        _database: &Namespace,
-        _options: CreateDatabaseOptions,
+        database: &Namespace,
+        options: CreateDatabaseOptions,
     ) -> CatalogResult<DatabaseStatus> {
-        Err(CatalogError::NotSupported(
-            "OneLake catalog does not support creating databases".to_string(),
-        ))
+        let status = self.inner.create_database(database, options).await?;
+        Ok(self.normalize_database_status(status))
     }
 
     async fn get_database(&self, database: &Namespace) -> CatalogResult<DatabaseStatus> {
-        let schema_name = Self::schema_name(database)?;
-        let client = self.get_client().await?;
-
-        // OneLake API requires full qualified schema name: catalog.schema
-        let full_schema_name = format!("{}.{}", self.catalog_name(), schema_name);
-        let url = format!(
-            "{}/api/2.1/unity-catalog/schemas/{}",
-            self.base_url(),
-            full_schema_name
-        );
-
-        let response = client
-            .head(&url)
-            .send()
-            .await
-            .map_err(|e| CatalogError::External(format!("Failed to check schema: {e}")))?;
-
-        if response.status().is_success() {
-            Ok(DatabaseStatus {
-                catalog: self.name.clone(),
-                database: vec![schema_name],
-                comment: None,
-                location: None,
-                properties: vec![],
-            })
-        } else if response.status().as_u16() == 404 {
-            Err(CatalogError::NotFound(CatalogObject::Schema, schema_name))
-        } else {
-            Err(CatalogError::External(format!(
-                "Failed to get schema: HTTP {}",
-                response.status()
-            )))
-        }
+        let status = self.inner.get_database(database).await?;
+        Ok(self.normalize_database_status(status))
     }
 
     async fn list_databases(
         &self,
-        _prefix: Option<&Namespace>,
+        prefix: Option<&Namespace>,
     ) -> CatalogResult<Vec<DatabaseStatus>> {
-        let client = self.get_client().await?;
-
-        // TODO: Use Url methods to construct URLs in case catalog/schema/table names contain special characters.
-        let url = format!(
-            "{}/api/2.1/unity-catalog/schemas?catalog_name={}",
-            self.base_url(),
-            self.catalog_name()
-        );
-
-        let response = client
-            .get(&url)
-            .send()
-            .await
-            .map_err(|e| CatalogError::External(format!("Failed to list schemas: {e}")))?;
-
-        if !response.status().is_success() {
-            return Err(CatalogError::External(format!(
-                "Failed to list schemas: HTTP {}",
-                response.status()
-            )));
-        }
-
-        let list_response: ListSchemasResponse = response.json().await.map_err(|e| {
-            CatalogError::External(format!("Failed to parse schemas response: {e}"))
-        })?;
-
-        Ok(list_response
-            .schemas
-            .into_iter()
-            .map(|s| self.schema_info_to_database_status(s))
-            .collect())
+        let statuses = self.inner.list_databases(prefix).await?;
+        Ok(self.normalize_database_statuses(statuses))
     }
 
     async fn drop_database(
         &self,
-        _database: &Namespace,
-        _options: DropDatabaseOptions,
+        database: &Namespace,
+        options: DropDatabaseOptions,
     ) -> CatalogResult<()> {
-        Err(CatalogError::NotSupported(
-            "OneLake catalog does not support dropping databases".to_string(),
-        ))
+        self.inner.drop_database(database, options).await
     }
 
     async fn create_table(
         &self,
-        _database: &Namespace,
-        _table: &str,
-        _options: CreateTableOptions,
+        database: &Namespace,
+        table: &str,
+        options: CreateTableOptions,
     ) -> CatalogResult<TableStatus> {
-        Err(CatalogError::NotSupported(
-            "OneLake catalog does not support creating tables via API".to_string(),
-        ))
+        let status = self.inner.create_table(database, table, options).await?;
+        Ok(self.normalize_table_status(status))
+    }
+
+    fn create_table_metadata_requirement(
+        &self,
+        options: &CreateTableOptions,
+    ) -> CatalogResult<CreateTableMetadataRequirement> {
+        self.inner.create_table_metadata_requirement(options)
+    }
+
+    fn lakehouse_capabilities(&self) -> Vec<LakehouseCapability> {
+        self.inner.lakehouse_capabilities()
+    }
+
+    async fn resolve_lakehouse_table(
+        &self,
+        database: &Namespace,
+        table: &str,
+        request: ResolveLakehouseTableRequest,
+    ) -> CatalogResult<LakehouseResolvedTable> {
+        self.inner
+            .resolve_lakehouse_table(database, table, request)
+            .await
+    }
+
+    async fn plan_lakehouse_create(
+        &self,
+        database: &Namespace,
+        table: &str,
+        request: LakehouseCreateRequest,
+    ) -> CatalogResult<LakehouseCreatePlan> {
+        self.inner
+            .plan_lakehouse_create(database, table, request)
+            .await
+    }
+
+    async fn begin_table_access(
+        &self,
+        database: &Namespace,
+        table: &str,
+        request: BeginTableAccessRequest,
+    ) -> CatalogResult<TableAccessSession> {
+        self.inner
+            .begin_table_access(database, table, request)
+            .await
+    }
+
+    async fn plan_lakehouse_scan(
+        &self,
+        database: &Namespace,
+        table: &str,
+        request: LakehouseScanPlanningRequest,
+    ) -> CatalogResult<LakehouseScanPlanningResponse> {
+        self.inner
+            .plan_lakehouse_scan(database, table, request)
+            .await
+    }
+
+    async fn commit_lakehouse_table(
+        &self,
+        database: &Namespace,
+        table: &str,
+        request: LakehouseCommitRequest,
+    ) -> CatalogResult<LakehouseCommitOutcome> {
+        self.inner
+            .commit_lakehouse_table(database, table, request)
+            .await
+    }
+
+    async fn get_delta_ratified_commits(
+        &self,
+        database: &Namespace,
+        table: &str,
+        request: DeltaRatifiedCommitRequest,
+    ) -> CatalogResult<DeltaRatifiedCommitResponse> {
+        self.inner
+            .get_delta_ratified_commits(database, table, request)
+            .await
     }
 
     async fn get_table(&self, database: &Namespace, table: &str) -> CatalogResult<TableStatus> {
-        let schema_name = Self::schema_name(database)?;
-        let client = self.get_client().await?;
-
-        let full_table_name = format!("{}.{}.{}", self.catalog_name(), schema_name, table);
-        let url = format!(
-            "{}/api/2.1/unity-catalog/tables/{}",
-            self.base_url(),
-            full_table_name
-        );
-
-        let response = client
-            .get(&url)
-            .send()
-            .await
-            .map_err(|e| CatalogError::External(format!("Failed to get table: {e}")))?;
-
-        if response.status().as_u16() == 404 {
-            return Err(CatalogError::NotFound(
-                CatalogObject::Table,
-                table.to_string(),
-            ));
-        }
-
-        if !response.status().is_success() {
-            return Err(CatalogError::External(format!(
-                "Failed to get table: HTTP {}",
-                response.status()
-            )));
-        }
-
-        let table_info: TableInfo = response
-            .json()
-            .await
-            .map_err(|e| CatalogError::External(format!("Failed to parse table response: {e}")))?;
-
-        self.table_info_to_table_status(table_info)
+        let status = self.inner.get_table(database, table).await?;
+        Ok(self.normalize_table_status(status))
     }
 
     async fn list_tables(&self, database: &Namespace) -> CatalogResult<Vec<TableStatus>> {
-        let schema_name = Self::schema_name(database)?;
-        let client = self.get_client().await?;
-
-        let url = format!(
-            "{}/api/2.1/unity-catalog/tables?catalog_name={}&schema_name={}",
-            self.base_url(),
-            self.catalog_name(),
-            schema_name
-        );
-
-        let response = client
-            .get(&url)
-            .send()
-            .await
-            .map_err(|e| CatalogError::External(format!("Failed to list tables: {e}")))?;
-
-        if !response.status().is_success() {
-            return Err(CatalogError::External(format!(
-                "Failed to list tables: HTTP {}",
-                response.status()
-            )));
-        }
-
-        let list_response: ListTablesResponse = response
-            .json()
-            .await
-            .map_err(|e| CatalogError::External(format!("Failed to parse tables response: {e}")))?;
-
-        list_response
-            .tables
-            .into_iter()
-            .map(|t| self.table_info_to_table_status(t))
-            .collect()
+        let statuses = self.inner.list_tables(database).await?;
+        Ok(self.normalize_table_statuses(statuses))
     }
 
     async fn drop_table(
         &self,
-        _database: &Namespace,
-        _table: &str,
-        _options: DropTableOptions,
+        database: &Namespace,
+        table: &str,
+        options: DropTableOptions,
     ) -> CatalogResult<()> {
-        Err(CatalogError::NotSupported(
-            "OneLake catalog does not support dropping tables via API".to_string(),
-        ))
+        self.inner.drop_table(database, table, options).await
     }
 
     async fn alter_table(
         &self,
-        _database: &Namespace,
-        _table: &str,
-        _options: AlterTableOptions,
+        database: &Namespace,
+        table: &str,
+        options: AlterTableOptions,
     ) -> CatalogResult<()> {
-        // OneLake tables commonly use Delta storage, and property updates may already
-        // be committed at the storage layer before the catalog provider is called.
-        // Until OneLake REST propagation is implemented, treat this as a no-op so we
-        // do not report a failure after the underlying table has already been altered.
-        Ok(())
+        self.inner.alter_table(database, table, options).await
     }
 
     async fn create_view(
         &self,
-        _database: &Namespace,
-        _view: &str,
-        _options: CreateViewOptions,
+        database: &Namespace,
+        view: &str,
+        options: CreateViewOptions,
     ) -> CatalogResult<TableStatus> {
-        Err(CatalogError::NotSupported(
-            "OneLake catalog does not support views".to_string(),
-        ))
+        let status = self.inner.create_view(database, view, options).await?;
+        Ok(self.normalize_table_status(status))
     }
 
-    async fn get_view(&self, _database: &Namespace, _view: &str) -> CatalogResult<TableStatus> {
-        Err(CatalogError::NotSupported(
-            "OneLake catalog does not support views".to_string(),
-        ))
+    async fn get_view(&self, database: &Namespace, view: &str) -> CatalogResult<TableStatus> {
+        let status = self.inner.get_view(database, view).await?;
+        Ok(self.normalize_table_status(status))
     }
 
-    async fn list_views(&self, _database: &Namespace) -> CatalogResult<Vec<TableStatus>> {
-        Err(CatalogError::NotSupported(
-            "OneLake catalog does not support views".to_string(),
-        ))
+    async fn list_views(&self, database: &Namespace) -> CatalogResult<Vec<TableStatus>> {
+        let statuses = self.inner.list_views(database).await?;
+        Ok(self.normalize_table_statuses(statuses))
     }
 
     async fn drop_view(
         &self,
-        _database: &Namespace,
-        _view: &str,
-        _options: DropViewOptions,
+        database: &Namespace,
+        view: &str,
+        options: DropViewOptions,
     ) -> CatalogResult<()> {
-        Err(CatalogError::NotSupported(
-            "OneLake catalog does not support views".to_string(),
-        ))
+        self.inner.drop_view(database, view, options).await
     }
 }

--- a/crates/sail-catalog-unity/build.rs
+++ b/crates/sail-catalog-unity/build.rs
@@ -35,6 +35,18 @@ fn build_unity_catalog() -> Result<(), Box<dyn std::error::Error>> {
             "Self::new_with_client(baseurl, client.build().unwrap())",
             "Ok(Self::new_with_client(baseurl, client.build()?))",
         )
+        .replace(
+            "pub(crate) client: reqwest::Client,\n}",
+            "pub(crate) client: reqwest::Client,\n    pub(crate) request_headers: reqwest::header::HeaderMap,\n}",
+        )
+        .replace(
+            "Self {\n            baseurl: baseurl.to_string(),\n            client,\n        }\n    }\n}",
+            "Self::new_with_client_and_headers(baseurl, client, reqwest::header::HeaderMap::new())\n    }\n\n    /// Construct a new client with an existing `reqwest::Client` and per-request headers.\n    pub fn new_with_client_and_headers(\n        baseurl: &str,\n        client: reqwest::Client,\n        request_headers: reqwest::header::HeaderMap,\n    ) -> Self {\n        Self {\n            baseurl: baseurl.to_string(),\n            client,\n            request_headers,\n        }\n    }\n}",
+        )
+        .replace(
+            "impl ClientHooks<()> for &Client {}\n",
+            "impl ClientHooks<()> for &Client {}\nimpl ClientHooks<()> for Client {\n    async fn pre<E>(\n        &self,\n        request: &mut reqwest::Request,\n        _info: &OperationInfo,\n    ) -> ::std::result::Result<(), Error<E>> {\n        request.headers_mut().extend(self.request_headers.clone());\n        Ok(())\n    }\n}\n",
+        )
         // We need to prevent the code examples from being treated as ignored tests.
         // These code snippets do not compile when running `cargo test -- --ignored`.
         .replace("```ignore", "```notrust");

--- a/crates/sail-catalog-unity/build.rs
+++ b/crates/sail-catalog-unity/build.rs
@@ -48,6 +48,7 @@ fn build_unity_catalog() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn add_column_type_name_aliases(content: String) -> String {
+    // OneLake returns data types in uppercase.
     [
         ("BOOLEAN", "boolean", "Boolean"),
         ("BYTE", "byte", "Byte"),
@@ -81,6 +82,7 @@ fn add_column_type_name_aliases(content: String) -> String {
 }
 
 fn add_nullable_array_deserializer(content: String) -> String {
+    // OneLake may return `null` for columns when listing tables.
     content.replace(
         "pub mod types {\n",
         r#"pub mod types {

--- a/crates/sail-catalog-unity/build.rs
+++ b/crates/sail-catalog-unity/build.rs
@@ -38,10 +38,81 @@ fn build_unity_catalog() -> Result<(), Box<dyn std::error::Error>> {
         // We need to prevent the code examples from being treated as ignored tests.
         // These code snippets do not compile when running `cargo test -- --ignored`.
         .replace("```ignore", "```notrust");
+    let content = add_column_type_name_aliases(content);
+    let content = add_nullable_array_deserializer(content);
+    let content = add_table_info_columns_deserializer(content);
 
     std::fs::write(out_file, content)?;
 
     Ok(())
+}
+
+fn add_column_type_name_aliases(content: String) -> String {
+    [
+        ("BOOLEAN", "boolean", "Boolean"),
+        ("BYTE", "byte", "Byte"),
+        ("SHORT", "short", "Short"),
+        ("INT", "int", "Int"),
+        ("LONG", "long", "Long"),
+        ("FLOAT", "float", "Float"),
+        ("DOUBLE", "double", "Double"),
+        ("DATE", "date", "Date"),
+        ("TIMESTAMP", "timestamp", "Timestamp"),
+        ("TIMESTAMP_NTZ", "timestamp_ntz", "TimestampNtz"),
+        ("STRING", "string", "String"),
+        ("BINARY", "binary", "Binary"),
+        ("DECIMAL", "decimal", "Decimal"),
+        ("INTERVAL", "interval", "Interval"),
+        ("ARRAY", "array", "Array"),
+        ("STRUCT", "struct", "Struct"),
+        ("MAP", "map", "Map"),
+        ("CHAR", "char", "Char"),
+        ("NULL", "null", "Null"),
+        ("USER_DEFINED_TYPE", "user_defined_type", "UserDefinedType"),
+        ("TABLE_TYPE", "table_type", "TableType"),
+    ]
+    .into_iter()
+    .fold(content, |content, (name, alias, variant)| {
+        content.replace(
+            &format!("#[serde(rename = \"{name}\")]\n        {variant},"),
+            &format!("#[serde(rename = \"{name}\", alias = \"{alias}\")]\n        {variant},"),
+        )
+    })
+}
+
+fn add_nullable_array_deserializer(content: String) -> String {
+    content.replace(
+        "pub mod types {\n",
+        r#"pub mod types {
+    fn deserialize_null_as_default<'de, D, T>(
+        deserializer: D,
+    ) -> ::std::result::Result<T, D::Error>
+    where
+        D: ::serde::Deserializer<'de>,
+        T: ::std::default::Default + ::serde::Deserialize<'de>,
+    {
+        Ok(<::std::option::Option<T> as ::serde::Deserialize>::deserialize(deserializer)?
+            .unwrap_or_default())
+    }
+"#,
+    )
+}
+
+fn add_table_info_columns_deserializer(content: String) -> String {
+    let marker = "    pub struct TableInfo {\n        ///Name of parent catalog.";
+    let old = r#"        #[serde(default, skip_serializing_if = "::std::vec::Vec::is_empty")]
+        pub columns: ::std::vec::Vec<ColumnInfo>,"#;
+    let new = r#"        #[serde(
+            default,
+            deserialize_with = "deserialize_null_as_default",
+            skip_serializing_if = "::std::vec::Vec::is_empty"
+        )]
+        pub columns: ::std::vec::Vec<ColumnInfo>,"#;
+    if let Some((before, after)) = content.split_once(marker) {
+        format!("{before}{marker}{}", after.replacen(old, new, 1))
+    } else {
+        content
+    }
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/sail-catalog-unity/src/config.rs
+++ b/crates/sail-catalog-unity/src/config.rs
@@ -22,7 +22,6 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use sail_catalog::error::{CatalogError, CatalogResult};
-use sail_catalog::utils::quote_name_if_needed;
 use secrecy::{ExposeSecret, SecretString};
 
 use crate::credential::{
@@ -221,7 +220,6 @@ impl AsRef<str> for UnityCatalogConfigKey {
 
 #[derive(Debug)]
 pub struct UnityCatalogConfig {
-    pub default_catalog: String,
     pub uri: String,
     pub bearer_token: Option<SecretString>,
     pub client_id: Option<String>,
@@ -234,7 +232,6 @@ pub struct UnityCatalogConfig {
     pub federated_token_file: Option<String>,
     pub use_azure_cli: bool,
     pub allow_http_url: bool,
-    pub credential_provider: Option<CredentialProvider>,
 }
 
 fn str_is_truthy(value: &str) -> bool {
@@ -248,15 +245,11 @@ fn str_is_truthy(value: &str) -> bool {
 
 impl UnityCatalogConfig {
     pub fn new(
-        default_catalog: Option<String>,
         uri: Option<String>,
         token: &Option<SecretString>,
         options: Option<HashMap<String, String>>,
     ) -> CatalogResult<Self> {
         let mut config = Self {
-            default_catalog: quote_name_if_needed(
-                &default_catalog.unwrap_or_else(|| "unity".to_string()),
-            ),
             uri: uri.unwrap_or_else(|| DEFAULT_URI.to_string()),
             bearer_token: None,
             client_id: None,
@@ -269,7 +262,6 @@ impl UnityCatalogConfig {
             federated_token_file: None,
             use_azure_cli: false,
             allow_http_url: false,
-            credential_provider: None,
         };
 
         if let Some(token) = token {
@@ -282,8 +274,6 @@ impl UnityCatalogConfig {
         }
 
         config.apply_env()?;
-
-        config.credential_provider = config.get_credential_provider();
 
         Ok(config)
     }

--- a/crates/sail-catalog-unity/src/credential.rs
+++ b/crates/sail-catalog-unity/src/credential.rs
@@ -23,6 +23,7 @@ use std::time::{Duration, Instant};
 
 use reqwest::header::{HeaderValue, ACCEPT};
 use reqwest::{Client, Method, Response};
+use sail_catalog::credentials::CatalogCredentials;
 use sail_catalog::error::{CatalogError, CatalogResult};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
@@ -67,6 +68,24 @@ pub enum CredentialProvider {
 
     /// a credential to fetch expiring auth tokens
     TokenCredential(TokenCache<String>, Box<dyn TokenCredential>),
+}
+
+#[async_trait::async_trait]
+impl CatalogCredentials for CredentialProvider {
+    async fn retrieve(&self) -> CatalogResult<Option<String>> {
+        match self {
+            CredentialProvider::BearerToken(token) => Ok(Some(token.clone())),
+            CredentialProvider::TokenCredential(cache, cred) => {
+                let oauth_client = Client::builder().build().map_err(|e| {
+                    CatalogError::External(format!("Failed to build OAuth client: {e}"))
+                })?;
+                let token = cache
+                    .get_or_insert_with(|| cred.fetch_token(&oauth_client))
+                    .await?;
+                Ok(Some(token))
+            }
+        }
+    }
 }
 
 #[derive(Deserialize, Debug)]

--- a/crates/sail-catalog-unity/src/lib.rs
+++ b/crates/sail-catalog-unity/src/lib.rs
@@ -20,4 +20,5 @@ pub mod unity {
     include!(concat!(env!("OUT_DIR"), "/unity_catalog.rs"));
 }
 
-pub use provider::UnityCatalogProvider;
+pub use config::UnityCatalogConfig;
+pub use provider::{UnityCatalogOptions, UnityCatalogProvider};

--- a/crates/sail-catalog-unity/src/provider.rs
+++ b/crates/sail-catalog-unity/src/provider.rs
@@ -46,6 +46,7 @@ pub(crate) const DEFAULT_URI: &str = "http://localhost:8080/api/2.1/unity-catalo
 pub struct UnityCatalogProvider {
     name: String,
     options: UnityCatalogOptions,
+    http_client: reqwest::Client,
 }
 
 #[derive(Debug, Clone)]
@@ -59,11 +60,15 @@ pub struct UnityCatalogOptions {
 
 impl UnityCatalogProvider {
     pub fn new(name: String, options: UnityCatalogOptions) -> CatalogResult<Self> {
-        Ok(Self { name, options })
+        let http_client = reqwest::Client::new();
+        Ok(Self {
+            name,
+            options,
+            http_client,
+        })
     }
 
     async fn get_client(&self) -> CatalogResult<Client> {
-        let mut client_builder = reqwest::Client::builder();
         let mut headers = reqwest::header::HeaderMap::new();
 
         if let Some(token) = self.options.credentials.retrieve().await? {
@@ -83,15 +88,11 @@ impl UnityCatalogProvider {
             headers.insert(reqwest::header::USER_AGENT, header);
         }
 
-        if !headers.is_empty() {
-            client_builder = client_builder.default_headers(headers);
-        }
-
-        let reqwest_client = client_builder
-            .build()
-            .map_err(|e| CatalogError::External(format!("Failed to build HTTP client: {e}")))?;
-
-        Ok(Client::new_with_client(&self.options.uri, reqwest_client))
+        Ok(Client::new_with_client_and_headers(
+            &self.options.uri,
+            self.http_client.clone(),
+            headers,
+        ))
     }
 
     fn object_name(&self, name: &str) -> String {

--- a/crates/sail-catalog-unity/src/provider.rs
+++ b/crates/sail-catalog-unity/src/provider.rs
@@ -982,7 +982,7 @@ impl CatalogProvider for UnityCatalogProvider {
             .await
             .map_err(|e| CatalogError::External(format!("Failed to load client: {e}")))?;
         let (catalog_name, schema_name) = self.get_catalog_and_schema_name(database)?;
-        let full_name = format!("{catalog_name}.{schema_name}.{table}");
+        let full_name = self.qualified_object_name(&[&catalog_name, &schema_name, table]);
 
         match client.get_commits().body(request).send().await {
             Ok(response) => {

--- a/crates/sail-catalog-unity/src/provider.rs
+++ b/crates/sail-catalog-unity/src/provider.rs
@@ -487,6 +487,7 @@ impl CatalogProvider for UnityCatalogProvider {
             {
                 Ok(())
             }
+            Err(e) if e.status().is_some_and(|status| status.is_success()) => Ok(()),
             Err(progenitor_client::Error::UnexpectedResponse(response))
                 if response.status().as_u16() == 404 && if_exists =>
             {
@@ -797,6 +798,7 @@ impl CatalogProvider for UnityCatalogProvider {
             {
                 Ok(())
             }
+            Err(e) if e.status().is_some_and(|status| status.is_success()) => Ok(()),
             Err(e)
                 if e.status()
                     .is_some_and(|status| status.as_u16() == 404 && if_exists) =>

--- a/crates/sail-catalog-unity/src/provider.rs
+++ b/crates/sail-catalog-unity/src/provider.rs
@@ -12,9 +12,10 @@
 
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::Arc;
 
 use arrow::datatypes::DataType;
-use reqwest::header::HeaderValue;
+use sail_catalog::credentials::CatalogCredentials;
 use sail_catalog::error::{CatalogError, CatalogObject, CatalogResult};
 use sail_catalog::lakehouse::{
     DeltaRatifiedCommit, DeltaRatifiedCommitRequest, DeltaRatifiedCommitResponse,
@@ -26,18 +27,14 @@ use sail_catalog::provider::{
     CreateViewOptions, DropDatabaseOptions, DropTableOptions, DropViewOptions, Namespace,
     TableFormatCreateMetadataMode,
 };
-use sail_catalog::utils::{get_property, quote_namespace_if_needed};
+use sail_catalog::utils::{get_property, quote_name_if_needed, quote_namespace_if_needed};
 use sail_common_datafusion::catalog::delta::{
     unity_table_id_value, DELTA_UNITY_TABLE_ID_KEY, DELTA_UNITY_TABLE_ID_LEGACY_KEY,
 };
 use sail_common_datafusion::catalog::{
     identity_partition_fields, DatabaseStatus, TableColumnStatus, TableKind, TableStatus,
 };
-use secrecy::SecretString;
-use tokio::sync::OnceCell;
 
-use crate::config::UnityCatalogConfig;
-use crate::credential::CredentialProvider;
 use crate::data_type::{
     data_type_to_unity_type, unity_struct_field_type_json, unity_type_to_data_type,
 };
@@ -48,82 +45,61 @@ pub(crate) const DEFAULT_URI: &str = "http://localhost:8080/api/2.1/unity-catalo
 /// Provider for Unity Catalog
 pub struct UnityCatalogProvider {
     name: String,
-    catalog_config: UnityCatalogConfig,
-    client: OnceCell<Client>,
+    options: UnityCatalogOptions,
+}
+
+#[derive(Debug, Clone)]
+pub struct UnityCatalogOptions {
+    pub default_catalog: String,
+    pub uri: String,
+    pub credentials: Arc<dyn CatalogCredentials>,
+    pub user_agent: Option<String>,
+    pub quote_object_name: bool,
 }
 
 impl UnityCatalogProvider {
-    pub fn new(
-        name: String,
-        default_catalog: &Option<String>,
-        uri: &Option<String>,
-        token: &Option<SecretString>,
-    ) -> CatalogResult<Self> {
-        Self::with_options(name, default_catalog.clone(), uri.clone(), token, None)
+    pub fn new(name: String, options: UnityCatalogOptions) -> CatalogResult<Self> {
+        Ok(Self { name, options })
     }
 
-    pub fn with_options(
-        name: String,
-        default_catalog: Option<String>,
-        uri: Option<String>,
-        token: &Option<SecretString>,
-        options: Option<HashMap<String, String>>,
-    ) -> CatalogResult<Self> {
-        let catalog_config = UnityCatalogConfig::new(default_catalog, uri, token, options)?;
-        Ok(Self {
-            name,
-            catalog_config,
-            client: OnceCell::new(),
-        })
-    }
+    async fn get_client(&self) -> CatalogResult<Client> {
+        let mut client_builder = reqwest::Client::builder();
+        let mut headers = reqwest::header::HeaderMap::new();
 
-    async fn get_client(&self) -> CatalogResult<&Client> {
-        let config = &self.catalog_config;
-        let client = self
-            .client
-            .get_or_try_init(|| async move {
-                let mut client_builder = reqwest::Client::builder();
-
-                if let Some(credential_provider) = &config.credential_provider {
-                    let header = match credential_provider {
-                        CredentialProvider::BearerToken(token) => {
-                            HeaderValue::from_str(&format!("Bearer {token}")).map_err(|e| {
-                                CatalogError::External(format!(
-                                    "Failed to create header value from token: {e}"
-                                ))
-                            })
-                        }
-                        CredentialProvider::TokenCredential(cache, cred) => {
-                            let oauth_client = reqwest::Client::builder().build().map_err(|e| {
-                                CatalogError::External(format!("Failed to build OAuth client: {e}"))
-                            })?;
-                            let token = cache
-                                .get_or_insert_with(|| cred.fetch_token(&oauth_client))
-                                .await?;
-                            HeaderValue::from_str(&format!("Bearer {token}")).map_err(|e| {
-                                CatalogError::External(format!(
-                                    "Failed to create header value from token: {e}"
-                                ))
-                            })
-                        }
-                    }?;
-                    let mut headers = reqwest::header::HeaderMap::new();
-                    headers.insert(reqwest::header::AUTHORIZATION, header);
-                    client_builder = client_builder.default_headers(headers);
-                }
-
-                if config.allow_http_url {
-                    client_builder = client_builder.https_only(false);
-                }
-
-                let reqwest_client = client_builder.build().map_err(|e| {
-                    CatalogError::External(format!("Failed to build HTTP client: {e}"))
+        if let Some(token) = self.options.credentials.retrieve().await? {
+            let header = reqwest::header::HeaderValue::from_str(&format!("Bearer {token}"))
+                .map_err(|e| {
+                    CatalogError::External(format!("Failed to create header value from token: {e}"))
                 })?;
+            headers.insert(reqwest::header::AUTHORIZATION, header);
+        }
 
-                Ok::<_, CatalogError>(Client::new_with_client(&config.uri, reqwest_client))
-            })
-            .await?;
-        Ok(client)
+        if let Some(user_agent) = &self.options.user_agent {
+            let header = reqwest::header::HeaderValue::from_str(user_agent).map_err(|e| {
+                CatalogError::External(format!(
+                    "Failed to create header value from user agent: {e}"
+                ))
+            })?;
+            headers.insert(reqwest::header::USER_AGENT, header);
+        }
+
+        if !headers.is_empty() {
+            client_builder = client_builder.default_headers(headers);
+        }
+
+        let reqwest_client = client_builder
+            .build()
+            .map_err(|e| CatalogError::External(format!("Failed to build HTTP client: {e}")))?;
+
+        Ok(Client::new_with_client(&self.options.uri, reqwest_client))
+    }
+
+    fn object_name(&self, name: &str) -> String {
+        if self.options.quote_object_name {
+            quote_name_if_needed(name)
+        } else {
+            name.to_string()
+        }
     }
 
     fn get_catalog_and_schema_name(
@@ -132,7 +108,7 @@ impl UnityCatalogProvider {
     ) -> CatalogResult<(String, String)> {
         match namespace.tail.as_slice() {
             [] => Ok((
-                self.catalog_config.default_catalog.to_string(),
+                self.options.default_catalog.to_string(),
                 namespace.head.to_string(),
             )),
             [x] => Ok((namespace.head.to_string(), x.to_string())),
@@ -143,15 +119,12 @@ impl UnityCatalogProvider {
         }
     }
 
-    // Unity Catalog does not quote names in full names even if they contain special characters,
-    // so we only concatenate the names with dot ('.').
-
-    fn get_full_schema_name(catalog_name: &str, schema_name: &str) -> String {
-        format!("{catalog_name}.{schema_name}")
-    }
-
-    fn get_full_table_name(catalog_name: &str, schema_name: &str, table_name: &str) -> String {
-        format!("{catalog_name}.{schema_name}.{table_name}")
+    fn qualified_object_name(&self, names: &[&str]) -> String {
+        names
+            .iter()
+            .map(|name| self.object_name(name))
+            .collect::<Vec<_>>()
+            .join(".")
     }
 
     fn schema_info_to_database_status(
@@ -241,6 +214,10 @@ impl UnityCatalogProvider {
         let database = vec![catalog.clone(), schema];
 
         let mut partition_by: Vec<String> = vec![];
+        // If all partition indices are 0, treat the table as unpartitioned.
+        // This can happen in the Unity Catalog endpoint in OneLake.
+        let ignore_partition_index =
+            !columns.is_empty() && columns.iter().all(|col| col.partition_index == Some(0));
         let columns = columns
             .into_iter()
             .map(|col| {
@@ -257,6 +234,11 @@ impl UnityCatalogProvider {
                     type_scale,
                     type_text,
                 } = col;
+                let partition_index = if ignore_partition_index {
+                    None
+                } else {
+                    partition_index
+                };
                 if partition_index.is_some() {
                     if let Some(col_name) = &name {
                         partition_by.push(col_name.to_string());
@@ -377,8 +359,8 @@ impl CatalogProvider for UnityCatalogProvider {
         let (catalog_name, schema_name) = self.get_catalog_and_schema_name(database)?;
 
         let request = types::CreateSchema::builder()
-            .catalog_name(&catalog_name)
-            .name(&schema_name)
+            .catalog_name(self.object_name(&catalog_name))
+            .name(self.object_name(&schema_name))
             .comment(comment)
             .properties(if props.is_empty() {
                 None
@@ -415,7 +397,7 @@ impl CatalogProvider for UnityCatalogProvider {
             .map_err(|e| CatalogError::External(format!("Failed to load config: {e}")))?;
 
         let (catalog_name, schema_name) = self.get_catalog_and_schema_name(database)?;
-        let full_name = Self::get_full_schema_name(&catalog_name, &schema_name);
+        let full_name = self.qualified_object_name(&[&catalog_name, &schema_name]);
 
         let result = client.get_schema().full_name(&full_name).send().await;
 
@@ -447,7 +429,7 @@ impl CatalogProvider for UnityCatalogProvider {
             .map_err(|e| CatalogError::External(format!("Failed to load config: {e}")))?;
 
         let catalog_name = match prefix {
-            None => self.catalog_config.default_catalog.to_string(),
+            None => self.options.default_catalog.to_string(),
             Some(Namespace { head, tail }) if tail.is_empty() => head.to_string(),
             Some(x) => {
                 return Err(CatalogError::InvalidArgument(format!(
@@ -458,7 +440,7 @@ impl CatalogProvider for UnityCatalogProvider {
         };
         let result = client
             .list_schemas()
-            .catalog_name(&catalog_name)
+            .catalog_name(self.object_name(&catalog_name))
             .send()
             .await;
 
@@ -492,7 +474,7 @@ impl CatalogProvider for UnityCatalogProvider {
             .map_err(|e| CatalogError::External(format!("Failed to load config: {e}")))?;
 
         let (catalog_name, schema_name) = self.get_catalog_and_schema_name(database)?;
-        let full_name = Self::get_full_schema_name(&catalog_name, &schema_name);
+        let full_name = self.qualified_object_name(&[&catalog_name, &schema_name]);
 
         let result = client
             .delete_schema()
@@ -668,17 +650,17 @@ impl CatalogProvider for UnityCatalogProvider {
             // The SQL planner supplies generated default locations for managed tables. Unity
             // managed table creation must use a staging location allocated by the catalog.
             let request = types::CreateStagingTable::builder()
-                .name(table)
-                .catalog_name(&catalog_name)
-                .schema_name(&schema_name);
-            let response = client
-                .create_staging_table()
-                .body(request)
-                .send()
-                .await
-                .map_err(|e| {
-                    CatalogError::External(format!("Failed to create staging table: {e}"))
-                })?;
+                .name(self.object_name(table))
+                .catalog_name(self.object_name(&catalog_name))
+                .schema_name(self.object_name(&schema_name));
+            let response = match client.create_staging_table().body(request).send().await {
+                Ok(response) => response,
+                Err(e) => {
+                    return Err(CatalogError::External(format!(
+                        "Failed to create staging table: {e}"
+                    )));
+                }
+            };
             response.into_inner().staging_location.ok_or_else(|| {
                 CatalogError::External(
                     "Unity Catalog staging table response is missing a staging location"
@@ -688,9 +670,9 @@ impl CatalogProvider for UnityCatalogProvider {
         };
 
         let request = types::CreateTable::builder()
-            .name(table)
-            .catalog_name(&catalog_name)
-            .schema_name(&schema_name)
+            .name(self.object_name(table))
+            .catalog_name(self.object_name(&catalog_name))
+            .schema_name(self.object_name(&schema_name))
             .table_type(table_type)
             .data_source_format(data_source_format)
             .columns(unity_columns)
@@ -737,7 +719,7 @@ impl CatalogProvider for UnityCatalogProvider {
             .map_err(|e| CatalogError::External(format!("Failed to load config: {e}")))?;
 
         let (catalog_name, schema_name) = self.get_catalog_and_schema_name(database)?;
-        let full_name = Self::get_full_table_name(&catalog_name, &schema_name, table);
+        let full_name = self.qualified_object_name(&[&catalog_name, &schema_name, table]);
 
         let result = client.get_table().full_name(&full_name).send().await;
 
@@ -765,8 +747,8 @@ impl CatalogProvider for UnityCatalogProvider {
 
         let result = client
             .list_tables()
-            .catalog_name(&catalog_name)
-            .schema_name(&schema_name)
+            .catalog_name(self.object_name(&catalog_name))
+            .schema_name(self.object_name(&schema_name))
             .send()
             .await;
 
@@ -807,7 +789,7 @@ impl CatalogProvider for UnityCatalogProvider {
             .map_err(|e| CatalogError::External(format!("Failed to load config: {e}")))?;
 
         let (catalog_name, schema_name) = self.get_catalog_and_schema_name(database)?;
-        let full_name = Self::get_full_table_name(&catalog_name, &schema_name, table);
+        let full_name = self.qualified_object_name(&[&catalog_name, &schema_name, table]);
 
         match client.delete_table().full_name(full_name).send().await {
             Ok(_) => Ok(()),
@@ -937,7 +919,7 @@ impl CatalogProvider for UnityCatalogProvider {
                 CatalogError::RateLimited(format!("Unity Catalog Delta commit rate limited: {e}")),
             ),
             Err(e) if e.status().is_some_and(|status| status.as_u16() == 501) => Err(
-                CatalogError::NotSupported("Unity Catalog Delta commit endpoint".to_string()),
+                CatalogError::NotSupported(format!("Unity Catalog Delta commit endpoint: {e}")),
             ),
             Err(e) => Err(CatalogError::External(format!(
                 "Failed to commit Delta table to Unity Catalog: {e}"
@@ -1003,7 +985,7 @@ impl CatalogProvider for UnityCatalogProvider {
             .await
             .map_err(|e| CatalogError::External(format!("Failed to load client: {e}")))?;
         let (catalog_name, schema_name) = self.get_catalog_and_schema_name(database)?;
-        let full_name = Self::get_full_table_name(&catalog_name, &schema_name, table);
+        let full_name = format!("{catalog_name}.{schema_name}.{table}");
 
         match client.get_commits().body(request).send().await {
             Ok(response) => {
@@ -1032,9 +1014,9 @@ impl CatalogProvider for UnityCatalogProvider {
                 Err(CatalogError::NotFound(CatalogObject::Table, full_name))
             }
             Err(e) if e.status().is_some_and(|status| status.as_u16() == 501) => {
-                Err(CatalogError::NotSupported(
-                    "Unity Catalog Delta commit discovery endpoint".to_string(),
-                ))
+                Err(CatalogError::NotSupported(format!(
+                    "Unity Catalog Delta commit discovery endpoint: {e}"
+                )))
             }
             Err(e) => Err(CatalogError::External(format!(
                 "Failed to get Delta commits from Unity Catalog: {e}"
@@ -1080,9 +1062,41 @@ impl CatalogProvider for UnityCatalogProvider {
 #[expect(clippy::unwrap_used)]
 #[cfg(test)]
 mod tests {
+    use sail_catalog::credentials::{CatalogCredentials, EmptyCatalogCredentials};
     use secrecy::ExposeSecret;
 
     use super::*;
+    use crate::config::UnityCatalogConfig;
+
+    fn options_from_config(
+        default_catalog: impl Into<String>,
+        config: UnityCatalogConfig,
+    ) -> UnityCatalogOptions {
+        let credentials = config
+            .get_credential_provider()
+            .map(|credentials| Arc::new(credentials) as Arc<dyn CatalogCredentials>)
+            .unwrap_or_else(|| Arc::new(EmptyCatalogCredentials));
+        UnityCatalogOptions {
+            default_catalog: default_catalog.into(),
+            uri: config.uri,
+            credentials,
+            user_agent: Some("Sail".to_string()),
+            quote_object_name: true,
+        }
+    }
+
+    fn empty_options(
+        default_catalog: impl Into<String>,
+        quote_object_name: bool,
+    ) -> UnityCatalogOptions {
+        UnityCatalogOptions {
+            default_catalog: default_catalog.into(),
+            uri: DEFAULT_URI.to_string(),
+            credentials: Arc::new(EmptyCatalogCredentials),
+            user_agent: Some("Sail".to_string()),
+            quote_object_name,
+        }
+    }
 
     #[test]
     fn test_config_with_token() {
@@ -1093,7 +1107,7 @@ mod tests {
             "https://test.databricks.com".to_string(),
         );
 
-        let config = UnityCatalogConfig::new(None, None, &None, Some(options)).unwrap();
+        let config = UnityCatalogConfig::new(None, &None, Some(options)).unwrap();
         assert!(config.bearer_token.is_some());
         assert_eq!(config.bearer_token.unwrap().expose_secret(), "test_token");
         assert_eq!(config.uri, "https://test.databricks.com");
@@ -1119,7 +1133,7 @@ mod tests {
             "test_tenant".to_string(),
         );
 
-        let config = UnityCatalogConfig::new(None, None, &None, Some(options)).unwrap();
+        let config = UnityCatalogConfig::new(None, &None, Some(options)).unwrap();
         assert_eq!(config.uri, "https://test.databricks.com");
         assert_eq!(config.client_id, Some("test_client_id".to_string()));
         assert!(config.client_secret.is_some());
@@ -1142,7 +1156,7 @@ mod tests {
             options.insert("unity_allow_http_url".to_string(), value.to_string());
             options.insert("unity_use_azure_cli".to_string(), value.to_string());
 
-            let config = UnityCatalogConfig::new(None, None, &None, Some(options)).unwrap();
+            let config = UnityCatalogConfig::new(None, &None, Some(options)).unwrap();
             assert_eq!(config.allow_http_url, expected, "Failed for value: {value}");
             assert_eq!(config.use_azure_cli, expected, "Failed for value: {value}");
         }
@@ -1166,7 +1180,7 @@ mod tests {
             let test_value = format!("test_value_for_{key}");
             options.insert(key.to_string(), test_value.clone());
 
-            let result = UnityCatalogConfig::new(None, None, &None, Some(options));
+            let result = UnityCatalogConfig::new(None, &None, Some(options));
             assert!(result.is_ok(), "Failed to parse key: {key}");
 
             let config = result.unwrap();
@@ -1188,18 +1202,197 @@ mod tests {
             "https://test.databricks.com".to_string(),
         );
 
-        let provider = UnityCatalogProvider::with_options(
+        let config = UnityCatalogConfig::new(None, &None, Some(options)).unwrap();
+        assert!(config.bearer_token.is_some());
+
+        let provider = UnityCatalogProvider::new(
             "test".to_string(),
-            Some("test_catalog".to_string()),
-            None,
-            &None,
-            Some(options),
+            options_from_config("test_catalog", config),
         )
         .unwrap();
 
         assert_eq!(provider.name, "test");
-        assert_eq!(provider.catalog_config.default_catalog, "test_catalog");
-        assert_eq!(provider.catalog_config.uri, "https://test.databricks.com");
-        assert!(provider.catalog_config.bearer_token.is_some());
+        assert_eq!(provider.options.default_catalog, "test_catalog");
+        assert_eq!(provider.options.uri, "https://test.databricks.com");
+    }
+
+    #[test]
+    fn test_provider_quotes_object_names_by_default() {
+        let config = UnityCatalogConfig::new(None, &None, None).unwrap();
+        let provider = UnityCatalogProvider::new(
+            "test".to_string(),
+            options_from_config("catalog.name", config),
+        )
+        .unwrap();
+
+        assert_eq!(provider.options.default_catalog, "catalog.name");
+        assert_eq!(
+            provider.object_name(&provider.options.default_catalog),
+            "`catalog.name`"
+        );
+        assert_eq!(provider.object_name("schema.name"), "`schema.name`");
+        assert_eq!(
+            provider.qualified_object_name(&["catalog.name", "schema.name", "table.name"]),
+            "`catalog.name`.`schema.name`.`table.name`"
+        );
+        let namespace = Namespace::try_from(vec!["schema.name"]).unwrap();
+        assert_eq!(
+            provider.get_catalog_and_schema_name(&namespace).unwrap(),
+            ("catalog.name".to_string(), "schema.name".to_string())
+        );
+    }
+
+    #[test]
+    fn test_provider_can_preserve_unquoted_object_names() {
+        let provider = UnityCatalogProvider::new(
+            "test".to_string(),
+            empty_options("lakehouse.Lakehouse", false),
+        )
+        .unwrap();
+
+        assert_eq!(provider.options.default_catalog, "lakehouse.Lakehouse");
+        assert_eq!(
+            provider.object_name(&provider.options.default_catalog),
+            "lakehouse.Lakehouse"
+        );
+        assert_eq!(provider.object_name("schema.name"), "schema.name");
+        assert_eq!(
+            provider.qualified_object_name(&["catalog.name", "schema.name", "table.name"]),
+            "catalog.name.schema.name.table.name"
+        );
+    }
+
+    #[test]
+    #[expect(clippy::panic)]
+    fn test_table_info_accepts_null_columns_and_lowercase_column_type_name() {
+        let response: types::ListTablesResponse = serde_json::from_value(serde_json::json!({
+            "tables": [{
+                "catalog_name": "catalog",
+                "schema_name": "schema",
+                "name": "empty_table",
+                "columns": null
+            }, {
+                "catalog_name": "catalog",
+                "schema_name": "schema",
+                "name": "typed_table",
+                "columns": [{
+                    "name": "value",
+                    "type_name": "string",
+                    "type_text": "string",
+                    "nullable": true
+                }]
+            }]
+        }))
+        .unwrap();
+
+        let provider =
+            UnityCatalogProvider::new("test".to_string(), empty_options("catalog", true)).unwrap();
+
+        let mut tables = response.tables.into_iter();
+        let empty_table = provider
+            .table_info_to_table_status(tables.next().unwrap(), "catalog", "schema")
+            .unwrap();
+        let typed_table = provider
+            .table_info_to_table_status(tables.next().unwrap(), "catalog", "schema")
+            .unwrap();
+
+        let TableKind::Table {
+            columns, comment, ..
+        } = empty_table.kind
+        else {
+            panic!("expected table status");
+        };
+        assert_eq!(comment, None);
+        assert!(columns.is_empty());
+
+        let TableKind::Table { columns, .. } = typed_table.kind else {
+            panic!("expected table status");
+        };
+        assert_eq!(columns[0].data_type, DataType::Utf8);
+    }
+
+    #[test]
+    #[expect(clippy::panic)]
+    fn test_table_info_ignores_onelake_all_zero_partition_indexes() {
+        let response: types::TableInfo = serde_json::from_value(serde_json::json!({
+            "catalog_name": "catalog",
+            "schema_name": "schema",
+            "name": "typed_table",
+            "columns": [{
+                "name": "id",
+                "type_name": "int",
+                "type_text": "int",
+                "nullable": true,
+                "partition_index": 0
+            }, {
+                "name": "value",
+                "type_name": "string",
+                "type_text": "string",
+                "nullable": true,
+                "partition_index": 0
+            }]
+        }))
+        .unwrap();
+
+        let provider =
+            UnityCatalogProvider::new("test".to_string(), empty_options("catalog", true)).unwrap();
+
+        let status = provider
+            .table_info_to_table_status(response, "catalog", "schema")
+            .unwrap();
+
+        let TableKind::Table {
+            columns,
+            partition_by,
+            ..
+        } = status.kind
+        else {
+            panic!("expected table status");
+        };
+        assert!(partition_by.is_empty());
+        assert!(columns.iter().all(|column| !column.is_partition));
+    }
+
+    #[test]
+    #[expect(clippy::panic)]
+    fn test_table_info_preserves_real_partition_index() {
+        let response: types::TableInfo = serde_json::from_value(serde_json::json!({
+            "catalog_name": "catalog",
+            "schema_name": "schema",
+            "name": "typed_table",
+            "columns": [{
+                "name": "id",
+                "type_name": "int",
+                "type_text": "int",
+                "nullable": true
+            }, {
+                "name": "value",
+                "type_name": "string",
+                "type_text": "string",
+                "nullable": true,
+                "partition_index": 0
+            }]
+        }))
+        .unwrap();
+
+        let provider =
+            UnityCatalogProvider::new("test".to_string(), empty_options("catalog", true)).unwrap();
+
+        let status = provider
+            .table_info_to_table_status(response, "catalog", "schema")
+            .unwrap();
+
+        let TableKind::Table {
+            columns,
+            partition_by,
+            ..
+        } = status.kind
+        else {
+            panic!("expected table status");
+        };
+        assert_eq!(partition_by.len(), 1);
+        assert_eq!(partition_by[0].column, "value");
+        assert!(!columns[0].is_partition);
+        assert!(columns[1].is_partition);
     }
 }

--- a/crates/sail-catalog-unity/src/provider.rs
+++ b/crates/sail-catalog-unity/src/provider.rs
@@ -28,6 +28,7 @@ use sail_catalog::provider::{
     TableFormatCreateMetadataMode,
 };
 use sail_catalog::utils::{get_property, quote_name_if_needed, quote_namespace_if_needed};
+use sail_common::http::SAIL_USER_AGENT;
 use sail_common_datafusion::catalog::delta::{
     unity_table_id_value, DELTA_UNITY_TABLE_ID_KEY, DELTA_UNITY_TABLE_ID_LEGACY_KEY,
 };
@@ -54,7 +55,6 @@ pub struct UnityCatalogOptions {
     pub default_catalog: String,
     pub uri: String,
     pub credentials: Arc<dyn CatalogCredentials>,
-    pub user_agent: Option<String>,
     pub quote_object_name: bool,
 }
 
@@ -79,14 +79,10 @@ impl UnityCatalogProvider {
             headers.insert(reqwest::header::AUTHORIZATION, header);
         }
 
-        if let Some(user_agent) = &self.options.user_agent {
-            let header = reqwest::header::HeaderValue::from_str(user_agent).map_err(|e| {
-                CatalogError::External(format!(
-                    "Failed to create header value from user agent: {e}"
-                ))
-            })?;
-            headers.insert(reqwest::header::USER_AGENT, header);
-        }
+        headers.insert(
+            reqwest::header::USER_AGENT,
+            reqwest::header::HeaderValue::from_static(SAIL_USER_AGENT),
+        );
 
         Ok(Client::new_with_client_and_headers(
             &self.options.uri,
@@ -1081,7 +1077,6 @@ mod tests {
             default_catalog: default_catalog.into(),
             uri: config.uri,
             credentials,
-            user_agent: Some("Sail".to_string()),
             quote_object_name: true,
         }
     }
@@ -1094,7 +1089,6 @@ mod tests {
             default_catalog: default_catalog.into(),
             uri: DEFAULT_URI.to_string(),
             credentials: Arc::new(EmptyCatalogCredentials),
-            user_agent: Some("Sail".to_string()),
             quote_object_name,
         }
     }

--- a/crates/sail-catalog-unity/tests/rest_integration_test.rs
+++ b/crates/sail-catalog-unity/tests/rest_integration_test.rs
@@ -150,7 +150,6 @@ async fn setup_catalog(
                     default_catalog: DEFAULT_CATALOG.to_string(),
                     uri: rest_url.clone(),
                     credentials: Arc::new(EmptyCatalogCredentials),
-                    user_agent: Some("Sail".to_string()),
                     quote_object_name: true,
                 },
             )

--- a/crates/sail-catalog-unity/tests/rest_integration_test.rs
+++ b/crates/sail-catalog-unity/tests/rest_integration_test.rs
@@ -16,13 +16,14 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field, Fields};
+use sail_catalog::credentials::EmptyCatalogCredentials;
 use sail_catalog::provider::{
     CatalogPartitionField, CatalogProvider, CreateDatabaseOptions, CreateTableColumnOptions,
     CreateTableMode, CreateTableOptions, DropDatabaseOptions, DropTableOptions, Namespace,
     RuntimeAwareCatalogProvider,
 };
 use sail_catalog_unity::unity::{types, Client};
-use sail_catalog_unity::UnityCatalogProvider;
+use sail_catalog_unity::{UnityCatalogOptions, UnityCatalogProvider};
 use sail_common::runtime::RuntimeHandle;
 use sail_common::spec::{
     SAIL_LIST_FIELD_NAME, SAIL_MAP_FIELD_NAME, SAIL_MAP_KEY_FIELD_NAME, SAIL_MAP_VALUE_FIELD_NAME,
@@ -145,9 +146,13 @@ async fn setup_catalog(
         || {
             UnityCatalogProvider::new(
                 "sail".to_string(),
-                &Some(DEFAULT_CATALOG.to_string()),
-                &Some(rest_url.clone()),
-                &None,
+                UnityCatalogOptions {
+                    default_catalog: DEFAULT_CATALOG.to_string(),
+                    uri: rest_url.clone(),
+                    credentials: Arc::new(EmptyCatalogCredentials),
+                    user_agent: Some("Sail".to_string()),
+                    quote_object_name: true,
+                },
             )
         },
         runtime.io().clone(),

--- a/crates/sail-catalog/src/credentials.rs
+++ b/crates/sail-catalog/src/credentials.rs
@@ -1,0 +1,36 @@
+use std::fmt::Debug;
+
+use crate::error::CatalogResult;
+
+#[async_trait::async_trait]
+pub trait CatalogCredentials: Debug + Send + Sync + 'static {
+    async fn retrieve(&self) -> CatalogResult<Option<String>>;
+}
+
+#[derive(Debug, Default)]
+pub struct EmptyCatalogCredentials;
+
+#[async_trait::async_trait]
+impl CatalogCredentials for EmptyCatalogCredentials {
+    async fn retrieve(&self) -> CatalogResult<Option<String>> {
+        Ok(None)
+    }
+}
+
+#[derive(Debug)]
+pub struct StaticCatalogCredentials {
+    credential: String,
+}
+
+impl StaticCatalogCredentials {
+    pub fn new(credential: String) -> Self {
+        Self { credential }
+    }
+}
+
+#[async_trait::async_trait]
+impl CatalogCredentials for StaticCatalogCredentials {
+    async fn retrieve(&self) -> CatalogResult<Option<String>> {
+        Ok(Some(self.credential.clone()))
+    }
+}

--- a/crates/sail-catalog/src/lib.rs
+++ b/crates/sail-catalog/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod command;
+pub mod credentials;
 pub mod error;
 pub mod hive_format;
 pub mod lakehouse;

--- a/crates/sail-catalog/src/manager/table.rs
+++ b/crates/sail-catalog/src/manager/table.rs
@@ -139,7 +139,7 @@ impl CatalogManager {
             // list_views; treat that as "no views" so SHOW TABLES still works there.
             let views = match views_res {
                 Ok(v) => v,
-                Err(CatalogError::NotSupported(_)) => vec![],
+                Err(CatalogError::NotSupported(_)) | Err(CatalogError::NotFound(_, _)) => vec![],
                 Err(e) => return Err(e),
             };
             tables.extend(views);

--- a/crates/sail-common/src/config/application.rs
+++ b/crates/sail-common/src/config/application.rs
@@ -512,8 +512,8 @@ pub struct OptimizerConfig {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum OneLakeApi {
-    #[default]
     Delta,
+    #[default]
     Iceberg,
 }
 

--- a/crates/sail-common/src/config/application.rs
+++ b/crates/sail-common/src/config/application.rs
@@ -509,6 +509,14 @@ pub struct OptimizerConfig {
     pub expand_views_at_output: bool,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OneLakeApi {
+    #[default]
+    Delta,
+    Iceberg,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -562,6 +570,8 @@ pub enum CatalogType {
     OneLake {
         name: String,
         url: String,
+        #[serde(default)]
+        api: OneLakeApi,
         #[serde(
             skip_serializing_if = "Option::is_none",
             serialize_with = "serialize_optional_secret"

--- a/crates/sail-common/src/http.rs
+++ b/crates/sail-common/src/http.rs
@@ -1,0 +1,7 @@
+/// User agent for Sail requests to remote services.
+///
+/// References:
+///   * <https://www.rfc-editor.org/info/rfc9110/#name-user-agent>
+///   * <https://www.rfc-editor.org/info/rfc7231/#section-5.5.3> (obsolete)
+///   * <https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/User-Agent>
+pub const SAIL_USER_AGENT: &str = concat!("Sail/", env!("CARGO_PKG_VERSION"));

--- a/crates/sail-common/src/lib.rs
+++ b/crates/sail-common/src/lib.rs
@@ -3,6 +3,7 @@ pub mod datetime;
 pub mod debug;
 pub mod error;
 pub mod geoarrow;
+pub mod http;
 pub mod object;
 pub mod runtime;
 pub mod spec;

--- a/crates/sail-iceberg/src/table/mod.rs
+++ b/crates/sail-iceberg/src/table/mod.rs
@@ -44,7 +44,11 @@ impl Table {
         table_url: Url,
         metadata_location: Option<String>,
     ) -> Result<Self> {
-        log::trace!("Loading Iceberg table: {}", table_url);
+        log::trace!(
+            "Loading Iceberg table: table_url={}, metadata_location={:?}",
+            table_url,
+            metadata_location,
+        );
         let object_store = ctx
             .runtime_env()
             .object_store_registry

--- a/crates/sail-iceberg/src/table_format.rs
+++ b/crates/sail-iceberg/src/table_format.rs
@@ -709,8 +709,8 @@ fn validate_iceberg_lakehouse_storage_access(
         .is_some_and(|session| session.remote_signing_enabled)
     {
         // TODO: Wire REST remote signing into Iceberg FileIO/object-store access.
-        return not_impl_err!(
-            "Iceberg REST catalog table {} requires remote signing, which is not implemented yet",
+        warn!(
+            "Iceberg REST catalog table {} advertises remote signing, which is not implemented yet",
             context.catalog_table().join(".")
         );
     }
@@ -721,7 +721,7 @@ fn validate_iceberg_lakehouse_storage_access(
     {
         // TODO: Apply REST vended credentials to operation-scoped storage access.
         warn!(
-            "Iceberg REST catalog table {} requires vended storage credentials, which is not implemented yet",
+            "Iceberg REST catalog table {} advertises vended storage credentials, which is not implemented yet",
             context.catalog_table().join(".")
         );
     }

--- a/crates/sail-iceberg/src/table_format.rs
+++ b/crates/sail-iceberg/src/table_format.rs
@@ -24,6 +24,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion_expr::expr::Sort;
 use datafusion_expr::{Expr, Extension, UserDefinedLogicalNodeCore};
 use educe::Educe;
+use log::warn;
 use object_store::ObjectStoreExt;
 use sail_common_datafusion::catalog::iceberg::is_iceberg_table_marker;
 use sail_common_datafusion::catalog::managed::metadata_location_value;
@@ -719,7 +720,7 @@ fn validate_iceberg_lakehouse_storage_access(
         .is_some_and(|session| session.storage_credential_count > 0)
     {
         // TODO: Apply REST vended credentials to operation-scoped storage access.
-        return not_impl_err!(
+        warn!(
             "Iceberg REST catalog table {} requires vended storage credentials, which is not implemented yet",
             context.catalog_table().join(".")
         );

--- a/crates/sail-iceberg/src/table_format.rs
+++ b/crates/sail-iceberg/src/table_format.rs
@@ -1290,7 +1290,7 @@ mod tests {
     }
 
     #[test]
-    fn storage_access_rejects_required_rest_vended_credentials() {
+    fn storage_access_allows_required_rest_vended_credentials() {
         let mut context = LakehouseExecutionContext::catalog_table_context(
             CatalogProviderId("rest".to_string()),
             vec!["rest".to_string(), "db".to_string(), "tbl".to_string()],
@@ -1315,9 +1315,6 @@ mod tests {
         });
 
         let result = validate_iceberg_lakehouse_storage_access(Some(&context));
-        assert!(matches!(
-            &result,
-            Err(err) if format!("{err}").contains("vended storage credentials")
-        ));
+        assert!(result.is_ok());
     }
 }

--- a/crates/sail-iceberg/src/table_format.rs
+++ b/crates/sail-iceberg/src/table_format.rs
@@ -1258,7 +1258,7 @@ mod tests {
     }
 
     #[test]
-    fn storage_access_rejects_required_rest_remote_signing() {
+    fn storage_access_allows_required_rest_remote_signing() {
         let mut context = LakehouseExecutionContext::catalog_table_context(
             CatalogProviderId("rest".to_string()),
             vec!["rest".to_string(), "db".to_string(), "tbl".to_string()],
@@ -1283,10 +1283,7 @@ mod tests {
         });
 
         let result = validate_iceberg_lakehouse_storage_access(Some(&context));
-        assert!(matches!(
-            &result,
-            Err(err) if format!("{err}").contains("requires remote signing")
-        ));
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/crates/sail-session/src/catalog.rs
+++ b/crates/sail-session/src/catalog.rs
@@ -3,6 +3,9 @@ use std::sync::Arc;
 
 use datafusion::common::{plan_datafusion_err, Result};
 use datafusion_common::plan_err;
+use sail_catalog::credentials::{
+    CatalogCredentials, EmptyCatalogCredentials, StaticCatalogCredentials,
+};
 use sail_catalog::error::CatalogResult;
 use sail_catalog::manager::{CatalogManager, CatalogManagerOptions};
 use sail_catalog::provider::{
@@ -10,12 +13,12 @@ use sail_catalog::provider::{
 };
 use sail_catalog_glue::{GlueCatalogConfig, GlueCatalogProvider};
 use sail_catalog_hms::{HmsCatalogConfig, HmsCatalogProvider};
-use sail_catalog_iceberg::IcebergRestCatalogProvider;
+use sail_catalog_iceberg::{IcebergRestCatalogOptions, IcebergRestCatalogProvider};
 use sail_catalog_memory::MemoryCatalogProvider;
-use sail_catalog_onelake::OneLakeCatalogProvider;
+use sail_catalog_onelake::{OneLakeApiKind, OneLakeCatalogProvider};
 use sail_catalog_system::{SystemCatalogProvider, SYSTEM_CATALOG_NAME};
-use sail_catalog_unity::UnityCatalogProvider;
-use sail_common::config::{AppConfig, CacheType, CatalogCacheConfig, CatalogType};
+use sail_catalog_unity::{UnityCatalogConfig, UnityCatalogOptions, UnityCatalogProvider};
+use sail_common::config::{AppConfig, CacheType, CatalogCacheConfig, CatalogType, OneLakeApi};
 use sail_common::runtime::RuntimeHandle;
 use secrecy::ExposeSecret;
 
@@ -66,23 +69,26 @@ pub fn create_catalog_manager(
                             namespace_separator.to_string(),
                         );
                     }
-                    if let Some(oauth_access_token) = oauth_access_token {
-                        properties.insert(
-                            "oauth-access-token".to_string(), // Iceberg uses kebab-case
-                            oauth_access_token.expose_secret().to_string(), // FIXME: Only expose when necessary
-                        );
-                    }
-                    if let Some(bearer_access_token) = bearer_access_token {
-                        properties.insert(
-                            "bearer-access-token".to_string(), // Iceberg uses kebab-case
-                            bearer_access_token.expose_secret().to_string(), // FIXME: Only expose when necessary
-                        );
-                    }
+                    let credentials = bearer_access_token
+                        .as_ref()
+                        .or(oauth_access_token.as_ref())
+                        .map(|token| {
+                            Arc::new(StaticCatalogCredentials::new(
+                                token.expose_secret().to_string(),
+                            )) as Arc<dyn CatalogCredentials>
+                        })
+                        .unwrap_or_else(|| Arc::new(EmptyCatalogCredentials));
 
                     let runtime_aware = RuntimeAwareCatalogProvider::try_new(
                         || {
-                            let provider =
-                                IcebergRestCatalogProvider::new(name.to_string(), properties);
+                            let provider = IcebergRestCatalogProvider::new(
+                                name.to_string(),
+                                IcebergRestCatalogOptions {
+                                    credentials,
+                                    properties,
+                                    user_agent: Some("Sail".to_string()),
+                                },
+                            );
                             Ok(provider)
                         },
                         runtime.io().clone(),
@@ -103,7 +109,28 @@ pub fn create_catalog_manager(
                     cache,
                 } => {
                     let runtime_aware = RuntimeAwareCatalogProvider::try_new(
-                        || UnityCatalogProvider::new(name.to_string(), default_catalog, uri, token),
+                        || {
+                            let config = UnityCatalogConfig::new(uri.clone(), token, None)?;
+                            let credentials = config
+                                .get_credential_provider()
+                                .map(|credentials| {
+                                    Arc::new(credentials) as Arc<dyn CatalogCredentials>
+                                })
+                                .unwrap_or_else(|| Arc::new(EmptyCatalogCredentials));
+                            let default_catalog = default_catalog
+                                .clone()
+                                .unwrap_or_else(|| "unity".to_string());
+                            UnityCatalogProvider::new(
+                                name.to_string(),
+                                UnityCatalogOptions {
+                                    default_catalog,
+                                    uri: config.uri,
+                                    credentials,
+                                    user_agent: Some("Sail".to_string()),
+                                    quote_object_name: true,
+                                },
+                            )
+                        },
                         runtime.io().clone(),
                     )?;
                     let provider = wrap_catalog_provider(
@@ -117,6 +144,7 @@ pub fn create_catalog_manager(
                 CatalogType::OneLake {
                     name,
                     url,
+                    api,
                     bearer_token,
                     cache,
                 } => {
@@ -137,15 +165,20 @@ pub fn create_catalog_manager(
                     })?;
 
                     let token = bearer_token.as_ref().map(|t| t.expose_secret().to_string());
+                    let api = match api {
+                        OneLakeApi::Delta => OneLakeApiKind::Delta,
+                        OneLakeApi::Iceberg => OneLakeApiKind::Iceberg,
+                    };
                     let runtime_aware = RuntimeAwareCatalogProvider::try_new(
                         || {
-                            Ok(OneLakeCatalogProvider::new(
+                            OneLakeCatalogProvider::new(
                                 name.clone(),
                                 workspace.to_string(),
                                 item_name.to_string(),
                                 item_type.to_string(),
+                                api,
                                 token.clone(),
-                            ))
+                            )
                         },
                         runtime.io().clone(),
                     )?;

--- a/crates/sail-session/src/catalog.rs
+++ b/crates/sail-session/src/catalog.rs
@@ -146,21 +146,24 @@ pub fn create_catalog_manager(
                     bearer_token,
                     cache,
                 } => {
-                    // Parse URL format: workspace/item.type (e.g., "duckrun/data.lakehouse", "duckrun/data.datawarehouse")
+                    // Parse URL format:
+                    //   - `workspace/item.type`: friendly names (e.g. "duckrun/data.lakehouse")
+                    //   - `workspaceId/itemId`: GUIDs (e.g. "8f.../3a...").
+                    // GUID form is required when the workspace has friendly-name support disabled,
+                    // because the data/metadata paths are then GUID-addressed at the storage layer.
                     let (workspace, item) = url.split_once('/').ok_or_else(|| {
                         plan_datafusion_err!(
-                            "Invalid OneLake URL format: expected 'workspace/item.type', got '{}'",
+                            "Invalid OneLake URL format: expected 'workspace/item.type' or 'workspaceId/itemId', got '{}'",
                             url
                         )
                     })?;
 
-                    // Extract item name and type (e.g., "data.Lakehouse" -> name="data", type="Lakehouse")
-                    let (item_name, item_type) = item.split_once('.').ok_or_else(|| {
-                        plan_datafusion_err!(
-                            "Invalid OneLake item format: expected 'name.type', got '{}'",
-                            item
-                        )
-                    })?;
+                    // Friendly form: ("data.Lakehouse" -> name="data", type=Some("Lakehouse"))
+                    // GUID form: ("data" -> name="data", type=None)
+                    let (item_name, item_type) = match item.split_once('.') {
+                        Some((name, item_type)) => (name, Some(item_type.to_string())),
+                        None => (item, None),
+                    };
 
                     let token = bearer_token.as_ref().map(|t| t.expose_secret().to_string());
                     let api = match api {
@@ -173,7 +176,7 @@ pub fn create_catalog_manager(
                                 name.clone(),
                                 workspace.to_string(),
                                 item_name.to_string(),
-                                item_type.to_string(),
+                                item_type,
                                 api,
                                 token.clone(),
                             )

--- a/crates/sail-session/src/catalog.rs
+++ b/crates/sail-session/src/catalog.rs
@@ -86,7 +86,6 @@ pub fn create_catalog_manager(
                                 IcebergRestCatalogOptions {
                                     credentials,
                                     properties,
-                                    user_agent: Some("Sail".to_string()),
                                 },
                             );
                             Ok(provider)
@@ -126,7 +125,6 @@ pub fn create_catalog_manager(
                                     default_catalog,
                                     uri: config.uri,
                                     credentials,
-                                    user_agent: Some("Sail".to_string()),
                                     quote_object_name: true,
                                 },
                             )

--- a/docs/development/recipes/iceberg-openapi-generation.md
+++ b/docs/development/recipes/iceberg-openapi-generation.md
@@ -71,9 +71,28 @@ After running the generation script, you must manually fix the following:
    - Replace `models::StructField` with `NestedFieldRef`
 
 4. In `src/models/table_update.rs` and `src/models/view_update.rs`:
+
    - The upstream spec declares `TableUpdate`/`ViewUpdate` as a bare `anyOf`
      with no discriminator (unlike `BaseUpdate`, which has one), so the
      generator emits a degenerate flat struct with every field of every
      variant marked required. Replace each generated struct with a
      hand-written `#[serde(tag = "action")]` enum (mirroring `base_update.rs`),
-     with one variant per action.
+     with one variant per action and with all payload fields preserved.
+
+5. In `src/models/table_requirement.rs`, `src/models/view_requirement.rs`,
+   `src/models/commit_view_request.rs`, and
+   `src/models/assert_ref_snapshot_id.rs`:
+
+   - Ensure `TableRequirement` is a hand-written `#[serde(tag = "type")]` enum
+     whose variants preserve their payload fields. In particular,
+     `AssertRefSnapshotId` must include `ref` and nullable `snapshot-id`; if it
+     is generated as an empty variant, Iceberg REST commits will serialize as
+     `{"type":"assert-ref-snapshot-id"}` and servers will reject the request
+     because `ref` is missing.
+   - Ensure `AssertRefSnapshotId.snapshot_id` is `Option<i64>` so create
+     transactions can send `"snapshot-id": null`, which means the ref must not
+     already exist.
+   - If the generator omits `ViewRequirement` because it has only one variant,
+     add it as a hand-written `#[serde(tag = "type")]` enum with
+     `AssertViewUuid { uuid }`, and keep `CommitViewRequest.requirements` typed
+     as `Option<Vec<ViewRequirement>>`.

--- a/docs/guide/catalog/onelake.md
+++ b/docs/guide/catalog/onelake.md
@@ -12,25 +12,85 @@ OneLake catalog can be configured using the following options:
 - `type` (required): The string `onelake`.
 - `name` (required): The name of the catalog.
 - `url` (required): The OneLake item location.
+- `api` (optional): The OneLake catalog API. Use `delta` for the Unity Catalog endpoint or `iceberg` for the Iceberg REST catalog endpoint. The default is `delta`.
 - `bearer_token` (optional): The bearer token for authentication.
 
 See [Common Options](./index.md#common-options) for caching configuration.
 
 The `url` should be in the format <code><SyntaxText raw="<workspace>'/'<item-name>'.'<item-type>" /></code>.
 
-If `bearer_token` is not provided, Sail will attempt to find credentials from the following sources in order:
+If `bearer_token` is not specified, Sail creates credentials from environment variables, similar to how authentication is handled in [Azure storage](../storage/azure.md).
+These credentials acquire Microsoft Entra tokens for the Azure Storage audience required by OneLake.
 
-1. The `AZURE_STORAGE_TOKEN` environment variable.
-2. The `AZURE_ACCESS_TOKEN` environment variable.
-3. Azure CLI (`az account get-access-token`).
+The following environment variables are supported:
+
+- `AZURE_STORAGE_TOKEN`, `AZURE_ACCESS_TOKEN`
+
+  The bearer token for authorizing requests.
+
+- `AZURE_STORAGE_CLIENT_ID`, `AZURE_CLIENT_ID`
+
+  The service principal client ID for authorizing requests. This can also identify a user-assigned managed identity.
+
+- `AZURE_STORAGE_CLIENT_SECRET`, `AZURE_CLIENT_SECRET`
+
+  The service principal client secret for authorizing requests.
+
+- `AZURE_STORAGE_TENANT_ID`, `AZURE_STORAGE_AUTHORITY_ID`, `AZURE_TENANT_ID`, `AZURE_AUTHORITY_ID`
+
+  The tenant ID used in OAuth flows.
+
+- `AZURE_STORAGE_AUTHORITY_HOST`, `AZURE_AUTHORITY_HOST`
+
+  The authority host used in OAuth flows.
+
+- `AZURE_MSI_ENDPOINT`, `AZURE_IDENTITY_ENDPOINT`
+
+  The endpoint for acquiring a managed identity token.
+
+- `AZURE_OBJECT_ID`
+
+  The object ID for use with managed identity authentication.
+
+- `AZURE_MSI_RESOURCE_ID`
+
+  The MSI resource ID for use with managed identity authentication.
+
+- `AZURE_FEDERATED_TOKEN_FILE`
+
+  The file containing a token for Azure AD workload identity federation.
+
+- `AZURE_USE_AZURE_CLI`
+
+  Whether to use Azure CLI for acquiring an access token.
+
+Tokens are refreshed automatically before expiry.
+
+::: warning
+Azure account keys and SAS tokens are not supported for OneLake catalog authentication. OneLake requires Microsoft Entra bearer tokens.
+:::
 
 ## Examples
 
 ```bash
-export SAIL_CATALOG__LIST='[{type="onelake", name="fabric", url="workspace/lakehouse.Lakehouse"}]'
+# Unity Catalog endpoint
+export SAIL_CATALOG__LIST='[{type="onelake", name="fabric", url="workspace/lakehouse.Lakehouse", api="delta"}]'
+
+# Iceberg REST catalog endpoint
+export SAIL_CATALOG__LIST='[{type="onelake", name="fabric", url="workspace/lakehouse.Lakehouse", api="iceberg"}]'
 
 # Bearer token authentication
 export SAIL_CATALOG__LIST='[{type="onelake", name="fabric", url="workspace/lakehouse.Lakehouse", bearer_token="..."}]'
+
+# OAuth authentication with a tenant ID
+export AZURE_TENANT_ID="00000000-0000-0000-0000-000000000000"
+export AZURE_CLIENT_ID="..."
+export AZURE_CLIENT_SECRET="..."
+export SAIL_CATALOG__LIST='[{type="onelake", name="fabric", url="workspace/lakehouse.Lakehouse"}]'
+
+# Azure CLI authentication via environment variables
+export AZURE_USE_AZURE_CLI=true
+export SAIL_CATALOG__LIST='[{type="onelake", name="fabric", url="workspace/lakehouse.Lakehouse"}]'
 ```
 
 <script setup>

--- a/docs/guide/catalog/onelake.md
+++ b/docs/guide/catalog/onelake.md
@@ -12,7 +12,7 @@ OneLake catalog can be configured using the following options:
 - `type` (required): The string `onelake`.
 - `name` (required): The name of the catalog.
 - `url` (required): The OneLake item location.
-- `api` (optional): The OneLake catalog API. Use `delta` for the Unity Catalog endpoint or `iceberg` for the Iceberg REST catalog endpoint. The default is `delta`.
+- `api` (optional): The OneLake catalog API. Use `delta` for the Unity Catalog endpoint or `iceberg` for the Iceberg REST catalog endpoint. The default is `iceberg`.
 - `bearer_token` (optional): The bearer token for authentication.
 
 See [Common Options](./index.md#common-options) for caching configuration.

--- a/docs/guide/catalog/onelake.md
+++ b/docs/guide/catalog/onelake.md
@@ -83,7 +83,7 @@ export SAIL_CATALOG__LIST='[{type="onelake", name="fabric", url="workspace/lakeh
 export SAIL_CATALOG__LIST='[{type="onelake", name="fabric", url="workspace/lakehouse.Lakehouse", bearer_token="..."}]'
 
 # OAuth authentication with a tenant ID
-export AZURE_TENANT_ID="00000000-0000-0000-0000-000000000000"
+export AZURE_TENANT_ID="..."
 export AZURE_CLIENT_ID="..."
 export AZURE_CLIENT_SECRET="..."
 export SAIL_CATALOG__LIST='[{type="onelake", name="fabric", url="workspace/lakehouse.Lakehouse"}]'

--- a/docs/guide/storage/azure.md
+++ b/docs/guide/storage/azure.md
@@ -45,7 +45,7 @@ Sail supports the following URI formats for Azure storage services:
       <li>
         <code
           ><SyntaxText
-            raw="'abfs'['s']'://'<container>'@'<account>'.dfs.fabric.windows.net/'<path>"
+            raw="'abfs'['s']'://'<container>'@'<account>'.dfs.fabric.microsoft.com/'<path>"
         /></code>
         (Hadoop driver convention with Microsoft Fabric)
       </li>

--- a/python/pysail/examples/spark/onelake_catalog.py
+++ b/python/pysail/examples/spark/onelake_catalog.py
@@ -33,7 +33,7 @@ def main():
 
     # Set up environment with the token
     os.environ["AZURE_STORAGE_TOKEN"] = token
-    os.environ["SAIL_CATALOG__LIST"] = '[{type="onelake", name="onelake", url="duckrun/data.Lakehouse"}]'
+    os.environ["SAIL_CATALOG__LIST"] = '[{type="onelake", name="onelake", url="duckrun/data.Lakehouse", api="delta"}]'
     os.environ["SAIL_CATALOG__DEFAULT_CATALOG"] = "onelake"
 
     # Start Sail server


### PR DESCRIPTION
- Add shared catalog credential plumbing and use it across Iceberg REST, Unity Catalog, and OneLake providers to support automatic credential refresh, while ensuring connection reuse for the HTTP client.
- Support proper OneLake authentication by using the credential utilities from Azure storage in `object_store`.
- Rework the OneLake catalog provider to delegate to protocol-specific providers, with selectable `api = "delta"` or `api = "iceberg"` configuration options.
- Improve Unity Catalog compatibility for OneLake responses.
- Fix more issues (after #2134) for the generated Iceberg REST catalog client code around table commit.
- Refactor configuration management for Iceberg REST and Unity Catalog.
- Add `User-Agent` header for catalog requests.

We don't yet have integration tests for OneLake, so the related functionalities are tested manually. The existing integration tests for Iceberg REST and Unity Catalog are still working.