### PR TITLE
feat: push down projections through ExplicitRepartitionExec

### DIFF
--- a/crates/sail-physical-plan/src/repartition.rs
+++ b/crates/sail-physical-plan/src/repartition.rs
@@ -7,16 +7,19 @@ use datafusion::arrow::compute::take_arrays;
 use datafusion::arrow::datatypes::UInt32Type;
 use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion::common::runtime::SpawnedTask;
+use datafusion::config::ConfigOptions;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
-use datafusion::physical_expr::Partitioning;
+use datafusion::physical_expr::{Partitioning, conjunction};
 use datafusion::physical_plan::execution_plan::{
     CardinalityEffect, EvaluationType, SchedulingType,
 };
+use datafusion::physical_plan::filter::FilterExec;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties, PhysicalExpr
 };
 use datafusion::physical_plan::projection::{ProjectionExec, all_columns, make_with_child, update_expr};
+use datafusion::physical_plan::filter_pushdown::{ChildPushdownResult, FilterDescription, FilterPushdownPhase, FilterPushdownPropagation, PushedDown};
 use datafusion_common::{internal_err, plan_err, Result, Statistics};
 use futures::{Stream, StreamExt};
 use sail_common_datafusion::extension::SessionExtensionAccessor;
@@ -501,7 +504,7 @@ impl ExecutionPlan for ExplicitRepartitionExec {
             return Ok(None);
         }
 
-        // Only push down simple column references — non-column expressions are potentially expensive
+        // Mostly no benefit if projection expressions are not simple column references
         if projection.benefits_from_input_partitioning()[0]
             || !all_columns(projection.expr())
         {
@@ -529,5 +532,48 @@ impl ExecutionPlan for ExplicitRepartitionExec {
             new_projection,
             new_partitioning
         ))))
+    }
+
+    fn gather_filters_for_pushdown(
+        &self,
+        _phase: FilterPushdownPhase,
+        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> Result<FilterDescription>
+    {
+        FilterDescription::from_children(parent_filters, &self.children())
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        _phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>>
+    {
+        // Collect parent filters that the child did NOT support
+        let unsupported_filters: Vec<Arc<dyn PhysicalExpr>> = child_pushdown_result
+            .parent_filters
+            .iter()
+            .filter(|&f| matches!(f.all(), PushedDown::No))
+            .map(|f| Arc::clone(&f.filter))
+            .collect();
+
+        if unsupported_filters.is_empty() {
+            return Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
+        }
+
+        // Build a single conjunctive predicate from the unsupported filters
+        // and insert a FilterExec between this ExplicitRepartitionExec and its child.
+        let predicate = conjunction(unsupported_filters);
+        let new_child = Arc::new(FilterExec::try_new(predicate, Arc::clone(self.input()))?);
+        let new_explicit_repartition = Arc::new(ExplicitRepartitionExec::new(
+            new_child,
+            self.properties.partitioning.clone()
+        ));
+
+        Ok(FilterPushdownPropagation::with_parent_pushdown_result(
+            vec![PushedDown::Yes; child_pushdown_result.parent_filters.len()]
+        ).with_updated_node(new_explicit_repartition))
     }
 }

--- a/crates/sail-physical-plan/src/repartition.rs
+++ b/crates/sail-physical-plan/src/repartition.rs
@@ -7,24 +7,17 @@ use datafusion::arrow::compute::take_arrays;
 use datafusion::arrow::datatypes::UInt32Type;
 use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion::common::runtime::SpawnedTask;
-use datafusion::config::ConfigOptions;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
-use datafusion::physical_expr::{Partitioning, conjunction};
+use datafusion::physical_expr::Partitioning;
 use datafusion::physical_plan::execution_plan::{
     CardinalityEffect, EvaluationType, SchedulingType,
-};
-use datafusion::physical_plan::filter::FilterExec;
-use datafusion::physical_plan::filter_pushdown::{
-    ChildPushdownResult, FilterDescription, FilterPushdownPhase, FilterPushdownPropagation,
-    PushedDown,
 };
 use datafusion::physical_plan::projection::{
     ProjectionExec, all_columns, make_with_child, update_expr,
 };
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PhysicalExpr,
-    PlanProperties,
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
 };
 use datafusion_common::{Result, Statistics, internal_err, plan_err};
 use futures::{Stream, StreamExt};
@@ -529,52 +522,7 @@ impl ExecutionPlan for ExplicitRepartitionExec {
         ))))
     }
 
