### PR TITLE
fix: honor NULL and overflow semantics in `make_ym_interval`

### DIFF
--- a/crates/sail-function/src/scalar/datetime/spark_make_ym_interval.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_make_ym_interval.rs
@@ -1,10 +1,16 @@
 use std::sync::Arc;
 
 use datafusion::arrow::array::{ArrayRef, AsArray, IntervalYearMonthArray};
+use datafusion::arrow::compute::try_binary;
 use datafusion::arrow::datatypes::{DataType, Int32Type, IntervalUnit};
+use datafusion::arrow::error::ArrowError;
 use datafusion_common::types::NativeType;
-use datafusion_common::{exec_err, plan_err, Result, ScalarValue};
+use datafusion_common::{plan_err, Result, ScalarValue};
 use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+
+use crate::error::invalid_arg_count_exec_err;
+
+const MONTHS_PER_YEAR: i32 = 12;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct SparkMakeYmInterval {
@@ -39,84 +45,72 @@ impl ScalarUDFImpl for SparkMakeYmInterval {
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
-        let ScalarFunctionArgs { args, .. } = args;
-        let [year, month] = args.as_slice() else {
-            return exec_err!(
-                "Spark `make_ym_interval` function requires 2 arguments, got {}",
-                args.len()
-            );
-        };
-        match (year, month) {
-            (
-                ColumnarValue::Scalar(ScalarValue::Int32(years)),
-                ColumnarValue::Scalar(ScalarValue::Int32(months)),
-            ) => {
-                let total_months = if years.is_none() && months.is_none() {
-                    None
-                } else {
-                    Some((years.unwrap_or(0) * 12) + months.unwrap_or(0))
-                };
-                Ok(ColumnarValue::Scalar(ScalarValue::IntervalYearMonth(
-                    total_months,
-                )))
-            }
-            (
-                ColumnarValue::Scalar(ScalarValue::Int32(years)),
-                ColumnarValue::Array(months_array),
-            ) => {
-                let years = years.unwrap_or(0) * 12;
-                let result: IntervalYearMonthArray = months_array
-                    .as_primitive::<Int32Type>()
-                    .unary(|months| years + months)
-                    .with_data_type(DataType::Interval(IntervalUnit::YearMonth));
-                Ok(ColumnarValue::Array(Arc::new(result) as ArrayRef))
-            }
-            (
-                ColumnarValue::Array(years_array),
-                ColumnarValue::Scalar(ScalarValue::Int32(months)),
-            ) => {
-                let months = months.unwrap_or(0);
-                let result: IntervalYearMonthArray = years_array
-                    .as_primitive::<Int32Type>()
-                    .unary(|years| (years * 12) + months)
-                    .with_data_type(DataType::Interval(IntervalUnit::YearMonth));
-                Ok(ColumnarValue::Array(Arc::new(result) as ArrayRef))
-            }
-            (ColumnarValue::Array(years_array), ColumnarValue::Array(months_array)) => {
-                let years_array = years_array.as_primitive::<Int32Type>();
-                let months_array = months_array.as_primitive::<Int32Type>();
-                let result: IntervalYearMonthArray = datafusion::arrow::compute::binary(
-                    years_array,
-                    months_array,
-                    |years, months| (years * 12) + months,
-                )?
-                .with_data_type(DataType::Interval(IntervalUnit::YearMonth));
-                Ok(ColumnarValue::Array(Arc::new(result) as ArrayRef))
-            }
-            other => exec_err!("Unsupported args {other:?} for Spark function `make_ym_interval"),
+        let ScalarFunctionArgs {
+            args, number_rows, ..
+        } = args;
+        if args.len() > 2 {
+            return Err(invalid_arg_count_exec_err(
+                "make_ym_interval",
+                (0, 2),
+                args.len(),
+            ));
         }
+
+        // Omitted arguments default to zero (Spark fills `Literal(0)` for absent years/months).
+        let zero = ColumnarValue::Scalar(ScalarValue::Int32(Some(0)));
+        let mut args = args.into_iter();
+        let year = args.next().unwrap_or_else(|| zero.clone());
+        let month = args.next().unwrap_or(zero);
+
+        // Spark's `MakeYMInterval` is null-intolerant: a NULL in a supplied argument yields NULL.
+        let scalar_null = |value: &ColumnarValue| matches!(value, ColumnarValue::Scalar(scalar) if scalar.is_null());
+        if scalar_null(&year) || scalar_null(&month) {
+            return Ok(ColumnarValue::Scalar(ScalarValue::IntervalYearMonth(None)));
+        }
+
+        let years = year.to_array(number_rows)?;
+        let months = month.to_array(number_rows)?;
+        let years = years.as_primitive::<Int32Type>();
+        let months = months.as_primitive::<Int32Type>();
+
+        // `try_binary` propagates array nulls and lets us surface Spark's overflow error, which is
+        // raised regardless of `spark.sql.ansi.enabled` (year-month interval math uses exact ops).
+        let result: IntervalYearMonthArray = try_binary(years, months, checked_ym_interval)?
+            .with_data_type(DataType::Interval(IntervalUnit::YearMonth));
+        Ok(ColumnarValue::Array(Arc::new(result) as ArrayRef))
     }
 
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>> {
-        if arg_types.len() != 2 {
-            return exec_err!(
-                "Spark `make_ym_interval` function requires 2 arguments, got {}",
-                arg_types.len()
-            );
+        if arg_types.len() > 2 {
+            return Err(invalid_arg_count_exec_err(
+                "make_ym_interval",
+                (0, 2),
+                arg_types.len(),
+            ));
         }
-
-        let (years, months): (NativeType, NativeType) =
-            ((&arg_types[0]).into(), (&arg_types[1]).into());
-        if (years.is_integer()
-            || matches!(years, NativeType::String)
-            || matches!(years, NativeType::Null))
-            && (months.is_integer()
-                || matches!(months, NativeType::String)
-                || matches!(months, NativeType::Null))
-        {
-            Ok(vec![DataType::Int32, DataType::Int32])
-        } else {
-            plan_err!("The arguments of Spark `make_ym_interval` must be integer or string or null")
+        for arg_type in arg_types {
+            let native: NativeType = arg_type.into();
+            if !(native.is_integer() || matches!(native, NativeType::String | NativeType::Null)) {
+                return plan_err!(
+                    "The arguments of Spark `make_ym_interval` must be integer or string or null"
+                );
+            }
         }
+        Ok(vec![DataType::Int32; arg_types.len()])
     }
+}
+
+/// Computes `years * 12 + months`, raising Spark's interval overflow error on wrap.
+///
+/// Matches Spark `MakeYMInterval`, which uses `Math.multiplyExact`/`Math.addExact` and therefore
+/// errors on Int32 overflow independently of `spark.sql.ansi.enabled`.
+fn checked_ym_interval(years: i32, months: i32) -> std::result::Result<i32, ArrowError> {
+    years
+        .checked_mul(MONTHS_PER_YEAR)
+        .and_then(|total| total.checked_add(months))
+        .ok_or_else(|| {
+            ArrowError::ComputeError(
+                "[INTERVAL_ARITHMETIC_OVERFLOW.WITHOUT_SUGGESTION] Integer overflow while operating with intervals.".to_string(),
+            )
+        })
 }

--- a/crates/sail-plan/src/function/scalar/datetime.rs
+++ b/crates/sail-plan/src/function/scalar/datetime.rs
@@ -700,15 +700,6 @@ fn to_utc_timestamp(input: ScalarFunctionInput) -> PlanResult<Expr> {
     Ok(cast(ts, DataType::Timestamp(unit, Some(session_tz))))
 }
 
-fn make_ym_interval(args: Vec<Expr>) -> PlanResult<Expr> {
-    let (years, months) = if args.len() == 2 {
-        args.two()?
-    } else {
-        (args.one()?, lit(0_i32))
-    };
-    Ok(ScalarUDF::from(SparkMakeYmInterval::new()).call(vec![years, months]))
-}
-
 fn make_timestamp_ltz(args: Vec<Expr>, session_tz: &Arc<str>, is_try: bool) -> PlanResult<Expr> {
     let ntz_ts = if args.len() == 2 || args.len() == 6 {
         ScalarUDF::from(SparkMakeTimestampNtz::new(is_try)).call(args)
@@ -1108,7 +1099,7 @@ pub(super) fn list_built_in_datetime_functions() -> Vec<(&'static str, ScalarFun
             "make_timestamp_ntz",
             F::custom(|input| make_timestamp_ntz(input.arguments, false)),
         ),
-        ("make_ym_interval", F::var_arg(make_ym_interval)),
+        ("make_ym_interval", F::udf(SparkMakeYmInterval::new())),
         ("minute", F::unary(|arg| integer_part(arg, "MINUTE"))),
         ("month", F::unary(|arg| integer_part(arg, "MONTH"))),
         (

--- a/python/pysail/tests/spark/function/features/make_ym_interval.feature
+++ b/python/pysail/tests/spark/function/features/make_ym_interval.feature
@@ -1,0 +1,150 @@
+@make_ym_interval
+Feature: make_ym_interval builds a year-month interval from years and months
+
+  Rule: A NULL in any argument yields NULL (Spark MakeYMInterval is null-intolerant)
+    Scenario: NULL months yields NULL
+      When query
+        """
+        SELECT make_ym_interval(1, NULL) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: NULL years yields NULL
+      When query
+        """
+        SELECT make_ym_interval(NULL, 6) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: both arguments NULL yields NULL
+      When query
+        """
+        SELECT make_ym_interval(NULL, NULL) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: typed NULL argument yields NULL
+      When query
+        """
+        SELECT make_ym_interval(CAST(NULL AS INT), 6) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: NULL propagates per row over a column
+      When query
+        """
+        SELECT make_ym_interval(y, m) AS result
+        FROM VALUES (1, 6), (CAST(NULL AS INT), 3), (2, CAST(NULL AS INT)) AS t(y, m)
+        """
+      Then query result
+        | result                       |
+        | INTERVAL '1-6' YEAR TO MONTH |
+        | NULL                         |
+        | NULL                         |
+
+  Rule: Non-NULL arguments build a year-month interval
+    Scenario: years and months combine
+      When query
+        """
+        SELECT make_ym_interval(1, 6) AS result
+        """
+      Then query result
+        | result                       |
+        | INTERVAL '1-6' YEAR TO MONTH |
+
+    Scenario: zero years and months
+      When query
+        """
+        SELECT make_ym_interval(0, 0) AS result
+        """
+      Then query result
+        | result                       |
+        | INTERVAL '0-0' YEAR TO MONTH |
+
+    Scenario: negative years and months
+      When query
+        """
+        SELECT make_ym_interval(-1, -6) AS result
+        """
+      Then query result
+        | result                        |
+        | INTERVAL '-1-6' YEAR TO MONTH |
+
+    Scenario: months overflowing into years are normalized
+      When query
+        """
+        SELECT make_ym_interval(2, 13) AS result
+        """
+      Then query result
+        | result                       |
+        | INTERVAL '3-1' YEAR TO MONTH |
+
+    Scenario: negative years with positive months normalize below zero
+      When query
+        """
+        SELECT make_ym_interval(-1, 1) AS result
+        """
+      Then query result
+        | result                         |
+        | INTERVAL '-0-11' YEAR TO MONTH |
+
+  Rule: Omitted arguments default to zero
+    Scenario: no arguments builds a zero interval
+      When query
+        """
+        SELECT make_ym_interval() AS result
+        """
+      Then query result
+        | result                       |
+        | INTERVAL '0-0' YEAR TO MONTH |
+
+    Scenario: single argument builds a whole-year interval
+      When query
+        """
+        SELECT make_ym_interval(2) AS result
+        """
+      Then query result
+        | result                       |
+        | INTERVAL '2-0' YEAR TO MONTH |
+
+    Scenario: single NULL argument yields NULL
+      When query
+        """
+        SELECT make_ym_interval(NULL) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+  Rule: More than two arguments is an error
+    Scenario: three arguments is rejected
+      When query
+        """
+        SELECT make_ym_interval(1, 2, 3) AS result
+        """
+      Then query error make_ym_interval
+
+  Rule: Integer overflow is an error regardless of ANSI mode
+    Scenario: overflow errors with ANSI enabled
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT make_ym_interval(200000000, 0) AS result
+        """
+      Then query error INTERVAL_ARITHMETIC_OVERFLOW
+
+    Scenario: overflow errors with ANSI disabled
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT make_ym_interval(200000000, 0) AS result
+        """
+      Then query error INTERVAL_ARITHMETIC_OVERFLOW


### PR DESCRIPTION
make_ym_interval diverged from Spark's MakeYMInterval:
- a NULL in either argument returned a value instead of NULL (null-intolerant semantics, same pattern as #2188 for make_timestamp_ntz)
- years * 12 + months could overflow silently instead of erroring
- the 0-argument form was rejected, and arity handling was split between the plan builder and the UDF