### PR TITLE
perf: various funcs StringBuilder byte-capacity 

### DIFF
--- a/crates/sail-function/src/scalar/json/from_json.rs
+++ b/crates/sail-function/src/scalar/json/from_json.rs
@@ -381,7 +381,7 @@ fn create_builder(
             })
         }
         DataType::LargeUtf8 => Ok(FieldBuilder::LargeString(
-            LargeStringBuilder::with_capacity(capacity, capacity * 16),
+            LargeStringBuilder::with_capacity(capacity, 0),
         )),
         DataType::Map(field, ordered) => {
             let (keys_field, values_field) = match field.data_type() {
@@ -420,8 +420,7 @@ fn create_builder(
             })
         }
         DataType::Utf8 => Ok(FieldBuilder::String(StringBuilder::with_capacity(
-            capacity,
-            capacity * 16,
+            capacity, 0,
         ))),
         DataType::Timestamp(time_unit, tz) => {
             let resolved_tz = tz.clone().unwrap_or(Arc::from(session_timezone));

--- a/crates/sail-function/src/scalar/json/to_json.rs
+++ b/crates/sail-function/src/scalar/json/to_json.rs
@@ -186,7 +186,7 @@ fn to_json_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
 }
 
 fn array_to_json_strings(array: &ArrayRef, options: &ToJsonOptions) -> Result<ArrayRef> {
-    let mut builder = StringBuilder::with_capacity(array.len(), array.len() * 64);
+    let mut builder = StringBuilder::with_capacity(array.len(), array.get_buffer_memory_size());
 
     for i in 0..array.len() {
         if array.is_null(i) {

--- a/crates/sail-function/src/scalar/math/spark_bin.rs
+++ b/crates/sail-function/src/scalar/math/spark_bin.rs
@@ -176,7 +176,7 @@ where
     // exactly once.
     let (lower, upper) = iter.size_hint();
     let cap = upper.unwrap_or(lower);
-    let mut builder = StringBuilder::with_capacity(cap, cap * 8);
+    let mut builder = StringBuilder::with_capacity(cap, 0);
     let mut scratch = String::with_capacity(64);
     for v in iter {
         match v {
@@ -225,9 +225,7 @@ fn bin_int_array_to_string(
     array: &datafusion::arrow::array::PrimitiveArray<Int64Type>,
 ) -> ArrayRef {
     let len = array.len();
-    // 8 chars/row average is a heuristic; the buffer grows as needed but
-    // starts close to the typical size so we avoid most reallocs.
-    let mut builder = StringBuilder::with_capacity(len, len * 8);
+    let mut builder = StringBuilder::with_capacity(len, 0);
     let mut scratch = String::with_capacity(64);
     if array.null_count() == 0 {
         for value in array.values().iter().copied() {
@@ -279,7 +277,7 @@ fn double_to_i64(value: f64, ansi: bool) -> Result<i64> {
 }
 
 fn bin_float_array(array: &PrimitiveArray<Float64Type>, ansi: bool) -> Result<StringArray> {
-    let mut builder = StringBuilder::with_capacity(array.len(), array.len() * 8);
+    let mut builder = StringBuilder::with_capacity(array.len(), 0);
     let mut scratch = String::with_capacity(64);
     for v in array.iter() {
         match v {

--- a/crates/sail-function/src/scalar/string/spark_concat_ws.rs
+++ b/crates/sail-function/src/scalar/string/spark_concat_ws.rs
@@ -116,7 +116,7 @@ fn concat_ws_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
         .map(ConcatArg::try_new)
         .collect::<Result<Vec<_>>>()?;
 
-    let mut builder = StringBuilder::with_capacity(num_rows, num_rows * 16);
+    let mut builder = StringBuilder::with_capacity(num_rows, 0);
     let mut row_buf = String::new(); // reused across rows; capacity is kept after clear()
 
     for row in 0..num_rows {

--- a/crates/sail-function/src/scalar/string/spark_encode_decode.rs
+++ b/crates/sail-function/src/scalar/string/spark_encode_decode.rs
@@ -114,7 +114,7 @@ impl ScalarUDFImpl for SparkEncode {
                                 let string_array = string_array.as_string::<i32>();
                                 let mut builder = BinaryBuilder::with_capacity(
                                     string_array.len(),
-                                    string_array.len(),
+                                    string_array.get_buffer_memory_size(),
                                 );
                                 for string in string_array.iter() {
                                     if let Some(string) = string {
@@ -129,7 +129,7 @@ impl ScalarUDFImpl for SparkEncode {
                                 let string_array = string_array.as_string::<i64>();
                                 let mut builder = LargeBinaryBuilder::with_capacity(
                                     string_array.len(),
-                                    string_array.len(),
+                                    string_array.get_buffer_memory_size(),
                                 );
                                 for string in string_array.iter() {
                                     if let Some(string) = string {
@@ -144,7 +144,7 @@ impl ScalarUDFImpl for SparkEncode {
                                 let string_array = string_array.as_string_view();
                                 let mut builder = BinaryBuilder::with_capacity(
                                     string_array.len(),
-                                    string_array.len(),
+                                    string_array.get_buffer_memory_size(),
                                 );
                                 for string in string_array.iter() {
                                     if let Some(string) = string {

--- a/crates/sail-function/src/scalar/variant/spark_schema_of_variant.rs
+++ b/crates/sail-function/src/scalar/variant/spark_schema_of_variant.rs
@@ -82,10 +82,8 @@ impl ScalarUDFImpl for SparkSchemaOfVariantUdf {
             }
             ColumnarValue::Array(variant_array) => {
                 let variant_array = VariantArray::try_new(variant_array.as_ref())?;
-                let mut builder = arrow::array::StringBuilder::with_capacity(
-                    variant_array.len(),
-                    variant_array.len() * 10,
-                );
+                let mut builder =
+                    arrow::array::StringBuilder::with_capacity(variant_array.len(), 0);
                 for v in variant_array.iter() {
                     match v {
                         Some(variant) => {


### PR DESCRIPTION
No magic numbers — a fabricated `len * N` byte hint is noise; use 0 (unknown) or the input's get_buffer_memory_size() (correlated).