### PR TITLE
feat: support Delta format MoR merge update operation

### DIFF
--- a/crates/sail-delta-lake/src/logical/merge.rs
+++ b/crates/sail-delta-lake/src/logical/merge.rs
@@ -16,7 +16,7 @@ use crate::logical::table_source::DeltaTableSource;
 
 /// Expand MERGE information into a unified row-level write node for Delta.
 pub fn expand_merge_node(info: MergeInfo) -> Result<LogicalPlan> {
-    let row_index_column = (merge_has_delete_actions(&info)
+    let row_index_column = ((merge_has_delete_actions(&info) || merge_has_update_actions(&info))
         && merge_target_supports_deletion_vectors(info.target.as_ref())?)
     .then_some(MERGE_ROW_INDEX_COLUMN);
     let mut target_plan = ensure_merge_metadata_columns(
@@ -111,6 +111,13 @@ fn merge_has_delete_actions(info: &MergeInfo) -> bool {
             .not_matched_by_source_clauses
             .iter()
             .any(|clause| matches!(clause.action, MergeNotMatchedBySourceAction::Delete))
+}
+
+fn merge_has_update_actions(info: &MergeInfo) -> bool {
+    info.options
+        .matched_clauses
+        .iter()
+        .any(|clause| matches!(clause.action, MergeMatchedAction::UpdateAll))
 }
 
 fn merge_target_supports_deletion_vectors(plan: &LogicalPlan) -> Result<bool> {

--- a/crates/sail-delta-lake/src/logical/merge.rs
+++ b/crates/sail-delta-lake/src/logical/merge.rs
@@ -114,10 +114,14 @@ fn merge_has_delete_actions(info: &MergeInfo) -> bool {
 }
 
 fn merge_has_update_actions(info: &MergeInfo) -> bool {
-    info.options
-        .matched_clauses
+    info.options.matched_clauses.iter().any(|clause| {
+        matches!(clause.action, MergeMatchedAction::UpdateAll)
+            || matches!(clause.action, MergeMatchedAction::UpdateSet(_))
+    }) || info
+        .options
+        .not_matched_by_source_clauses
         .iter()
-        .any(|clause| matches!(clause.action, MergeMatchedAction::UpdateAll))
+        .any(|clause| matches!(clause.action, MergeNotMatchedBySourceAction::UpdateSet(_)))
 }
 
 fn merge_target_supports_deletion_vectors(plan: &LogicalPlan) -> Result<bool> {

--- a/crates/sail-delta-lake/src/physical_plan/planner/op_merge.rs
+++ b/crates/sail-delta-lake/src/physical_plan/planner/op_merge.rs
@@ -200,11 +200,6 @@ pub async fn build_merge_plan_mor(
     ctx: &PlannerContext<'_>,
     merge_info: RowLevelWriteInfo,
 ) -> Result<Arc<dyn ExecutionPlan>> {
-    if merge_has_update_actions(&merge_info) {
-        return not_impl_err!(
-            "Merge-on-Read strategy for MERGE UPDATE clauses is not yet implemented for Delta Lake"
-        );
-    }
     if merge_has_delete_actions(&merge_info) && merge_info.deletion_vector_plan.is_none() {
         return internal_err!(
             "Merge-on-Read MERGE DELETE clauses require file-local row-index metadata"
@@ -239,12 +234,7 @@ pub async fn build_merge_plan_mor(
     let deletion_vector_plan = merge_info.deletion_vector_plan.clone();
     let touched_plan_opt = merge_info.touched_file_plan.clone();
 
-    let writer_input = if deletion_vector_plan.is_some() {
-        build_insert_rows_input(&expanded)?
-    } else {
-        Arc::clone(&expanded)
-    };
-    let writer_input = strip_internal_columns(writer_input)?;
+    let writer_input = strip_internal_columns(expanded)?;
     let writer_schema = writer_input.schema();
     let write_context = prepare_delta_write_context(
         ctx.table_url(),
@@ -445,27 +435,6 @@ fn build_targeted_writer_input(
     UnionExec::try_new(vec![insert_rows, touched_rows])
 }
 
-/// Build MERGE MoR writer input for source-only INSERT rows.
-fn build_insert_rows_input(expanded: &Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionPlan>> {
-    let projected_schema = expanded.schema();
-    if projected_schema.column_with_name(PATH_COLUMN).is_none() {
-        return internal_err!(
-            "MERGE writer input is missing required column '{PATH_COLUMN}' for insert filtering"
-        );
-    }
-
-    let path_idx = projected_schema
-        .index_of(PATH_COLUMN)
-        .map_err(|e| DataFusionError::Plan(format!("{e}")))?;
-    let insert_pred: Arc<dyn datafusion_physical_expr::PhysicalExpr> = Arc::new(IsNullExpr::new(
-        Arc::new(Column::new(PATH_COLUMN, path_idx)),
-    ));
-    Ok(Arc::new(FilterExec::try_new(
-        insert_pred,
-        Arc::clone(expanded),
-    )?))
-}
-
 /// Strip internal merge metadata columns already consumed by the physical planner.
 fn strip_internal_columns(input: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionPlan>> {
     let schema = input.schema();
@@ -519,22 +488,6 @@ fn build_merge_operation(info: &RowLevelWriteInfo) -> Option<DeltaOperation> {
         not_matched_predicates: to_kernel_preds(not_matched_predicates),
         not_matched_by_source_predicates: to_kernel_preds(not_matched_by_source_predicates),
     })
-}
-
-fn merge_has_update_actions(info: &RowLevelWriteInfo) -> bool {
-    let Some(OperationOverride::Merge {
-        matched_predicates,
-        not_matched_by_source_predicates,
-        ..
-    }) = info.operation_override.as_ref()
-    else {
-        return false;
-    };
-
-    matched_predicates
-        .iter()
-        .chain(not_matched_by_source_predicates)
-        .any(|p| p.action_type.eq_ignore_ascii_case("update"))
 }
 
 fn merge_has_delete_actions(info: &RowLevelWriteInfo) -> bool {

--- a/crates/sail-logical-plan/src/merge.rs
+++ b/crates/sail-logical-plan/src/merge.rs
@@ -859,7 +859,10 @@ fn build_default_merge_expansion(
             MergeMatchedAction::Delete => {
                 delete_pred = or_pred(delete_pred, pred);
             }
-            MergeMatchedAction::UpdateAll | MergeMatchedAction::UpdateSet(_) => {}
+            MergeMatchedAction::UpdateAll | MergeMatchedAction::UpdateSet(_) => {
+                delete_pred = or_pred(delete_pred, pred.clone());
+                insert_pred = or_pred(insert_pred, pred);
+            }
         }
     }
 
@@ -872,7 +875,10 @@ fn build_default_merge_expansion(
             MergeNotMatchedBySourceAction::Delete => {
                 delete_pred = or_pred(delete_pred, pred);
             }
-            MergeNotMatchedBySourceAction::UpdateSet(_) => {}
+            MergeNotMatchedBySourceAction::UpdateSet(_) => {
+                delete_pred = or_pred(delete_pred, pred.clone());
+                insert_pred = or_pred(insert_pred, pred);
+            }
         }
     }
 

--- a/crates/sail-logical-plan/src/merge.rs
+++ b/crates/sail-logical-plan/src/merge.rs
@@ -897,10 +897,9 @@ fn build_default_merge_expansion(
 
     let delete_expr = delete_pred.unwrap_or_else(|| lit(false));
     let insert_expr = insert_pred.unwrap_or_else(|| lit(false));
-    let active_expr = target_present.or(insert_expr);
 
     let filtered = LogicalPlanBuilder::from(join.as_ref().clone())
-        .filter(active_expr)?
+        .filter(insert_expr)?
         .build()?;
 
     let projection_exprs = build_merge_projection(

--- a/python/pysail/tests/spark/delta/features/merge.feature
+++ b/python/pysail/tests/spark/delta/features/merge.feature
@@ -373,18 +373,49 @@ Feature: Delta Lake Merge
         | 1  | keep     | target |
         | 3  | stay     | target |
         | 4  | inserted | insert |
-
-    Scenario: Matched updates are rejected for Merge-on-Read MERGE
-      When query
+  
+  Scenario: Matched updates use deletion vectors while unmatched rows are inserted
+      Given statement
+        """
+        INSERT INTO delta_merge_dv 
+        SELECT * FROM VALUES
+          (2, 'test', 'test')
+        """
+      Given statement
         """
         MERGE INTO delta_merge_dv AS t
         USING src_merge_dv AS s
         ON t.id = s.id
         WHEN MATCHED THEN
-          UPDATE SET value = s.value
+          UPDATE SET *
+        WHEN NOT MATCHED THEN
+          INSERT (id, value, flag)
+          VALUES (s.id, s.value, s.flag)
         """
-      Then query error Merge-on-Read strategy for MERGE UPDATE clauses
-
+      Then delta log latest commit info matches snapshot
+      Then delta log latest commit info contains
+        | path                                               | value                  |
+        | operation                                          | "MERGE"                |
+        | operationParameters.mergePredicate                 | "t . id = s . id " |
+        | operationParameters.matchedPredicates[0].actionType | "update"               |
+        | operationParameters.notMatchedPredicates[0].actionType | "insert"            |
+      Then file tree in location matches
+        """
+        📂 <hex-prefix>
+          📄 deletion_vector_<uuid>.bin
+        📄 part-<id>.<codec>.parquet
+        📄 part-<id>.<codec>.parquet
+        """
+      When query
+        """
+        SELECT id, value, flag FROM delta_merge_dv ORDER BY id
+        """
+      Then query result ordered
+        | id | value    | flag   |
+        | 1  | keep     | target |
+        | 2  | remove   | delete |
+        | 3  | stay     | target |
+        | 4  | inserted | insert |
 
   Rule: Updates for rows not matched by source and explicit insert columns
     Background:


### PR DESCRIPTION
## Overview

When the table uses delta format with deletion vector enabled, the current merge operation doesn't support update clause in either matched and unmatched case. This is pretty impactful, as merge update is commonly used feature with MoR. To be more specific, the query throws unsupported exception today,

```sql
MERGE INTO users_table AS target
USING incoming_batch AS source
ON target.id = source.id
WHEN MATCHED THEN
  UPDATE SET *
WHEN NOT MATCHED THEN
  INSERT (id, name) VALUES (source.id, source.name)
WHEN NOT MATCHED BY SOURCE THEN
  UPDATE SET target.name = 'Unknown'
```

##  Quick smoke test

```sql
CREATE TABLE IF NOT EXISTS users_table (
  id INT,
  name STRING
) 
USING delta
LOCATION '{path}'
TBLPROPERTIES ('delta.enableDeletionVectors' = 'true')

INSERT INTO users_table VALUES 
    (1, 'David'),
    (2, 'Eva')
```

```python
incoming_data = [
    (1, "Bobby"),  # Existing ID: This will trigger an UPDATE
    (3, "Frank")   # New ID: This will trigger an INSERT
]
incoming_df = spark.createDataFrame(incoming_data, schema="id INT, name STRING")
incoming_df.createOrReplaceTempView("incoming_batch")
```

```sql
MERGE INTO users_table AS target
USING incoming_batch AS source
ON target.id = source.id
WHEN MATCHED THEN
  UPDATE SET *
WHEN NOT MATCHED THEN
  INSERT (id, name) VALUES (source.id, source.name)
WHEN NOT MATCHED BY SOURCE THEN
  UPDATE SET target.name = 'Unknown'

SELECT * FROM users_table ORDER BY id
```

### Before
Unsupported error

### After

```
+---+-------+
| id|   name|
+---+-------+
|  1|  Bobby|
|  2|Unknown|
|  3|  Frank|
+---+-------+
```

