### PR TITLE
feat: support replace table for the hive metastore catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7496,6 +7496,7 @@ dependencies = [
  "datafusion",
  "futures",
  "libloading 0.8.9",
+ "log",
  "pilota",
  "sail-catalog",
  "sail-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7485,6 +7485,7 @@ dependencies = [
  "datafusion",
  "futures",
  "libloading 0.8.9",
+ "log",
  "pilota",
  "sail-catalog",
  "sail-common",

--- a/crates/sail-catalog-hms/Cargo.toml
+++ b/crates/sail-catalog-hms/Cargo.toml
@@ -19,6 +19,7 @@ chrono = { workspace = true }
 datafusion = { workspace = true }
 futures = { workspace = true }
 libloading = { workspace = true }
+log = { workspace = true }
 pilota = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/sail-catalog-hms/src/managed_table.rs
+++ b/crates/sail-catalog-hms/src/managed_table.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use sail_catalog::error::{CatalogError, CatalogResult};
 use sail_catalog::provider::AlterTableOptions;
 use sail_common_datafusion::catalog::managed::{
-    metadata_location_update, metadata_location_value, previous_metadata_location_update,
+    metadata_location_update, previous_metadata_location_update,
 };
 use sail_common_hms::hms::{
     CheckLockRequest, DataOperationType, LockComponent, LockLevel, LockRequest, LockState,
@@ -12,7 +12,7 @@ use sail_common_hms::hms::{
 };
 use volo_thrift::MaybeException;
 
-use crate::provider::{apply_alter_table_options, HmsCatalogProvider};
+use crate::provider::{apply_alter_table_options, hms_metadata_location, HmsCatalogProvider};
 
 const HMS_LOCK_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(30);
 const HMS_LOCK_CHECK_INTERVAL: Duration = Duration::from_millis(200);
@@ -38,14 +38,7 @@ pub(crate) fn validate_metadata_location_precondition(
     if metadata_location_update(properties).is_none() {
         return Ok(());
     }
-    let current = hms_table.parameters.as_ref().and_then(|parameters| {
-        metadata_location_value(
-            parameters
-                .iter()
-                .map(|(key, value)| (key.as_str(), value.as_str())),
-        )
-        .map(ToString::to_string)
-    });
+    let current = hms_metadata_location(hms_table);
     if current.as_deref() != Some(expected) {
         return Err(CatalogError::Conflict(format!(
             "Cannot commit catalog-managed table '{db_name}.{table_name}' because base metadata location '{expected}' does not match current HMS metadata location '{}'",
@@ -75,6 +68,113 @@ pub(crate) async fn alter_table_with_lock(
         .await?;
         apply_alter_table_options(&mut hms_table, db_name, table_name, options)?;
         HmsCatalogProvider::alter_table_with_client(&client, db_name, table_name, hms_table).await
+    }
+    .await;
+    let unlock_result = release_table_lock(&client, db_name, table_name, lock_id).await;
+    match (result, unlock_result) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Ok(()), Ok(())) => Ok(()),
+    }
+}
+
+/// Pre-validates a replacement `Table` before the drop, so client-detectable defects fail
+/// while the original is still present. Rejects duplicate column names (case-insensitive, per
+/// HMS/Spark), which HMS would otherwise reject server-side only after the drop.
+fn validate_replacement_table(
+    replacement: &Table,
+    db_name: &str,
+    table_name: &str,
+) -> CatalogResult<()> {
+    let mut seen = std::collections::HashSet::new();
+    let columns = replacement
+        .sd
+        .as_ref()
+        .and_then(|sd| sd.cols.as_deref())
+        .into_iter()
+        .flatten();
+    let partitions = replacement.partition_keys.as_deref().into_iter().flatten();
+    for field in columns.chain(partitions) {
+        if let Some(name) = field.name.as_deref() {
+            if !seen.insert(name.to_ascii_lowercase()) {
+                return Err(CatalogError::InvalidArgument(format!(
+                    "Cannot replace table '{db_name}.{table_name}': duplicate column name '{name}'"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Replaces an HMS table by drop-then-create under an exclusive lock: HMS has no atomic
+/// swap (`alter_table` can't change `partition_keys`, rename/create over an existing name
+/// throw, and DDL isn't transactional), so the result is a fresh, unrelated table.
+///
+/// Re-reads under the lock and re-validates `expected_metadata_location` (OCC) so a commit
+/// that landed since the caller's read is rejected, not clobbered. On create failure the
+/// original is restored from the pre-drop snapshot; a failed restore yields a
+/// `CatalogError::External` making the "table left dropped" state explicit.
+///
+/// Residual non-atomic window: between drop and create the table is absent to any reader
+/// bypassing the advisory lock. Drop is metadata-only (`delete_data = false`); Sail creates
+/// only EXTERNAL tables. See `create_table` for the same-location stale-data note.
+pub(crate) async fn replace_table_with_lock(
+    provider: &HmsCatalogProvider,
+    db_name: &str,
+    table_name: &str,
+    mut replacement: Table,
+    expected_metadata_location: Option<String>,
+) -> CatalogResult<()> {
+    validate_replacement_table(&replacement, db_name, table_name)?;
+    let (_, client) = provider.current_client().await?;
+    let lock_id = acquire_table_lock(&client, db_name, table_name).await?;
+    let result = async {
+        let current = HmsCatalogProvider::get_table_with_client(
+            &client,
+            db_name,
+            table_name,
+            "Failed to fetch HMS table for locked replace",
+        )
+        .await?;
+        crate::provider::assert_replace_metadata_location_unchanged(
+            expected_metadata_location.as_deref(),
+            &current,
+            db_name,
+            table_name,
+        )?;
+        // Carry the owner forward so REPLACE doesn't reset it (only `owner` is exposed;
+        // grants are not carried).
+        if let Some(owner) = current.owner.clone() {
+            replacement.owner = Some(owner);
+        }
+        HmsCatalogProvider::drop_table_with_client(&client, db_name, table_name, false, false)
+            .await?;
+        match HmsCatalogProvider::create_table_with_client(
+            &client,
+            db_name,
+            table_name,
+            replacement,
+        )
+        .await
+        {
+            Ok(()) => Ok(()),
+            Err(create_error) => {
+                // Compensating restore: the drop already committed, so re-create the
+                // original from the pre-drop snapshot; combine errors if that also fails.
+                match HmsCatalogProvider::create_table_with_client(
+                    &client, db_name, table_name, current,
+                )
+                .await
+                {
+                    Ok(()) => Err(create_error),
+                    Err(restore_error) => Err(CatalogError::External(format!(
+                        "Failed to replace table '{db_name}.{table_name}': create failed ({create_error}) \
+                         and the compensating restore of the original also failed ({restore_error}); \
+                         the table has been left dropped in HMS and must be recovered manually"
+                    ))),
+                }
+            }
+        }
     }
     .await;
     let unlock_result = release_table_lock(&client, db_name, table_name, lock_id).await;
@@ -239,4 +339,68 @@ fn hms_unlock_error(
     error: ThriftHiveMetastoreUnlockException,
 ) -> CatalogError {
     CatalogError::External(format!("{context} for '{db_name}.{table_name}': {error:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::unwrap_used)]
+
+    use sail_common_hms::hms::{FieldSchema, StorageDescriptor, Table};
+
+    use super::validate_replacement_table;
+
+    fn field(name: &str) -> FieldSchema {
+        FieldSchema {
+            name: Some(name.to_string().into()),
+            r#type: Some("string".into()),
+            ..Default::default()
+        }
+    }
+
+    fn table_with(cols: Vec<FieldSchema>, partitions: Vec<FieldSchema>) -> Table {
+        Table {
+            sd: Some(StorageDescriptor {
+                cols: Some(cols),
+                ..Default::default()
+            }),
+            partition_keys: (!partitions.is_empty()).then_some(partitions),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn accepts_distinct_columns() {
+        let table = table_with(vec![field("id"), field("value")], vec![field("day")]);
+        assert!(validate_replacement_table(&table, "db", "t").is_ok());
+    }
+
+    #[test]
+    fn rejects_duplicate_regular_columns() {
+        let table = table_with(vec![field("id"), field("id")], vec![]);
+        let error = validate_replacement_table(&table, "db", "t").unwrap_err();
+        assert!(matches!(
+            error,
+            sail_catalog::error::CatalogError::InvalidArgument(_)
+        ));
+        assert!(error.to_string().contains("duplicate column name 'id'"));
+    }
+
+    #[test]
+    fn rejects_duplicate_across_regular_and_partition() {
+        // HMS stores partition keys in the same COLUMNS namespace; a name shared
+        // between a regular column and a partition key would also collide.
+        let table = table_with(vec![field("id"), field("day")], vec![field("day")]);
+        let error = validate_replacement_table(&table, "db", "t").unwrap_err();
+        assert!(matches!(
+            error,
+            sail_catalog::error::CatalogError::InvalidArgument(_)
+        ));
+    }
+
+    #[test]
+    fn duplicate_detection_is_case_insensitive() {
+        // HMS/Spark treat column identity case-insensitively.
+        let table = table_with(vec![field("ID"), field("id")], vec![]);
+        assert!(validate_replacement_table(&table, "db", "t").is_err());
+    }
 }

--- a/crates/sail-catalog-hms/src/managed_table.rs
+++ b/crates/sail-catalog-hms/src/managed_table.rs
@@ -1,3 +1,5 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use sail_catalog::error::{CatalogError, CatalogResult};
@@ -6,9 +8,10 @@ use sail_common_datafusion::catalog::managed::{
     metadata_location_update, previous_metadata_location_update,
 };
 use sail_common_hms::hms::{
-    CheckLockRequest, DataOperationType, LockComponent, LockLevel, LockRequest, LockState,
-    LockType, Table, ThriftHiveMetastoreCheckLockException, ThriftHiveMetastoreClient,
-    ThriftHiveMetastoreLockException, ThriftHiveMetastoreUnlockException, UnlockRequest,
+    CheckLockRequest, DataOperationType, HeartbeatRequest, LockComponent, LockLevel, LockRequest,
+    LockState, LockType, Table, ThriftHiveMetastoreCheckLockException, ThriftHiveMetastoreClient,
+    ThriftHiveMetastoreHeartbeatException, ThriftHiveMetastoreLockException,
+    ThriftHiveMetastoreUnlockException, UnlockRequest,
 };
 use volo_thrift::MaybeException;
 
@@ -16,6 +19,10 @@ use crate::provider::{apply_alter_table_options, hms_metadata_location, HmsCatal
 
 const HMS_LOCK_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(30);
 const HMS_LOCK_CHECK_INTERVAL: Duration = Duration::from_millis(200);
+/// Interval between lock heartbeats sent during the critical section. HMS expires idle locks
+/// at the server `hive.txn.timeout` (default 300s); a fixed 60s interval stays comfortably
+/// below any realistic timeout (~timeout/5) while keeping RPC overhead negligible.
+const HMS_LOCK_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(60);
 
 pub(crate) fn is_metadata_location_update(options: &AlterTableOptions) -> bool {
     match options {
@@ -55,27 +62,23 @@ pub(crate) async fn alter_table_with_lock(
     options: AlterTableOptions,
 ) -> CatalogResult<()> {
     let (_, client) = provider.current_client().await?;
-    let lock_id = acquire_table_lock(&client, db_name, table_name).await?;
-    // TODO: Distinguish HMS lock/heartbeat/alter failures that make commit
-    // state unknown from ordinary conflicts or external errors.
-    let result = async {
-        let mut hms_table = HmsCatalogProvider::get_table_with_client(
-            &client,
-            db_name,
-            table_name,
-            "Failed to fetch HMS table for locked alter",
-        )
-        .await?;
-        apply_alter_table_options(&mut hms_table, db_name, table_name, options)?;
-        HmsCatalogProvider::alter_table_with_client(&client, db_name, table_name, hms_table).await
-    }
-    .await;
-    let unlock_result = release_table_lock(&client, db_name, table_name, lock_id).await;
-    match (result, unlock_result) {
-        (Err(error), _) => Err(error),
-        (Ok(()), Err(error)) => Err(error),
-        (Ok(()), Ok(())) => Ok(()),
-    }
+    let guard = LockGuard::acquire(client, db_name, table_name).await?;
+    // Clone the handle for the critical section; the guard keeps its own for heartbeat/unlock.
+    let client = guard.client().clone();
+    guard
+        .run_locked(async {
+            let mut hms_table = HmsCatalogProvider::get_table_with_client(
+                &client,
+                db_name,
+                table_name,
+                "Failed to fetch HMS table for locked alter",
+            )
+            .await?;
+            apply_alter_table_options(&mut hms_table, db_name, table_name, options)?;
+            HmsCatalogProvider::alter_table_with_client(&client, db_name, table_name, hms_table)
+                .await
+        })
+        .await
 }
 
 /// Pre-validates a replacement `Table` before the drop, so client-detectable defects fail
@@ -127,61 +130,239 @@ pub(crate) async fn replace_table_with_lock(
 ) -> CatalogResult<()> {
     validate_replacement_table(&replacement, db_name, table_name)?;
     let (_, client) = provider.current_client().await?;
-    let lock_id = acquire_table_lock(&client, db_name, table_name).await?;
-    let result = async {
-        let current = HmsCatalogProvider::get_table_with_client(
-            &client,
-            db_name,
-            table_name,
-            "Failed to fetch HMS table for locked replace",
-        )
-        .await?;
-        crate::provider::assert_replace_metadata_location_unchanged(
-            expected_metadata_location.as_deref(),
-            &current,
-            db_name,
-            table_name,
-        )?;
-        // Carry the owner forward so REPLACE doesn't reset it (only `owner` is exposed;
-        // grants are not carried).
-        if let Some(owner) = current.owner.clone() {
-            replacement.owner = Some(owner);
-        }
-        HmsCatalogProvider::drop_table_with_client(&client, db_name, table_name, false, false)
+    let guard = LockGuard::acquire(client, db_name, table_name).await?;
+    // Clone the handle for the critical section; the guard keeps its own for heartbeat/unlock.
+    let client = guard.client().clone();
+    guard
+        .run_locked(async {
+            let current = HmsCatalogProvider::get_table_with_client(
+                &client,
+                db_name,
+                table_name,
+                "Failed to fetch HMS table for locked replace",
+            )
             .await?;
-        match HmsCatalogProvider::create_table_with_client(
-            &client,
-            db_name,
-            table_name,
-            replacement,
-        )
+            crate::provider::assert_replace_metadata_location_unchanged(
+                expected_metadata_location.as_deref(),
+                &current,
+                db_name,
+                table_name,
+            )?;
+            // Carry the owner forward so REPLACE doesn't reset it (only `owner` is exposed;
+            // grants are not carried).
+            if let Some(owner) = current.owner.clone() {
+                replacement.owner = Some(owner);
+            }
+            HmsCatalogProvider::drop_table_with_client(&client, db_name, table_name, false, false)
+                .await?;
+            match HmsCatalogProvider::create_table_with_client(
+                &client,
+                db_name,
+                table_name,
+                replacement,
+            )
+            .await
+            {
+                Ok(()) => Ok(()),
+                Err(create_error) => {
+                    // Compensating restore: the drop already committed, so re-create the
+                    // original from the pre-drop snapshot; combine errors if that also fails.
+                    match HmsCatalogProvider::create_table_with_client(
+                        &client, db_name, table_name, current,
+                    )
+                    .await
+                    {
+                        Ok(()) => Err(create_error),
+                        Err(restore_error) => Err(CatalogError::External(format!(
+                            "Failed to replace table '{db_name}.{table_name}': create failed ({create_error}) \
+                             and the compensating restore of the original also failed ({restore_error}); \
+                             the table has been left dropped in HMS and must be recovered manually"
+                        ))),
+                    }
+                }
+            }
+        })
         .await
-        {
-            Ok(()) => Ok(()),
-            Err(create_error) => {
-                // Compensating restore: the drop already committed, so re-create the
-                // original from the pre-drop snapshot; combine errors if that also fails.
-                match HmsCatalogProvider::create_table_with_client(
-                    &client, db_name, table_name, current,
-                )
+}
+
+/// RAII holder for an acquired HMS table lock.
+///
+/// Owns the `lock_id` and a client handle, and drives a periodic heartbeat while a critical
+/// section runs so the server does not expire the lock mid-operation (HMS drops idle locks at
+/// `hive.txn.timeout`, default 300s). The lock is released via `unlock` on every exit path:
+/// [`LockGuard::run_locked`] always unlocks (success and error), and [`Drop`] provides a
+/// best-effort fallback so the lock is freed even on an early return or panic that bypasses
+/// `run_locked`.
+///
+/// The heartbeat runs as a detached background task that only keeps the lock alive; it can
+/// **never** cancel the critical section. On a heartbeat RPC failure it records the loss in a
+/// shared flag and stops. [`LockGuard::run_locked`] awaits the critical section to completion
+/// (whose own compensating-restore logic handles a create failure), and only *before* the
+/// irreversible `drop_table` may a caller consult the flag and bail; past the drop the section
+/// always finishes so no code path drops the critical future between `drop_table` and its
+/// restore. The server-side `hive.txn.timeout` is the real backstop for a genuinely lost lock.
+struct LockGuard {
+    client: ThriftHiveMetastoreClient,
+    lock_id: i64,
+    db_name: String,
+    table_name: String,
+    /// Set once the lock has been released so [`Drop`] does not attempt a redundant unlock.
+    released: bool,
+}
+
+impl LockGuard {
+    async fn acquire(
+        client: ThriftHiveMetastoreClient,
+        db_name: &str,
+        table_name: &str,
+    ) -> CatalogResult<Self> {
+        let lock_id = acquire_table_lock(&client, db_name, table_name).await?;
+        Ok(Self {
+            client,
+            lock_id,
+            db_name: db_name.to_string(),
+            table_name: table_name.to_string(),
+            released: false,
+        })
+    }
+
+    /// Borrow the client so the critical section can reuse the same connection.
+    fn client(&self) -> &ThriftHiveMetastoreClient {
+        &self.client
+    }
+
+    /// Runs `critical` while heartbeating the lock, then releases it.
+    ///
+    /// The heartbeat is spawned as a detached background task that only keeps the lock alive; it
+    /// can never cancel `critical`. `critical` is awaited to completion here — no `select!` that
+    /// could drop it mid-operation — so its own compensating-restore logic always gets to run on
+    /// a create failure. After it finishes, the heartbeat task is aborted. A heartbeat RPC
+    /// failure is recorded in a shared flag and, since the lock may then have been lost, is
+    /// surfaced only as a warning (the server-side `hive.txn.timeout` is the real backstop): it
+    /// does **not** override the outcome of an already-committed critical section. The lock is
+    /// unlocked on both the success and error paths; an unlock failure is surfaced only when the
+    /// critical section itself succeeded.
+    async fn run_locked<F>(mut self, critical: F) -> CatalogResult<()>
+    where
+        F: std::future::Future<Output = CatalogResult<()>>,
+    {
+        let heartbeat_failed = Arc::new(AtomicBool::new(false));
+        let heartbeat = tokio::spawn(Self::heartbeat_loop(
+            self.client.clone(),
+            self.lock_id,
+            self.db_name.clone(),
+            self.table_name.clone(),
+            Arc::clone(&heartbeat_failed),
+        ));
+
+        // Await the critical section to completion: never cancelled by the heartbeat, so the
+        // drop+create+restore sequence always runs as a unit.
+        let result = critical.await;
+
+        // The critical section is done; stop heartbeating.
+        heartbeat.abort();
+
+        if heartbeat_failed.load(Ordering::Acquire) {
+            // Best-effort signal only: the operation has already committed (or restored), so a
+            // lost lock cannot un-commit it. The server lock timeout is the real backstop.
+            log::warn!(
+                "HMS lock heartbeat for '{}.{}' failed during the operation; the lock may have \
+                 been lost, but the critical section had already run to completion",
+                self.db_name,
+                self.table_name
+            );
+        }
+
+        let unlock_result = self.release().await;
+        match (result, unlock_result) {
+            (Err(error), _) => Err(error),
+            (Ok(()), Err(error)) => Err(error),
+            (Ok(()), Ok(())) => Ok(()),
+        }
+    }
+
+    /// Sends a heartbeat every [`HMS_LOCK_HEARTBEAT_INTERVAL`] to keep the lock alive while the
+    /// critical section runs. Loops until aborted by [`LockGuard::run_locked`]; on a heartbeat
+    /// RPC failure it records the loss in `heartbeat_failed` and stops. It never returns a value
+    /// that could cancel or influence the critical section — the flag is advisory only.
+    async fn heartbeat_loop(
+        client: ThriftHiveMetastoreClient,
+        lock_id: i64,
+        db_name: String,
+        table_name: String,
+        heartbeat_failed: Arc<AtomicBool>,
+    ) {
+        let mut interval = tokio::time::interval(HMS_LOCK_HEARTBEAT_INTERVAL);
+        // Skip the immediate first tick: the lock was just acquired, so heartbeat only after
+        // the first interval has elapsed.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            match client
+                .heartbeat(HeartbeatRequest {
+                    lockid: Some(lock_id),
+                    txnid: None,
+                })
                 .await
-                {
-                    Ok(()) => Err(create_error),
-                    Err(restore_error) => Err(CatalogError::External(format!(
-                        "Failed to replace table '{db_name}.{table_name}': create failed ({create_error}) \
-                         and the compensating restore of the original also failed ({restore_error}); \
-                         the table has been left dropped in HMS and must be recovered manually"
-                    ))),
+            {
+                Ok(MaybeException::Ok(())) => {}
+                Ok(MaybeException::Exception(err)) => {
+                    let error = hms_heartbeat_error(
+                        "Lost HMS lock during operation",
+                        &db_name,
+                        &table_name,
+                        err,
+                    );
+                    log::warn!("{error}");
+                    heartbeat_failed.store(true, Ordering::Release);
+                    return;
+                }
+                Err(err) => {
+                    let error = HmsCatalogProvider::hms_client_error(
+                        &format!(
+                            "Failed to heartbeat HMS lock for '{db_name}.{table_name}'; the lock may have been lost"
+                        ),
+                        err,
+                    );
+                    log::warn!("{error}");
+                    heartbeat_failed.store(true, Ordering::Release);
+                    return;
                 }
             }
         }
     }
-    .await;
-    let unlock_result = release_table_lock(&client, db_name, table_name, lock_id).await;
-    match (result, unlock_result) {
-        (Err(error), _) => Err(error),
-        (Ok(()), Err(error)) => Err(error),
-        (Ok(()), Ok(())) => Ok(()),
+
+    /// Releases the lock exactly once, marking the guard so [`Drop`] does not repeat it.
+    async fn release(&mut self) -> CatalogResult<()> {
+        if self.released {
+            return Ok(());
+        }
+        self.released = true;
+        release_table_lock(&self.client, &self.db_name, &self.table_name, self.lock_id).await
+    }
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        if self.released {
+            return;
+        }
+        // `run_locked` normally releases the lock; this is the fallback for paths that bypass
+        // it (early return before `run_locked`, or a panic unwinding through it). Drop is
+        // synchronous, so spawn a detached best-effort unlock — but only if a runtime is
+        // entered. A bare `tokio::spawn` panics with no runtime, and panicking in `Drop` during
+        // a panic-unwind aborts the process; when there is no runtime we skip the unlock and
+        // rely on the server lock timeout as the backstop.
+        self.released = true;
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            let client = self.client.clone();
+            let request = UnlockRequest {
+                lockid: self.lock_id,
+            };
+            handle.spawn(async move {
+                let _ = client.unlock(request).await;
+            });
+        }
     }
 }
 
@@ -341,13 +522,36 @@ fn hms_unlock_error(
     CatalogError::External(format!("{context} for '{db_name}.{table_name}': {error:?}"))
 }
 
+fn hms_heartbeat_error(
+    context: &str,
+    db_name: &str,
+    table_name: &str,
+    error: ThriftHiveMetastoreHeartbeatException,
+) -> CatalogError {
+    CatalogError::External(format!("{context} for '{db_name}.{table_name}': {error:?}"))
+}
+
 #[cfg(test)]
 mod tests {
     #![expect(clippy::unwrap_used)]
 
     use sail_common_hms::hms::{FieldSchema, StorageDescriptor, Table};
 
-    use super::validate_replacement_table;
+    use super::{
+        validate_replacement_table, HMS_LOCK_ACQUIRE_TIMEOUT, HMS_LOCK_HEARTBEAT_INTERVAL,
+    };
+
+    #[test]
+    fn heartbeat_interval_stays_below_default_hms_txn_timeout() {
+        // HMS expires idle locks at `hive.txn.timeout` (default 300s). The heartbeat interval
+        // must leave a comfortable margin so a heartbeat lands well before expiry even with
+        // jitter or a slow RPC. Guard against anyone bumping the interval past that margin.
+        let default_hms_txn_timeout = std::time::Duration::from_secs(300);
+        assert!(HMS_LOCK_HEARTBEAT_INTERVAL * 3 <= default_hms_txn_timeout);
+        // Sanity: the first heartbeat fires after the acquire timeout window, so a lock that
+        // took a while to acquire is still refreshed promptly rather than left idle.
+        assert!(HMS_LOCK_HEARTBEAT_INTERVAL >= HMS_LOCK_ACQUIRE_TIMEOUT);
+    }
 
     fn field(name: &str) -> FieldSchema {
         FieldSchema {

--- a/crates/sail-catalog-hms/src/managed_table.rs
+++ b/crates/sail-catalog-hms/src/managed_table.rs
@@ -64,18 +64,21 @@ pub(crate) async fn alter_table_with_lock(
     let (_, client) = provider.current_client().await?;
     let guard = LockGuard::acquire(client, db_name, table_name).await?;
     // Clone the handle for the critical section; the guard keeps its own for heartbeat/unlock.
+    // The section is spawned as a `'static` task, so it owns its inputs.
     let client = guard.client().clone();
+    let db_name = db_name.to_string();
+    let table_name = table_name.to_string();
     guard
-        .run_locked(async {
+        .run_locked(async move {
             let mut hms_table = HmsCatalogProvider::get_table_with_client(
                 &client,
-                db_name,
-                table_name,
+                &db_name,
+                &table_name,
                 "Failed to fetch HMS table for locked alter",
             )
             .await?;
-            apply_alter_table_options(&mut hms_table, db_name, table_name, options)?;
-            HmsCatalogProvider::alter_table_with_client(&client, db_name, table_name, hms_table)
+            apply_alter_table_options(&mut hms_table, &db_name, &table_name, options)?;
+            HmsCatalogProvider::alter_table_with_client(&client, &db_name, &table_name, hms_table)
                 .await
         })
         .await
@@ -132,33 +135,36 @@ pub(crate) async fn replace_table_with_lock(
     let (_, client) = provider.current_client().await?;
     let guard = LockGuard::acquire(client, db_name, table_name).await?;
     // Clone the handle for the critical section; the guard keeps its own for heartbeat/unlock.
+    // The section is spawned as a `'static` task, so it owns its inputs.
     let client = guard.client().clone();
+    let db_name = db_name.to_string();
+    let table_name = table_name.to_string();
     guard
-        .run_locked(async {
+        .run_locked(async move {
             let current = HmsCatalogProvider::get_table_with_client(
                 &client,
-                db_name,
-                table_name,
+                &db_name,
+                &table_name,
                 "Failed to fetch HMS table for locked replace",
             )
             .await?;
             crate::provider::assert_replace_metadata_location_unchanged(
                 expected_metadata_location.as_deref(),
                 &current,
-                db_name,
-                table_name,
+                &db_name,
+                &table_name,
             )?;
             // Carry the owner forward so REPLACE doesn't reset it (only `owner` is exposed;
             // grants are not carried).
             if let Some(owner) = current.owner.clone() {
                 replacement.owner = Some(owner);
             }
-            HmsCatalogProvider::drop_table_with_client(&client, db_name, table_name, false, false)
+            HmsCatalogProvider::drop_table_with_client(&client, &db_name, &table_name, false, false)
                 .await?;
             match HmsCatalogProvider::create_table_with_client(
                 &client,
-                db_name,
-                table_name,
+                &db_name,
+                &table_name,
                 replacement,
             )
             .await
@@ -168,7 +174,7 @@ pub(crate) async fn replace_table_with_lock(
                     // Compensating restore: the drop already committed, so re-create the
                     // original from the pre-drop snapshot; combine errors if that also fails.
                     match HmsCatalogProvider::create_table_with_client(
-                        &client, db_name, table_name, current,
+                        &client, &db_name, &table_name, current,
                     )
                     .await
                     {
@@ -185,6 +191,16 @@ pub(crate) async fn replace_table_with_lock(
         .await
 }
 
+/// Aborts the wrapped task when dropped, so a cancelled or unwinding `run_locked` never leaks
+/// the heartbeat task (dropping a bare `JoinHandle` only detaches it — it keeps running).
+struct AbortOnDrop(tokio::task::JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}
+
 /// RAII holder for an acquired HMS table lock.
 ///
 /// Owns the `lock_id` and a client handle, and drives a periodic heartbeat while a critical
@@ -194,13 +210,13 @@ pub(crate) async fn replace_table_with_lock(
 /// best-effort fallback so the lock is freed even on an early return or panic that bypasses
 /// `run_locked`.
 ///
-/// The heartbeat runs as a detached background task that only keeps the lock alive; it can
-/// **never** cancel the critical section. On a heartbeat RPC failure it records the loss in a
-/// shared flag and stops. [`LockGuard::run_locked`] awaits the critical section to completion
-/// (whose own compensating-restore logic handles a create failure), and only *before* the
-/// irreversible `drop_table` may a caller consult the flag and bail; past the drop the section
-/// always finishes so no code path drops the critical future between `drop_table` and its
-/// restore. The server-side `hive.txn.timeout` is the real backstop for a genuinely lost lock.
+/// The heartbeat runs as a background task that only keeps the lock alive; it can **never**
+/// cancel the critical section. On a heartbeat RPC failure it records the loss in a shared flag
+/// and stops. [`LockGuard::run_locked`] runs the critical section on a spawned task with the
+/// guard moved in, so drop+create+restore completes as a unit even if the caller's future is
+/// dropped. The staleness flag is advisory only — it is read after the section has completed and
+/// merely warns; nothing consults it to abort, and the server-side `hive.txn.timeout` is the
+/// real backstop for a genuinely lost lock.
 struct LockGuard {
     client: ThriftHiveMetastoreClient,
     lock_id: i64,
@@ -233,51 +249,66 @@ impl LockGuard {
 
     /// Runs `critical` while heartbeating the lock, then releases it.
     ///
-    /// The heartbeat is spawned as a detached background task that only keeps the lock alive; it
-    /// can never cancel `critical`. `critical` is awaited to completion here — no `select!` that
-    /// could drop it mid-operation — so its own compensating-restore logic always gets to run on
-    /// a create failure. After it finishes, the heartbeat task is aborted. A heartbeat RPC
-    /// failure is recorded in a shared flag and, since the lock may then have been lost, is
-    /// surfaced only as a warning (the server-side `hive.txn.timeout` is the real backstop): it
-    /// does **not** override the outcome of an already-committed critical section. The lock is
-    /// unlocked on both the success and error paths; an unlock failure is surfaced only when the
-    /// critical section itself succeeded.
-    async fn run_locked<F>(mut self, critical: F) -> CatalogResult<()>
+    /// The critical section is run on its own spawned task and the guard is moved into that task,
+    /// so the drop+create+restore sequence completes **even if the caller's future is dropped**
+    /// (client disconnect, request timeout): a torn-in-half replace would leave the table dropped
+    /// with no restore. Awaiting the guard inline (no `spawn`) would not survive external
+    /// cancellation; `select!` was already avoided so the heartbeat cannot cancel it either.
+    ///
+    /// The heartbeat only keeps the lock alive; it can never cancel the critical section, and is
+    /// aborted (via [`AbortOnDrop`]) as soon as the section finishes or the task unwinds. A
+    /// heartbeat RPC failure is recorded in a flag and surfaced only as a warning — the operation
+    /// has already committed (or restored) by the time it is read, so it cannot un-commit; the
+    /// server-side `hive.txn.timeout` is the real backstop. The lock is released on the success,
+    /// error, and panic paths; an unlock failure is surfaced only when the section itself
+    /// succeeded.
+    async fn run_locked<F>(self, critical: F) -> CatalogResult<()>
     where
-        F: std::future::Future<Output = CatalogResult<()>>,
+        F: std::future::Future<Output = CatalogResult<()>> + Send + 'static,
     {
-        let heartbeat_failed = Arc::new(AtomicBool::new(false));
-        let heartbeat = tokio::spawn(Self::heartbeat_loop(
-            self.client.clone(),
-            self.lock_id,
-            self.db_name.clone(),
-            self.table_name.clone(),
-            Arc::clone(&heartbeat_failed),
-        ));
+        // Keep names for the join-error message; the guard itself is moved into the task.
+        let db_name = self.db_name.clone();
+        let table_name = self.table_name.clone();
 
-        // Await the critical section to completion: never cancelled by the heartbeat, so the
-        // drop+create+restore sequence always runs as a unit.
-        let result = critical.await;
+        let supervisor = tokio::spawn(async move {
+            // The guard is owned here: its `Drop` releases the lock if `critical` panics.
+            let mut guard = self;
+            let heartbeat_failed = Arc::new(AtomicBool::new(false));
+            let heartbeat = AbortOnDrop(tokio::spawn(Self::heartbeat_loop(
+                guard.client.clone(),
+                guard.lock_id,
+                guard.db_name.clone(),
+                guard.table_name.clone(),
+                Arc::clone(&heartbeat_failed),
+            )));
 
-        // The critical section is done; stop heartbeating.
-        heartbeat.abort();
+            let result = critical.await;
 
-        if heartbeat_failed.load(Ordering::Acquire) {
-            // Best-effort signal only: the operation has already committed (or restored), so a
-            // lost lock cannot un-commit it. The server lock timeout is the real backstop.
-            log::warn!(
-                "HMS lock heartbeat for '{}.{}' failed during the operation; the lock may have \
-                 been lost, but the critical section had already run to completion",
-                self.db_name,
-                self.table_name
-            );
-        }
+            // Section done; stop heartbeating before releasing the lock.
+            drop(heartbeat);
 
-        let unlock_result = self.release().await;
-        match (result, unlock_result) {
-            (Err(error), _) => Err(error),
-            (Ok(()), Err(error)) => Err(error),
-            (Ok(()), Ok(())) => Ok(()),
+            if heartbeat_failed.load(Ordering::Acquire) {
+                log::warn!(
+                    "HMS lock heartbeat for '{}.{}' failed during the operation; the lock may \
+                     have been lost, but the critical section had already run to completion",
+                    guard.db_name,
+                    guard.table_name
+                );
+            }
+
+            let unlock_result = guard.release().await;
+            (result, unlock_result)
+        });
+
+        match supervisor.await {
+            Ok((result, unlock_result)) => match (result, unlock_result) {
+                (Err(error), _) => Err(error),
+                (Ok(()), Err(error)) => Err(error),
+                (Ok(()), Ok(())) => Ok(()),
+            },
+            Err(join_error) => Err(CatalogError::External(format!(
+                "HMS locked operation for '{db_name}.{table_name}' failed to complete: {join_error}"
+            ))),
         }
     }
 

--- a/crates/sail-catalog-hms/src/managed_table.rs
+++ b/crates/sail-catalog-hms/src/managed_table.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use sail_catalog::error::{CatalogError, CatalogResult};
 use sail_catalog::provider::AlterTableOptions;
 use sail_common_datafusion::catalog::managed::{
-    metadata_location_update, metadata_location_value, previous_metadata_location_update,
+    metadata_location_update, previous_metadata_location_update,
 };
 use sail_common_hms::hms::{
     CheckLockRequest, DataOperationType, LockComponent, LockLevel, LockRequest, LockState,
@@ -12,7 +12,7 @@ use sail_common_hms::hms::{
 };
 use volo_thrift::MaybeException;
 
-use crate::provider::{HmsCatalogProvider, apply_alter_table_options};
+use crate::provider::{apply_alter_table_options, hms_metadata_location, HmsCatalogProvider};
 
 const HMS_LOCK_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(30);
 const HMS_LOCK_CHECK_INTERVAL: Duration = Duration::from_millis(200);
@@ -38,14 +38,7 @@ pub(crate) fn validate_metadata_location_precondition(
     if metadata_location_update(properties).is_none() {
         return Ok(());
     }
-    let current = hms_table.parameters.as_ref().and_then(|parameters| {
-        metadata_location_value(
-            parameters
-                .iter()
-                .map(|(key, value)| (key.as_str(), value.as_str())),
-        )
-        .map(ToString::to_string)
-    });
+    let current = hms_metadata_location(hms_table);
     if current.as_deref() != Some(expected) {
         return Err(CatalogError::Conflict(format!(
             "Cannot commit catalog-managed table '{db_name}.{table_name}' because base metadata location '{expected}' does not match current HMS metadata location '{}'",
@@ -75,6 +68,113 @@ pub(crate) async fn alter_table_with_lock(
         .await?;
         apply_alter_table_options(&mut hms_table, db_name, table_name, options)?;
         HmsCatalogProvider::alter_table_with_client(&client, db_name, table_name, hms_table).await
+    }
+    .await;
+    let unlock_result = release_table_lock(&client, db_name, table_name, lock_id).await;
+    match (result, unlock_result) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Ok(()), Ok(())) => Ok(()),
+    }
+}
+
+/// Pre-validates a replacement `Table` before the drop, so client-detectable defects fail
+/// while the original is still present. Rejects duplicate column names (case-insensitive, per
+/// HMS/Spark), which HMS would otherwise reject server-side only after the drop.
+fn validate_replacement_table(
+    replacement: &Table,
+    db_name: &str,
+    table_name: &str,
+) -> CatalogResult<()> {
+    let mut seen = std::collections::HashSet::new();
+    let columns = replacement
+        .sd
+        .as_ref()
+        .and_then(|sd| sd.cols.as_deref())
+        .into_iter()
+        .flatten();
+    let partitions = replacement.partition_keys.as_deref().into_iter().flatten();
+    for field in columns.chain(partitions) {
+        if let Some(name) = field.name.as_deref() {
+            if !seen.insert(name.to_ascii_lowercase()) {
+                return Err(CatalogError::InvalidArgument(format!(
+                    "Cannot replace table '{db_name}.{table_name}': duplicate column name '{name}'"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Replaces an HMS table by drop-then-create under an exclusive lock: HMS has no atomic
+/// swap (`alter_table` can't change `partition_keys`, rename/create over an existing name
+/// throw, and DDL isn't transactional), so the result is a fresh, unrelated table.
+///
+/// Re-reads under the lock and re-validates `expected_metadata_location` (OCC) so a commit
+/// that landed since the caller's read is rejected, not clobbered. On create failure the
+/// original is restored from the pre-drop snapshot; a failed restore yields a
+/// `CatalogError::External` making the "table left dropped" state explicit.
+///
+/// Residual non-atomic window: between drop and create the table is absent to any reader
+/// bypassing the advisory lock. Drop is metadata-only (`delete_data = false`); Sail creates
+/// only EXTERNAL tables. See `create_table` for the same-location stale-data note.
+pub(crate) async fn replace_table_with_lock(
+    provider: &HmsCatalogProvider,
+    db_name: &str,
+    table_name: &str,
+    mut replacement: Table,
+    expected_metadata_location: Option<String>,
+) -> CatalogResult<()> {
+    validate_replacement_table(&replacement, db_name, table_name)?;
+    let (_, client) = provider.current_client().await?;
+    let lock_id = acquire_table_lock(&client, db_name, table_name).await?;
+    let result = async {
+        let current = HmsCatalogProvider::get_table_with_client(
+            &client,
+            db_name,
+            table_name,
+            "Failed to fetch HMS table for locked replace",
+        )
+        .await?;
+        crate::provider::assert_replace_metadata_location_unchanged(
+            expected_metadata_location.as_deref(),
+            &current,
+            db_name,
+            table_name,
+        )?;
+        // Carry the owner forward so REPLACE doesn't reset it (only `owner` is exposed;
+        // grants are not carried).
+        if let Some(owner) = current.owner.clone() {
+            replacement.owner = Some(owner);
+        }
+        HmsCatalogProvider::drop_table_with_client(&client, db_name, table_name, false, false)
+            .await?;
+        match HmsCatalogProvider::create_table_with_client(
+            &client,
+            db_name,
+            table_name,
+            replacement,
+        )
+        .await
+        {
+            Ok(()) => Ok(()),
+            Err(create_error) => {
+                // Compensating restore: the drop already committed, so re-create the
+                // original from the pre-drop snapshot; combine errors if that also fails.
+                match HmsCatalogProvider::create_table_with_client(
+                    &client, db_name, table_name, current,
+                )
+                .await
+                {
+                    Ok(()) => Err(create_error),
+                    Err(restore_error) => Err(CatalogError::External(format!(
+                        "Failed to replace table '{db_name}.{table_name}': create failed ({create_error}) \
+                         and the compensating restore of the original also failed ({restore_error}); \
+                         the table has been left dropped in HMS and must be recovered manually"
+                    ))),
+                }
+            }
+        }
     }
     .await;
     let unlock_result = release_table_lock(&client, db_name, table_name, lock_id).await;
@@ -239,4 +339,68 @@ fn hms_unlock_error(
     error: ThriftHiveMetastoreUnlockException,
 ) -> CatalogError {
     CatalogError::External(format!("{context} for '{db_name}.{table_name}': {error:?}"))
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::unwrap_used)]
+
+    use sail_common_hms::hms::{FieldSchema, StorageDescriptor, Table};
+
+    use super::validate_replacement_table;
+
+    fn field(name: &str) -> FieldSchema {
+        FieldSchema {
+            name: Some(name.to_string().into()),
+            r#type: Some("string".into()),
+            ..Default::default()
+        }
+    }
+
+    fn table_with(cols: Vec<FieldSchema>, partitions: Vec<FieldSchema>) -> Table {
+        Table {
+            sd: Some(StorageDescriptor {
+                cols: Some(cols),
+                ..Default::default()
+            }),
+            partition_keys: (!partitions.is_empty()).then_some(partitions),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn accepts_distinct_columns() {
+        let table = table_with(vec![field("id"), field("value")], vec![field("day")]);
+        assert!(validate_replacement_table(&table, "db", "t").is_ok());
+    }
+
+    #[test]
+    fn rejects_duplicate_regular_columns() {
+        let table = table_with(vec![field("id"), field("id")], vec![]);
+        let error = validate_replacement_table(&table, "db", "t").unwrap_err();
+        assert!(matches!(
+            error,
+            sail_catalog::error::CatalogError::InvalidArgument(_)
+        ));
+        assert!(error.to_string().contains("duplicate column name 'id'"));
+    }
+
+    #[test]
+    fn rejects_duplicate_across_regular_and_partition() {
+        // HMS stores partition keys in the same COLUMNS namespace; a name shared
+        // between a regular column and a partition key would also collide.
+        let table = table_with(vec![field("id"), field("day")], vec![field("day")]);
+        let error = validate_replacement_table(&table, "db", "t").unwrap_err();
+        assert!(matches!(
+            error,
+            sail_catalog::error::CatalogError::InvalidArgument(_)
+        ));
+    }
+
+    #[test]
+    fn duplicate_detection_is_case_insensitive() {
+        // HMS/Spark treat column identity case-insensitively.
+        let table = table_with(vec![field("ID"), field("id")], vec![]);
+        assert!(validate_replacement_table(&table, "db", "t").is_err());
+    }
 }

--- a/crates/sail-catalog-hms/src/managed_table.rs
+++ b/crates/sail-catalog-hms/src/managed_table.rs
@@ -101,12 +101,12 @@ fn validate_replacement_table(
         .flatten();
     let partitions = replacement.partition_keys.as_deref().into_iter().flatten();
     for field in columns.chain(partitions) {
-        if let Some(name) = field.name.as_deref() {
-            if !seen.insert(name.to_ascii_lowercase()) {
-                return Err(CatalogError::InvalidArgument(format!(
-                    "Cannot replace table '{db_name}.{table_name}': duplicate column name '{name}'"
-                )));
-            }
+        if let Some(name) = field.name.as_deref()
+            && !seen.insert(name.to_ascii_lowercase())
+        {
+            return Err(CatalogError::InvalidArgument(format!(
+                "Cannot replace table '{db_name}.{table_name}': duplicate column name '{name}'"
+            )));
         }
     }
     Ok(())

--- a/crates/sail-catalog-hms/src/managed_table.rs
+++ b/crates/sail-catalog-hms/src/managed_table.rs
@@ -1,5 +1,5 @@
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use sail_catalog::error::{CatalogError, CatalogResult};
@@ -15,7 +15,7 @@ use sail_common_hms::hms::{
 };
 use volo_thrift::MaybeException;
 
-use crate::provider::{apply_alter_table_options, hms_metadata_location, HmsCatalogProvider};
+use crate::provider::{HmsCatalogProvider, apply_alter_table_options, hms_metadata_location};
 
 const HMS_LOCK_ACQUIRE_TIMEOUT: Duration = Duration::from_secs(30);
 const HMS_LOCK_CHECK_INTERVAL: Duration = Duration::from_millis(200);
@@ -569,7 +569,7 @@ mod tests {
     use sail_common_hms::hms::{FieldSchema, StorageDescriptor, Table};
 
     use super::{
-        validate_replacement_table, HMS_LOCK_ACQUIRE_TIMEOUT, HMS_LOCK_HEARTBEAT_INTERVAL,
+        HMS_LOCK_ACQUIRE_TIMEOUT, HMS_LOCK_HEARTBEAT_INTERVAL, validate_replacement_table,
     };
 
     #[test]

--- a/crates/sail-catalog-hms/src/provider.rs
+++ b/crates/sail-catalog-hms/src/provider.rs
@@ -11,6 +11,7 @@ use sail_catalog::provider::{
     TableFormatCreateMetadataMode,
 };
 use sail_common::runtime::RuntimeHandle;
+use sail_common_datafusion::catalog::managed::metadata_location_value;
 use sail_common_datafusion::catalog::{DatabaseStatus, TableStatus};
 use sail_common_hms::hms::{
     EnvironmentContext, GetTableRequest, Table, ThriftHiveMetastoreAlterTableException,
@@ -91,6 +92,38 @@ fn build_drop_table_request(purge: bool) -> DropTableRequest {
         delete_data: false,
         environment_context,
     }
+}
+
+/// Returns the metadata-location pointer from an HMS table's parameters, if present.
+pub(crate) fn hms_metadata_location(table: &Table) -> Option<String> {
+    let parameters = table.parameters.as_ref()?;
+    metadata_location_value(
+        parameters
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str())),
+    )
+    .map(ToString::to_string)
+}
+
+/// OCC guard for REPLACE: HMS has no CAS, so lakehouse tables re-validate the
+/// metadata-location pointer under the lock. Plain tables (no stamp) rely on the lock alone.
+pub(crate) fn assert_replace_metadata_location_unchanged(
+    expected: Option<&str>,
+    current: &Table,
+    db_name: &str,
+    table_name: &str,
+) -> CatalogResult<()> {
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    let current_location = hms_metadata_location(current);
+    if current_location.as_deref() != Some(expected) {
+        return Err(CatalogError::Conflict(format!(
+            "Cannot replace table '{db_name}.{table_name}': a concurrent modification advanced its metadata location from '{expected}' to '{}'",
+            current_location.as_deref().unwrap_or("<none>")
+        )));
+    }
+    Ok(())
 }
 
 pub(crate) fn apply_alter_table_options(
@@ -612,6 +645,67 @@ impl HmsCatalogProvider {
         }
     }
 
+    /// Creates a table on a specific client, for use under an already-held lock (where
+    /// failover-selecting `create_hms_table` could switch clients mid-critical-section).
+    pub(crate) async fn create_table_with_client(
+        client: &ThriftHiveMetastoreClient,
+        db_name: &str,
+        table_name: &str,
+        table: Table,
+    ) -> CatalogResult<()> {
+        match client.create_table(table).await {
+            Ok(MaybeException::Ok(())) => Ok(()),
+            Ok(MaybeException::Exception(ThriftHiveMetastoreCreateTableException::O1(_))) => {
+                Err(CatalogError::AlreadyExists(
+                    CatalogObject::Table,
+                    format!("{db_name}.{table_name}"),
+                ))
+            }
+            Ok(MaybeException::Exception(err)) => Err(CatalogError::External(format!(
+                "Failed to create HMS table '{db_name}.{table_name}': {err:?}"
+            ))),
+            Err(err) => Err(Self::hms_client_error(
+                &format!("Failed to create HMS table '{db_name}.{table_name}'"),
+                err,
+            )),
+        }
+    }
+
+    /// Drops a table on a specific client, for use under an already-held lock.
+    pub(crate) async fn drop_table_with_client(
+        client: &ThriftHiveMetastoreClient,
+        db_name: &str,
+        table_name: &str,
+        delete_data: bool,
+        if_exists: bool,
+    ) -> CatalogResult<()> {
+        match client
+            .drop_table(
+                db_name.to_string().into(),
+                table_name.to_string().into(),
+                delete_data,
+            )
+            .await
+        {
+            Ok(MaybeException::Ok(())) => Ok(()),
+            Ok(MaybeException::Exception(ThriftHiveMetastoreDropTableException::O1(_)))
+                if if_exists =>
+            {
+                Ok(())
+            }
+            Ok(MaybeException::Exception(ThriftHiveMetastoreDropTableException::O1(_))) => Err(
+                CatalogError::NotFound(CatalogObject::Table, format!("{db_name}.{table_name}")),
+            ),
+            Ok(MaybeException::Exception(err)) => Err(CatalogError::External(format!(
+                "Failed to drop HMS table '{db_name}.{table_name}': {err:?}"
+            ))),
+            Err(err) => Err(Self::hms_client_error(
+                &format!("Failed to drop HMS table '{db_name}.{table_name}'"),
+                err,
+            )),
+        }
+    }
+
     pub(crate) async fn create_hms_table(
         &self,
         database: &Namespace,
@@ -828,11 +922,6 @@ impl HmsCatalogProvider {
 }
 
 fn validate_create_table_options(options: &CreateTableOptions) -> CatalogResult<()> {
-    if options.mode.is_replace() {
-        return Err(CatalogError::NotSupported(
-            "Hive Metastore catalog does not support REPLACE".to_string(),
-        ));
-    }
     if !options.constraints.is_empty() {
         return Err(CatalogError::NotSupported(
             "Hive Metastore catalog does not support constraints for generic tables".to_string(),
@@ -1030,12 +1119,13 @@ impl CatalogProvider for HmsCatalogProvider {
         table: &str,
         options: CreateTableOptions,
     ) -> CatalogResult<TableStatus> {
-        let format = options.format.trim().to_lowercase();
+        let format_str = options.format.trim().to_lowercase();
         let if_not_exists = options.mode.ignore_if_exists();
+        let is_replace = options.mode.is_replace();
 
         validate_create_table_options(&options)?;
         let db_name = validate_namespace(database)?;
-        let format = HiveCatalogFormat::from_format(&format)?;
+        let format = HiveCatalogFormat::from_format(&format_str)?;
         let partition_columns: Vec<String> = options
             .partition_by
             .iter()
@@ -1062,6 +1152,46 @@ impl CatalogProvider for HmsCatalogProvider {
             &partition_columns,
             &format_for_metadata,
         )?;
+
+        if is_replace {
+            // REPLACE is drop-then-create under an exclusive lock (see
+            // `replace_table_with_lock`). Limitation: a plain-Hive EXTERNAL REPLACE reusing
+            // the SAME location leaves stale files (drop is metadata-only, no object-store
+            // handle here); lakehouse formats mask this via rewritten metadata.
+            let replace_requires_existing = options.mode.replace_requires_existing();
+            let existing = match self.fetch_hms_table(database, table).await {
+                Ok(t) => Some(t),
+                Err(CatalogError::NotFound(_, _)) => None,
+                Err(other) => return Err(other),
+            };
+
+            match existing {
+                None if replace_requires_existing => {
+                    return Err(CatalogError::NotFound(
+                        CatalogObject::Table,
+                        format!("{db_name}.{table}"),
+                    ));
+                }
+                None => {
+                    // CreateOrReplace on a non-existent table: fall through to create.
+                }
+                Some(existing_table) => {
+                    // OCC stamp; replace_table_with_lock re-validates it under the HMS lock.
+                    let expected_metadata_location = hms_metadata_location(&existing_table);
+
+                    managed_table::replace_table_with_lock(
+                        self,
+                        &db_name,
+                        table,
+                        hms_table.clone(),
+                        expected_metadata_location,
+                    )
+                    .await?;
+
+                    return table_to_status(&self.name, database, &hms_table);
+                }
+            }
+        }
 
         self.create_hms_table(database, table, hms_table, if_not_exists)
             .await
@@ -1682,5 +1812,56 @@ mod tests {
         });
 
         assert_eq!(timeout, Duration::from_secs(12));
+    }
+
+    fn iceberg_table_with_metadata_location(location: &str) -> Table {
+        Table {
+            parameters: Some(AHashMap::from_iter([(
+                FastStr::from_static_str("metadata_location"),
+                FastStr::from(location.to_string()),
+            )])),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_replace_precondition_errors_on_metadata_location_mismatch() {
+        let current = iceberg_table_with_metadata_location(
+            "s3://warehouse/items/metadata/00002-new.metadata.json",
+        );
+
+        let error = super::assert_replace_metadata_location_unchanged(
+            Some("s3://warehouse/items/metadata/00001-old.metadata.json"),
+            &current,
+            "default",
+            "items",
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, CatalogError::Conflict(_)));
+        assert!(error.to_string().contains("concurrent modification"));
+    }
+
+    #[test]
+    fn test_replace_precondition_accepts_unchanged_metadata_location() {
+        let location = "s3://warehouse/items/metadata/00001-current.metadata.json";
+        let current = iceberg_table_with_metadata_location(location);
+
+        super::assert_replace_metadata_location_unchanged(
+            Some(location),
+            &current,
+            "default",
+            "items",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_replace_precondition_noop_without_expected_location() {
+        // Plain tables carry no metadata-location stamp; the precondition is a no-op.
+        let current = Table::default();
+
+        super::assert_replace_metadata_location_unchanged(None, &current, "default", "items")
+            .unwrap();
     }
 }

--- a/crates/sail-catalog-hms/src/provider.rs
+++ b/crates/sail-catalog-hms/src/provider.rs
@@ -11,6 +11,7 @@ use sail_catalog::provider::{
     plain_lakehouse_create_table_metadata_requirement,
 };
 use sail_common::runtime::RuntimeHandle;
+use sail_common_datafusion::catalog::managed::metadata_location_value;
 use sail_common_datafusion::catalog::{DatabaseStatus, TableStatus};
 use sail_common_hms::hms::{
     EnvironmentContext, GetTableRequest, Table, ThriftHiveMetastoreAlterTableException,
@@ -90,6 +91,38 @@ fn build_drop_table_request(purge: bool) -> DropTableRequest {
         delete_data: false,
         environment_context,
     }
+}
+
+/// Returns the metadata-location pointer from an HMS table's parameters, if present.
+pub(crate) fn hms_metadata_location(table: &Table) -> Option<String> {
+    let parameters = table.parameters.as_ref()?;
+    metadata_location_value(
+        parameters
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str())),
+    )
+    .map(ToString::to_string)
+}
+
+/// OCC guard for REPLACE: HMS has no CAS, so lakehouse tables re-validate the
+/// metadata-location pointer under the lock. Plain tables (no stamp) rely on the lock alone.
+pub(crate) fn assert_replace_metadata_location_unchanged(
+    expected: Option<&str>,
+    current: &Table,
+    db_name: &str,
+    table_name: &str,
+) -> CatalogResult<()> {
+    let Some(expected) = expected else {
+        return Ok(());
+    };
+    let current_location = hms_metadata_location(current);
+    if current_location.as_deref() != Some(expected) {
+        return Err(CatalogError::Conflict(format!(
+            "Cannot replace table '{db_name}.{table_name}': a concurrent modification advanced its metadata location from '{expected}' to '{}'",
+            current_location.as_deref().unwrap_or("<none>")
+        )));
+    }
+    Ok(())
 }
 
 pub(crate) fn apply_alter_table_options(
@@ -611,6 +644,67 @@ impl HmsCatalogProvider {
         }
     }
 
+    /// Creates a table on a specific client, for use under an already-held lock (where
+    /// failover-selecting `create_hms_table` could switch clients mid-critical-section).
+    pub(crate) async fn create_table_with_client(
+        client: &ThriftHiveMetastoreClient,
+        db_name: &str,
+        table_name: &str,
+        table: Table,
+    ) -> CatalogResult<()> {
+        match client.create_table(table).await {
+            Ok(MaybeException::Ok(())) => Ok(()),
+            Ok(MaybeException::Exception(ThriftHiveMetastoreCreateTableException::O1(_))) => {
+                Err(CatalogError::AlreadyExists(
+                    CatalogObject::Table,
+                    format!("{db_name}.{table_name}"),
+                ))
+            }
+            Ok(MaybeException::Exception(err)) => Err(CatalogError::External(format!(
+                "Failed to create HMS table '{db_name}.{table_name}': {err:?}"
+            ))),
+            Err(err) => Err(Self::hms_client_error(
+                &format!("Failed to create HMS table '{db_name}.{table_name}'"),
+                err,
+            )),
+        }
+    }
+
+    /// Drops a table on a specific client, for use under an already-held lock.
+    pub(crate) async fn drop_table_with_client(
+        client: &ThriftHiveMetastoreClient,
+        db_name: &str,
+        table_name: &str,
+        delete_data: bool,
+        if_exists: bool,
+    ) -> CatalogResult<()> {
+        match client
+            .drop_table(
+                db_name.to_string().into(),
+                table_name.to_string().into(),
+                delete_data,
+            )
+            .await
+        {
+            Ok(MaybeException::Ok(())) => Ok(()),
+            Ok(MaybeException::Exception(ThriftHiveMetastoreDropTableException::O1(_)))
+                if if_exists =>
+            {
+                Ok(())
+            }
+            Ok(MaybeException::Exception(ThriftHiveMetastoreDropTableException::O1(_))) => Err(
+                CatalogError::NotFound(CatalogObject::Table, format!("{db_name}.{table_name}")),
+            ),
+            Ok(MaybeException::Exception(err)) => Err(CatalogError::External(format!(
+                "Failed to drop HMS table '{db_name}.{table_name}': {err:?}"
+            ))),
+            Err(err) => Err(Self::hms_client_error(
+                &format!("Failed to drop HMS table '{db_name}.{table_name}'"),
+                err,
+            )),
+        }
+    }
+
     pub(crate) async fn create_hms_table(
         &self,
         database: &Namespace,
@@ -827,11 +921,6 @@ impl HmsCatalogProvider {
 }
 
 fn validate_create_table_options(options: &CreateTableOptions) -> CatalogResult<()> {
-    if options.mode.is_replace() {
-        return Err(CatalogError::NotSupported(
-            "Hive Metastore catalog does not support REPLACE".to_string(),
-        ));
-    }
     if !options.constraints.is_empty() {
         return Err(CatalogError::NotSupported(
             "Hive Metastore catalog does not support constraints for generic tables".to_string(),
@@ -1029,12 +1118,13 @@ impl CatalogProvider for HmsCatalogProvider {
         table: &str,
         options: CreateTableOptions,
     ) -> CatalogResult<TableStatus> {
-        let format = options.format.trim().to_lowercase();
+        let format_str = options.format.trim().to_lowercase();
         let if_not_exists = options.mode.ignore_if_exists();
+        let is_replace = options.mode.is_replace();
 
         validate_create_table_options(&options)?;
         let db_name = validate_namespace(database)?;
-        let format = HiveCatalogFormat::from_format(&format)?;
+        let format = HiveCatalogFormat::from_format(&format_str)?;
         let partition_columns: Vec<String> = options
             .partition_by
             .iter()
@@ -1061,6 +1151,46 @@ impl CatalogProvider for HmsCatalogProvider {
             &partition_columns,
             &format_for_metadata,
         )?;
+
+        if is_replace {
+            // REPLACE is drop-then-create under an exclusive lock (see
+            // `replace_table_with_lock`). Limitation: a plain-Hive EXTERNAL REPLACE reusing
+            // the SAME location leaves stale files (drop is metadata-only, no object-store
+            // handle here); lakehouse formats mask this via rewritten metadata.
+            let replace_requires_existing = options.mode.replace_requires_existing();
+            let existing = match self.fetch_hms_table(database, table).await {
+                Ok(t) => Some(t),
+                Err(CatalogError::NotFound(_, _)) => None,
+                Err(other) => return Err(other),
+            };
+
+            match existing {
+                None if replace_requires_existing => {
+                    return Err(CatalogError::NotFound(
+                        CatalogObject::Table,
+                        format!("{db_name}.{table}"),
+                    ));
+                }
+                None => {
+                    // CreateOrReplace on a non-existent table: fall through to create.
+                }
+                Some(existing_table) => {
+                    // OCC stamp; replace_table_with_lock re-validates it under the HMS lock.
+                    let expected_metadata_location = hms_metadata_location(&existing_table);
+
+                    managed_table::replace_table_with_lock(
+                        self,
+                        &db_name,
+                        table,
+                        hms_table.clone(),
+                        expected_metadata_location,
+                    )
+                    .await?;
+
+                    return table_to_status(&self.name, database, &hms_table);
+                }
+            }
+        }
 
         self.create_hms_table(database, table, hms_table, if_not_exists)
             .await
@@ -1687,5 +1817,56 @@ mod tests {
         });
 
         assert_eq!(timeout, Duration::from_secs(12));
+    }
+
+    fn iceberg_table_with_metadata_location(location: &str) -> Table {
+        Table {
+            parameters: Some(AHashMap::from_iter([(
+                FastStr::from_static_str("metadata_location"),
+                FastStr::from(location.to_string()),
+            )])),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn test_replace_precondition_errors_on_metadata_location_mismatch() {
+        let current = iceberg_table_with_metadata_location(
+            "s3://warehouse/items/metadata/00002-new.metadata.json",
+        );
+
+        let error = super::assert_replace_metadata_location_unchanged(
+            Some("s3://warehouse/items/metadata/00001-old.metadata.json"),
+            &current,
+            "default",
+            "items",
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, CatalogError::Conflict(_)));
+        assert!(error.to_string().contains("concurrent modification"));
+    }
+
+    #[test]
+    fn test_replace_precondition_accepts_unchanged_metadata_location() {
+        let location = "s3://warehouse/items/metadata/00001-current.metadata.json";
+        let current = iceberg_table_with_metadata_location(location);
+
+        super::assert_replace_metadata_location_unchanged(
+            Some(location),
+            &current,
+            "default",
+            "items",
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_replace_precondition_noop_without_expected_location() {
+        // Plain tables carry no metadata-location stamp; the precondition is a no-op.
+        let current = Table::default();
+
+        super::assert_replace_metadata_location_unchanged(None, &current, "default", "items")
+            .unwrap();
     }
 }

--- a/crates/sail-catalog-hms/tests/table_tests.rs
+++ b/crates/sail-catalog-hms/tests/table_tests.rs
@@ -176,3 +176,14 @@ async fn test_list_tables_excludes_views() {
     assert!(tables.iter().any(|table| table.name == "items"));
     assert!(tables.iter().all(|table| table.name != "v_items"));
 }
+
+// NOTE: REPLACE / CREATE OR REPLACE TABLE behaviour for the HMS provider is now covered by
+// the Spark-SQL `.feature` tests in
+// `python/pysail/tests/spark/catalog/hms/features/replace_table.feature`
+// (schema change, dropped columns, partition change, replaced-table reads, create-vs-replace
+// on a missing table, and the critical "invalid replacement preserves the original" regression).
+// The client-side pre-validation that backs that regression is unit-tested in
+// `sail-catalog-hms/src/managed_table.rs` (`validate_replacement_table`). The REPLACE-path
+// metadata-location OCC (`assert_replace_metadata_location_unchanged`) is unit-tested in
+// `sail-catalog-hms/src/provider.rs`; the ALTER-path OCC conflict is covered by the Python
+// test `test_hms_rejects_stale_iceberg_metadata_location_update`.

--- a/python/pysail/tests/spark/catalog/hms/conftest.py
+++ b/python/pysail/tests/spark/catalog/hms/conftest.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 import pytest
 from pyspark.sql import SparkSession
 from pyspark.sql.utils import AnalysisException
+from pytest_bdd import given, parsers
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.network import Network
 from testcontainers.core.waiting_utils import wait_for_logs
@@ -417,6 +418,24 @@ def hms_s3_database(
         jvm_spark.sql(f"DROP DATABASE IF EXISTS {database} CASCADE")
     except Exception:  # noqa: BLE001
         spark.sql(f"DROP DATABASE IF EXISTS {database} CASCADE")
+
+
+# ---------------------------------------------------------------------------
+# pytest-bdd steps for `.feature` scenarios
+# ---------------------------------------------------------------------------
+
+
+@given(parsers.parse("the HMS test database as {name}"), target_fixture="variables")
+def hms_test_database_variable(name: str, hms_s3_database: str, variables: dict) -> dict:
+    """Expose the S3-backed HMS database name as a `.feature` template variable.
+
+    The database is provisioned by the ``hms_s3_database`` fixture (created via
+    reference Spark with an ``s3://`` LOCATION, dropped on teardown). Scenarios
+    reference it as e.g. ``{{ db }}`` in ``statement template`` / ``query template``
+    steps so managed tables land under the MinIO-backed warehouse.
+    """
+    variables[name] = hms_s3_database
+    return variables
 
 
 # ---------------------------------------------------------------------------

--- a/python/pysail/tests/spark/catalog/hms/conftest.py
+++ b/python/pysail/tests/spark/catalog/hms/conftest.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 import pytest
 from pyspark.sql import SparkSession
 from pyspark.sql.utils import AnalysisException
+from pytest_bdd import given, parsers
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.network import Network
 from testcontainers.core.waiting_utils import wait_for_logs
@@ -475,6 +476,24 @@ def hms_s3_database(
         jvm_spark.sql(f"DROP DATABASE IF EXISTS {database} CASCADE")
     except Exception:  # noqa: BLE001
         spark.sql(f"DROP DATABASE IF EXISTS {database} CASCADE")
+
+
+# ---------------------------------------------------------------------------
+# pytest-bdd steps for `.feature` scenarios
+# ---------------------------------------------------------------------------
+
+
+@given(parsers.parse("the HMS test database as {name}"), target_fixture="variables")
+def hms_test_database_variable(name: str, hms_s3_database: str, variables: dict) -> dict:
+    """Expose the S3-backed HMS database name as a `.feature` template variable.
+
+    The database is provisioned by the ``hms_s3_database`` fixture (created via
+    reference Spark with an ``s3://`` LOCATION, dropped on teardown). Scenarios
+    reference it as e.g. ``{{ db }}`` in ``statement template`` / ``query template``
+    steps so managed tables land under the MinIO-backed warehouse.
+    """
+    variables[name] = hms_s3_database
+    return variables
 
 
 # ---------------------------------------------------------------------------

--- a/python/pysail/tests/spark/catalog/hms/features/replace_table.feature
+++ b/python/pysail/tests/spark/catalog/hms/features/replace_table.feature
@@ -1,0 +1,144 @@
+Feature: HMS catalog CREATE OR REPLACE TABLE
+
+  REPLACE on the Hive Metastore is a drop-then-create under an exclusive table
+  lock (HMS has no atomic swap). These scenarios exercise the observable
+  behaviour through Spark SQL against Sail's HMS provider: schema and
+  partitioning changes, correct reads of the replaced definition, the
+  create-vs-replace-on-missing distinction, and the critical regression that an
+  invalid replacement must leave the original table intact.
+
+  Background:
+    Given the HMS test database as db
+
+  Scenario: CREATE OR REPLACE TABLE changes the schema
+    Given statement template
+      """
+      CREATE TABLE {{ db }}.t_schema (id INT) USING PARQUET
+      """
+    Given statement template
+      """
+      CREATE OR REPLACE TABLE {{ db }}.t_schema (id INT, value DOUBLE) USING PARQUET
+      """
+    When query template
+      """
+      DESCRIBE TABLE {{ db }}.t_schema
+      """
+    Then query result has row where "col_name" is "id"
+    Then query result has row where "col_name" is "value"
+    Then query result row where "col_name" is "value" has "data_type" equal to "double"
+
+  Scenario: CREATE OR REPLACE TABLE drops a column from the declared schema
+    Given statement template
+      """
+      CREATE TABLE {{ db }}.t_drop_col (id INT, legacy STRING) USING PARQUET
+      """
+    Given statement template
+      """
+      CREATE OR REPLACE TABLE {{ db }}.t_drop_col (id INT) USING PARQUET
+      """
+    # REPLACE is a metadata drop+create; the catalog now reports only `id`. (The projected
+    # header of an empty read is exactly the new schema, so a dropped column cannot leak in.)
+    When query template
+      """
+      SELECT * FROM {{ db }}.t_drop_col LIMIT 0
+      """
+    Then query result
+      | id |
+    When query template
+      """
+      DESCRIBE TABLE {{ db }}.t_drop_col
+      """
+    Then query result has row where "col_name" is "id"
+
+  Scenario: CREATE OR REPLACE TABLE changes the partitioning
+    Given statement template
+      """
+      CREATE TABLE {{ db }}.t_part (id INT, region STRING, country STRING)
+      USING PARQUET
+      PARTITIONED BY (region)
+      """
+    Given statement template
+      """
+      CREATE OR REPLACE TABLE {{ db }}.t_part (id INT, region STRING, country STRING)
+      USING PARQUET
+      PARTITIONED BY (country)
+      """
+    When query template
+      """
+      DESCRIBE TABLE EXTENDED {{ db }}.t_part
+      """
+    Then query result has row where "col_name" is "# Partition Information"
+    Then query result has row where "col_name" is "country"
+
+  Scenario: Replaced table reads back under the new schema, not the old one
+    Given statement template
+      """
+      CREATE TABLE {{ db }}.t_read (id INT, legacy STRING) USING PARQUET
+      """
+    Given statement template
+      """
+      CREATE OR REPLACE TABLE {{ db }}.t_read (id INT, label STRING) USING PARQUET
+      """
+    Given statement template
+      """
+      INSERT INTO {{ db }}.t_read VALUES (10, 'fresh')
+      """
+    # The replaced definition exposes exactly the new columns (id, label); the old `legacy`
+    # column is gone from the schema, and a row written after REPLACE reads back correctly.
+    When query template
+      """
+      SELECT * FROM {{ db }}.t_read WHERE id = 10 ORDER BY id
+      """
+    Then query result ordered
+      | id | label |
+      | 10 | fresh |
+
+  Scenario: CREATE OR REPLACE on a missing table creates it
+    Given statement template
+      """
+      CREATE OR REPLACE TABLE {{ db }}.t_cor_new (id INT, name STRING) USING PARQUET
+      """
+    When query template
+      """
+      SHOW TABLES IN {{ db }} LIKE 't_cor_new'
+      """
+    Then query result has row where "tableName" is "t_cor_new"
+    When query template
+      """
+      DESCRIBE TABLE {{ db }}.t_cor_new
+      """
+    Then query result has row where "col_name" is "id"
+    Then query result has row where "col_name" is "name"
+
+  Scenario: bare REPLACE TABLE on a missing table errors
+    Given statement template with error (TABLE_OR_VIEW_NOT_FOUND|not found|does not exist|cannot be found|NoSuchTable)
+      """
+      REPLACE TABLE {{ db }}.t_missing_replace (id INT) USING PARQUET
+      """
+
+  Scenario: invalid replacement preserves the original table
+    Given statement template
+      """
+      CREATE TABLE {{ db }}.t_survive (id INT COMMENT 'original id', keep STRING) USING PARQUET
+      """
+    Given statement template
+      """
+      INSERT INTO {{ db }}.t_survive VALUES (1, 'alive')
+      """
+    Given statement template with error (duplicate column|COLUMN_ALREADY_EXISTS|already exists|duplicate)
+      """
+      CREATE OR REPLACE TABLE {{ db }}.t_survive (id INT, id INT) USING PARQUET
+      """
+    When query template
+      """
+      DESCRIBE TABLE {{ db }}.t_survive
+      """
+    Then query result has row where "col_name" is "id"
+    Then query result has row where "col_name" is "keep"
+    When query template
+      """
+      SELECT id, keep FROM {{ db }}.t_survive ORDER BY id
+      """
+    Then query result ordered
+      | id | keep  |
+      | 1  | alive |

--- a/python/pysail/tests/spark/catalog/hms/test_replace_table.py
+++ b/python/pysail/tests/spark/catalog/hms/test_replace_table.py
@@ -1,0 +1,107 @@
+# ruff: noqa: S608
+"""HMS CREATE OR REPLACE TABLE tests that need a second query to inspect state.
+
+Behaviour that is fully observable in a single SQL result lives in the
+``.feature`` scenarios (``features/replace_table.feature``). The cases here need
+to parse a *second* query result -- the partition section of
+``DESCRIBE EXTENDED`` -- to assert precisely which columns are partition keys
+after a REPLACE, which the row-existence ``.feature`` steps cannot distinguish
+from ordinary columns.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyspark.sql import SparkSession
+
+
+def _partition_columns(spark: SparkSession, table_fqn: str) -> list[str]:
+    """Return the partition column names from Sail's DESCRIBE EXTENDED output.
+
+    Sail emits a ``# Partition Information`` marker row, then a ``# col_name``
+    header row, then one row per partition column, then a blank row followed by
+    ``# Detailed Table Information``. Everything between the header and that
+    trailing block is a partition column.
+    """
+    rows = spark.sql(f"DESCRIBE EXTENDED {table_fqn}").collect()
+    names = [(row.col_name or "").strip() for row in rows]
+    if "# Partition Information" not in names:
+        return []
+    start = names.index("# Partition Information") + 1
+    # Skip the "# col_name" header row that follows the marker.
+    if start < len(names) and names[start] == "# col_name":
+        start += 1
+    partitions: list[str] = []
+    for name in names[start:]:
+        if name == "" or name.startswith("#"):
+            break
+        partitions.append(name)
+    return partitions
+
+
+def test_create_or_replace_changes_partitioning_region_to_country(
+    spark: SparkSession,
+    hms_s3_database: str,
+) -> None:
+    """The headline capability: REPLACE swaps the partition key set entirely.
+
+    HMS ``alter_table`` cannot change ``partition_keys``; Sail implements REPLACE
+    as drop+create under an exclusive lock, so the replaced table is a fresh
+    definition partitioned by ``country`` alone -- the old ``region`` partition
+    key must be gone.
+    """
+    table_fqn = f"{hms_s3_database}.t_repartition"
+
+    spark.sql(
+        f"""
+        CREATE TABLE {table_fqn} (id INT, region STRING, country STRING)
+        USING PARQUET
+        PARTITIONED BY (region)
+        """
+    )
+    assert _partition_columns(spark, table_fqn) == ["region"]
+
+    spark.sql(
+        f"""
+        CREATE OR REPLACE TABLE {table_fqn} (id INT, region STRING, country STRING)
+        USING PARQUET
+        PARTITIONED BY (country)
+        """
+    )
+    assert _partition_columns(spark, table_fqn) == ["country"], (
+        "REPLACE must swap the partition key from region to country, not merge them"
+    )
+
+
+def test_invalid_replacement_preserves_original_partitioning(
+    spark: SparkSession,
+    hms_s3_database: str,
+) -> None:
+    """A rejected REPLACE must leave the original table -- schema, rows and
+    partitioning -- untouched (pre-validate before drop / compensating restore).
+    """
+    import pytest
+
+    table_fqn = f"{hms_s3_database}.t_survive_part"
+
+    spark.sql(
+        f"""
+        CREATE TABLE {table_fqn} (id INT, region STRING) USING PARQUET
+        PARTITIONED BY (region)
+        """
+    )
+    spark.sql(f"INSERT INTO {table_fqn} VALUES (1, 'eu'), (2, 'us')")
+
+    with pytest.raises(Exception, match="(?i)duplicate|already exists|COLUMN_ALREADY_EXISTS"):
+        spark.sql(
+            f"""
+            CREATE OR REPLACE TABLE {table_fqn} (id INT, id INT) USING PARQUET
+            """
+        )
+
+    # Original schema, partitioning and rows must all survive.
+    assert _partition_columns(spark, table_fqn) == ["region"]
+    rows = spark.sql(f"SELECT id, region FROM {table_fqn} ORDER BY id").collect()
+    assert [(row.id, row.region) for row in rows] == [(1, "eu"), (2, "us")]

--- a/python/pysail/tests/spark/catalog/hms/test_replace_table.py
+++ b/python/pysail/tests/spark/catalog/hms/test_replace_table.py
@@ -94,7 +94,7 @@ def test_invalid_replacement_preserves_original_partitioning(
     )
     spark.sql(f"INSERT INTO {table_fqn} VALUES (1, 'eu'), (2, 'us')")
 
-    with pytest.raises(Exception, match="(?i)duplicate|already exists|COLUMN_ALREADY_EXISTS"):
+    with pytest.raises(Exception, match=r"(?i)duplicate|already exists|COLUMN_ALREADY_EXISTS"):
         spark.sql(
             f"""
             CREATE OR REPLACE TABLE {table_fqn} (id INT, id INT) USING PARQUET

--- a/python/pysail/tests/spark/catalog/hms/test_replace_table_features.py
+++ b/python/pysail/tests/spark/catalog/hms/test_replace_table_features.py
@@ -1,0 +1,3 @@
+from pytest_bdd import scenarios
+
+scenarios("features/replace_table.feature")


### PR DESCRIPTION
## What
`CREATE OR REPLACE` / `REPLACE TABLE` for the Hive Metastore catalog (was `NotSupported`).

## Design (grounded in Spark 4.x + Hive 4.0.0)
- HMS has **no atomic table-swap** (Hive 4.0.0: rename-over throws, `alter_table` can't change partition keys, metastore DDL isn't transactional). So — like Spark's own non-`StagingTableCatalog` path — REPLACE is **drop + create under an exclusive lock**, made **atomic-or-nothing** as far as HMS allows:
  - **pre-validation** (e.g. duplicate columns) before the drop, and **compensating restore** of the original if the create fails (only a restore-failure surfaces a "recover manually" error).
  - `metadata_location` OCC precondition (`Conflict` on concurrent advance); owner carried forward; fresh identity otherwise (allows arbitrary schema/partition change).

## Test coverage — pytest/`.feature` against live Hive 4.0.0 (no Rust integration tests)
| Behavior | How verified | Where |
| --- | --- | --- |
| schema change, drop column, partition change `region`→`country`, read-back under new schema, create-on-missing, `REPLACE` missing → error, **duplicate-column → fails + original survives** | SQL through Sail → live HMS | `catalog/hms/features/replace_table.feature` (7) |
| partition swap = exactly `[country]`; invalid replacement preserves original schema/partition/rows | SQL + `DESCRIBE EXTENDED` | `catalog/hms/test_replace_table.py` (2) |
| duplicate-column pre-validation; `metadata_location` OCC → `Conflict` | deterministic `src/` unit tests (not integration) | `managed_table.rs` (3), `provider.rs` (3) |

<details><summary><b>Results</b> — pytest 32 passed (+4 pre-existing xfail) against live Hive 4.0.0 (verbatim; replace tests shown)</summary>

```
# pytest -m integration python/pysail/tests/spark/catalog/hms/
test_replace_table.py::test_create_or_replace_changes_partitioning_region_to_country PASSED
test_replace_table.py::test_invalid_replacement_preserves_original_partitioning PASSED
test_replace_table_features.py::test_create_or_replace_table_changes_the_schema PASSED
test_replace_table_features.py::test_create_or_replace_table_drops_a_column_from_the_declared_schema PASSED
test_replace_table_features.py::test_create_or_replace_table_changes_the_partitioning PASSED
test_replace_table_features.py::test_replaced_table_reads_back_under_the_new_schema_not_the_old_one PASSED
test_replace_table_features.py::test_create_or_replace_on_a_missing_table_creates_it PASSED
test_replace_table_features.py::test_bare_replace_table_on_a_missing_table_errors PASSED
test_replace_table_features.py::test_invalid_replacement_preserves_the_original_table PASSED
============ 32 passed, 4 xfailed, 30 warnings in 95.33s (0:01:35) =============

# cargo test -p sail-catalog-hms --lib
test result: ok. 81 passed; 0 failed   (2 kerberos tests need libgssapi, absent on host — env-only)
```
clippy `-D warnings` clean.
</details>

Closes #2166.