-    fn gather_filters_for_pushdown(
-        &self,
-        _phase: FilterPushdownPhase,
-        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
-        _config: &ConfigOptions,
-    ) -> Result<FilterDescription> {
-        FilterDescription::from_children(parent_filters, &self.children())
-    }
-
-    fn handle_child_pushdown_result(
-        &self,
-        phase: FilterPushdownPhase,
-        child_pushdown_result: ChildPushdownResult,
-        _config: &ConfigOptions,
-    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
-        if !matches!(phase, FilterPushdownPhase::Pre) {
-            return Ok(FilterPushdownPropagation::if_all(child_pushdown_result));
-        }
-
-        // Collect parent filters that the child did not support
-        let unsupported_filters: Vec<Arc<dyn PhysicalExpr>> = child_pushdown_result
-            .parent_filters
-            .iter()
-            .filter(|&f| matches!(f.all(), PushedDown::No))
-            .map(|f| Arc::clone(&f.filter))
-            .collect();
-
-        if unsupported_filters.is_empty() {
-            return Ok(FilterPushdownPropagation::if_all(child_pushdown_result));
-        }
-
-        // Build a single conjunctive predicate from the unsupported filters
-        // and insert a FilterExec between this ExplicitRepartitionExec and its child.
-        let predicate = conjunction(unsupported_filters);
-        let new_child = Arc::new(FilterExec::try_new(predicate, Arc::clone(self.input()))?);
-        let new_explicit_repartition = Arc::new(ExplicitRepartitionExec::new(
-            new_child,
-            self.properties.partitioning.clone(),
-        ));
-
-        Ok(FilterPushdownPropagation::with_parent_pushdown_result(vec![
-            PushedDown::Yes;
-            child_pushdown_result
-                .parent_filters
-                .len()
-        ])
-        .with_updated_node(new_explicit_repartition))
-    }
+    // Do not implement Filter pushdown, as its evaluation can be potentially
+    // expensive, and the presence of explicit repartitioning indicates that
+    // the user wants to evaluate the filters after repartitioning.
 }

--- a/crates/sail-physical-plan/src/repartition.rs
+++ b/crates/sail-physical-plan/src/repartition.rs
@@ -9,17 +9,23 @@ use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion::common::runtime::SpawnedTask;
 use datafusion::config::ConfigOptions;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
-use datafusion::physical_expr::{Partitioning, conjunction};
+use datafusion::physical_expr::{conjunction, Partitioning};
 use datafusion::physical_plan::execution_plan::{
     CardinalityEffect, EvaluationType, SchedulingType,
 };
 use datafusion::physical_plan::filter::FilterExec;
+use datafusion::physical_plan::filter_pushdown::{
+    ChildPushdownResult, FilterDescription, FilterPushdownPhase, FilterPushdownPropagation,
+    PushedDown,
+};
+use datafusion::physical_plan::projection::{
+    all_columns, make_with_child, update_expr, ProjectionExec,
+};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties, PhysicalExpr
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PhysicalExpr,
+    PlanProperties,
 };
-use datafusion::physical_plan::projection::{ProjectionExec, all_columns, make_with_child, update_expr};
-use datafusion::physical_plan::filter_pushdown::{ChildPushdownResult, FilterDescription, FilterPushdownPhase, FilterPushdownPropagation, PushedDown};
 use datafusion_common::{internal_err, plan_err, Result, Statistics};
 use futures::{Stream, StreamExt};
 use sail_common_datafusion::extension::SessionExtensionAccessor;
@@ -487,27 +493,17 @@ impl ExecutionPlan for ExplicitRepartitionExec {
         CardinalityEffect::Equal
     }
 
-    // TODO: Implement the logic to push down filters or projections.
-    //   The filters and projections are safe to push down if they are
-    //   column references. For other expressions, we may not want to
-    //   push them down since the evaluation can be potentially expensive,
-    //   and the presence of explicit repartitioning indicates that the user
-    //   wants to evaluate these expressions after repartitioning.
-
     fn try_swapping_with_projection(
         &self,
         projection: &ProjectionExec,
-    ) -> Result<Option<Arc<dyn ExecutionPlan>>>
-    {
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
         // No benefit if projection does not narrow the schema
         if projection.expr().len() >= projection.input().schema().fields().len() {
             return Ok(None);
         }
 
-        // Mostly no benefit if projection expressions are not simple column references
-        if projection.benefits_from_input_partitioning()[0]
-            || !all_columns(projection.expr())
-        {
+        // Skip if projection expressions are not simple column references
+        if projection.benefits_from_input_partitioning()[0] || !all_columns(projection.expr()) {
             return Ok(None);
         }
 
@@ -517,20 +513,19 @@ impl ExecutionPlan for ExplicitRepartitionExec {
             Partitioning::Hash(partitions, size) => {
                 let mut new_partitions = vec![];
                 for partition in partitions {
-                    let Some(new_partition) =
-                        update_expr(partition, projection.expr(), false)?
+                    let Some(new_partition) = update_expr(partition, projection.expr(), false)?
                     else {
                         return Ok(None);
                     };
                     new_partitions.push(new_partition);
                 }
                 Partitioning::Hash(new_partitions, *size)
-            },
-            other => other.clone()
+            }
+            other => other.clone(),
         };
         Ok(Some(Arc::new(ExplicitRepartitionExec::new(
             new_projection,
-            new_partitioning
+            new_partitioning,
         ))))
     }
 
