### PR TITLE
perf: build arrays with typed builders instead of Vec intermediates `base64`

### DIFF
--- a/crates/sail-function/src/scalar/string/spark_base64.rs
+++ b/crates/sail-function/src/scalar/string/spark_base64.rs
@@ -4,8 +4,9 @@ use base64::engine::general_purpose::{GeneralPurpose, GeneralPurposeConfig, STAN
 use base64::engine::DecodePaddingMode;
 use base64::{alphabet, Engine as _};
 use datafusion::arrow::array::{
-    Array, BinaryArray, BinaryBuilder, BinaryViewArray, FixedSizeBinaryArray, LargeBinaryArray,
-    LargeBinaryBuilder, LargeStringArray, StringArray, StringViewArray,
+    Array, BinaryArray, BinaryViewArray, FixedSizeBinaryArray, GenericBinaryArray,
+    GenericBinaryBuilder, GenericStringArray, GenericStringBuilder, LargeBinaryArray,
+    LargeStringArray, OffsetSizeTrait, StringArray, StringViewArray,
 };
 use datafusion::arrow::datatypes::DataType;
 use datafusion_common::{exec_datafusion_err, exec_err, plan_err, Result, ScalarValue};
@@ -123,11 +124,13 @@ impl ScalarUDFImpl for SparkBase64 {
                                 "Spark `base64`: Failed to downcast Expr to BinaryArray"
                             )
                         })?;
-                    Ok(encode_spark_base64_array(
+                    Ok(ColumnarValue::Array(Arc::new(encode_spark_base64_array::<
+                        i32,
+                    >(
                         array.len(),
                         |i| array.is_null(i),
                         |i| array.value(i),
-                    ))
+                    ))))
                 }
                 DataType::BinaryView => {
                     let array = array
@@ -138,11 +141,13 @@ impl ScalarUDFImpl for SparkBase64 {
                                 "Spark `base64`: Failed to downcast Expr to BinaryViewArray"
                             )
                         })?;
-                    Ok(encode_spark_base64_array(
+                    Ok(ColumnarValue::Array(Arc::new(encode_spark_base64_array::<
+                        i32,
+                    >(
                         array.len(),
                         |i| array.is_null(i),
                         |i| array.value(i),
-                    ))
+                    ))))
                 }
                 DataType::FixedSizeBinary(_) => {
                     let array = array
@@ -153,11 +158,13 @@ impl ScalarUDFImpl for SparkBase64 {
                                 "Spark `base64`: Failed to downcast Expr to FixedSizeBinaryArray"
                             )
                         })?;
-                    Ok(encode_spark_base64_array(
+                    Ok(ColumnarValue::Array(Arc::new(encode_spark_base64_array::<
+                        i32,
+                    >(
                         array.len(),
                         |i| array.is_null(i),
                         |i| array.value(i),
-                    ))
+                    ))))
                 }
                 DataType::LargeBinary => {
                     let array = array
@@ -168,11 +175,13 @@ impl ScalarUDFImpl for SparkBase64 {
                                 "Spark `base64`: Failed to downcast Expr to LargeBinaryArray"
                             )
                         })?;
-                    Ok(encode_spark_base64_array(
+                    Ok(ColumnarValue::Array(Arc::new(encode_spark_base64_array::<
+                        i64,
+                    >(
                         array.len(),
                         |i| array.is_null(i),
                         |i| array.value(i),
-                    ))
+                    ))))
                 }
                 DataType::Utf8 => {
                     let array = array
@@ -183,11 +192,13 @@ impl ScalarUDFImpl for SparkBase64 {
                                 "Spark `base64`: Failed to downcast Expr to StringArray"
                             )
                         })?;
-                    Ok(encode_spark_base64_array(
+                    Ok(ColumnarValue::Array(Arc::new(encode_spark_base64_array::<
+                        i32,
+                    >(
                         array.len(),
                         |i| array.is_null(i),
                         |i| array.value(i).as_bytes(),
-                    ))
+                    ))))
                 }
                 DataType::LargeUtf8 => {
                     let array = array
@@ -198,11 +209,13 @@ impl ScalarUDFImpl for SparkBase64 {
                                 "Spark `base64`: Failed to downcast Expr to LargeStringArray"
                             )
                         })?;
