### PR TITLE
perf: implement simplify hook on `concat` and null-fold

### DIFF
--- a/crates/sail-function/src/scalar/collection/spark_concat.rs
+++ b/crates/sail-function/src/scalar/collection/spark_concat.rs
@@ -5,16 +5,17 @@ use datafusion::arrow::array::{BooleanArray, StringArray};
 use datafusion::arrow::compute::cast;
 use datafusion::arrow::compute::kernels::boolean::{is_null, or};
 use datafusion::arrow::compute::kernels::nullif::nullif;
-use datafusion::arrow::datatypes::DataType;
+use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion::functions::string::concat::ConcatFunc;
 use datafusion_common::utils::list_ndims;
-use datafusion_common::{plan_err, ExprSchema, Result, ScalarValue};
+use datafusion_common::{internal_err, plan_err, Result, ScalarValue};
 use datafusion_expr::simplify::{ExprSimplifyResult, SimplifyContext};
 use datafusion_expr::{
-    ColumnarValue, Expr, ExprSchemable, ScalarFunctionArgs, ScalarUDFImpl, Signature,
+    ColumnarValue, Expr, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature,
     TypeSignature, Volatility,
 };
 use datafusion_functions_nested::concat::ArrayConcat;
+use sail_common_datafusion::utils::items::ItemTaker;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct SparkConcat {
@@ -47,86 +48,76 @@ impl ScalarUDFImpl for SparkConcat {
         &self.signature
     }
 
-    /// [Credit]: <https://github.com/apache/datafusion/blob/7ccc6d7c55ae9dbcb7dee031f394bf11a03000ba/datafusion/functions-nested/src/concat.rs#L276-L310>
-    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
-        if arg_types.is_empty() {
-            return Ok(DataType::Utf8);
-        }
-        if arg_types
-            .iter()
-            .any(|arg_type| matches!(arg_type, DataType::List(_)))
-        {
-            let mut expr_type: Option<DataType> = None;
-            let mut max_dims = 0;
-            for arg_type in arg_types {
-                match arg_type {
-                    DataType::List(field) => {
-                        if !field.data_type().equals_datatype(&DataType::Null) {
-                            let dims = list_ndims(arg_type);
-                            expr_type = Some(match max_dims.cmp(&dims) {
-                                Ordering::Greater => expr_type.unwrap_or_else(|| arg_type.clone()),
-                                Ordering::Equal => {
-                                    if let Some(expr_type) = expr_type {
-                                        merge_list_types(&expr_type, arg_type).ok_or_else(|| {
-                                            datafusion_common::plan_datafusion_err!(
-                                                "It is not possible to concatenate arrays of different types. Expected: {expr_type}, got: {arg_type}"
-                                            )
-                                        })?
-                                    } else {
-                                        arg_type.clone()
-                                    }
-                                }
-                                Ordering::Less => {
-                                    max_dims = dims;
-                                    arg_type.clone()
-                                }
-                            });
-                        }
-                    }
-                    _ => {
-                        return plan_err!(
-                            "The array_concat function can only accept list as the args."
-                        )
-                    }
-                }
-            }
-            // All arrays had Null element type (e.g. array() + array()) — keep as List(Null)
-            Ok(expr_type.unwrap_or_else(|| arg_types[0].clone()))
-        } else if arg_types
-            .iter()
-            .all(|arg_type| matches!(arg_type, DataType::Binary))
-        {
-            Ok(DataType::Binary)
-        } else if arg_types
-            .iter()
-            .all(|arg_type| matches!(arg_type, DataType::Binary | DataType::LargeBinary))
-        {
-            Ok(DataType::LargeBinary)
-        } else {
-            Ok(arg_types
-                .iter()
-                .find(|&arg_type| matches!(arg_type, &DataType::Utf8View))
-                .or_else(|| {
-                    arg_types
-                        .iter()
-                        .find(|&arg_type| matches!(arg_type, &DataType::LargeUtf8))
-                })
-                .unwrap_or(&DataType::Utf8)
-                .clone())
-        }
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        internal_err!(
+            "spark_concat: `return_type` should not be called; `return_field_from_args` is used instead"
+        )
     }
 