@@ -539,8 +534,7 @@ impl ExecutionPlan for ExplicitRepartitionExec {
         _phase: FilterPushdownPhase,
         parent_filters: Vec<Arc<dyn PhysicalExpr>>,
         _config: &ConfigOptions,
-    ) -> Result<FilterDescription>
-    {
+    ) -> Result<FilterDescription> {
         FilterDescription::from_children(parent_filters, &self.children())
     }
 
@@ -549,9 +543,8 @@ impl ExecutionPlan for ExplicitRepartitionExec {
         _phase: FilterPushdownPhase,
         child_pushdown_result: ChildPushdownResult,
         _config: &ConfigOptions,
-    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>>
-    {
-        // Collect parent filters that the child did NOT support
+    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        // Collect parent filters that the child did not support
         let unsupported_filters: Vec<Arc<dyn PhysicalExpr>> = child_pushdown_result
             .parent_filters
             .iter()
@@ -560,7 +553,7 @@ impl ExecutionPlan for ExplicitRepartitionExec {
             .collect();
 
         if unsupported_filters.is_empty() {
-            return Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
+            return Ok(FilterPushdownPropagation::if_all(child_pushdown_result));
         }
 
         // Build a single conjunctive predicate from the unsupported filters
@@ -569,11 +562,15 @@ impl ExecutionPlan for ExplicitRepartitionExec {
         let new_child = Arc::new(FilterExec::try_new(predicate, Arc::clone(self.input()))?);
         let new_explicit_repartition = Arc::new(ExplicitRepartitionExec::new(
             new_child,
-            self.properties.partitioning.clone()
+            self.properties.partitioning.clone(),
         ));
 
-        Ok(FilterPushdownPropagation::with_parent_pushdown_result(
-            vec![PushedDown::Yes; child_pushdown_result.parent_filters.len()]
-        ).with_updated_node(new_explicit_repartition))
+        Ok(FilterPushdownPropagation::with_parent_pushdown_result(vec![
+            PushedDown::Yes;
+            child_pushdown_result
+                .parent_filters
+                .len()
+        ])
+        .with_updated_node(new_explicit_repartition))
     }
 }

--- a/crates/sail-physical-plan/src/repartition.rs
+++ b/crates/sail-physical-plan/src/repartition.rs
@@ -7,14 +7,24 @@ use datafusion::arrow::compute::take_arrays;
 use datafusion::arrow::datatypes::UInt32Type;
 use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion::common::runtime::SpawnedTask;
+use datafusion::config::ConfigOptions;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
-use datafusion::physical_expr::Partitioning;
+use datafusion::physical_expr::{Partitioning, conjunction};
 use datafusion::physical_plan::execution_plan::{
     CardinalityEffect, EvaluationType, SchedulingType,
 };
+use datafusion::physical_plan::filter::FilterExec;
+use datafusion::physical_plan::filter_pushdown::{
+    ChildPushdownResult, FilterDescription, FilterPushdownPhase, FilterPushdownPropagation,
+    PushedDown,
+};
+use datafusion::physical_plan::projection::{
+    ProjectionExec, all_columns, make_with_child, update_expr,
+};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PhysicalExpr,
+    PlanProperties,
 };
 use datafusion_common::{Result, Statistics, internal_err, plan_err};
 use futures::{Stream, StreamExt};
@@ -483,10 +493,88 @@ impl ExecutionPlan for ExplicitRepartitionExec {
         CardinalityEffect::Equal
     }
 
-    // TODO: Implement the logic to push down filters or projections.
-    //   The filters and projections are safe to push down if they are
-    //   column references. For other expressions, we may not want to
-    //   push them down since the evaluation can be potentially expensive,
-    //   and the presence of explicit repartitioning indicates that the user
-    //   wants to evaluate these expressions after repartitioning.
+    fn try_swapping_with_projection(
+        &self,
+        projection: &ProjectionExec,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
+        // No benefit if projection does not narrow the schema
+        if projection.expr().len() >= projection.input().schema().fields().len() {
+            return Ok(None);
+        }
+
+        // Skip if projection expressions are not simple column references
+        if projection.benefits_from_input_partitioning()[0] || !all_columns(projection.expr()) {
+            return Ok(None);
+        }
+
+        let new_projection = make_with_child(projection, self.input())?;
+        // Handle all partitioning variants — 'ProjectionPushdown' runs before 'RewriteExplicitRepartition'
+        let new_partitioning = match &self.properties.partitioning {
+            Partitioning::Hash(partitions, size) => {
+                let mut new_partitions = vec![];
+                for partition in partitions {
+                    let Some(new_partition) = update_expr(partition, projection.expr(), false)?
+                    else {
+                        return Ok(None);
+                    };
+                    new_partitions.push(new_partition);
+                }
+                Partitioning::Hash(new_partitions, *size)
+            }
+            other => other.clone(),
+        };
+        Ok(Some(Arc::new(ExplicitRepartitionExec::new(
+            new_projection,
+            new_partitioning,
+        ))))
+    }
+
+    fn gather_filters_for_pushdown(
+        &self,
+        _phase: FilterPushdownPhase,
+        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
+        _config: &ConfigOptions,
+    ) -> Result<FilterDescription> {
+        FilterDescription::from_children(parent_filters, &self.children())
+    }
+
+    fn handle_child_pushdown_result(
+        &self,
+        phase: FilterPushdownPhase,
+        child_pushdown_result: ChildPushdownResult,
+        _config: &ConfigOptions,
+    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
+        if !matches!(phase, FilterPushdownPhase::Pre) {
+            return Ok(FilterPushdownPropagation::if_all(child_pushdown_result));
+        }
+
+        // Collect parent filters that the child did not support
+        let unsupported_filters: Vec<Arc<dyn PhysicalExpr>> = child_pushdown_result
+            .parent_filters
+            .iter()
+            .filter(|&f| matches!(f.all(), PushedDown::No))
+            .map(|f| Arc::clone(&f.filter))
+            .collect();
+
+        if unsupported_filters.is_empty() {
+            return Ok(FilterPushdownPropagation::if_all(child_pushdown_result));
+        }
+
+        // Build a single conjunctive predicate from the unsupported filters
+        // and insert a FilterExec between this ExplicitRepartitionExec and its child.
+        let predicate = conjunction(unsupported_filters);
+        let new_child = Arc::new(FilterExec::try_new(predicate, Arc::clone(self.input()))?);
+        let new_explicit_repartition = Arc::new(ExplicitRepartitionExec::new(
+            new_child,
+            self.properties.partitioning.clone(),
+        ));
+
+        Ok(FilterPushdownPropagation::with_parent_pushdown_result(vec![
+            PushedDown::Yes;
+            child_pushdown_result
+                .parent_filters
+                .len()
+        ])
+        .with_updated_node(new_explicit_repartition))
+    }
 }