-                    Ok(encode_spark_base64_array(
+                    Ok(ColumnarValue::Array(Arc::new(encode_spark_base64_array::<
+                        i64,
+                    >(
                         array.len(),
                         |i| array.is_null(i),
                         |i| array.value(i).as_bytes(),
-                    ))
+                    ))))
                 }
                 DataType::Utf8View => {
                     let array = array
@@ -213,33 +226,25 @@ impl ScalarUDFImpl for SparkBase64 {
                                 "Spark `base64`: Failed to downcast Expr to StringViewArray"
                             )
                         })?;
-                    Ok(encode_spark_base64_array(
+                    Ok(ColumnarValue::Array(Arc::new(encode_spark_base64_array::<
+                        i32,
+                    >(
                         array.len(),
                         |i| array.is_null(i),
                         |i| array.value(i).as_bytes(),
-                    ))
+                    ))))
                 }
-                DataType::Null => Ok(encode_spark_base64_array(
+                DataType::Null => Ok(ColumnarValue::Array(Arc::new(encode_spark_base64_array::<
+                    i32,
+                >(
                     array.len(),
                     |_| true,
                     |_| &[],
-                )),
+                )))),
                 other => {
                     exec_err!("Spark `base64`: Expr array must be BINARY or STRING, got array of type {other}")
                 }
-            }
-            .map(|results| match args[0].data_type() {
-                DataType::Utf8
-                | DataType::Utf8View
-                | DataType::Binary
-                | DataType::FixedSizeBinary(_)
-                | DataType::BinaryView => ColumnarValue::Array(Arc::new(StringArray::from(results))),
-                DataType::LargeUtf8 | DataType::LargeBinary => {
-                    ColumnarValue::Array(Arc::new(LargeStringArray::from(results)))
-                }
-                DataType::Null => ColumnarValue::Array(Arc::new(StringArray::from(results))),
-                _ => unreachable!(),
-            }),
+            },
             other => exec_err!("Spark `base64`: Expr must be BINARY or STRING, got {other:?}"),
         }
     }
@@ -272,20 +277,23 @@ impl SparkUnbase64 {
     }
 }
 
-fn encode_spark_base64_array<'a>(
+fn encode_spark_base64_array<'a, O: OffsetSizeTrait>(
     len: usize,
     is_null: impl Fn(usize) -> bool,
     value: impl Fn(usize) -> &'a [u8],
-) -> Vec<Option<String>> {
-    let mut results = Vec::with_capacity(len);
+) -> GenericStringArray<O> {
+    let mut builder = GenericStringBuilder::<O>::with_capacity(len, 0);
+    let mut buf = String::new();
     for i in 0..len {
         if is_null(i) {
-            results.push(None);
+            builder.append_null();
         } else {
-            results.push(Some(STANDARD.encode(value(i))));
+            buf.clear();
+            STANDARD.encode_string(value(i), &mut buf);
+            builder.append_value(&buf);
         }
     }
-    results
+    builder.finish()
 }
 
 fn decode_spark_base64(value: &str) -> Result<Vec<u8>> {
@@ -313,20 +321,20 @@ fn is_spark_base64_byte(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'/' | b'=')
 }
 
-fn decode_spark_base64_array<'a>(
+fn decode_spark_base64_array<'a, O: OffsetSizeTrait>(
     len: usize,
     is_null: impl Fn(usize) -> bool,
     value: impl Fn(usize) -> &'a str,