+    /// `concat` propagates NULL: the result is null iff any argument is null
+    /// (mirrors Spark `Concat.nullable`). Set here rather than in the deprecated
+    /// `is_nullable`, which DataFusion no longer consults to derive the field.
+    fn return_field_from_args(&self, args: ReturnFieldArgs) -> Result<FieldRef> {
+        let data_types = args
+            .arg_fields
+            .iter()
+            .map(|field| field.data_type().clone())
+            .collect::<Vec<_>>();
+        let return_type = concat_return_type(&data_types)?;
+        let nullable =
+            args.arg_fields.is_empty() || args.arg_fields.iter().any(|field| field.is_nullable());
+        Ok(Arc::new(Field::new(self.name(), return_type, nullable)))
+    }
+
+    /// Plan-time simplifications that mirror Spark's `concat` semantics.
+    ///
+    /// concat — simplify summary:
+    /// ```text
+    /// concat(concat(a, b), c)  -> concat(a, b, c)  (R1: CombineConcats — flatten nested)
+    /// concat(a, NULL, b)       -> NULL             (R2: null propagation — any null arg)
+    /// concat(x)                -> x                (R3: single-arg identity: string/array/binary)
+    /// ```
+    ///
+    /// * **R1** — flatten nested `concat` calls first, so deeply nested calls
+    ///   collapse in one bottom-up pass and a NULL bubbled up from an inner call
+    ///   is caught by R2. Only flattens when the return type is preserved.
+    /// * **R2** — `concat` propagates NULL: a literal NULL argument folds the whole
+    ///   call to a typed NULL at planning time, eliminating the other argument
+    ///   subtrees (DCE) and enabling column pruning. Falls through on a type-invalid
+    ///   combo (e.g. array + untyped NULL) so the normal path still raises the error.
+    /// * **R3** — single-argument identity for string/array/binary inputs; other
+    ///   types fall through so the invoke path can apply Spark coercions.
     fn simplify(&self, args: Vec<Expr>, info: &SimplifyContext) -> Result<ExprSimplifyResult> {
+        // R1: flatten nested concat (Spark's CombineConcats).
+        let args = flatten_nested_concats(args, info)?;
+
+        // R2: null propagation. Only fold when the arg types form a valid concat —
+        // otherwise fall through so the normal path still raises the type error
+        // (e.g. array + untyped NULL).
+        if args
+            .iter()
+            .any(|arg| matches!(arg, Expr::Literal(scalar, _) if scalar.is_null()))
+        {
+            let arg_types = args
+                .iter()
+                .map(|arg| info.get_data_type(arg))
+                .collect::<Result<Vec<_>>>()?;
+            if let Ok(return_type) = concat_return_type(&arg_types) {
+                if let Ok(null) = ScalarValue::try_from(&return_type) {
+                    return Ok(ExprSimplifyResult::Simplified(Expr::Literal(null, None)));
+                }
+            }
+        }
+
         if args.len() != 1 {
             return Ok(ExprSimplifyResult::Original(args));
         }
-        let mut args = args;
-        let arg = args.remove(0);
-        // `FixedSizeList` and `LargeList` are intentionally omitted: `return_type`
-        // does not recognize them as array inputs (it falls through to `Utf8`),
-        // so the invoke path coerces them to strings. Returning the argument
-        // unchanged here would break the type contract advertised by
-        // `return_type`. Numeric, timestamp, and other non-string scalars are
+        let arg = args.one()?;
+        // `FixedSizeList` and `LargeList` are intentionally omitted:
+        // `concat_return_type` does not recognize them as array inputs (it falls
+        // through to `Utf8`), so the invoke path coerces them to strings. Returning
+        // the argument unchanged here would break the type contract advertised by
+        // `concat_return_type`. Numeric, timestamp, and other non-string scalars are
         // also excluded so the invoke path can apply Spark-specific coercions
         // (e.g. timestamp formatting via `spark_format_timestamp_str`).
         if matches!(
@@ -145,29 +136,23 @@ impl ScalarUDFImpl for SparkConcat {
         }
     }
 
-    fn is_nullable(&self, args: &[Expr], schema: &dyn ExprSchema) -> bool {
-        if args.is_empty() {
-            true
-        } else {
-            args.iter().any(|arg| arg.nullable(schema).unwrap_or(true))
-        }
-    }
-
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         if args.args.is_empty() {
             return Ok(ColumnarValue::Scalar(ScalarValue::Utf8(
                 Some(String::new()),
             )));
         }
+        // `return_type` is cloned because `args.return_field` is moved into the
+        // delegate call below, but the null-typed early-return still needs it.
         let return_type = args.return_field.data_type().clone();
         let mut null_mask = None;
-        for arg in args.args.clone() {
+        for arg in &args.args {
             match arg {
                 ColumnarValue::Scalar(s) if s.is_null() => {
                     return Ok(ColumnarValue::Scalar(ScalarValue::try_from(&return_type)?));
                 }
                 ColumnarValue::Array(a) => {
-                    let mask = is_null(&a)?;
+                    let mask = is_null(a)?;
                     null_mask = match null_mask {
                         Some(existing) => Some(or(&existing, &mask)?),
                         None => Some(mask),
@@ -270,21 +255,17 @@ fn cast_columnar_values(
 /// "2024-01-15 12:00:00+08:00"). Spark uses a space separator and no timezone
 /// suffix (e.g. "2024-01-15 12:00:00").
 fn spark_format_timestamp_str(s: &str) -> String {
-    // Replace ISO 8601 'T' separator with a space
-    let s = s.replace('T', " ");
-    // Strip timezone suffix (Z, +HH:MM, -HH:MM) that starts after the seconds
-    // part. "YYYY-MM-DD HH:MM:SS" is 19 chars, so search from position 19 to
-    // avoid matching the '-' in the date portion.
-    let cutoff = s
+    // Strip the timezone suffix (Z, +HH:MM, -HH:MM) that starts after the seconds
+    // part. "YYYY-MM-DD HH:MM:SS" is 19 chars, so search from position 19 to avoid
+    // matching the '-' in the date portion. The cutoff is the same on `s` as on the
+    // 'T'-replaced string (the 'T' is at index 10, before 19), so we slice first and
+    // replace once — a single allocation instead of replace-then-slice.
+    let end = s
         .char_indices()
         .skip_while(|(i, _)| *i < 19)
         .find(|(_, c)| matches!(c, 'Z' | '+' | '-'))
-        .map(|(i, _)| i);
-    if let Some(idx) = cutoff {
-        s[..idx].to_string()
-    } else {
-        s
-    }
+        .map_or(s.len(), |(i, _)| i);
+    s[..end].replace('T', " ")
 }
 
 fn spark_format_timestamp_scalar(scalar: ScalarValue) -> Result<ScalarValue> {
@@ -343,6 +324,118 @@ fn cast_list_columnar_values(
             }
         })
         .collect()
+}
+
+/// If `expr` is a nested `spark_concat` call, return its arguments.
+fn nested_concat_args(expr: &Expr) -> Option<&[Expr]> {
+    match expr {
+        Expr::ScalarFunction(inner)
+            if inner.func.inner().downcast_ref::<SparkConcat>().is_some() =>
+        {
+            Some(&inner.args)
+        }
+        _ => None,
+    }
+}
+
+/// Spark's `CombineConcats`: flatten nested `spark_concat` children,
+/// `concat(concat(a, b), c)` -> `concat(a, b, c)`, reducing nesting to a single
+/// kernel pass. Only flatten when it keeps the same return type — this guards the
+/// array element-type / dimension merge in `return_type`; otherwise the arguments
+/// are returned unchanged.
+fn flatten_nested_concats(args: Vec<Expr>, info: &SimplifyContext) -> Result<Vec<Expr>> {
+    if !args.iter().any(|arg| nested_concat_args(arg).is_some()) {
+        return Ok(args);
+    }
+    let mut flattened = Vec::with_capacity(args.len());
+    for arg in &args {
+        match nested_concat_args(arg) {
+            Some(inner) => flattened.extend(inner.iter().cloned()),
+            None => flattened.push(arg.clone()),
+        }
+    }
+    let before = args
+        .iter()
+        .map(|arg| info.get_data_type(arg))
+        .collect::<Result<Vec<_>>>()?;
+    let after = flattened
+        .iter()
+        .map(|arg| info.get_data_type(arg))
+        .collect::<Result<Vec<_>>>()?;
+    match (concat_return_type(&before), concat_return_type(&after)) {
+        (Ok(before_type), Ok(after_type)) if before_type == after_type => Ok(flattened),
+        _ => Ok(args),
+    }
+}
+
+/// Spark `concat` output type: array concat (list dim/element merge), all-binary,
+/// or string (widest of Utf8View / LargeUtf8 / Utf8).
+///
+/// [Credit]: <https://github.com/apache/datafusion/blob/7ccc6d7c55ae9dbcb7dee031f394bf11a03000ba/datafusion/functions-nested/src/concat.rs#L276-L310>
+fn concat_return_type(arg_types: &[DataType]) -> Result<DataType> {
+    if arg_types.is_empty() {
+        return Ok(DataType::Utf8);
+    }
+    if arg_types
+        .iter()
+        .any(|arg_type| matches!(arg_type, DataType::List(_)))
+    {
+        let mut expr_type: Option<DataType> = None;
+        let mut max_dims = 0;
+        for arg_type in arg_types {
+            match arg_type {
+                DataType::List(field) => {
+                    if !field.data_type().equals_datatype(&DataType::Null) {
+                        let dims = list_ndims(arg_type);
+                        expr_type = Some(match max_dims.cmp(&dims) {
+                            Ordering::Greater => expr_type.unwrap_or_else(|| arg_type.clone()),
+                            Ordering::Equal => {
+                                if let Some(expr_type) = expr_type {
+                                    merge_list_types(&expr_type, arg_type).ok_or_else(|| {
+                                        datafusion_common::plan_datafusion_err!(
+                                            "It is not possible to concatenate arrays of different types. Expected: {expr_type}, got: {arg_type}"
+                                        )
+                                    })?
+                                } else {
+                                    arg_type.clone()
+                                }
+                            }
+                            Ordering::Less => {
+                                max_dims = dims;
+                                arg_type.clone()
+                            }
+                        });
+                    }
+                }
+                _ => {
+                    return plan_err!("The array_concat function can only accept list as the args.")
+                }
+            }
+        }
+        // All arrays had Null element type (e.g. array() + array()) — keep as List(Null)
+        Ok(expr_type.unwrap_or_else(|| arg_types[0].clone()))
+    } else if arg_types
+        .iter()
+        .all(|arg_type| matches!(arg_type, DataType::Binary))
+    {
+        Ok(DataType::Binary)
+    } else if arg_types
+        .iter()
+        .all(|arg_type| matches!(arg_type, DataType::Binary | DataType::LargeBinary))
+    {
+        Ok(DataType::LargeBinary)
+    } else {
+        Ok(arg_types
+            .iter()
+            .find(|&arg_type| matches!(arg_type, &DataType::Utf8View))
+            .or_else(|| {
+                arg_types
+                    .iter()
+                    .find(|&arg_type| matches!(arg_type, &DataType::LargeUtf8))
+            })
+            .unwrap_or(&DataType::Utf8)
+            .clone())
+    }
 }
 
 fn merge_list_types(left: &DataType, right: &DataType) -> Option<DataType> {

--- a/crates/sail-function/src/scalar/collection/spark_concat.rs
+++ b/crates/sail-function/src/scalar/collection/spark_concat.rs
@@ -64,8 +64,7 @@ impl ScalarUDFImpl for SparkConcat {
             .map(|field| field.data_type().clone())
             .collect::<Vec<_>>();
         let return_type = concat_return_type(&data_types)?;
-        let nullable =
-            args.arg_fields.is_empty() || args.arg_fields.iter().any(|field| field.is_nullable());
+        let nullable = args.arg_fields.iter().any(|field| field.is_nullable());
         Ok(Arc::new(Field::new(self.name(), return_type, nullable)))
     }
 

--- a/python/pysail/tests/spark/__snapshots__/test_tpcds.plan.yaml
+++ b/python/pysail/tests/spark/__snapshots__/test_tpcds.plan.yaml
@@ -5597,7 +5597,7 @@ data:
       ProjectionExec: expr=[#68@0 as #68, #69@1 as #69]
         SortPreservingMergeExec: [#1@2 ASC], fetch=100
           SortExec: TopK(fetch=100), expr=[#68@0 ASC], preserve_partitioning=[true]
-            ProjectionExec: expr=[#1@0 as #68, spark_concat(spark_concat(CASE WHEN #9@2 IS NOT NULL THEN #9@2 ELSE  END, , ), CASE WHEN #8@1 IS NOT NULL THEN #8@1 ELSE  END) as #69, #1@0 as #1]
+            ProjectionExec: expr=[#1@0 as #68, spark_concat(CASE WHEN #9@2 IS NOT NULL THEN #9@2 ELSE  END, , , CASE WHEN #8@1 IS NOT NULL THEN #8@1 ELSE  END) as #69, #1@0 as #1]
               RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
                 HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(CAST(customer_demographics.#31 AS Float64)@4, #52@0)], projection=[#1@0, #8@1, #9@2, #31@3, #52@5]
                   CoalescePartitionsExec

--- a/python/pysail/tests/spark/function/__snapshots__/features/concat_simplify.yaml
+++ b/python/pysail/tests/spark/function/__snapshots__/features/concat_simplify.yaml
@@ -1,12 +1,12 @@
 # serializer version: 1
 ---
-name: "test_explain_concat_of_single_string_column__no_spark_concat_in_plan"
+name: "test_explain_allliteral_concat_has_no_spark_concat_in_the_plan"
 data:
   |-
     == Physical Plan ==
-    ProjectionExec: expr=[#2@0 as result]
-      ProjectionExec: expr=[column1@0 as #2]
-        DataSourceExec: partitions=1, partition_sizes=[1]
+    ProjectionExec: expr=[#0@0 as result]
+      ProjectionExec: expr=[abcdef as #0]
+        PlaceholderRowExec
 ---
 name: "test_explain_concat_of_single_integer_column__spark_concat_stays_in_plan"
 data:
@@ -16,10 +16,58 @@ data:
       ProjectionExec: expr=[spark_concat(column1@0) as #2]
         DataSourceExec: partitions=1, partition_sizes=[1]
 ---
+name: "test_explain_concat_of_single_string_column__no_spark_concat_in_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#2@0 as result]
+      ProjectionExec: expr=[column1@0 as #2]
+        DataSourceExec: partitions=1, partition_sizes=[1]
+---
 name: "test_explain_concat_of_two_array_columns__spark_concat_stays_in_plan"
 data:
   |-
     == Physical Plan ==
     ProjectionExec: expr=[#4@0 as result]
       ProjectionExec: expr=[spark_concat(column1@0, column2@1) as #4]
+        DataSourceExec: partitions=1, partition_sizes=[1]
+---
+name: "test_explain_concat_with_a_null_literal_drops_an_expensive_argument"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#2@0 as result]
+      ProjectionExec: expr=[NULL as #2]
+        DataSourceExec: partitions=1, partition_sizes=[1]
+---
+name: "test_explain_deeply_nested_concat_over_columns_flattens_to_one_spark_concat"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#8@0 as result]
+      ProjectionExec: expr=[spark_concat(column1@0, column2@1, column3@2, column4@3) as #8]
+        DataSourceExec: partitions=1, partition_sizes=[1]
+---
+name: "test_explain_inner_null_folds_the_flattened_concat_and_drops_abs"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#6@0 as result]
+      ProjectionExec: expr=[NULL as #6]
+        DataSourceExec: partitions=1, partition_sizes=[1]
+---
+name: "test_explain_nested_concat_flattens_and_keeps_the_abs_argument"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#6@0 as result]
+      ProjectionExec: expr=[spark_concat(column1@0, column2@1, CAST(spark_abs(column3@2) AS Utf8)) as #6]
+        DataSourceExec: partitions=1, partition_sizes=[1]
+---
+name: "test_explain_nested_concat_over_columns_flattens_to_one_spark_concat"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#6@0 as result]
+      ProjectionExec: expr=[spark_concat(column1@0, column2@1, column3@2) as #6]
         DataSourceExec: partitions=1, partition_sizes=[1]

--- a/python/pysail/tests/spark/function/features/concat.feature
+++ b/python/pysail/tests/spark/function/features/concat.feature
@@ -595,7 +595,7 @@ Feature: concat function
         | result |
         | abc    |
 
-    Scenario: nested concat with column does not flatten but returns correct result
+    Scenario: nested concat with column flattens and returns correct result
       When query
         """
         SELECT concat(concat(v, 'b'), 'c') AS result

--- a/python/pysail/tests/spark/function/features/concat_simplify.feature
+++ b/python/pysail/tests/spark/function/features/concat_simplify.feature
@@ -349,6 +349,19 @@ Feature: concat() — simplify hook (single-argument identity)
          |-- result: string (nullable = true)
         """
 
+    # Zero arguments: Spark's `Concat.nullable = children.exists(_.nullable)` is
+    # false for an empty child list, and `concat()` returns a non-null empty string.
+    Scenario: zero arguments yield a non-nullable result
+      When query
+        """
+        SELECT concat() AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: string (nullable = false)
+        """
+
   Rule: All-literal calls are constant-folded by DataFusion (not the simplify hook)
 
     # `concat` is Immutable, so an all-literal call is evaluated at planning time by

--- a/python/pysail/tests/spark/function/features/concat_simplify.feature
+++ b/python/pysail/tests/spark/function/features/concat_simplify.feature
@@ -1,3 +1,4 @@
+@concat_simplify
 Feature: concat() — simplify hook (single-argument identity)
 
   Rule: String, array, and binary inputs — identity, no coercion needed
@@ -125,7 +126,263 @@ Feature: concat() — simplify hook (single-argument identity)
         | result              |
         | 2024-01-15 12:00:00 |
 
+    Scenario: concat of a non-midnight timestamp strips the Arrow T separator
+      When query
+        """
+        SELECT concat(CAST('2024-12-31 23:59:59' AS TIMESTAMP)) AS result
+        """
+      Then query result
+        | result              |
+        | 2024-12-31 23:59:59 |
+
+    Scenario: concat of a string and a timestamp formats the timestamp in place
+      When query
+        """
+        SELECT concat('ts=', CAST('2024-01-15 12:30:45' AS TIMESTAMP)) AS result
+        """
+      Then query result
+        | result                 |
+        | ts=2024-01-15 12:30:45 |
+
+  Rule: Null propagation — any NULL argument makes the whole concat NULL
+
+    Scenario: string concat with a NULL literal is null
+      When query
+        """
+        SELECT concat('a', NULL, 'b') AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: string concat with a typed NULL is null
+      When query
+        """
+        SELECT concat('a', CAST(NULL AS STRING)) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: binary concat with a NULL is null
+      When query
+        """
+        SELECT concat(X'4869', CAST(NULL AS BINARY)) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: array concat with a typed NULL array is null
+      When query
+        """
+        SELECT concat(array(1, 2), CAST(NULL AS ARRAY<INT>)) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    # Folding to NULL must NOT mask the type error: an array concatenated with an
+    # untyped NULL is still invalid, exactly as in Spark.
+    Scenario: array concat with an untyped NULL still errors
+      When query
+        """
+        SELECT concat(array(1, 2), NULL) AS result
+        """
+      Then query error .*
+
+    # Null propagation over a column: the NULL literal forces every row to NULL.
+    Scenario: string concat with a NULL literal over a column is null per row
+      When query
+        """
+        SELECT concat(v, NULL) AS result FROM VALUES
+          ('a'),
+          ('b')
+        AS t(v) ORDER BY v
+        """
+      Then query result ordered
+        | result |
+        | NULL   |
+        | NULL   |
+
+  Rule: CombineConcats — nested concat flattens (semantics preserved)
+
+    Scenario: left-nested string concat
+      When query
+        """
+        SELECT concat(concat('a', 'b'), 'c') AS result
+        """
+      Then query result
+        | result |
+        | abc    |
+
+    Scenario: both-sides-nested string concat
+      When query
+        """
+        SELECT concat(concat('a', 'b'), concat('c', 'd')) AS result
+        """
+      Then query result
+        | result |
+        | abcd   |
+
+    Scenario: deeply nested string concat
+      When query
+        """
+        SELECT concat(concat(concat('a', 'b'), 'c'), 'd') AS result
+        """
+      Then query result
+        | result |
+        | abcd   |
+
+    Scenario: NULL bubbled up from an inner concat propagates
+      When query
+        """
+        SELECT concat(concat('a', NULL), 'c') AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: nested array concat flattens
+      When query
+        """
+        SELECT concat(concat(array(1, 2), array(3)), array(4)) AS result
+        """
+      Then query result
+        | result       |
+        | [1, 2, 3, 4] |
+
+    Scenario: nested array concat with a NULL array propagates
+      When query
+        """
+        SELECT concat(concat(array(1), CAST(NULL AS ARRAY<INT>)), array(2)) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: nested binary concat flattens
+      When query
+        """
+        SELECT hex(concat(concat(X'01', X'02'), X'03')) AS result
+        """
+      Then query result
+        | result |
+        | 010203 |
+
+    Scenario: nested concat with integer coercion flattens
+      When query
+        """
+        SELECT concat(concat('a', 1), 'b') AS result
+        """
+      Then query result
+        | result |
+        | a1b    |
+
+  Rule: CombineConcats composes with null propagation when a value arg is an expression
+
+    Scenario: nested concat keeps an abs() value argument (last position)
+      When query
+        """
+        SELECT concat(concat(a, b), CAST(abs(x) AS STRING)) AS result FROM VALUES
+          ('a', 'b', -5),
+          ('c', 'd', 3)
+        AS t(a, b, x) ORDER BY a
+        """
+      Then query result ordered
+        | result |
+        | ab5    |
+        | cd3    |
+
+    Scenario: nested concat keeps an abs() value argument (inner position)
+      When query
+        """
+        SELECT concat(concat(a, CAST(abs(x) AS STRING)), b) AS result FROM VALUES
+          ('a', 'b', -5),
+          ('c', 'd', 3)
+        AS t(a, b, x) ORDER BY a
+        """
+      Then query result ordered
+        | result |
+        | a5b    |
+        | c3d    |
+
+    Scenario: an inner NULL forces NULL and drops the abs() argument
+      When query
+        """
+        SELECT concat(concat(a, NULL), CAST(abs(x) AS STRING)) AS result FROM VALUES
+          ('a', 'b', -5),
+          ('c', 'd', 3)
+        AS t(a, b, x) ORDER BY a
+        """
+      Then query result ordered
+        | result |
+        | NULL   |
+        | NULL   |
+
+  Rule: Nullability — the result is null iff any argument is null
+
+    # Non-null literal arguments (Sail marks VALUES-derived columns nullable even
+    # without a NULL row, unlike Spark — orthogonal to concat, so use literals).
+    Scenario: all non-null arguments yield a non-nullable result
+      When query
+        """
+        SELECT concat('a', 'b') AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: string (nullable = false)
+        """
+
+    Scenario: a nullable argument yields a nullable result
+      When query
+        """
+        SELECT concat(a, b) AS result FROM VALUES
+          ('x', 'y'),
+          (CAST(NULL AS STRING), 'z')
+        AS t(a, b)
+        """
+      Then query schema
+        """
+        root
+         |-- result: string (nullable = true)
+        """
+
+  Rule: All-literal calls are constant-folded by DataFusion (not the simplify hook)
+
+    # `concat` is Immutable, so an all-literal call is evaluated at planning time by
+    # DataFusion's generic `ConstEvaluator` — independent of `SparkConcat::simplify`.
+    # Documented here as a regression guard in case that generic folding changes.
+    Scenario: all-literal concat folds to a single string
+      When query
+        """
+        SELECT concat('abc', 'def') AS result
+        """
+      Then query result
+        | result |
+        | abcdef |
+
+    Scenario: all-literal concat of three strings folds
+      When query
+        """
+        SELECT concat('abc', 'def', 'ghi') AS result
+        """
+      Then query result
+        | result    |
+        | abcdefghi |
+
   Rule: Plan snapshots — simplify removes UDF call only for single-argument identity cases (string/array/binary), and keeps it for coercion or multi-arg array concat
+
+    # ConstEvaluator (generic, not the simplify hook) folds an all-literal concat to
+    # the resulting string literal — no spark_concat survives in the plan.
+    @sail-only
+    Scenario: EXPLAIN all-literal concat has no spark_concat in the plan
+      When query
+        """
+        EXPLAIN SELECT concat('abc', 'def') AS result
+        """
+      Then query plan matches snapshot
 
     @sail-only
     Scenario: EXPLAIN concat of single string column — no spark_concat in plan
@@ -134,6 +391,69 @@ Feature: concat() — simplify hook (single-argument identity)
         EXPLAIN SELECT concat(v) AS result FROM VALUES
           ('hello'),
           ('world')
+        AS t(v)
+        """
+      Then query plan matches snapshot
+
+    # CombineConcats: nested concat over columns collapses to a single flat
+    # spark_concat call in the plan (one kernel pass instead of two).
+    @sail-only
+    Scenario: EXPLAIN nested concat over columns flattens to one spark_concat
+      When query
+        """
+        EXPLAIN SELECT concat(concat(a, b), c) AS result FROM VALUES
+          ('x', 'y', 'z'),
+          ('p', 'q', 'r')
+        AS t(a, b, c)
+        """
+      Then query plan matches snapshot
+
+    @sail-only
+    Scenario: EXPLAIN deeply nested concat over columns flattens to one spark_concat
+      When query
+        """
+        EXPLAIN SELECT concat(concat(concat(a, b), c), d) AS result FROM VALUES
+          ('w', 'x', 'y', 'z')
+        AS t(a, b, c, d)
+        """
+      Then query plan matches snapshot
+
+    # CombineConcats keeps a real value argument: the nested concat flattens and
+    # the abs() is spliced in (still evaluated) — one flat spark_concat call.
+    @sail-only
+    Scenario: EXPLAIN nested concat flattens and keeps the abs argument
+      When query
+        """
+        EXPLAIN SELECT concat(concat(a, b), CAST(abs(x) AS STRING)) AS result FROM VALUES
+          ('a', 'b', -5),
+          ('c', 'd', 3)
+        AS t(a, b, x)
+        """
+      Then query plan matches snapshot
+
+    # Composition with null propagation: an inner NULL folds the whole call to
+    # NULL, so even the abs() inside the flattened call is dropped (never run).
+    @sail-only
+    Scenario: EXPLAIN inner NULL folds the flattened concat and drops abs
+      When query
+        """
+        EXPLAIN SELECT concat(concat(a, NULL), CAST(abs(x) AS STRING)) AS result FROM VALUES
+          ('a', 'b', -5),
+          ('c', 'd', 3)
+        AS t(a, b, x)
+        """
+      Then query plan matches snapshot
+
+    # Dead-code elimination: a NULL literal argument folds the whole concat to
+    # NULL, so an expensive sibling argument (here spark_abs) is dropped from the
+    # plan entirely and never evaluated.
+    @sail-only
+    Scenario: EXPLAIN concat with a NULL literal drops an expensive argument
+      When query
+        """
+        EXPLAIN SELECT concat(CAST(abs(v) AS STRING), CAST(NULL AS STRING)) AS result FROM VALUES
+          (-5),
+          (3)
         AS t(v)
         """
       Then query plan matches snapshot


### PR DESCRIPTION
Plan-time simplifications mirroring Spark's concat semantics:
- `CombineConcats`: flatten nested concat(concat(a, b), c) -> concat(a, b, c) in one bottom-up pass, only when the return type is preserved (guards the array element-type / dimension merge)
- null propagation: a literal NULL argument folds the whole call to a typed NULL at planning time, eliminating the other argument subtrees (DCE) and letting columns referenced only here be pruned from the scan; falls through on a type-invalid combo (array + untyped NULL) so the normal path still errors

Also folded in:
- report nullability via return_field_from_args (null iff any argument is null, per Spark Concat.nullable); DataFusion no longer consults the deprecated is_nullable, so the old override was dead code (return_type becomes a guard, the type logic moves to the free fn concat_return_type)
- micro-perf in invoke_with_args: iterate args by reference instead of cloning the Vec, and format timestamps in a single allocation
- use ItemTaker::one() for the single-arg identity path