### PR TITLE
fix: delta lake legacy protocol check blocking writes to delta-spark-created column-mapping tables

### DIFF
--- a/crates/sail-delta-lake/src/transaction/mod.rs
+++ b/crates/sail-delta-lake/src/transaction/mod.rs
@@ -880,13 +880,13 @@ fn validate_effective_commit_target(
         return Err(TransactionError::TableFeaturesRequired(TableFeature::DeletionVectors).into());
     }
 
-    // TODO(cdf-writes): Data-changing operations still do not emit AddCDCFile actions. Commit-time
-    // protocol checks currently reject changeDataFeed tables before these writes can land, but once
-    // the feature is enabled here we need an operation-aware validation instead of relying on that.
-    if table_property_enabled(&metadata, "delta.enableChangeDataFeed")
-        && !protocol_supports_legacy_change_data_feed(&protocol)
-        && !protocol_has_writer_feature(&protocol, &TableFeature::ChangeDataFeed)
-    {
+    // TODO(cdf-writes): Data-changing operations still do not emit AddCDCFile actions. Until CDF
+    // write support is implemented, reject all writes to tables with CDF enabled, regardless of
+    // whether the protocol support is legacy (writer v4-6) or explicit (writer v7+ feature).
+    // Previously this guard only rejected v7+ tables, relying on `can_write_to_protocol` to reject
+    // legacy tables via implied-feature expansion. Now that legacy versions no longer expand
+    // implied features (matching delta-spark), this guard must cover legacy tables too.
+    if table_property_enabled(&metadata, "delta.enableChangeDataFeed") {
         return Err(TransactionError::TableFeaturesRequired(TableFeature::ChangeDataFeed).into());
     }
 

--- a/crates/sail-delta-lake/src/transaction/protocol.rs
+++ b/crates/sail-delta-lake/src/transaction/protocol.rs
@@ -27,48 +27,6 @@ use crate::spec::{
 };
 use crate::table::DeltaSnapshot;
 
-static READER_V2: LazyLock<HashSet<TableFeature>> =
-    LazyLock::new(|| HashSet::from_iter([TableFeature::ColumnMapping]));
-static WRITER_V2: LazyLock<HashSet<TableFeature>> =
-    LazyLock::new(|| HashSet::from_iter([TableFeature::AppendOnly, TableFeature::Invariants]));
-static WRITER_V3: LazyLock<HashSet<TableFeature>> = LazyLock::new(|| {
-    HashSet::from_iter([
-        TableFeature::AppendOnly,
-        TableFeature::Invariants,
-        TableFeature::CheckConstraints,
-    ])
-});
-static WRITER_V4: LazyLock<HashSet<TableFeature>> = LazyLock::new(|| {
-    HashSet::from_iter([
-        TableFeature::AppendOnly,
-        TableFeature::Invariants,
-        TableFeature::CheckConstraints,
-        TableFeature::ChangeDataFeed,
-        TableFeature::GeneratedColumns,
-    ])
-});
-static WRITER_V5: LazyLock<HashSet<TableFeature>> = LazyLock::new(|| {
-    HashSet::from_iter([
-        TableFeature::AppendOnly,
-        TableFeature::Invariants,
-        TableFeature::CheckConstraints,
-        TableFeature::ChangeDataFeed,
-        TableFeature::GeneratedColumns,
-        TableFeature::ColumnMapping,
-    ])
-});
-static WRITER_V6: LazyLock<HashSet<TableFeature>> = LazyLock::new(|| {
-    HashSet::from_iter([
-        TableFeature::AppendOnly,
-        TableFeature::Invariants,
-        TableFeature::CheckConstraints,
-        TableFeature::ChangeDataFeed,
-        TableFeature::GeneratedColumns,
-        TableFeature::ColumnMapping,
-        TableFeature::IdentityColumns,
-    ])
-});
-
 pub struct ProtocolChecker {
     reader_features: HashSet<TableFeature>,
     writer_features: HashSet<TableFeature>,
@@ -107,9 +65,13 @@ impl ProtocolChecker {
         &self,
         protocol: &Protocol,
     ) -> Result<Option<HashSet<TableFeature>>, TransactionError> {
+        // Legacy reader versions (1, 2) do not carry explicit feature lists. The version
+        // number implies a feature set (e.g. reader v2 implies columnMapping), but —
+        // matching delta-spark's `protocolCheck` — we do not expand the implied set here.
+        // Whether a legacy-implied feature is actually *active* is validated separately
+        // at operation time (e.g. `verify_column_mapping`).
         match protocol.min_reader_version() {
-            0 | 1 => Ok(None),
-            2 => Ok(Some(READER_V2.clone())),
+            0..=2 => Ok(None),
             3 => Ok(Some(
                 protocol
                     .reader_features()
@@ -128,16 +90,19 @@ impl ProtocolChecker {
         &self,
         protocol: &Protocol,
     ) -> Result<Option<HashSet<TableFeature>>, TransactionError> {
-        // Delta protocol differs here:
-        // - writer versions 2..=6 imply a fixed feature set from `minWriterVersion`
-        // - writer version 7 uses the explicit `writerFeatures` declared by the table
+        // Legacy writer versions (1..=6) do not carry explicit feature lists. The version
+        // number implies a feature set (e.g. writer v5 implies columnMapping, changeDataFeed,
+        // ...), but — matching delta-spark's `protocolCheck` — we do not expand the implied
+        // set here. Whether a legacy-implied feature is actually *active* is validated
+        // separately at operation time (e.g. append-only check, CDF guard).
+        //
+        // Previously this method expanded the full implied set for each version and required
+        // the writer to support every implied feature. That was stricter than delta-spark
+        // and blocked writes to tables that did not actually use the unsupported features
+        // (e.g. a v5 column-mapping table without CDF enabled was rejected because CDF is
+        // implied by v5 but not implemented). See lakehq/sail#2041.
         match protocol.min_writer_version() {
-            0 | 1 => Ok(None),
-            2 => Ok(Some(WRITER_V2.clone())),
-            3 => Ok(Some(WRITER_V3.clone())),
-            4 => Ok(Some(WRITER_V4.clone())),
-            5 => Ok(Some(WRITER_V5.clone())),
-            6 => Ok(Some(WRITER_V6.clone())),
+            0..=6 => Ok(None),
             7 => Ok(Some(
                 protocol
                     .writer_features()
@@ -346,8 +311,9 @@ pub static INSTANCE: LazyLock<ProtocolChecker> = LazyLock::new(|| {
     reader_features.insert(TableFeature::CatalogManaged);
     let mut writer_features = HashSet::new();
     // Keep this list aligned with end-to-end behavior, not just protocol parsing.
-    // For writer versions 2..=6, claiming support here also means accepting older tables whose
-    // `minWriterVersion` implies the feature set in WRITER_V2..WRITER_V6.
+    // These features are only checked against the explicit `writerFeatures` list on
+    // writer version 7+ tables. Legacy tables (writer version 1..=6) do not have
+    // explicit feature lists; their implied features are validated at operation time.
     writer_features.insert(TableFeature::AppendOnly);
     writer_features.insert(TableFeature::InCommitTimestamp);
     writer_features.insert(TableFeature::TimestampWithoutTimezone);
@@ -480,5 +446,112 @@ mod tests {
             err,
             TransactionError::TableFeaturesRequired(TableFeature::VariantShredding)
         ));
+    }
+
+    // --- Legacy protocol version tests (writer versions 1..=6) ---
+    //
+    // These tests verify that the protocol checker does NOT expand implied feature
+    // sets for legacy writer versions. A table at writer version 5 implies support
+    // for ChangeDataFeed, but if CDF is not enabled the write should succeed even
+    // though sail does not implement CDF writes. See lakehq/sail#2041.
+
+    #[test]
+    fn global_checker_accepts_legacy_writer_v5_without_explicit_features() {
+        // Simulates a delta-spark-created table with column mapping mode=name.
+        // delta-spark produces Protocol(2, 5) with no explicit feature lists.
+        let protocol = Protocol::new(2, 5, None, None);
+
+        INSTANCE.can_read_from_protocol(&protocol).unwrap();
+        INSTANCE.can_write_to_protocol(&protocol).unwrap();
+    }
+
+    #[test]
+    fn global_checker_accepts_legacy_writer_v4_without_explicit_features() {
+        // Writer v4 implies ChangeDataFeed + GeneratedColumns, but we should not
+        // require them unless they are actually active on the table.
+        let protocol = Protocol::new(1, 4, None, None);
+
+        INSTANCE.can_read_from_protocol(&protocol).unwrap();
+        INSTANCE.can_write_to_protocol(&protocol).unwrap();
+    }
+
+    #[test]
+    fn global_checker_accepts_legacy_writer_v6_without_explicit_features() {
+        // Writer v6 implies IdentityColumns on top of v5 features.
+        let protocol = Protocol::new(2, 6, None, None);
+
+        INSTANCE.can_read_from_protocol(&protocol).unwrap();
+        INSTANCE.can_write_to_protocol(&protocol).unwrap();
+    }
+
+    #[test]
+    fn global_checker_accepts_legacy_writer_v2_and_v3() {
+        let v2 = Protocol::new(1, 2, None, None);
+        INSTANCE.can_write_to_protocol(&v2).unwrap();
+
+        let v3 = Protocol::new(1, 3, None, None);
+        INSTANCE.can_write_to_protocol(&v3).unwrap();
+    }
+
+    #[test]
+    fn global_checker_accepts_legacy_reader_v2_without_explicit_features() {
+        // Reader v2 implies ColumnMapping, but we should not require it at the
+        // protocol-check level. Column mapping activation is verified separately.
+        let protocol = Protocol::new(2, 2, None, None);
+
+        INSTANCE.can_read_from_protocol(&protocol).unwrap();
+        INSTANCE.can_write_to_protocol(&protocol).unwrap();
+    }
+
+    #[test]
+    fn global_checker_rejects_v7_with_unsupported_change_data_feed_feature() {
+        // Writer v7 with explicit changeDataFeed writer feature should still be
+        // rejected, since sail does not implement CDF writes.
+        let protocol = Protocol::new(
+            3,
+            7,
+            Some(vec![TableFeature::ColumnMapping]),
+            Some(vec![
+                TableFeature::ColumnMapping,
+                TableFeature::ChangeDataFeed,
+            ]),
+        );
+
+        let err = INSTANCE.can_write_to_protocol(&protocol).unwrap_err();
+        assert!(matches!(
+            err,
+            TransactionError::UnsupportedTableFeatures(features)
+                if features.contains(&TableFeature::ChangeDataFeed)
+        ));
+    }
+
+    #[test]
+    fn global_checker_rejects_v7_with_unsupported_reader_feature() {
+        // Reader v3 with an unsupported explicit reader feature should be rejected.
+        let protocol = Protocol::new(
+            3,
+            7,
+            Some(vec![TableFeature::RowTracking]),
+            Some(vec![TableFeature::AppendOnly]),
+        );
+
+        let err = INSTANCE.can_read_from_protocol(&protocol).unwrap_err();
+        assert!(matches!(
+            err,
+            TransactionError::UnsupportedTableFeatures(features)
+                if features.contains(&TableFeature::RowTracking)
+        ));
+    }
+
+    #[test]
+    fn global_checker_rejects_unknown_writer_version() {
+        let protocol = Protocol::new(1, 99, None, None);
+        assert!(INSTANCE.can_write_to_protocol(&protocol).is_err());
+    }
+
+    #[test]
+    fn global_checker_rejects_unknown_reader_version() {
+        let protocol = Protocol::new(99, 7, None, Some(vec![]));
+        assert!(INSTANCE.can_read_from_protocol(&protocol).is_err());
     }
 }


### PR DESCRIPTION
Fixes https://github.com/lakehq/sail/issues/2147

## Proposed fix

Stop expanding implied features for legacy versions (1–6). Just check the version number is supported, matching delta-spark. Feature activation is already validated at operation time by existing guards:

- **Append-only**: `can_commit` checks `delta.appendOnly` property ([`protocol.rs`](https://github.com/lakehq/sail/blob/main/crates/sail-delta-lake/src/transaction/protocol.rs) `can_commit`)
- **Change Data Feed**: [`transaction/mod.rs`](https://github.com/lakehq/sail/blob/main/crates/sail-delta-lake/src/transaction/mod.rs) rejects writes when `delta.enableChangeDataFeed=true` (the guard at line 889)
- **Column mapping**: `verify_column_mapping()` in [`snapshot/mod.rs`](https://github.com/lakehq/sail/blob/main/crates/sail-delta-lake/src/snapshot/mod.rs) validates `delta.columnMapping.mode`
- **Deletion vectors**: [`transaction/mod.rs`](https://github.com/lakehq/sail/blob/main/crates/sail-delta-lake/src/transaction/mod.rs) rejects when `delta.enableDeletionVectors=true` without protocol support

The change is ~10 lines in `required_writer_features` and `required_reader_features`:

```rust
// Before:
match protocol.min_writer_version() {
    0 | 1 => Ok(None),
    2 => Ok(Some(WRITER_V2.clone())),
    3 => Ok(Some(WRITER_V3.clone())),
    4 => Ok(Some(WRITER_V4.clone())),
    5 => Ok(Some(WRITER_V5.clone())),
    6 => Ok(Some(WRITER_V6.clone())),
    7 => Ok(Some(protocol.writer_features()...)),
    ...
}

// After:
match protocol.min_writer_version() {
    0..=6 => Ok(None),
    7 => Ok(Some(protocol.writer_features()...)),
    ...
}
```

The `WRITER_V2` through `WRITER_V6` and `READER_V2` static sets become dead code and are removed.

Additionally, the CDF guard in [`transaction/mod.rs`](https://github.com/lakehq/sail/blob/main/crates/sail-delta-lake/src/transaction/mod.rs) (line 889) must be updated to reject ALL CDF-enabled tables, not just v7+ tables. Previously the guard only rejected v7+ tables, relying on `can_write_to_protocol` to reject legacy v4–6 tables via implied-feature expansion. Now that legacy versions no longer expand implied features, the guard must cover legacy tables too.

## Safety

The only behavioral change: inactive unsupported features no longer block writes to legacy-protocol tables. Active unsupported features are still rejected by the existing operation-time guards. No silent data corruption.