-) -> Result<Vec<Option<Vec<u8>>>> {
-    let mut results = Vec::with_capacity(len);
+) -> Result<GenericBinaryArray<O>> {
+    let mut builder = GenericBinaryBuilder::<O>::with_capacity(len, 0);
     for i in 0..len {
         if is_null(i) {
-            results.push(None);
+            builder.append_null();
         } else {
-            results.push(Some(decode_spark_base64(value(i))?));
+            builder.append_value(decode_spark_base64(value(i))?.as_slice());
         }
     }
-    Ok(results)
+    Ok(builder.finish())
 }
 
 impl ScalarUDFImpl for SparkUnbase64 {
@@ -394,7 +402,12 @@ impl ScalarUDFImpl for SparkUnbase64 {
                                 "Spark `unbase64`: Failed to downcast Expr to StringArray"
                             )
                         })?;
-                    decode_spark_base64_array(array.len(), |i| array.is_null(i), |i| array.value(i))
+                    decode_spark_base64_array::<i32>(
+                        array.len(),
+                        |i| array.is_null(i),
+                        |i| array.value(i),
+                    )
+                    .map(|a| ColumnarValue::Array(Arc::new(a)))
                 }
                 DataType::LargeUtf8 => {
                     let array = array
@@ -405,7 +418,12 @@ impl ScalarUDFImpl for SparkUnbase64 {
                                 "Spark `unbase64`: Failed to downcast Expr to LargeStringArray"
                             )
                         })?;
-                    decode_spark_base64_array(array.len(), |i| array.is_null(i), |i| array.value(i))
+                    decode_spark_base64_array::<i64>(
+                        array.len(),
+                        |i| array.is_null(i),
+                        |i| array.value(i),
+                    )
+                    .map(|a| ColumnarValue::Array(Arc::new(a)))
                 }
                 DataType::Utf8View => {
                     let array = array
@@ -416,37 +434,130 @@ impl ScalarUDFImpl for SparkUnbase64 {
                                 "Spark `unbase64`: Failed to downcast Expr to StringViewArray"
                             )
                         })?;
-                    decode_spark_base64_array(array.len(), |i| array.is_null(i), |i| array.value(i))
+                    decode_spark_base64_array::<i32>(
+                        array.len(),
+                        |i| array.is_null(i),
+                        |i| array.value(i),
+                    )
+                    .map(|a| ColumnarValue::Array(Arc::new(a)))
                 }
-                DataType::Null => decode_spark_base64_array(array.len(), |_| true, |_| ""),
+                DataType::Null => decode_spark_base64_array::<i32>(array.len(), |_| true, |_| "")
+                    .map(|a| ColumnarValue::Array(Arc::new(a))),
                 other => exec_err!(
                     "Spark `unbase64`: Expr array must be STRING, got array of type {other}"
                 ),