--- a/crates/sail-physical-plan/src/repartition.rs
+++ b/crates/sail-physical-plan/src/repartition.rs
@@ -16,7 +16,8 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
 };
-use datafusion_common::{Result, Statistics, internal_err, plan_err};
+use datafusion::physical_plan::projection::{ProjectionExec, all_columns, make_with_child, update_expr};
+use datafusion_common::{internal_err, plan_err, Result, Statistics};
 use futures::{Stream, StreamExt};
 use sail_common_datafusion::extension::SessionExtensionAccessor;
 use sail_common_datafusion::session::repartition::{
@@ -489,4 +490,44 @@ impl ExecutionPlan for ExplicitRepartitionExec {
     //   push them down since the evaluation can be potentially expensive,
     //   and the presence of explicit repartitioning indicates that the user
     //   wants to evaluate these expressions after repartitioning.
+
+    fn try_swapping_with_projection(
+        &self,
+        projection: &ProjectionExec,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>>
+    {
+        // No benefit if projection does not narrow the schema
+        if projection.expr().len() >= projection.input().schema().fields().len() {
+            return Ok(None);
+        }
+
+        // Only push down simple column references — non-column expressions are potentially expensive
+        if projection.benefits_from_input_partitioning()[0]
+            || !all_columns(projection.expr())
+        {
+            return Ok(None);
+        }
+
+        let new_projection = make_with_child(projection, self.input())?;
+        // Handle all partitioning variants — 'ProjectionPushdown' runs before 'RewriteExplicitRepartition'
+        let new_partitioning = match &self.properties.partitioning {
+            Partitioning::Hash(partitions, size) => {
+                let mut new_partitions = vec![];
+                for partition in partitions {
+                    let Some(new_partition) =
+                        update_expr(partition, projection.expr(), false)?
+                    else {
+                        return Ok(None);
+                    };
+                    new_partitions.push(new_partition);
+                }
+                Partitioning::Hash(new_partitions, *size)
+            },
+            other => other.clone()
+        };
+        Ok(Some(Arc::new(ExplicitRepartitionExec::new(
+            new_projection,
+            new_partitioning
+        ))))
+    }
 }

--- a/crates/sail-physical-plan/src/repartition.rs
+++ b/crates/sail-physical-plan/src/repartition.rs
@@ -7,26 +7,16 @@ use datafusion::arrow::compute::take_arrays;
 use datafusion::arrow::datatypes::UInt32Type;
 use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
 use datafusion::common::runtime::SpawnedTask;
-use datafusion::config::ConfigOptions;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
-use datafusion::physical_expr::{conjunction, Partitioning};
+use datafusion::physical_expr::Partitioning;
 use datafusion::physical_plan::execution_plan::{
     CardinalityEffect, EvaluationType, SchedulingType,
 };
-use datafusion::physical_plan::filter::FilterExec;
-use datafusion::physical_plan::filter_pushdown::{
-    ChildPushdownResult, FilterDescription, FilterPushdownPhase, FilterPushdownPropagation,
-    PushedDown,
-};
-use datafusion::physical_plan::projection::{
-    all_columns, make_with_child, update_expr, ProjectionExec,
-};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PhysicalExpr,
-    PlanProperties,
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
 };
-use datafusion_common::{internal_err, plan_err, Result, Statistics};
+use datafusion_common::{Result, Statistics, internal_err, plan_err};
 use futures::{Stream, StreamExt};
 use sail_common_datafusion::extension::SessionExtensionAccessor;
 use sail_common_datafusion::session::repartition::{
@@ -493,84 +483,10 @@ impl ExecutionPlan for ExplicitRepartitionExec {
         CardinalityEffect::Equal
     }
 
-    fn try_swapping_with_projection(
-        &self,
-        projection: &ProjectionExec,
-    ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
-        // No benefit if projection does not narrow the schema
-        if projection.expr().len() >= projection.input().schema().fields().len() {
-            return Ok(None);
-        }
-
-        // Skip if projection expressions are not simple column references
-        if projection.benefits_from_input_partitioning()[0] || !all_columns(projection.expr()) {
-            return Ok(None);
-        }
-
-        let new_projection = make_with_child(projection, self.input())?;
-        // Handle all partitioning variants — 'ProjectionPushdown' runs before 'RewriteExplicitRepartition'
-        let new_partitioning = match &self.properties.partitioning {
-            Partitioning::Hash(partitions, size) => {
-                let mut new_partitions = vec![];
-                for partition in partitions {
-                    let Some(new_partition) = update_expr(partition, projection.expr(), false)?
-                    else {
-                        return Ok(None);
-                    };
-                    new_partitions.push(new_partition);
-                }
-                Partitioning::Hash(new_partitions, *size)
-            }
-            other => other.clone(),
-        };
-        Ok(Some(Arc::new(ExplicitRepartitionExec::new(
-            new_projection,
-            new_partitioning,
-        ))))
-    }
-
-    fn gather_filters_for_pushdown(
-        &self,
-        _phase: FilterPushdownPhase,
-        parent_filters: Vec<Arc<dyn PhysicalExpr>>,
-        _config: &ConfigOptions,
-    ) -> Result<FilterDescription> {
-        FilterDescription::from_children(parent_filters, &self.children())
-    }
-
-    fn handle_child_pushdown_result(
-        &self,
-        _phase: FilterPushdownPhase,
-        child_pushdown_result: ChildPushdownResult,
-        _config: &ConfigOptions,
-    ) -> Result<FilterPushdownPropagation<Arc<dyn ExecutionPlan>>> {
-        // Collect parent filters that the child did not support
-        let unsupported_filters: Vec<Arc<dyn PhysicalExpr>> = child_pushdown_result
-            .parent_filters
-            .iter()
-            .filter(|&f| matches!(f.all(), PushedDown::No))
-            .map(|f| Arc::clone(&f.filter))
-            .collect();
-
-        if unsupported_filters.is_empty() {
-            return Ok(FilterPushdownPropagation::if_all(child_pushdown_result));
-        }
-
-        // Build a single conjunctive predicate from the unsupported filters
-        // and insert a FilterExec between this ExplicitRepartitionExec and its child.
-        let predicate = conjunction(unsupported_filters);
-        let new_child = Arc::new(FilterExec::try_new(predicate, Arc::clone(self.input()))?);
-        let new_explicit_repartition = Arc::new(ExplicitRepartitionExec::new(
-            new_child,
-            self.properties.partitioning.clone(),
-        ));
-
-        Ok(FilterPushdownPropagation::with_parent_pushdown_result(vec![
-            PushedDown::Yes;
-            child_pushdown_result
-                .parent_filters
-                .len()
-        ])
-        .with_updated_node(new_explicit_repartition))
-    }
+    // TODO: Implement the logic to push down filters or projections.
+    //   The filters and projections are safe to push down if they are
+    //   column references. For other expressions, we may not want to
+    //   push them down since the evaluation can be potentially expensive,
+    //   and the presence of explicit repartitioning indicates that the user
+    //   wants to evaluate these expressions after repartitioning.
 }

--- a/python/pysail/tests/spark/dataframe/__snapshots__/test_repartition.plan.yaml
+++ b/python/pysail/tests/spark/dataframe/__snapshots__/test_repartition.plan.yaml
@@ -1,15 +1,5 @@
 # serializer version: 1
 ---
-name: "test_explicit_repartition_pushes_filter_down_plan"
-data:
-  |-
-    == Physical Plan ==
-    ProjectionExec: expr=[#0@0 as id]
-      ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=4
-        FilterExec: #0@0 % 2 = 0
-          RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
-            RangeExec
----
 name: "test_explicit_repartition_pushes_column_projection_down_plan"
 data:
   |-

--- a/python/pysail/tests/spark/dataframe/__snapshots__/test_repartition.plan.yaml
+++ b/python/pysail/tests/spark/dataframe/__snapshots__/test_repartition.plan.yaml
@@ -37,3 +37,13 @@ data:
             RepartitionExec: partitioning=Hash([#5@0], 4), input_partitions=1
               ProjectionExec: expr=[id@0 as #5]
                 RangeExec
+---
+name: "test_explicit_repartition_does_not_push_filter_down_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      FilterExec: #0@0 % 2 = 0
+        RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
+          ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+            RangeExec

--- a/python/pysail/tests/spark/dataframe/__snapshots__/test_repartition.plan.yaml
+++ b/python/pysail/tests/spark/dataframe/__snapshots__/test_repartition.plan.yaml
@@ -1,0 +1,49 @@
+# serializer version: 1
+---
+name: "test_explicit_repartition_pushes_filter_down_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=4
+        FilterExec: #0@0 % 2 = 0
+          RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+            RangeExec
+---
+name: "test_explicit_repartition_pushes_column_projection_down_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#6@0 as id1, #7@1 as id2]
+      ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=4
+        ProjectionExec: expr=[#1@0 as #6, #3@1 as #7]
+          HashJoinExec: mode=Partitioned, join_type=Inner, on=[(#1@0, #5@0)], projection=[#1@0, #3@1]
+            HashJoinExec: mode=Partitioned, join_type=Inner, on=[(#1@0, #3@0)]
+              RepartitionExec: partitioning=Hash([#1@0], 4), input_partitions=1
+                ProjectionExec: expr=[id@0 as #1]
+                  RangeExec
+              RepartitionExec: partitioning=Hash([#3@0], 4), input_partitions=1
+                ProjectionExec: expr=[id@0 as #3]
+                  RangeExec
+            RepartitionExec: partitioning=Hash([#5@0], 4), input_partitions=1
+              ProjectionExec: expr=[id@0 as #5]
+                RangeExec
+---
+name: "test_explicit_repartition_hash_partitioning_remaps_after_projection_pushdown_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#6@0 as id1, #7@1 as id2]
+      RepartitionExec: partitioning=Hash([#6@0, #7@1], 3), input_partitions=4
+        ProjectionExec: expr=[#1@0 as #6, #3@1 as #7]
+          HashJoinExec: mode=Partitioned, join_type=Inner, on=[(#1@0, #5@0)], projection=[#1@0, #3@1]
+            HashJoinExec: mode=Partitioned, join_type=Inner, on=[(#1@0, #3@0)]
+              RepartitionExec: partitioning=Hash([#1@0], 4), input_partitions=1
+                ProjectionExec: expr=[id@0 as #1]
+                  RangeExec
+              RepartitionExec: partitioning=Hash([#3@0], 4), input_partitions=1
+                ProjectionExec: expr=[id@0 as #3]
+                  RangeExec
+            RepartitionExec: partitioning=Hash([#5@0], 4), input_partitions=1
+              ProjectionExec: expr=[id@0 as #5]
+                RangeExec

--- a/python/pysail/tests/spark/dataframe/test_repartition.py
+++ b/python/pysail/tests/spark/dataframe/test_repartition.py
@@ -29,14 +29,6 @@ def normalized_plan(df):
     return normalize_plan_text(df._explain_string())  # noqa: SLF001
 
 
-def explicit_repartition_child_is(plan_text: str, child_name: str) -> bool:
-    lines = [line for line in plan_text.splitlines() if line.strip()]
-    for i, line in enumerate(lines[:-1]):
-        if "ExplicitRepartitionExec:" in line:
-            return child_name in lines[i + 1]
-    return False
-
-
 def test_explicit_repartition(spark):
     assert partition_count(spark.range(0, 10, 1, 2)) == 2  # noqa: PLR2004
     assert (
@@ -101,21 +93,72 @@ def test_explicit_repartition_plan_shape_uses_expected_physical_nodes(spark):
     assert "RepartitionExec: partitioning=Hash([" in hash_plan
 
 
-def test_explicit_repartition_pushes_filter_down(spark):
-    df = spark.range(6).repartition(5).filter(F.col("id") % 2 == 0)
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_explicit_repartition_pushes_filter_down_plan(spark, snapshot):
+    df = spark.range(6).repartition(3).filter(F.col("id") % 2 == 0)
     plan = normalized_plan(df)
 
-    assert explicit_repartition_child_is(plan, "FilterExec:")
+    assert plan == snapshot
 
 
-def test_explicit_repartition_pushes_column_projection_down(spark):
+def test_explicit_repartition_pushes_filter_down_result(spark):
+    df = spark.range(6).repartition(3).filter(F.col("id") % 2 == 0).orderBy("id")
+    result = df.collect()
+
+    assert [row["id"] for row in result] == [0, 2, 4]
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_explicit_repartition_pushes_column_projection_down_plan(spark, snapshot):
     df1 = spark.sql("SELECT id AS id1 FROM range(6)")
     df2 = spark.sql("SELECT id AS id2 FROM range(6)")
     df3 = spark.sql("SELECT id AS id3 FROM range(6)")
-    df = df1.join(df2, df1.id1 == df2.id2).join(df3, df1.id1 == df3.id3).repartition(5).select("id1", "id2")
+    df = df1.join(df2, df1.id1 == df2.id2).join(df3, df1.id1 == df3.id3).repartition(3).select("id1", "id2")
     plan = normalized_plan(df)
 
-    assert explicit_repartition_child_is(plan, "ProjectionExec:")
+    assert plan == snapshot
+
+
+def test_explicit_repartition_pushes_column_projection_down_result(spark):
+    df1 = spark.sql("SELECT id AS id1 FROM range(6)")
+    df2 = spark.sql("SELECT id AS id2 FROM range(6)")
+    df3 = spark.sql("SELECT id AS id3 FROM range(6)")
+    df = (
+        df1.join(df2, df1.id1 == df2.id2)
+        .join(df3, df1.id1 == df3.id3)
+        .repartition(3)
+        .select("id1", "id2")
+        .orderBy("id1", "id2")
+    )
+    result = df.collect()
+
+    assert [(row["id1"], row["id2"]) for row in result] == [
+        (0, 0),
+        (1, 1),
+        (2, 2),
+        (3, 3),
+        (4, 4),
+        (5, 5),
+    ]
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_explicit_repartition_hash_partitioning_remaps_after_projection_pushdown_plan(spark, snapshot):
+    df1 = spark.sql("SELECT id AS id1 FROM range(6)")
+    df2 = spark.sql("SELECT id AS id2 FROM range(6)")
+    df3 = spark.sql("SELECT id AS id3 FROM range(6)")
+    df = (
+        df1.join(df2, df1.id1 == df2.id2)
+        .join(df3, df1.id1 == df3.id3)
+        .repartition(3, "id1", "id2")
+        .select("id1", "id2")
+    )
+    plan = normalized_plan(df)
+
+    assert plan == snapshot
 
 
 def test_explicit_coalesce(spark):

--- a/python/pysail/tests/spark/dataframe/test_repartition.py
+++ b/python/pysail/tests/spark/dataframe/test_repartition.py
@@ -95,22 +95,6 @@ def test_explicit_repartition_plan_shape_uses_expected_physical_nodes(spark):
 
 @pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
 @pytest.mark.yamlsnapshot(group="plan")
-def test_explicit_repartition_pushes_filter_down_plan(spark, snapshot):
-    df = spark.range(6).repartition(3).filter(F.col("id") % 2 == 0)
-    plan = normalized_plan(df)
-
-    assert plan == snapshot
-
-
-def test_explicit_repartition_pushes_filter_down_result(spark):
-    df = spark.range(6).repartition(3).filter(F.col("id") % 2 == 0).orderBy("id")
-    result = df.collect()
-
-    assert [row["id"] for row in result] == [0, 2, 4]
-
-
-@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
-@pytest.mark.yamlsnapshot(group="plan")
 def test_explicit_repartition_pushes_column_projection_down_plan(spark, snapshot):
     df1 = spark.sql("SELECT id AS id1 FROM range(6)")
     df2 = spark.sql("SELECT id AS id2 FROM range(6)")

--- a/python/pysail/tests/spark/dataframe/test_repartition.py
+++ b/python/pysail/tests/spark/dataframe/test_repartition.py
@@ -145,6 +145,15 @@ def test_explicit_repartition_hash_partitioning_remaps_after_projection_pushdown
     assert plan == snapshot
 
 
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_explicit_repartition_does_not_push_filter_down_plan(spark, snapshot):
+    df = spark.range(6).repartition(3).filter(F.col("id") % 2 == 0)
+    plan = normalized_plan(df)
+
+    assert plan == snapshot
+
+
 def test_explicit_coalesce(spark):
     assert partition_count(spark.range(0, 10, 1, 2).coalesce(1)) == 1
     assert partition_count(spark.range(0, 10, 1, 2).coalesce(2)) == 2  # noqa: PLR2004

--- a/python/pysail/tests/spark/dataframe/test_repartition.py
+++ b/python/pysail/tests/spark/dataframe/test_repartition.py
@@ -29,6 +29,14 @@ def normalized_plan(df):
     return normalize_plan_text(df._explain_string())  # noqa: SLF001
 
 
+def explicit_repartition_child_is(plan_text: str, child_name: str) -> bool:
+    lines = [line for line in plan_text.splitlines() if line.strip()]
+    for i, line in enumerate(lines[:-1]):
+        if "ExplicitRepartitionExec:" in line:
+            return child_name in lines[i + 1]
+    return False
+
+
 def test_explicit_repartition(spark):
     assert partition_count(spark.range(0, 10, 1, 2)) == 2  # noqa: PLR2004
     assert (
@@ -91,6 +99,23 @@ def test_explicit_repartition_plan_shape_uses_expected_physical_nodes(spark):
     assert "RepartitionExec: partitioning=RoundRobinBatch(5)" in round_robin_plan
     assert "RepartitionExec: partitioning=RoundRobinBatch(1)" in repartition_one_plan
     assert "RepartitionExec: partitioning=Hash([" in hash_plan
+
+
+def test_explicit_repartition_pushes_filter_down(spark):
+    df = spark.range(6).repartition(5).filter(F.col("id") % 2 == 0)
+    plan = normalized_plan(df)
+
+    assert explicit_repartition_child_is(plan, "FilterExec:")
+
+
+def test_explicit_repartition_pushes_column_projection_down(spark):
+    df1 = spark.sql("SELECT id AS id1 FROM range(6)")
+    df2 = spark.sql("SELECT id AS id2 FROM range(6)")
+    df3 = spark.sql("SELECT id AS id3 FROM range(6)")
+    df = df1.join(df2, df1.id1 == df2.id2).join(df3, df1.id1 == df3.id3).repartition(5).select("id1", "id2")
+    plan = normalized_plan(df)
+
+    assert explicit_repartition_child_is(plan, "ProjectionExec:")
 
 
 def test_explicit_coalesce(spark):


### PR DESCRIPTION
## Summary

Implements projection pushdown through `ExplicitRepartitionExec`, allowing the physical optimizer to push projections below explicit repartition nodes.

## Projection Pushdown

Pushes `ProjectionExec` below `ExplicitRepartitionExec` when all projection expressions are simple column references and the schema is narrowed.

