### PR TITLE
fix: preserve all error cause in cluster mode

### DIFF
--- a/crates/sail-common-datafusion/src/error.rs
+++ b/crates/sail-common-datafusion/src/error.rs
@@ -1,40 +1,23 @@
 use std::collections::HashSet;
+use std::fmt;
+use std::fmt::Formatter;
 
 use datafusion::arrow::error::ArrowError;
 use datafusion_common::DataFusionError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-/// A Python error in text form. This could be a remote error from a worker.
+/// An error with a cause received from a remote worker.
 #[derive(Debug, Clone, Error)]
-#[error("remote Python error: {summary}")]
-pub struct RemotePythonError {
-    pub summary: String,
-    pub traceback: Option<Vec<String>>,
+#[error("remote error: {cause}")]
+pub struct RemoteError {
+    pub cause: CommonErrorCause,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PythonErrorCause {
     pub summary: String,
     pub traceback: Option<Vec<String>>,
-}
-
-impl From<RemotePythonError> for PythonErrorCause {
-    fn from(error: RemotePythonError) -> Self {
-        Self {
-            summary: error.summary,
-            traceback: error.traceback,
-        }
-    }
-}
-
-impl From<PythonErrorCause> for RemotePythonError {
-    fn from(cause: PythonErrorCause) -> Self {
-        Self {
-            summary: cause.summary,
-            traceback: cause.traceback,
-        }
-    }
 }
 
 /// A trait to extract Python error cause from a generic error.
@@ -78,6 +61,41 @@ pub enum CommonErrorCause {
     Configuration(String),
     Execution(String),
     DeltaTable(String),
+}
+
+impl fmt::Display for CommonErrorCause {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            CommonErrorCause::Unknown(x)
+            | CommonErrorCause::Internal(x)
+            | CommonErrorCause::NotImplemented(x)
+            | CommonErrorCause::InvalidArgument(x)
+            | CommonErrorCause::Io(x)
+            | CommonErrorCause::ArrowCast(x)
+            | CommonErrorCause::ArrowMemory(x)
+            | CommonErrorCause::ArrowParse(x)
+            | CommonErrorCause::ArrowCompute(x)
+            | CommonErrorCause::ArrowIpc(x)
+            | CommonErrorCause::ArrowCDataInterface(x)
+            | CommonErrorCause::ArrowDivideByZero(x)
+            | CommonErrorCause::ArrowArithmeticOverflow(x)
+            | CommonErrorCause::ArrowDictionaryKeyOverflow(x)
+            | CommonErrorCause::ArrowRunEndIndexOverflow(x)
+            | CommonErrorCause::ArrowOffsetOverflow(x)
+            | CommonErrorCause::FormatCsv(x)
+            | CommonErrorCause::FormatJson(x)
+            | CommonErrorCause::FormatParquet(x)
+            | CommonErrorCause::FormatAvro(x)
+            | CommonErrorCause::Plan(x)
+            | CommonErrorCause::Schema(x)
+            | CommonErrorCause::Configuration(x)
+            | CommonErrorCause::Execution(x)
+            | CommonErrorCause::DeltaTable(x) => write!(f, "{x}"),
+            CommonErrorCause::Python(PythonErrorCause { summary, .. }) => {
+                write!(f, "{summary}")
+            }
+        }
+    }
 }
 
 impl CommonErrorCause {
@@ -152,8 +170,8 @@ impl CommonErrorCause {
             return Self::Python(cause);
         }
 
-        if let Some(e) = error.downcast_ref::<RemotePythonError>() {
-            return Self::Python(e.clone().into());
+        if let Some(e) = error.downcast_ref::<RemoteError>() {
+            return e.cause.clone();
         }
 
         if let Some(e) = error.source() {

--- a/crates/sail-execution/src/stream/error.rs
+++ b/crates/sail-execution/src/stream/error.rs
@@ -4,7 +4,7 @@ use std::fmt::Formatter;
 use std::sync::Arc;
 
 use arrow_flight::error::FlightError;
-use sail_common_datafusion::error::{CommonErrorCause, RemotePythonError};
+use sail_common_datafusion::error::{CommonErrorCause, RemoteError};
 use sail_python_udf::error::PyErrExtractor;
 use tonic::{Code, Status};
 use tonic_types::{ErrorDetails, StatusExt};
@@ -84,36 +84,7 @@ impl From<FlightError> for TaskStreamError {
 
 impl From<CommonErrorCause> for TaskStreamError {
     fn from(value: CommonErrorCause) -> Self {
-        match value {
-            CommonErrorCause::Unknown(x)
-            | CommonErrorCause::Internal(x)
-            | CommonErrorCause::NotImplemented(x)
-            | CommonErrorCause::InvalidArgument(x)
-            | CommonErrorCause::Io(x)
-            | CommonErrorCause::ArrowCast(x)
-            | CommonErrorCause::ArrowMemory(x)
-            | CommonErrorCause::ArrowParse(x)
-            | CommonErrorCause::ArrowCompute(x)
-            | CommonErrorCause::ArrowIpc(x)
-            | CommonErrorCause::ArrowCDataInterface(x)
-            | CommonErrorCause::ArrowDivideByZero(x)
-            | CommonErrorCause::ArrowArithmeticOverflow(x)
-            | CommonErrorCause::ArrowDictionaryKeyOverflow(x)
-            | CommonErrorCause::ArrowRunEndIndexOverflow(x)
-            | CommonErrorCause::ArrowOffsetOverflow(x)
-            | CommonErrorCause::FormatCsv(x)
-            | CommonErrorCause::FormatJson(x)
-            | CommonErrorCause::FormatParquet(x)
-            | CommonErrorCause::FormatAvro(x)
-            | CommonErrorCause::Plan(x)
-            | CommonErrorCause::Schema(x)
-            | CommonErrorCause::Configuration(x)
-            | CommonErrorCause::Execution(x)
-            | CommonErrorCause::DeltaTable(x) => Self::Unknown(x),
-            CommonErrorCause::Python(cause) => {
-                Self::External(Arc::new(RemotePythonError::from(cause)))
-            }
-        }
+        Self::External(Arc::new(RemoteError { cause: value }))
     }
 }
 
@@ -121,7 +92,7 @@ impl From<TaskStreamError> for CommonErrorCause {
     fn from(value: TaskStreamError) -> Self {
         match value {
             TaskStreamError::Unknown(x) => CommonErrorCause::Unknown(x),
-            TaskStreamError::External(e) => CommonErrorCause::new::<PyErrExtractor>(&e),
+            TaskStreamError::External(e) => CommonErrorCause::new::<PyErrExtractor>(e.as_ref()),
         }
     }
 }


### PR DESCRIPTION
This PR removes `RemotePythonError` but adds `RemoteError` so that all types of error causes can be preserved in cluster mode.