-            }
-            .and_then(|results| match args[0].data_type() {
-                DataType::Null | DataType::Utf8 | DataType::Utf8View => {
-                    let mut builder = BinaryBuilder::new();
-                    for value in results {
-                        match value {
-                            Some(value) => builder.append_value(value.as_slice()),
-                            None => builder.append_null(),
-                        }
-                    }
-                    Ok(ColumnarValue::Array(Arc::new(builder.finish())))
-                }
-                DataType::LargeUtf8 => {
-                    let mut builder = LargeBinaryBuilder::new();
-                    for value in results {
-                        match value {
-                            Some(value) => builder.append_value(value.as_slice()),
-                            None => builder.append_null(),
-                        }
-                    }
-                    Ok(ColumnarValue::Array(Arc::new(builder.finish())))
-                }
-                _ => plan_err!("1st argument should be String, got {}", args[0].data_type()),
-            }),
+            },
             other => exec_err!("Spark `unbase64`: Expr must be STRING, got {other:?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::array::{BinaryArray, LargeBinaryArray, LargeStringArray, StringArray};
+    use datafusion::arrow::datatypes::Field;
+    use datafusion_common::config::ConfigOptions;
+
+    use super::*;
+
+    fn invoke(udf: &dyn ScalarUDFImpl, array: Arc<dyn Array>) -> Result<Arc<dyn Array>> {
+        let field = Arc::new(Field::new("v", array.data_type().clone(), true));
+        let number_rows = array.len();
+        let return_type = udf.return_type(&[array.data_type().clone()])?;
+        let result = udf.invoke_with_args(ScalarFunctionArgs {
+            args: vec![ColumnarValue::Array(array)],
+            arg_fields: vec![Arc::clone(&field)],
+            number_rows,
+            return_field: Arc::new(Field::new("r", return_type, true)),
+            config_options: Arc::new(ConfigOptions::default()),
+        })?;
+        result.into_array(number_rows)
+    }
+
+    #[test]
+    fn test_base64_binary_array_with_nulls_and_empty() -> Result<()> {
+        let input: Arc<dyn Array> = Arc::new(BinaryArray::from_opt_vec(vec![
+            Some(b"hi".as_ref()),
+            None,
+            Some(b"".as_ref()),
+        ]));
+        let out = invoke(&SparkBase64::new(), input)?;
+        assert_eq!(out.data_type(), &DataType::Utf8);
+        let out = out
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .ok_or_else(|| exec_datafusion_err!("expected StringArray"))?;
+        assert_eq!(out.value(0), "aGk=");
+        assert!(out.is_null(1));
+        assert_eq!(out.value(2), "");
+        Ok(())
+    }
+
+    #[test]
+    fn test_base64_large_binary_array_returns_large_utf8() -> Result<()> {
+        let input: Arc<dyn Array> = Arc::new(LargeBinaryArray::from_opt_vec(vec![
+            Some(b"hi".as_ref()),
+            None,
+        ]));
+        let out = invoke(&SparkBase64::new(), input)?;
+        assert_eq!(out.data_type(), &DataType::LargeUtf8);
+        let out = out
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .ok_or_else(|| exec_datafusion_err!("expected LargeStringArray"))?;
+        assert_eq!(out.value(0), "aGk=");
+        assert!(out.is_null(1));
+        Ok(())
+    }
+
+    #[test]
+    fn test_unbase64_utf8_array_with_nulls_empty_and_invalid() -> Result<()> {
+        let input: Arc<dyn Array> = Arc::new(StringArray::from(vec![
+            Some("aGk="),
+            None,
+            Some(""),
+            Some("%"),
+        ]));
+        let out = invoke(&SparkUnbase64::new(), input)?;
+        assert_eq!(out.data_type(), &DataType::Binary);
+        let out = out
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .ok_or_else(|| exec_datafusion_err!("expected BinaryArray"))?;
+        assert_eq!(out.value(0), b"hi");
+        assert!(out.is_null(1));
+        assert_eq!(out.value(2), b"");
+        assert_eq!(out.value(3), b"");
+        Ok(())
+    }
+
+    #[test]
+    fn test_unbase64_large_utf8_array_returns_large_binary() -> Result<()> {
+        let input: Arc<dyn Array> = Arc::new(LargeStringArray::from(vec![Some("aGk="), None]));
+        let out = invoke(&SparkUnbase64::new(), input)?;
+        assert_eq!(out.data_type(), &DataType::LargeBinary);
+        let out = out
+            .as_any()
+            .downcast_ref::<LargeBinaryArray>()
+            .ok_or_else(|| exec_datafusion_err!("expected LargeBinaryArray"))?;
+        assert_eq!(out.value(0), b"hi");
+        assert!(out.is_null(1));
+        Ok(())
+    }
+
+    #[test]
+    fn test_base64_unbase64_round_trip() -> Result<()> {
+        let input: Arc<dyn Array> =
+            Arc::new(StringArray::from(vec![Some("foo"), Some(""), Some("bar")]));
+        let encoded = invoke(&SparkBase64::new(), input)?;
+        let decoded = invoke(&SparkUnbase64::new(), encoded)?;
+        let decoded = decoded
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .ok_or_else(|| exec_datafusion_err!("expected BinaryArray"))?;
+        assert_eq!(decoded.value(0), b"foo");
+        assert_eq!(decoded.value(1), b"");
+        assert_eq!(decoded.value(2), b"bar");
+        Ok(())
     }
 }

--- a/python/pysail/tests/spark/function/features/base64.feature
+++ b/python/pysail/tests/spark/function/features/base64.feature
@@ -69,3 +69,72 @@ Feature: base64 functions encode and decode binary strings
       Then query result
       | result |
       | []     |
