### PR TITLE
docs: track LakeCat catalog & Iceberg changes on the lakecat branch

### DIFF
--- a/LAKECAT-SAIL.md
+++ b/LAKECAT-SAIL.md
@@ -1,0 +1,173 @@
+# LakeCat ↔ Sail: Catalog & Iceberg Changes
+
+This document summarizes the bug fixes and enabling changes we have made to
+**Sail** in the course of building **LakeCat**, an Iceberg REST catalog designed
+to sit as close to the engine as possible. It is the running record of what
+lives on the `lakecat` branch of our Sail fork (`querygraph/sail`), why it is
+kept on a branch rather than merged to `lakehq/sail` `main`, and which pieces
+have been proposed upstream.
+
+> **Status as of 2026-06-26.** Base = `lakehq/sail@7da486db` (the merged
+> foundation, PR #2134). The `lakecat` branch carries four additional commits on
+> top of that base.
+
+## Why a branch
+
+LakeCat needs Sail's Iceberg layer to be **correct** (so reads return the right
+rows) and **extensible** (so a thin REST bridge can drive table commits without
+forking Sail's generated models). Two of these needs overlap with an active
+upstream redesign:
+
+- **PR #2141 (@linhr), _"feat: improve catalog providers"_** is reworking the
+  `CatalogProvider` surface in parallel. Our provider-seam additions
+  (`commit_table` / `get_table_commits`) touch the same trait, so we hold them on
+  `lakecat` to avoid churning against a moving target and to let that design
+  land first.
+- **Issue #982, _"[Catalog] Support Iceberg"_** is the umbrella for Iceberg
+  catalog support; the metadata-evolution work (server-side `apply_table_updates`)
+  depends on decisions still being settled there.
+
+The correctness **bug fixes**, by contrast, are independent of that redesign and
+have been proposed upstream as standalone PRs.
+
+## Summary
+
+| # | Change | Kind | Area | Upstream PR | Status |
+|---|--------|------|------|-------------|--------|
+| 1 | `TableUpdate`/`ViewUpdate` as discriminated enums | enablement | `sail-catalog-iceberg` models | **#2134** | ✅ merged (base) |
+| 2 | Round-trip manifest lower/upper bounds through Avro | **bug fix** | `sail-iceberg` manifest serde | **#2139** | 🟢 open |
+| 3 | Skip type-mismatched bound stats in pruning | **bug fix** | `sail-iceberg` datasource pruning | **#2139** | 🟢 open |
+| 4 | `apply_table_updates` — evolve `TableMetadata` server-side | enablement | `sail-iceberg` metadata | **#2135** | 🔴 closed (held) |
+| 5 | Expose planning helpers + commit-table provider seam | enablement | `sail-catalog`, `sail-catalog-iceberg` | **#2140** | 🟢 open |
+
+`lakecat` = base + commits 2–5 (commit 1 is already in `main`).
+
+---
+
+## Bug fixes (Iceberg correctness)
+
+These are pure correctness fixes in Sail's Iceberg reader; they benefit any Sail
+user, not just LakeCat, and are offered upstream as such.
+
+### 1. Manifest lower/upper bounds were silently lost on write — PR #2139
+*Commit `dcc83743` · `crates/sail-iceberg/src/spec/manifest/_serde.rs`*
+
+`IntBytesMapEntry.value` is a `Vec<u8>` typed as Avro `bytes` in the manifest
+schema, but serde's default `Vec<u8>` serialization emits an Avro **array**. That
+array fails to resolve against the `bytes` schema, so the nullable
+`lower_bounds` / `upper_bounds` maps were written as **null** — every per-column
+bound was lost on read.
+
+**Fix:** force byte-string (de)serialization on the entry value, while still
+tolerating the legacy array form on read for backward compatibility, so bounds
+survive the write/parse round-trip. (`sail-iceberg`: 79 tests pass.)
+
+**Impact:** without this, column bounds never reach the query planner, so
+manifest-level pruning is a no-op — full scans where a pruned scan was expected.
+
+### 2. Pruning could panic / mis-type on bound stats — PR #2139
+*Commit `eba9090d` · `crates/sail-iceberg/src/datasource/pruning.rs`*
+
+Once bounds round-trip correctly (fix #1), `IcebergPruningStats` feeds them to
+DataFusion's `PruningPredicate`. An Iceberg bound can decode to a primitive whose
+Arrow scalar type differs from how the predicate treats the column (the
+`to_scalar` fallback yields e.g. an `Int32` for a value the predicate compares as
+`Timestamp`/`Date`), tripping DataFusion's "same data type are comparable"
+assertion on partition-transform reads.
+
+**Fix:** wire up the previously-unused `arrow_schema` — `min_values` / `max_values`
+now **skip** stats whose array type does not match the logical column type, so
+pruning only applies with well-typed bounds and falls back to a full scan
+otherwise. No false pruning, no wrong results. (`sail-iceberg`: 79 tests pass;
+clippy + nightly fmt clean.)
+
+> Fixes 1 and 2 are sequential: #1 makes the bounds *exist*, #2 makes consuming
+> them *safe*. They ship together as PR #2139.
+
+---
+
+## Enabling changes (necessary updates for catalog features)
+
+These add the surface LakeCat needs. They are intentionally **additive and
+default-safe** — existing providers are unaffected — but because they extend the
+catalog provider trait, they are coordinated with the upstream redesign (#2141)
+rather than merged unilaterally.
+
+### 3. `TableUpdate` / `ViewUpdate` as discriminated enums — PR #2134 (merged)
+*Base `7da486db` · `crates/sail-catalog-iceberg/src/models/{table_update,view_update}.rs`, `lib.rs`*
+
+The OpenAPI-generated models represented Iceberg REST `TableUpdate` /
+`ViewUpdate` as flat structs, so the `action` discriminator could not be matched
+exhaustively. We hand-patched them into proper **discriminated (tagged) enums**,
+documenting the post-generation patch in
+`recipes/iceberg-openapi-generation.md`. This is the foundation everything below
+builds on — it is already merged into `main` and forms the `lakecat` base.
+
+### 4. `apply_table_updates` — server-side metadata evolution — PR #2135 (held)
+*Commit `cbccedf3` · `crates/sail-iceberg/src/spec/metadata/apply.rs`*
+
+A reusable `apply_table_updates(&mut TableMetadata, &[TableUpdate], now_ms)` that
+applies Iceberg REST metadata updates to produce new table metadata
+**server-side**, so a catalog (LakeCat) can materialize new metadata on commit
+instead of relying on the client to author it.
+
+- **Handled:** properties, location, uuid, format-version, schema,
+  current-schema, default-spec, sort-order, removals, statistics.
+- **Deliberately `NotImplemented`** (rather than producing incorrect metadata):
+  add-spec binding, add-snapshot sequencing, snapshot-ref state — the updates
+  that need deeper machinery.
+
+**Why held:** PR #2135 was opened as a draft and **closed** pending the Iceberg
+catalog-support decisions tracked in #982. The code remains on `lakecat` and is
+ready to re-propose once that direction is settled.
+
+### 5. Planning helpers + commit-table provider seam — PR #2140
+*Commit `a224c478` · `crates/sail-catalog-iceberg/src/{lib,planning,provider}.rs`, `crates/sail-catalog/src/provider/{mod,options}.rs`*
+
+Surfaces the symbols a thin REST-catalog bridge needs **without forking the
+generated models**:
+
+- **`sail-catalog-iceberg`:** make `models` public; add planning result helpers
+  (`completed_planning[_with_id]_result_from_values`,
+  `fetch_scan_tasks_result_from_values`); re-export `LoadTableResult` /
+  `TableMetadata`; expose `load_table_result_to_status` as a standalone
+  `pub fn` (the existing method now delegates to it).
+- **`sail-catalog`:** add `CommitTableOptions`, `GetTableCommitsOptions`,
+  `TableCommitInfo`, `GetTableCommitsResponse`, and **default** trait methods
+  `CatalogProvider::{commit_table, get_table_commits}` that return
+  `NotSupported`. Existing providers compile unchanged.
+
+**Why open but branch-tracked:** this is the piece that overlaps PR #2141's
+provider rework. It is proposed (PR #2140) for visibility and review, but kept on
+`lakecat` so LakeCat can build against it today regardless of when/how #2141
+lands.
+
+---
+
+## Consuming the branch
+
+LakeCat depends on these crates via git, pinned to the `lakecat` branch of the
+fork:
+
+```toml
+[dependencies]
+sail-catalog           = { git = "https://github.com/querygraph/sail", branch = "lakecat" }
+sail-catalog-iceberg   = { git = "https://github.com/querygraph/sail", branch = "lakecat" }
+sail-common-datafusion = { git = "https://github.com/querygraph/sail", branch = "lakecat" }
+```
+
+(`querygraph/sail` is our canonical fork; `lakecat` rebases onto `lakehq/sail`
+`main` as upstream moves. The two bug-fix commits, #2139, are also offered
+upstream and will drop out of the branch delta once merged.)
+
+## Upstream coordination
+
+- **Merge as they are:** #2139 (bug fixes 1–2) — independent of the redesign.
+- **Coordinate with #2141:** #2140 (provider seam) — same trait surface.
+- **Re-propose after #982 settles:** #2135 (`apply_table_updates`).
+
+## Related earlier catalog work (merged, for context)
+
+- **#2134** — `TableUpdate`/`ViewUpdate` discriminated enums (the base above).
+- **#1924** — fix `create()` table for Nessie, with a regression test.
+- **#1928** — improve the missing-JDBC-data-source error message.

--- a/crates/sail-catalog-iceberg/src/lib.rs
+++ b/crates/sail-catalog-iceberg/src/lib.rs
@@ -11,17 +11,23 @@
 // limitations under the License.
 
 #![expect(unused_imports)]
-#![expect(dead_code)]
 #![expect(clippy::all)]
 
 pub mod apis;
-mod models;
+pub mod models;
+mod planning;
 mod provider;
 
-pub use provider::{
-    IcebergRestCatalogProvider, REST_CATALOG_PROP_PREFIX, REST_CATALOG_PROP_URI,
-    REST_CATALOG_PROP_WAREHOUSE,
+pub use planning::{
+    completed_planning_result_from_values, completed_planning_with_id_result_from_values,
+    fetch_scan_tasks_result_from_values,
 };
+pub use provider::{
+    load_table_result_to_status, IcebergRestCatalogProvider, REST_CATALOG_PROP_PREFIX,
+    REST_CATALOG_PROP_URI, REST_CATALOG_PROP_WAREHOUSE,
+};
+
+pub use crate::models::{LoadTableResult, TableMetadata};
 
 #[cfg(test)]
 mod table_update_tests {

--- a/crates/sail-catalog-iceberg/src/planning.rs
+++ b/crates/sail-catalog-iceberg/src/planning.rs
@@ -1,0 +1,173 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use sail_catalog::error::{CatalogError, CatalogResult};
+use serde_json::Value;
+
+use crate::models;
+
+pub fn completed_planning_result_from_values(
+    plan_tasks: Vec<String>,
+    file_scan_tasks: Vec<Value>,
+    delete_files: Vec<Value>,
+) -> CatalogResult<models::CompletedPlanningResult> {
+    let mut result = models::CompletedPlanningResult::new(models::PlanStatus::Completed);
+    result.plan_tasks = non_empty(plan_tasks);
+    result.file_scan_tasks = parse_optional_values(file_scan_tasks, "file-scan-tasks")?;
+    result.delete_files = parse_delete_files(delete_files)?;
+    Ok(result)
+}
+
+pub fn completed_planning_with_id_result_from_values(
+    plan_id: Option<String>,
+    plan_tasks: Vec<String>,
+    file_scan_tasks: Vec<Value>,
+    delete_files: Vec<Value>,
+) -> CatalogResult<models::CompletedPlanningWithIdResult> {
+    let mut result = models::CompletedPlanningWithIdResult::new(models::PlanStatus::Completed);
+    result.plan_id = plan_id;
+    result.plan_tasks = non_empty(plan_tasks);
+    result.file_scan_tasks = parse_optional_values(file_scan_tasks, "file-scan-tasks")?;
+    result.delete_files = parse_delete_files(delete_files)?;
+    Ok(result)
+}
+
+pub fn fetch_scan_tasks_result_from_values(
+    plan_tasks: Vec<String>,
+    file_scan_tasks: Vec<Value>,
+    delete_files: Vec<Value>,
+) -> CatalogResult<models::FetchScanTasksResult> {
+    let mut result = models::FetchScanTasksResult::new();
+    result.plan_tasks = non_empty(plan_tasks);
+    result.file_scan_tasks = parse_optional_values(file_scan_tasks, "file-scan-tasks")?;
+    result.delete_files = parse_delete_files(delete_files)?;
+    Ok(result)
+}
+
+fn non_empty<T>(values: Vec<T>) -> Option<Vec<T>> {
+    (!values.is_empty()).then_some(values)
+}
+
+fn parse_optional_values<T: serde::de::DeserializeOwned>(
+    values: Vec<Value>,
+    label: &str,
+) -> CatalogResult<Option<Vec<T>>> {
+    if values.is_empty() {
+        return Ok(None);
+    }
+    serde_json::from_value(Value::Array(values))
+        .map(Some)
+        .map_err(|err| {
+            CatalogError::External(format!("invalid Iceberg REST {label} payload: {err}"))
+        })
+}
+
+fn parse_delete_files(values: Vec<Value>) -> CatalogResult<Option<Vec<models::DeleteFile>>> {
+    if values.is_empty() {
+        return Ok(None);
+    }
+    values
+        .into_iter()
+        .map(parse_delete_file)
+        .collect::<CatalogResult<Vec<_>>>()
+        .map(Some)
+}
+
+fn parse_delete_file(value: Value) -> CatalogResult<models::DeleteFile> {
+    match value.get("content").and_then(Value::as_str) {
+        Some("position-deletes") => serde_json::from_value(value)
+            .map(|file| models::DeleteFile::PositionDeletes(Box::new(file)))
+            .map_err(delete_file_error),
+        Some("equality-deletes") => serde_json::from_value(value)
+            .map(|file| models::DeleteFile::EqualityDeletes(Box::new(file)))
+            .map_err(delete_file_error),
+        Some(content) => Err(CatalogError::External(format!(
+            "invalid Iceberg REST delete-files payload: unsupported content {content}"
+        ))),
+        None => Err(CatalogError::External(
+            "invalid Iceberg REST delete-files payload: missing content".to_string(),
+        )),
+    }
+}
+
+fn delete_file_error(err: serde_json::Error) -> CatalogError {
+    CatalogError::External(format!("invalid Iceberg REST delete-files payload: {err}"))
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn builds_completed_planning_result_from_plan_tokens() {
+        let result = completed_planning_result_from_values(
+            vec!["task-1".to_string(), "task-2".to_string()],
+            Vec::new(),
+            Vec::new(),
+        )
+        .expect("planning result");
+
+        assert_eq!(result.status, models::PlanStatus::Completed);
+        assert_eq!(
+            result.plan_tasks,
+            Some(vec!["task-1".to_string(), "task-2".to_string()])
+        );
+        assert!(result.file_scan_tasks.is_none());
+        assert!(result.delete_files.is_none());
+    }
+
+    #[test]
+    fn builds_fetch_scan_tasks_result_from_concrete_delete_files() {
+        let data_file = json!({
+            "content": "data",
+            "file-path": "file:///tmp/events/data-1.parquet",
+            "file-format": "parquet",
+            "spec-id": 0,
+            "partition": [],
+            "file-size-in-bytes": 100,
+            "record-count": 10
+        });
+        let delete_file = json!({
+            "content": "position-deletes",
+            "file-path": "file:///tmp/events/delete-1.parquet",
+            "file-format": "parquet",
+            "spec-id": 0,
+            "partition": [],
+            "file-size-in-bytes": 50,
+            "record-count": 1
+        });
+
+        let result = fetch_scan_tasks_result_from_values(
+            vec!["child-task".to_string()],
+            vec![json!({
+                "data-file": data_file,
+                "delete-file-references": [0]
+            })],
+            vec![delete_file],
+        )
+        .expect("fetch scan tasks result");
+
+        assert_eq!(result.plan_tasks, Some(vec!["child-task".to_string()]));
+        assert_eq!(result.file_scan_tasks.as_ref().unwrap().len(), 1);
+        assert_eq!(
+            result.file_scan_tasks.as_ref().unwrap()[0].delete_file_references,
+            Some(vec![0])
+        );
+        assert!(matches!(
+            result.delete_files.as_ref().unwrap()[0],
+            models::DeleteFile::PositionDeletes(_)
+        ));
+    }
+}

--- a/crates/sail-catalog-iceberg/src/provider.rs
+++ b/crates/sail-catalog-iceberg/src/provider.rs
@@ -543,241 +543,7 @@ impl IcebergRestCatalogProvider {
         database: &Namespace,
         result: crate::models::LoadTableResult,
     ) -> CatalogResult<TableStatus> {
-        // Table-specific config and storage credentials are access-session state, not
-        // display table properties.
-        // TODO: Preserve unused fields in `TableMetadata` when Sail exposes them.
-        let crate::models::TableMetadata {
-            format_version,
-            table_uuid,
-            location,
-            last_updated_ms,
-            next_row_id,
-            properties,
-            schemas,
-            current_schema_id,
-            last_column_id,
-            partition_specs,
-            default_spec_id,
-            last_partition_id,
-            sort_orders,
-            default_sort_order_id,
-            encryption_keys: _,
-            snapshots: _,
-            refs: _,
-            current_snapshot_id,
-            last_sequence_number,
-            snapshot_log: _,
-            metadata_log: _,
-            statistics,
-            partition_statistics,
-        } = *result.metadata;
-
-        let current_schema =
-            find_by_id_or_last(schemas.as_ref(), current_schema_id, |s| s.schema_id);
-        let default_partition_spec =
-            find_by_id_or_last(partition_specs.as_ref(), default_spec_id, |s| s.spec_id);
-
-        let partition_field_ids: std::collections::HashSet<i32> = default_partition_spec
-            .map(|spec| spec.fields.iter().map(|f| f.source_id).collect())
-            .unwrap_or_default();
-
-        let bucket_field_ids: std::collections::HashSet<i32> = default_partition_spec
-            .map(|spec| {
-                spec.fields
-                    .iter()
-                    .filter(|f| f.transform.trim().to_lowercase().starts_with("bucket"))
-                    .map(|f| f.source_id)
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        let partition_by = match (current_schema, default_partition_spec) {
-            (Some(schema), Some(spec)) => spec
-                .fields
-                .iter()
-                .map(|field| {
-                    let source_column = schema
-                        .fields
-                        .iter()
-                        .find(|f| f.id == field.source_id)
-                        .ok_or_else(|| {
-                            CatalogError::External(format!(
-                                "Partition field source id {} not found in schema",
-                                field.source_id
-                            ))
-                        })?
-                        .name
-                        .clone();
-                    let transform = field.transform.parse().map_err(CatalogError::External)?;
-                    catalog_partition_field_from_iceberg(source_column, transform)
-                        .map_err(CatalogError::External)
-                })
-                .collect::<CatalogResult<Vec<_>>>()?,
-            _ => Vec::new(),
-        };
-
-        let columns = if let Some(schema) = current_schema {
-            let mut cols = Vec::new();
-            for field in &schema.fields {
-                let data_type = iceberg_type_to_arrow(&field.field_type).map_err(|e| {
-                    CatalogError::External(format!(
-                        "Failed to convert Iceberg type to Arrow type for field '{}': {e}",
-                        field.name
-                    ))
-                })?;
-                let field_id = field.id;
-                cols.push(TableColumnStatus {
-                    name: field.name.clone(),
-                    data_type,
-                    nullable: !field.required,
-                    comment: field.doc.clone(),
-                    default: None,
-                    generated_always_as: None,
-                    identity: None,
-                    is_partition: partition_field_ids.contains(&field_id),
-                    is_bucket: bucket_field_ids.contains(&field_id),
-                    is_cluster: false,
-                });
-            }
-            cols
-        } else {
-            Vec::new()
-        };
-
-        let default_sort_order =
-            find_by_id_or_last(sort_orders.as_ref(), default_sort_order_id, |o| {
-                Some(o.order_id)
-            });
-
-        let sort_by: Vec<CatalogTableSort> = default_sort_order
-            .map(|order| {
-                order
-                    .fields
-                    .iter()
-                    .filter_map(|sort_field| {
-                        let field_id = sort_field.source_id;
-                        current_schema.and_then(|schema| {
-                            schema
-                                .fields
-                                .iter()
-                                .find(|f| f.id == field_id)
-                                .map(|field| {
-                                    let ascending = match sort_field.direction {
-                                        crate::models::SortDirection::Asc => true,
-                                        crate::models::SortDirection::Desc => false,
-                                    };
-                                    CatalogTableSort {
-                                        column: field.name.clone(),
-                                        ascending,
-                                    }
-                                })
-                        })
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        let constraints = current_schema
-            .and_then(|schema| {
-                schema.identifier_field_ids.as_ref().and_then(|ids| {
-                    if ids.is_empty() {
-                        None
-                    } else {
-                        let pk_columns: Vec<String> = ids
-                            .iter()
-                            .filter_map(|id| {
-                                schema
-                                    .fields
-                                    .iter()
-                                    .find(|f| f.id == *id)
-                                    .map(|f| f.name.clone())
-                            })
-                            .collect();
-                        if pk_columns.is_empty() {
-                            None
-                        } else {
-                            Some(vec![CatalogTableConstraint::PrimaryKey {
-                                name: None,
-                                columns: pk_columns,
-                            }])
-                        }
-                    }
-                })
-            })
-            .unwrap_or_default();
-
-        let mut properties: HashMap<String, String> = properties.unwrap_or_default();
-
-        let comment = get_property(&properties, "comment");
-
-        if let Some(metadata_location) = result.metadata_location {
-            properties.insert(METADATA_LOCATION_KEY.to_string(), metadata_location);
-        }
-        properties.insert(
-            "metadata.format-version".to_string(),
-            format_version.to_string(),
-        );
-        properties.insert("metadata.table-uuid".to_string(), table_uuid);
-
-        if let Some(v) = last_updated_ms {
-            properties.insert("metadata.last-updated-ms".to_string(), v.to_string());
-        }
-        if let Some(v) = next_row_id {
-            properties.insert("metadata.next-row-id".to_string(), v.to_string());
-        }
-        if let Some(v) = current_schema_id {
-            properties.insert("metadata.current-schema-id".to_string(), v.to_string());
-        }
-        if let Some(v) = last_column_id {
-            properties.insert("metadata.last-column-id".to_string(), v.to_string());
-        }
-        if let Some(v) = default_spec_id {
-            properties.insert("metadata.default-spec-id".to_string(), v.to_string());
-        }
-        if let Some(v) = last_partition_id {
-            properties.insert("metadata.last-partition-id".to_string(), v.to_string());
-        }
-        if let Some(v) = default_sort_order_id {
-            properties.insert("metadata.default-sort-order-id".to_string(), v.to_string());
-        }
-        if let Some(v) = current_snapshot_id {
-            properties.insert("metadata.current-snapshot-id".to_string(), v.to_string());
-        }
-        if let Some(v) = last_sequence_number {
-            properties.insert("metadata.last-sequence-number".to_string(), v.to_string());
-        }
-        if let Some(v) = statistics {
-            properties.insert(
-                "metadata.statistics".to_string(),
-                serde_json::to_string(&v).unwrap_or_default(),
-            );
-        }
-        if let Some(v) = partition_statistics {
-            properties.insert(
-                "metadata.partition-statistics".to_string(),
-                serde_json::to_string(&v).unwrap_or_default(),
-            );
-        }
-
-        let properties: Vec<_> = properties.into_iter().collect();
-
-        Ok(TableStatus {
-            catalog: Some(self.name.clone()),
-            database: database.clone().into(),
-            name: table_name.to_string(),
-            kind: TableKind::Table {
-                columns,
-                comment,
-                constraints,
-                location,
-                format: "iceberg".to_string(),
-                partition_by,
-                sort_by,
-                bucket_by: None,
-                properties,
-                is_external: true,
-            },
-        })
+        load_table_result_to_status(&self.name, table_name, database, result)
     }
 
     fn load_view_result_to_status(
@@ -3471,4 +3237,248 @@ mod tests {
         test_get_database_impl(None).await;
         test_get_database_impl(Some("test")).await;
     }
+}
+
+/// Converts an Iceberg REST API table load result into a catalog `TableStatus`
+/// for an explicitly named catalog. Standalone form of the provider method so
+/// callers (e.g. the LakeCat Sail bridge) can reuse the conversion.
+pub fn load_table_result_to_status(
+    catalog: &str,
+    table_name: &str,
+    database: &Namespace,
+    result: crate::models::LoadTableResult,
+) -> CatalogResult<TableStatus> {
+    // Table-specific config and storage credentials are access-session state, not
+    // display table properties.
+    // TODO: Preserve unused fields in `TableMetadata` when Sail exposes them.
+    let crate::models::TableMetadata {
+        format_version,
+        table_uuid,
+        location,
+        last_updated_ms,
+        next_row_id,
+        properties,
+        schemas,
+        current_schema_id,
+        last_column_id,
+        partition_specs,
+        default_spec_id,
+        last_partition_id,
+        sort_orders,
+        default_sort_order_id,
+        encryption_keys: _,
+        snapshots: _,
+        refs: _,
+        current_snapshot_id,
+        last_sequence_number,
+        snapshot_log: _,
+        metadata_log: _,
+        statistics,
+        partition_statistics,
+    } = *result.metadata;
+
+    let current_schema = find_by_id_or_last(schemas.as_ref(), current_schema_id, |s| s.schema_id);
+    let default_partition_spec =
+        find_by_id_or_last(partition_specs.as_ref(), default_spec_id, |s| s.spec_id);
+
+    let partition_field_ids: std::collections::HashSet<i32> = default_partition_spec
+        .map(|spec| spec.fields.iter().map(|f| f.source_id).collect())
+        .unwrap_or_default();
+
+    let bucket_field_ids: std::collections::HashSet<i32> = default_partition_spec
+        .map(|spec| {
+            spec.fields
+                .iter()
+                .filter(|f| f.transform.trim().to_lowercase().starts_with("bucket"))
+                .map(|f| f.source_id)
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let partition_by = match (current_schema, default_partition_spec) {
+        (Some(schema), Some(spec)) => spec
+            .fields
+            .iter()
+            .map(|field| {
+                let source_column = schema
+                    .fields
+                    .iter()
+                    .find(|f| f.id == field.source_id)
+                    .ok_or_else(|| {
+                        CatalogError::External(format!(
+                            "Partition field source id {} not found in schema",
+                            field.source_id
+                        ))
+                    })?
+                    .name
+                    .clone();
+                let transform = field.transform.parse().map_err(CatalogError::External)?;
+                catalog_partition_field_from_iceberg(source_column, transform)
+                    .map_err(CatalogError::External)
+            })
+            .collect::<CatalogResult<Vec<_>>>()?,
+        _ => Vec::new(),
+    };
+
+    let columns = if let Some(schema) = current_schema {
+        let mut cols = Vec::new();
+        for field in &schema.fields {
+            let data_type = iceberg_type_to_arrow(&field.field_type).map_err(|e| {
+                CatalogError::External(format!(
+                    "Failed to convert Iceberg type to Arrow type for field '{}': {e}",
+                    field.name
+                ))
+            })?;
+            let field_id = field.id;
+            cols.push(TableColumnStatus {
+                name: field.name.clone(),
+                data_type,
+                nullable: !field.required,
+                comment: field.doc.clone(),
+                default: None,
+                generated_always_as: None,
+                identity: None,
+                is_partition: partition_field_ids.contains(&field_id),
+                is_bucket: bucket_field_ids.contains(&field_id),
+                is_cluster: false,
+            });
+        }
+        cols
+    } else {
+        Vec::new()
+    };
+
+    let default_sort_order = find_by_id_or_last(sort_orders.as_ref(), default_sort_order_id, |o| {
+        Some(o.order_id)
+    });
+
+    let sort_by: Vec<CatalogTableSort> = default_sort_order
+        .map(|order| {
+            order
+                .fields
+                .iter()
+                .filter_map(|sort_field| {
+                    let field_id = sort_field.source_id;
+                    current_schema.and_then(|schema| {
+                        schema
+                            .fields
+                            .iter()
+                            .find(|f| f.id == field_id)
+                            .map(|field| {
+                                let ascending = match sort_field.direction {
+                                    crate::models::SortDirection::Asc => true,
+                                    crate::models::SortDirection::Desc => false,
+                                };
+                                CatalogTableSort {
+                                    column: field.name.clone(),
+                                    ascending,
+                                }
+                            })
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let constraints = current_schema
+        .and_then(|schema| {
+            schema.identifier_field_ids.as_ref().and_then(|ids| {
+                if ids.is_empty() {
+                    None
+                } else {
+                    let pk_columns: Vec<String> = ids
+                        .iter()
+                        .filter_map(|id| {
+                            schema
+                                .fields
+                                .iter()
+                                .find(|f| f.id == *id)
+                                .map(|f| f.name.clone())
+                        })
+                        .collect();
+                    if pk_columns.is_empty() {
+                        None
+                    } else {
+                        Some(vec![CatalogTableConstraint::PrimaryKey {
+                            name: None,
+                            columns: pk_columns,
+                        }])
+                    }
+                }
+            })
+        })
+        .unwrap_or_default();
+
+    let mut properties: HashMap<String, String> = properties.unwrap_or_default();
+
+    let comment = get_property(&properties, "comment");
+
+    if let Some(metadata_location) = result.metadata_location {
+        properties.insert(METADATA_LOCATION_KEY.to_string(), metadata_location);
+    }
+    properties.insert(
+        "metadata.format-version".to_string(),
+        format_version.to_string(),
+    );
+    properties.insert("metadata.table-uuid".to_string(), table_uuid);
+
+    if let Some(v) = last_updated_ms {
+        properties.insert("metadata.last-updated-ms".to_string(), v.to_string());
+    }
+    if let Some(v) = next_row_id {
+        properties.insert("metadata.next-row-id".to_string(), v.to_string());
+    }
+    if let Some(v) = current_schema_id {
+        properties.insert("metadata.current-schema-id".to_string(), v.to_string());
+    }
+    if let Some(v) = last_column_id {
+        properties.insert("metadata.last-column-id".to_string(), v.to_string());
+    }
+    if let Some(v) = default_spec_id {
+        properties.insert("metadata.default-spec-id".to_string(), v.to_string());
+    }
+    if let Some(v) = last_partition_id {
+        properties.insert("metadata.last-partition-id".to_string(), v.to_string());
+    }
+    if let Some(v) = default_sort_order_id {
+        properties.insert("metadata.default-sort-order-id".to_string(), v.to_string());
+    }
+    if let Some(v) = current_snapshot_id {
+        properties.insert("metadata.current-snapshot-id".to_string(), v.to_string());
+    }
+    if let Some(v) = last_sequence_number {
+        properties.insert("metadata.last-sequence-number".to_string(), v.to_string());
+    }
+    if let Some(v) = statistics {
+        properties.insert(
+            "metadata.statistics".to_string(),
+            serde_json::to_string(&v).unwrap_or_default(),
+        );
+    }
+    if let Some(v) = partition_statistics {
+        properties.insert(
+            "metadata.partition-statistics".to_string(),
+            serde_json::to_string(&v).unwrap_or_default(),
+        );
+    }
+
+    let properties: Vec<_> = properties.into_iter().collect();
+
+    Ok(TableStatus {
+        catalog: Some(catalog.to_string()),
+        database: database.clone().into(),
+        name: table_name.to_string(),
+        kind: TableKind::Table {
+            columns,
+            comment,
+            constraints,
+            location,
+            format: "iceberg".to_string(),
+            partition_by,
+            sort_by,
+            bucket_by: None,
+            properties,
+            is_external: true,
+        },
+    })
 }

--- a/crates/sail-catalog/src/provider/mod.rs
+++ b/crates/sail-catalog/src/provider/mod.rs
@@ -182,6 +182,35 @@ pub trait CatalogProvider: Send + Sync {
         options: AlterTableOptions,
     ) -> CatalogResult<()>;
 
+    /// Commits requirement-guarded updates to a table (Iceberg REST commit-table
+    /// extension). Providers that do not support server-side commit return
+    /// `NotSupported`.
+    async fn commit_table(
+        &self,
+        database: &Namespace,
+        table: &str,
+        options: CommitTableOptions,
+    ) -> CatalogResult<TableStatus> {
+        let _ = (database, table, options);
+        Err(CatalogError::NotSupported(
+            "commit_table is not supported by this catalog provider".to_string(),
+        ))
+    }
+
+    /// Lists historical table commits (Iceberg REST extension). Providers that do
+    /// not track commit history return `NotSupported`.
+    async fn get_table_commits(
+        &self,
+        database: &Namespace,
+        table: &str,
+        options: GetTableCommitsOptions,
+    ) -> CatalogResult<GetTableCommitsResponse> {
+        let _ = (database, table, options);
+        Err(CatalogError::NotSupported(
+            "get_table_commits is not supported by this catalog provider".to_string(),
+        ))
+    }
+
     /// Creates a view in the catalog.
     async fn create_view(
         &self,

--- a/crates/sail-catalog/src/provider/options.rs
+++ b/crates/sail-catalog/src/provider/options.rs
@@ -157,3 +157,41 @@ pub enum AlterTableOptions {
         expression: String,
     },
 }
+
+/// Options for [`CatalogProvider::commit_table`](super::CatalogProvider::commit_table),
+/// the Iceberg REST commit-table extension. `requirements` and `updates` carry the
+/// raw Iceberg REST JSON requirement/update objects.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct CommitTableOptions {
+    pub format: String,
+    pub requirements: Vec<serde_json::Value>,
+    pub updates: Vec<serde_json::Value>,
+}
+
+/// Options for
+/// [`CatalogProvider::get_table_commits`](super::CatalogProvider::get_table_commits).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct GetTableCommitsOptions {
+    pub format: String,
+    pub table_uri: String,
+    pub start_version: i64,
+    pub end_version: Option<i64>,
+}
+
+/// A single historical table-commit descriptor returned by `get_table_commits`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TableCommitInfo {
+    pub version: i64,
+    pub timestamp: i64,
+    pub file_name: String,
+    pub file_size: i64,
+    pub file_modification_timestamp: i64,
+}
+
+/// Response for
+/// [`CatalogProvider::get_table_commits`](super::CatalogProvider::get_table_commits).
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct GetTableCommitsResponse {
+    pub latest_table_version: i64,
+    pub commits: Vec<TableCommitInfo>,
+}

--- a/crates/sail-iceberg/src/datasource/pruning.rs
+++ b/crates/sail-iceberg/src/datasource/pruning.rs
@@ -35,7 +35,6 @@ use crate::utils::transform::apply_transform;
 /// Pruning statistics over Iceberg DataFiles
 pub struct IcebergPruningStats {
     files: Vec<DataFile>,
-    #[expect(unused)]
     arrow_schema: Arc<ArrowSchema>,
     /// Arrow field name -> Iceberg field id
     name_to_field_id: HashMap<String, i32>,
@@ -101,6 +100,20 @@ impl IcebergPruningStats {
             }
         }
     }
+
+    /// True when `arr`'s Arrow type matches the logical column type, so
+    /// DataFusion's pruning comparisons are well-typed. An Iceberg bound can
+    /// decode to a primitive whose scalar type differs from how the predicate
+    /// treats the column (e.g. an `Int32` fallback for a `Timestamp`/`Date`
+    /// column), and feeding that to the pruning predicate trips DataFusion's
+    /// "same data type are comparable" assertion. Callers skip mismatched
+    /// stats rather than prune on an incomparable type.
+    fn stats_type_matches(&self, column: &Column, arr: &ArrayRef) -> bool {
+        match self.arrow_schema.field_with_name(&column.name) {
+            Ok(field) => field.data_type() == arr.data_type(),
+            Err(_) => false,
+        }
+    }
 }
 
 impl PruningStatistics for IcebergPruningStats {
@@ -118,6 +131,9 @@ impl PruningStatistics for IcebergPruningStats {
         let values =
             scalars.map(|opt| opt.unwrap_or(datafusion::common::scalar::ScalarValue::Null));
         let arr = datafusion::common::scalar::ScalarValue::iter_to_array(values).ok()?;
+        if !self.stats_type_matches(column, &arr) {
+            return None;
+        }
         self.min_cache.borrow_mut().insert(field_id, arr.clone());
         Some(arr)
     }
@@ -135,6 +151,9 @@ impl PruningStatistics for IcebergPruningStats {
         let values =
             scalars.map(|opt| opt.unwrap_or(datafusion::common::scalar::ScalarValue::Null));
         let arr = datafusion::common::scalar::ScalarValue::iter_to_array(values).ok()?;
+        if !self.stats_type_matches(column, &arr) {
+            return None;
+        }
         self.max_cache.borrow_mut().insert(field_id, arr.clone());
         Some(arr)
     }

--- a/crates/sail-iceberg/src/spec/manifest/_serde.rs
+++ b/crates/sail-iceberg/src/spec/manifest/_serde.rs
@@ -35,7 +35,63 @@ pub(super) struct IntLongMapEntry {
 #[derive(Serialize, Deserialize)]
 pub(super) struct IntBytesMapEntry {
     key: i32,
+    // The Iceberg manifest Avro schema types this as `bytes`. `serde`'s default
+    // for `Vec<u8>` emits an Avro *array*, which fails to resolve against the
+    // `bytes` schema and silently nulls out the (nullable) bounds map. Force the
+    // byte-string encoding on both sides so lower/upper bounds round-trip.
+    #[serde(
+        serialize_with = "serialize_byte_buf",
+        deserialize_with = "deserialize_byte_buf"
+    )]
     value: Vec<u8>,
+}
+
+fn serialize_byte_buf<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_bytes(bytes)
+}
+
+fn deserialize_byte_buf<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct ByteBufVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for ByteBufVisitor {
+        type Value = Vec<u8>;
+
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("Avro bytes or a sequence of byte values")
+        }
+
+        fn visit_bytes<E>(self, v: &[u8]) -> Result<Vec<u8>, E> {
+            Ok(v.to_vec())
+        }
+
+        fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Vec<u8>, E> {
+            Ok(v)
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Vec<u8>, E> {
+            Ok(v.as_bytes().to_vec())
+        }
+
+        // Backward-compat: tolerate manifests previously written as an array.
+        fn visit_seq<A>(self, mut seq: A) -> Result<Vec<u8>, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut out = Vec::new();
+            while let Some(byte) = seq.next_element::<u8>()? {
+                out.push(byte);
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_byte_buf(ByteBufVisitor)
 }
 
 #[derive(Deserialize)]

--- a/crates/sail-iceberg/src/spec/metadata/apply.rs
+++ b/crates/sail-iceberg/src/spec/metadata/apply.rs
@@ -1,0 +1,197 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Apply Iceberg REST `TableUpdate`s to a [`TableMetadata`].
+//!
+//! A catalog receiving an `updateTable` (commit) request needs to evolve the
+//! current table metadata by the requested updates to produce the new metadata
+//! document it then persists. This is engine-owned table-format work, so it
+//! lives in Sail rather than being hand-rolled in the catalog.
+//!
+//! The metadata-only and removal updates are implemented fully. Updates that
+//! require deeper engine machinery (partition-spec binding, snapshot
+//! sequencing, snapshot-ref state) return `NotImplemented` rather than
+//! silently producing incorrect metadata; those belong in a complete
+//! `TableMetadataBuilder` port.
+
+use datafusion_common::{not_impl_err, DataFusionError, Result};
+
+use crate::spec::catalog::TableUpdate;
+use crate::spec::metadata::table_metadata::TableMetadata;
+
+/// Apply a sequence of `TableUpdate`s to `metadata` in order. On any applied
+/// change, `last_updated_ms` is advanced to `now_ms`.
+pub fn apply_table_updates(
+    metadata: &mut TableMetadata,
+    updates: &[TableUpdate],
+    now_ms: i64,
+) -> Result<()> {
+    for update in updates {
+        apply_one(metadata, update)?;
+    }
+    if !updates.is_empty() {
+        metadata.last_updated_ms = now_ms;
+    }
+    Ok(())
+}
+
+fn apply_one(metadata: &mut TableMetadata, update: &TableUpdate) -> Result<()> {
+    match update {
+        TableUpdate::SetProperties { updates } => {
+            for (k, v) in updates {
+                metadata.properties.insert(k.clone(), v.clone());
+            }
+        }
+        TableUpdate::RemoveProperties { removals } => {
+            for k in removals {
+                metadata.properties.remove(k);
+            }
+        }
+        TableUpdate::SetLocation { location } => {
+            metadata.location = location.clone();
+        }
+        TableUpdate::AssignUuid { uuid } => {
+            metadata.table_uuid = Some(*uuid);
+        }
+        TableUpdate::UpgradeFormatVersion { format_version } => {
+            metadata.format_version = *format_version;
+        }
+        TableUpdate::AddSchema { schema } => {
+            let schema_id = schema.schema_id();
+            metadata.last_column_id = metadata.last_column_id.max(schema.highest_field_id());
+            if let Some(existing) = metadata
+                .schemas
+                .iter_mut()
+                .find(|s| s.schema_id() == schema_id)
+            {
+                *existing = (**schema).clone();
+            } else {
+                metadata.schemas.push((**schema).clone());
+            }
+        }
+        TableUpdate::SetCurrentSchema { schema_id } => {
+            let resolved = if *schema_id == -1 {
+                metadata
+                    .schemas
+                    .last()
+                    .map(|s| s.schema_id())
+                    .ok_or_else(|| invalid("set-current-schema -1 with no schemas added"))?
+            } else {
+                *schema_id
+            };
+            if !metadata.schemas.iter().any(|s| s.schema_id() == resolved) {
+                return Err(invalid(format!("unknown schema-id {resolved}")));
+            }
+            metadata.current_schema_id = resolved;
+        }
+        TableUpdate::SetDefaultSpec { spec_id } => {
+            let resolved = if *spec_id == -1 {
+                metadata
+                    .partition_specs
+                    .last()
+                    .map(|s| s.spec_id())
+                    .ok_or_else(|| invalid("set-default-spec -1 with no specs added"))?
+            } else {
+                *spec_id
+            };
+            metadata.default_spec_id = resolved;
+        }
+        TableUpdate::AddSortOrder { sort_order } => {
+            let order_id = sort_order.order_id;
+            if let Some(existing) = metadata
+                .sort_orders
+                .iter_mut()
+                .find(|o| o.order_id == order_id)
+            {
+                *existing = sort_order.clone();
+            } else {
+                metadata.sort_orders.push(sort_order.clone());
+            }
+        }
+        TableUpdate::SetDefaultSortOrder { sort_order_id } => {
+            let resolved = if *sort_order_id == -1 {
+                metadata
+                    .sort_orders
+                    .last()
+                    .map(|o| o.order_id)
+                    .ok_or_else(|| invalid("set-default-sort-order -1 with no sort orders added"))?
+            } else {
+                *sort_order_id
+            };
+            metadata.default_sort_order_id = Some(resolved as i32);
+        }
+        TableUpdate::RemoveSnapshots { snapshot_ids } => {
+            metadata
+                .snapshots
+                .retain(|s| !snapshot_ids.contains(&s.snapshot_id()));
+            if let Some(current) = metadata.current_snapshot_id {
+                if snapshot_ids.contains(&current) {
+                    metadata.current_snapshot_id = None;
+                }
+            }
+        }
+        TableUpdate::RemoveSnapshotRef { ref_name } => {
+            metadata.refs.remove(ref_name);
+            if ref_name == "main" {
+                metadata.current_snapshot_id = None;
+            }
+        }
+        TableUpdate::RemovePartitionSpecs { spec_ids } => {
+            metadata
+                .partition_specs
+                .retain(|s| !spec_ids.contains(&s.spec_id()));
+        }
+        TableUpdate::RemoveSchemas { schema_ids } => {
+            metadata
+                .schemas
+                .retain(|s| !schema_ids.contains(&s.schema_id()));
+        }
+        TableUpdate::SetStatistics { statistics } => {
+            let snapshot_id = statistics.snapshot_id;
+            metadata.statistics.retain(|s| s.snapshot_id != snapshot_id);
+            metadata.statistics.push(statistics.clone());
+        }
+        TableUpdate::RemoveStatistics { snapshot_id } => {
+            metadata
+                .statistics
+                .retain(|s| s.snapshot_id != *snapshot_id);
+        }
+        // These require partition-spec binding, snapshot sequencing, or
+        // snapshot-ref state machinery — defer to a complete builder rather than
+        // produce incorrect metadata.
+        other => {
+            return not_impl_err!(
+                "TableUpdate not yet supported by apply_table_updates: {}",
+                update_kind(other)
+            );
+        }
+    }
+    Ok(())
+}
+
+fn update_kind(update: &TableUpdate) -> &'static str {
+    match update {
+        TableUpdate::AddSpec { .. } => "add-spec",
+        TableUpdate::AddSnapshot { .. } => "add-snapshot",
+        TableUpdate::SetSnapshotRef { .. } => "set-snapshot-ref",
+        _ => "unsupported",
+    }
+}
+
+fn invalid(msg: impl Into<String>) -> DataFusionError {
+    DataFusionError::Plan(msg.into())
+}

--- a/crates/sail-iceberg/src/spec/metadata/mod.rs
+++ b/crates/sail-iceberg/src/spec/metadata/mod.rs
@@ -10,11 +10,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod apply;
 pub mod format;
 pub mod statistic_file;
 pub mod table_metadata;
 pub mod table_metadata_builder;
 
+pub use apply::apply_table_updates;
 pub use format::*;
 pub use statistic_file::*;
 pub use table_metadata::*;


### PR DESCRIPTION
## LakeCat ↔ Sail: catalog & Iceberg changes (tracking)

This PR bundles the Sail-side changes that **LakeCat** (an Iceberg REST catalog
sitting close to the engine) depends on, and adds **`LAKECAT-SAIL.md`** as the
running record of what they are, why they live on the `lakecat` branch, and
which pieces are proposed upstream.

It is a **tracking / overview PR** against our fork — not a request to merge into
`lakehq/sail` `main`. The correctness fixes are offered upstream separately; the
provider-surface changes are held here to avoid churning against the parallel
upstream redesign.

### What's in the branch (atop `lakehq/sail@7da486db`, the merged #2134)

| Change | Kind | Orig. PR | Status |
|--------|------|----------|--------|
| Round-trip manifest lower/upper bounds through Avro | **bug fix** | #2139 | consolidated here |
| Skip type-mismatched bound stats in pruning | **bug fix** | #2139 | consolidated here |
| `apply_table_updates` — evolve `TableMetadata` server-side | enablement | #2135 | consolidated here (held) |
| Expose planning helpers + commit-table provider seam | enablement | #2140 | consolidated here |
| `docs(lakecat)`: add `LAKECAT-SAIL.md` | docs | — | this PR |

### Correctness fixes (#2139)
- Manifest `lower_bounds`/`upper_bounds` were silently written as `null` because
  serde encoded the `bytes`-typed value as an Avro array — bounds were lost on
  read, defeating pruning. Forced byte-string (de)serialization, tolerant of the
  legacy array form.
- Once bounds exist, pruning skips stats whose Arrow type doesn't match the
  logical column type, avoiding DataFusion's comparability assertion on
  partition-transform reads (no false pruning, no wrong results).

### Enablement (coordinated with upstream)
- `apply_table_updates(&mut TableMetadata, &[TableUpdate], now_ms)` materializes
  new metadata server-side (properties, schema, spec, sort-order, statistics, …),
  returning `NotImplemented` for updates needing deeper machinery. Held pending
  Iceberg catalog decisions (#982); originally #2135.
- Additive, default-safe provider seam: public `models`, planning-result helpers,
  and default `CatalogProvider::{commit_table, get_table_commits}` →
  `NotSupported`. Overlaps the provider rework in **#2141**, so kept on-branch;
  proposed as **#2140** for review.

### Note: the bug fixes are independently mergeable

This PR is a tracking/overview of the whole `lakecat` branch, but it is now the
only open carrier of the two **correctness fixes** (manifest-bounds round-trip
and pruning type-safety, formerly #2139). Those are independent of the
catalog-provider redesign (#2141) and of the Iceberg catalog-support decisions
(#982) — they should **not** be blocked behind the enablement work in this
bundle. They can be merged as-is, either by taking them straight from here or via
a focused fixes-only PR re-spun from those commits. The enablement pieces
(`apply_table_updates`, the provider seam) remain coordinated with #2141 / #982.

### Superseded PRs (for additional context)

These were consolidated into this PR; their original descriptions, diffs, and
review threads carry extra detail on each change:

- **#2139** — _fix: round-trip Iceberg manifest lower/upper bounds through Avro_
  — the two correctness fixes (bounds round-trip + pruning type-safety). Closed
  in favor of this PR.
- **#2140** — _feat: expose Iceberg planning helpers and commit-table provider
  seam_ — the provider seam. Closed in favor of this PR.
- **#2135** — _feat(iceberg): apply REST TableUpdates to TableMetadata_ — the
  `apply_table_updates` server-side metadata evolution. Closed earlier pending
  the Iceberg catalog-support decisions (#982).
- **#2134** — _fix: make `TableUpdate`/`ViewUpdate` discriminated enums_ — the
  merged foundation this branch builds on.

See **`LAKECAT-SAIL.md`** for the full write-up, file-level detail, and the
upstream-coordination plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJGCWiVM3DW1Keu4Pwuqjs
