### PR TITLE
feat: write one file per output partition to match Spark behaviour

### DIFF
--- a/crates/sail-data-source/src/listing/planner.rs
+++ b/crates/sail-data-source/src/listing/planner.rs
@@ -18,7 +18,7 @@ use datafusion::logical_expr::{Expr, LogicalPlan, TableScan, UserDefinedLogicalN
 use datafusion::physical_expr::create_lex_ordering;
 use datafusion::physical_expr_common::sort_expr::LexOrdering;
 use datafusion::physical_plan::empty::EmptyExec;
-use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 use datafusion_common::stats::Precision;
 use datafusion_common::{internal_err, plan_err, project_schema, Statistics};
@@ -31,6 +31,7 @@ use object_store::ObjectStore;
 use sail_common_datafusion::datasource::create_sort_order;
 use sail_common_datafusion::streaming::event::schema::is_flow_event_schema;
 use sail_physical_plan::barrier::BarrierExec;
+use sail_physical_plan::output_file_count::OutputFileCountExec;
 
 use crate::listing::delete::FileDeleteExec;
 use crate::listing::source::{ListingScanInput, ListingSinkInput};
@@ -230,6 +231,7 @@ async fn plan_file_write(
         file_output_mode: FileOutputMode::Automatic,
     };
     let sort_order = create_sort_order(session_state, sort_by.clone(), logical_input.schema())?;
+    let num_output_partitions = physical_input.output_partitioning().partition_count();
     let plan = format
         .sink(
             session_state,
@@ -240,6 +242,7 @@ async fn plan_file_write(
             },
         )
         .await?;
+    let plan = Arc::new(OutputFileCountExec::new(plan, num_output_partitions));
     if *overwrite {
         let delete = Arc::new(FileDeleteExec::new(
             object_store_url,

--- a/crates/sail-physical-plan/src/lib.rs
+++ b/crates/sail-physical-plan/src/lib.rs
@@ -4,6 +4,7 @@ pub mod coalesce;
 pub mod map_partitions;
 pub mod merge_cardinality_check;
 pub mod monotonic_id;
+pub mod output_file_count;
 pub mod range;
 pub mod repartition;
 pub mod schema_pivot;

--- a/crates/sail-physical-plan/src/output_file_count.rs
+++ b/crates/sail-physical-plan/src/output_file_count.rs
@@ -1,39 +1,33 @@
 use std::sync::Arc;
 
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
-use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
-};
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
 use datafusion_common::{internal_err, Result};
 
 /// A wrapper around a `DataSinkExec` that overrides `minimum_parallel_output_files`
-/// in the `TaskContext` session config to match the number of upstream partitions.
+/// in the `TaskContext` session config to match the number of output partitions.
 ///
-/// This ensures the demuxer in `row_count_demuxer()` creates one output file per
-/// upstream partition, matching Apache Spark's behavior of "one file per output partition."
-///
-/// **Architecture:**
-/// - The desired file count is captured at **planning time** from
-///   `physical_input.output_partitioning().partition_count()`.
-/// - It is injected into the `SessionConfig` at **execution time** by cloning the
-///   `TaskContext`, modifying the config, and delegating to the inner plan.
-/// - The downstream `row_count_demuxer()` reads the modified config value and creates
-///   the corresponding number of parallel output streams.
+/// The output partition count is captured at **planning time** from
+/// `physical_input.output_partitioning().partition_count()`. It is injected into
+/// the `SessionConfig` at **execution time** by cloning the `TaskContext`, modifying
+/// the config, and delegating to the inner plan. The downstream `row_count_demuxer()`
+/// then reads the modified config value and creates the corresponding number of
+/// parallel output streams.
 
 #[derive(Debug, Clone)]
 pub struct OutputFileCountExec {
     input: Arc<dyn ExecutionPlan>,
-    num_output_files:  usize,
-    properties: Arc<PlanProperties>
+    num_output_partitions: usize,
+    properties: Arc<PlanProperties>,
 }
 
 impl OutputFileCountExec {
-    pub fn new(input: Arc<dyn ExecutionPlan>, num_output_files: usize) -> Self {
+    pub fn new(input: Arc<dyn ExecutionPlan>, num_output_partitions: usize) -> Self {
         let properties = Arc::new(input.properties().as_ref().clone());
         Self {
             input,
-            num_output_files,
-            properties
+            num_output_partitions,
+            properties,
         }
     }
 
@@ -41,14 +35,18 @@ impl OutputFileCountExec {
         &self.input
     }
 
-    pub fn num_output_files(&self) -> usize {
-        self.num_output_files
+    pub fn num_output_partitions(&self) -> usize {
+        self.num_output_partitions
     }
 }
 
 impl DisplayAs for OutputFileCountExec {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "OutputFileCountExec: files={}", self.num_output_files)
+        write!(
+            f,
+            "OutputFileCountExec: partitions={}",
+            self.num_output_partitions
+        )
     }
 }
 
@@ -72,26 +70,23 @@ impl ExecutionPlan for OutputFileCountExec {
     fn with_new_children(
         self: Arc<Self>,
         mut children: Vec<Arc<dyn ExecutionPlan>>,
-    ) -> Result<Arc<dyn ExecutionPlan>>
-    {
+    ) -> Result<Arc<dyn ExecutionPlan>> {
         let (Some(child), true) = (children.pop(), children.is_empty()) else {
             return internal_err!("{} expects exactly one child", self.name());
         };
-        Ok(Arc::new(Self::new(child, self.num_output_files)))
+        Ok(Arc::new(Self::new(child, self.num_output_partitions)))
     }
 
     fn execute(
         &self,
         partition: usize,
         context: Arc<TaskContext>,
-    ) -> Result<SendableRecordBatchStream>
-    {
-
+    ) -> Result<SendableRecordBatchStream> {
         let mut session_config = context.session_config().clone();
         session_config
             .options_mut()
             .execution
-            .minimum_parallel_output_files = self.num_output_files;
+            .minimum_parallel_output_files = std::cmp::max(1, self.num_output_partitions);
 
         let new_context = Arc::new(TaskContext::new(
             context.task_id(),
@@ -107,5 +102,3 @@ impl ExecutionPlan for OutputFileCountExec {
         self.input.execute(partition, new_context)
     }
 }
-
-

--- a/crates/sail-physical-plan/src/output_file_count.rs
+++ b/crates/sail-physical-plan/src/output_file_count.rs
@@ -1,0 +1,111 @@
+use std::sync::Arc;
+
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties,
+};
+use datafusion_common::{internal_err, Result};
+
+/// A wrapper around a `DataSinkExec` that overrides `minimum_parallel_output_files`
+/// in the `TaskContext` session config to match the number of upstream partitions.
+///
+/// This ensures the demuxer in `row_count_demuxer()` creates one output file per
+/// upstream partition, matching Apache Spark's behavior of "one file per output partition."
+///
+/// **Architecture:**
+/// - The desired file count is captured at **planning time** from
+///   `physical_input.output_partitioning().partition_count()`.
+/// - It is injected into the `SessionConfig` at **execution time** by cloning the
+///   `TaskContext`, modifying the config, and delegating to the inner plan.
+/// - The downstream `row_count_demuxer()` reads the modified config value and creates
+///   the corresponding number of parallel output streams.
+
+#[derive(Debug, Clone)]
+pub struct OutputFileCountExec {
+    input: Arc<dyn ExecutionPlan>,
+    num_output_files:  usize,
+    properties: Arc<PlanProperties>
+}
+
+impl OutputFileCountExec {
+    pub fn new(input: Arc<dyn ExecutionPlan>, num_output_files: usize) -> Self {
+        let properties = Arc::new(input.properties().as_ref().clone());
+        Self {
+            input,
+            num_output_files,
+            properties
+        }
+    }
+
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
+    pub fn num_output_files(&self) -> usize {
+        self.num_output_files
+    }
+}
+
+impl DisplayAs for OutputFileCountExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "OutputFileCountExec: files={}", self.num_output_files)
+    }
+}
+
+impl ExecutionPlan for OutputFileCountExec {
+    fn name(&self) -> &str {
+        Self::static_name()
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn benefits_from_input_partitioning(&self) -> Vec<bool> {
+        vec![false]
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>>
+    {
+        let (Some(child), true) = (children.pop(), children.is_empty()) else {
+            return internal_err!("{} expects exactly one child", self.name());
+        };
+        Ok(Arc::new(Self::new(child, self.num_output_files)))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream>
+    {
+
+        let mut session_config = context.session_config().clone();
+        session_config
+            .options_mut()
+            .execution
+            .minimum_parallel_output_files = self.num_output_files;
+
+        let new_context = Arc::new(TaskContext::new(
+            context.task_id(),
+            context.session_id(),
+            session_config,
+            context.scalar_functions().clone(),
+            context.higher_order_functions().clone(),
+            context.aggregate_functions().clone(),
+            context.window_functions().clone(),
+            context.runtime_env(),
+        ));
+
+        self.input.execute(partition, new_context)
+    }
+}
+
+


### PR DESCRIPTION
# Problem

Spark outputs one file per output partition, but Sail does not behave similarly.

Specifically, the Listing formats (Parquet, Avro, CSV, JSON, Arrow, and Text) behave differently and mostly output **4 data files**.

## Reason

In DataFusion, compute parallelism and write parallelism are decoupled:
https://github.com/apache/datafusion/issues/7767

DataFusion uses two configs to determine write parallelism:

* `datafusion.execution.minimum_parallel_output_files` (default: `4`)
* `datafusion.execution.soft_max_rows_per_output_file` (default: `50000000`)

The default value of `minimum_parallel_output_files` (`4`) is the reason why 4 data files are produced in most cases.

# Approach

For Listing formats, these configs are set when `DataSinkExec` is created.

The proposed prototype is to create a wrapper `OutputFileCountExec` around `DataSinkExec` that updates `minimum_parallel_output_files` to match the output partition count.

## Exact Approach

The output partition count is captured at **planning time** from:

```rust
physical_input.output_partitioning().partition_count()
```

It is then injected into the `SessionConfig` at **execution time** by:

1. Cloning the `TaskContext`.
2. Modifying the `minimum_parallel_output_files` config.
3. Delegating execution to the inner plan.

The downstream `row_count_demuxer()` then reads the modified config value and creates the corresponding number of parallel output streams.

## How to Test

A simple way to verify the behavior is:

```python
df =  spark.range(int(1e5))
df.repartition(50).write.format("csv").save(path)
```

-------------------------

 **This PR is raised as a prototype to explore how one file per output partition can be achieved. Test cases and distributed execution support are intentionally skipped.**

 **@linhr, I hope this prototype will be helpful in the process of building a custom `DataSink`.**

 **And sorry if I misunderstood anything or presented any part incorrectly.**

