### PR TITLE
fix: restore SPARK_REMOTE="local" JVM validation under PySpark 4.1

### DIFF
--- a/python/pysail/testing/spark/session.py
+++ b/python/pysail/testing/spark/session.py
@@ -25,7 +25,12 @@ class _SparkSessionFactory:
 
     def create(self) -> SparkSession:
         app = f"test-{uuid.uuid4().hex}"
-        session = SparkSession.builder.appName(app).remote(self._remote).create()
+        builder = SparkSession.builder.appName(app).remote(self._remote)
+        # PySpark 4.1 removed `local` connection-string support from `.create()`
+        # (raises UNSUPPORTED_LOCAL_CONNECTION_STRING), but `.getOrCreate()` still
+        # boots a local JVM-backed Spark Connect server. Use it so feature tests can
+        # run against real Spark via `SPARK_REMOTE="local"`.
+        session = builder.getOrCreate() if self._remote.startswith("local") else builder.create()
         configure_spark_session(session)
         patch_spark_connect_session(session)
         self._sessions.append(session)


### PR DESCRIPTION
PySpark 4.1 removed `local` connection-string support from
`SparkSession.builder...create()` (raises UNSUPPORTED_LOCAL_CONNECTION_STRING),
but `.getOrCreate()` still boots a local JVM-backed Spark Connect server.

This was a regression from #2111 (session consolidation): pre-#2111 the default
`spark` fixture used `.getOrCreate()` — the path PySpark 4.1 still honors for
`local` — while `.create()` was reserved for the session-isolation factory. The
consolidation routed everything through `.create()`, silently breaking
`SPARK_REMOTE="local"` feature-test validation against real Spark.

Use `.getOrCreate()` for `local` remotes (restores JVM validation) and keep
`.create()` for `sc://` remotes (preserves the per-module isolation #2111 intended).

The `sc://` path is byte-for-byte unchanged, so the Sail-server session isolation
(`test_python_session_isolation`) is unaffected. The `local`-via-`.create()` path
already threw under PySpark 4.1, so this revives a dead path rather than changing
any working behavior.