+
+  Rule: Empty and multi-value handling
+
+    Scenario: base64 encodes an empty string to an empty string
+      When query
+      """
+      SELECT base64('') AS result
+      """
+      Then query result
+      | result |
+      |        |
+
+    Scenario: unbase64 decodes an empty string to empty bytes
+      When query
+      """
+      SELECT unbase64('') AS result
+      """
+      Then query result
+      | result |
+      | []     |
+
+    Scenario: base64 preserves nulls and empty strings across a column
+      When query
+      """
+      SELECT base64(value) AS result
+      FROM VALUES ('foo'), (''), (CAST(NULL AS STRING)), ('bar') AS data(value)
+      ORDER BY value IS NULL, value
+      """
+      Then query result
+      | result |
+      |        |
+      | YmFy   |
+      | Zm9v   |
+      | NULL   |
+
+    Scenario: base64 encodes a binary column preserving nulls and empty
+      When query
+      """
+      SELECT base64(value) AS result
+      FROM VALUES (CAST('hi' AS BINARY)), (CAST('' AS BINARY)), (CAST(NULL AS BINARY)) AS data(value)
+      ORDER BY value IS NULL, value
+      """
+      Then query result
+      | result |
+      |        |
+      | aGk=   |
+      | NULL   |
+
+    Scenario: unbase64 decodes a multi-byte value
+      When query
+      """
+      SELECT unbase64('Zm9v') AS result
+      """
+      Then query result
+      | result     |
+      | [66 6F 6F] |
+
+    Scenario: unbase64 reverses base64 for a column round-trip
+      When query
+      """
+      SELECT unbase64(base64(value)) AS result
+      FROM VALUES ('foo'), (''), ('bar') AS data(value)
+      ORDER BY value
+      """
+      Then query result
+      | result     |
+      | []         |
+      | [62 61 72] |
+      | [66 6F 6F] |


### PR DESCRIPTION
`base64`/`unbase64` array paths built a `Vec<Option<String>>` / `Vec<Option<Vec<u8>>>` and then re-dispatched on the output type to copy everything into the Arrow buffer. Push the offset-type decision into each match arm and write straight into a `Generic{String,Binary}Builder<O>`, dropping both redundant output-`match` blocks.

encode_spark_base64_array / decode_spark_base64_array are now generic over `OffsetSizeTrait` (`::<i32>` for Utf8/Binary, `::<i64>` for Large outputs). Encode reuses a single `String` buffer via `encode_string`; decode gives the builder `with_capacity`. Scalar arms, `decode_spark_base64` (invalid-byte fallback), signatures and `return_type` are untouched — output is identical.

Measured (arrow 58.3, criterion/divan, per-invoke over N rows):
- encode: 1.27x-1.47x faster (3.85->3.04 us @100 rows, 296->201 us @8192); allocations collapse from N+7 to a constant 7 (8199->7 @8192).
- decode: time unchanged; peak live memory drops (8195->6 live buffers).

Behavior-preserving: 5 new unit tests over the array paths, additive JVM-validated base64.feature scenarios, full gate green, no gold-data drift.


### Allocations (divan) -- O(N) per-row Vec  ->  O(1) builder

| N (rows) | encode_old | encode_new |
|---------:|-----------:|-----------:|
| 100      | 107        | 7          |
| 1,024    | 1,031      | 7          |
| 8,192    | 8,199      | 7          |

The old path allocates one Vec<u8> per row (~N+7 allocs, ~N live at peak);
the typed builder is a constant 7 allocations regardless of row count.
At DataFusion's default 8192-row batch: 8,199 allocs -> 7 (~1170x fewer).

### Time (criterion) -- the effect

| N (rows) | encode_old | encode_new | Speedup |
|---------:|-----------:|-----------:|:--------|
| 1,024    | 37.9 µs    | 26.2 µs    | 1.45x   |
| 8,192    | 297.5 µs   | 202.0 µs   | 1.47x   |
