### PR TITLE
fix: correct empty-aggregate fill values in `pivot` count and collect_list/collect_set

### DIFF
--- a/crates/sail-plan/src/function/aggregate.rs
+++ b/crates/sail-plan/src/function/aggregate.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::datatypes::{DataType, Field};
+use datafusion::functions::expr_fn::coalesce;
 use datafusion::functions_aggregate::{
     approx_distinct, approx_percentile_cont, array_agg, average, bit_and_or_xor, bool_and_or,
     correlation, count, covariance, first_last, grouping, min_max, percentile_cont, stddev, sum,
@@ -388,71 +389,79 @@ fn count_if(input: AggFunctionInput) -> PlanResult<expr::Expr> {
 }
 
 fn collect_set(input: AggFunctionInput) -> PlanResult<expr::Expr> {
+    let schema = input.function_context.schema;
     // Spark's collect_set ignores NULLs by default
     let ignore_nulls = input.ignore_nulls.or(Some(true));
+    let arg = input.arguments.one()?;
+    let element_type = arg.get_type(schema)?;
 
     // WORKAROUND: DataFusion's array_agg doesn't properly handle null_treatment when distinct=true
     // So we need to add an explicit filter for NULLs
-    let (args, filter, null_treatment) = if ignore_nulls == Some(true) {
-        let arg = input.arguments.one()?;
+    let (filter, null_treatment) = if ignore_nulls == Some(true) {
         let null_filter = arg.clone().is_not_null();
         let combined_filter = match input.filter {
-            Some(existing) => Some(Box::new(existing.as_ref().clone().and(null_filter))),
-            None => Some(Box::new(null_filter)),
+            Some(existing) => existing.as_ref().clone().and(null_filter),
+            None => null_filter,
         };
-        (vec![arg], combined_filter, None) // Don't use null_treatment when we have explicit filter
+        // Don't use null_treatment when we have explicit filter
+        (Some(Box::new(combined_filter)), None)
     } else {
-        (
-            input.arguments,
-            input.filter,
-            get_null_treatment(ignore_nulls),
-        )
+        (input.filter, get_null_treatment(ignore_nulls))
     };
 
-    Ok(expr::Expr::AggregateFunction(AggregateFunction {
+    let agg = expr::Expr::AggregateFunction(AggregateFunction {
         func: array_agg::array_agg_udaf(),
         params: AggregateFunctionParams {
-            args,
+            args: vec![arg],
             distinct: true,
             order_by: input.order_by,
             filter,
             null_treatment,
         },
-    }))
+    });
+    Ok(coalesce_to_empty_array(agg, &element_type))
 }
 
 fn array_agg_compacted(input: AggFunctionInput) -> PlanResult<expr::Expr> {
+    let schema = input.function_context.schema;
     // Spark's collect_list ignores NULLs by default
     let ignore_nulls = input.ignore_nulls.or(Some(true));
+    let arg = input.arguments.one()?;
+    let element_type = arg.get_type(schema)?;
 
     // WORKAROUND: DataFusion's array_agg doesn't properly handle null_treatment when distinct=true
     // So we need to add an explicit filter for NULLs when both distinct and ignore_nulls are true
-    let (args, filter, null_treatment) = if input.distinct && ignore_nulls == Some(true) {
-        let arg = input.arguments.one()?;
+    let (filter, null_treatment) = if input.distinct && ignore_nulls == Some(true) {
         let null_filter = arg.clone().is_not_null();
         let combined_filter = match input.filter {
-            Some(existing) => Some(Box::new(existing.as_ref().clone().and(null_filter))),
-            None => Some(Box::new(null_filter)),
+            Some(existing) => existing.as_ref().clone().and(null_filter),
+            None => null_filter,
         };
-        (vec![arg], combined_filter, None) // Don't use null_treatment when we have explicit filter
+        // Don't use null_treatment when we have explicit filter
+        (Some(Box::new(combined_filter)), None)
     } else {
-        (
-            input.arguments,
-            input.filter,
-            get_null_treatment(ignore_nulls),
-        )
+        (input.filter, get_null_treatment(ignore_nulls))
     };
 
-    Ok(expr::Expr::AggregateFunction(AggregateFunction {
+    let agg = expr::Expr::AggregateFunction(AggregateFunction {
         func: array_agg::array_agg_udaf(),
         params: AggregateFunctionParams {
-            args,
+            args: vec![arg],
             distinct: input.distinct,
             order_by: input.order_by,
             filter,
             null_treatment,
         },
-    }))
+    });
+    Ok(coalesce_to_empty_array(agg, &element_type))
+}
+
+/// Spark's `collect_list`/`collect_set` return an empty array for a group with no (non-NULL)
+/// values to collect, but DataFusion's `array_agg` returns NULL over zero rows. Coalesce the
+/// aggregate to a typed empty array so the empty case matches Spark instead of yielding NULL.
+fn coalesce_to_empty_array(agg: expr::Expr, element_type: &DataType) -> expr::Expr {
+    let empty = ScalarValue::List(ScalarValue::new_list_nullable(&[], element_type));
+    coalesce(vec![agg, lit(empty)])
 }
 
 fn listagg(input: AggFunctionInput) -> PlanResult<expr::Expr> {

--- a/crates/sail-plan/src/resolver/query/pivoting.rs
+++ b/crates/sail-plan/src/resolver/query/pivoting.rs
@@ -2,11 +2,12 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use arrow::datatypes::DataType;
+use datafusion::functions_aggregate::count::count_udaf;
 use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRecursion};
 use datafusion_common::{Column, DFSchema, DFSchemaRef, ScalarValue};
-use datafusion_expr::expr::NullTreatment;
+use datafusion_expr::expr::{AggregateFunctionParams, NullTreatment};
 use datafusion_expr::{
-    col, expr, lit, ExprSchemable, LogicalPlan, LogicalPlanBuilder, Projection, ScalarUDF,
+    col, expr, lit, when, ExprSchemable, LogicalPlan, LogicalPlanBuilder, Projection, ScalarUDF,
 };
 use datafusion_functions_nested::expr_fn as nested_fn;
 use sail_common::spec;
@@ -156,12 +157,31 @@ impl PlanResolver<'_> {
                     pivot_column.clone().eq(lit(scalar))
                 }
             };
+            // On the PivotFirst path, an absent (group, pivot-value) combination is NULL even
+            // for `count` (Spark only computes the aggregate over (group, value) pairs that
+            // occur in the data). The aggregate FILTER below makes `count` return 0 for such a
+            // group, so gate each cell on whether any row matched the pivot value. This is a
+            // no-op for sum/avg/min/max (already NULL on empty) and corrects the counting
+            // family (count, count(DISTINCT), approx_count_distinct). On the general path
+            // (`spark_uses_pivot_first == false`) Spark itself returns 0 there, matching the
+            // unguarded FILTER, so no guard is applied.
+            let row_present = if spark_uses_pivot_first {
+                Some(count_rows_matching(&predicate).gt(lit(0i64)))
+            } else {
+                None
+            };
             for agg in &aggregates {
                 let expr = inject_pivot_filter(
                     agg.expr.clone(),
                     &predicate,
                     force_first_last_ignore_nulls,
                 )?;
+                let expr = match &row_present {
+                    Some(condition) => {
+                        when(condition.clone(), expr).otherwise(lit(ScalarValue::Null))?
+                    }
+                    None => expr,
+                };
                 let name = if single_aggregate {
                     value_name.clone()
                 } else {
@@ -505,6 +525,22 @@ fn scalar_is_nan(scalar: &ScalarValue) -> bool {
         ScalarValue::Float64(Some(value)) => value.is_nan(),
         _ => false,
     }
+}
+
+/// Build `count(1) FILTER (WHERE predicate)`: the number of rows in the group that match
+/// the pivot value. Used to distinguish an absent (group, pivot-value) combination (zero
+/// matching rows -> NULL cell) from a present one whose aggregate happens to be `0`.
+fn count_rows_matching(predicate: &expr::Expr) -> expr::Expr {
+    expr::Expr::AggregateFunction(expr::AggregateFunction {
+        func: count_udaf(),
+        params: AggregateFunctionParams {
+            args: vec![lit(1i64)],
+            distinct: false,
+            filter: Some(Box::new(predicate.clone())),
+            order_by: vec![],
+            null_treatment: None,
+        },
+    })
 }
 
 /// Add `predicate` as a FILTER to every aggregate function inside `expr`,

--- a/python/pysail/tests/spark/dataframe/test_pivot.py
+++ b/python/pysail/tests/spark/dataframe/test_pivot.py
@@ -113,7 +113,11 @@ def test_pivot_allows_duplicate_aliases(spark):
 
 
 def test_pivot_allows_literal_aggregate_expression(spark):
-    actual = spark.sql("""
+    # A literal aggregate (Int32) goes through Spark's PivotFirst path, so an absent
+    # (group, value) combination is NULL, not the literal: group 'b' has no 'y' row, so
+    # b/y is NULL (JVM-verified). collect() keeps the exact NULL (toPandas would coerce
+    # the int column to float/NaN).
+    rows = spark.sql("""
         SELECT * FROM (
           SELECT g, k FROM VALUES
             ('a', 'x'),
@@ -122,9 +126,9 @@ def test_pivot_allows_literal_aggregate_expression(spark):
           AS t(g, k)
         ) PIVOT (1 FOR (k) IN ('x', 'y'))
         ORDER BY g
-    """).toPandas()
-    assert list(actual.columns) == ["g", "x", "y"]
-    assert actual.values.tolist() == [["a", 1, 1], ["b", 1, 1]]
+    """)
+    assert rows.columns == ["g", "x", "y"]
+    assert [tuple(r) for r in rows.collect()] == [("a", 1, 1), ("b", 1, None)]
 
 
 def test_pivot_rejects_bare_column_outside_aggregate(spark):

--- a/python/pysail/tests/spark/function/features/collect_list.feature
+++ b/python/pysail/tests/spark/function/features/collect_list.feature
@@ -1,0 +1,258 @@
+@collect_list @collect_set
+Feature: collect_list / collect_set
+
+  collect_list gathers all values of a group into an array (order and duplicates preserved);
+  collect_set gathers the distinct values. Both ignore NULLs and return an empty array `[]`
+  for a group with no (non-NULL) values.
+
+  Sail maps both onto DataFusion's array_agg (sail-plan `aggregate.rs`: `array_agg_compacted`
+  for collect_list, `collect_set` for collect_set). DataFusion's array_agg returns NULL over
+  zero rows, so the empty case is coalesced to a typed empty array to match Spark.
+
+  Rule: collect_list collects values of any type, preserving order and duplicates
+
+    Scenario: integers keep input order and duplicates
+      When query
+        """
+        SELECT collect_list(v) AS r FROM VALUES (1), (2), (1) AS t(v)
+        """
+      Then query result
+        | r         |
+        | [1, 2, 1] |
+
+    Scenario: strings
+      When query
+        """
+        SELECT collect_list(v) AS r FROM VALUES ('a'), ('b'), ('a') AS t(v)
+        """
+      Then query result
+        | r         |
+        | [a, b, a] |
+
+    Scenario: doubles
+      When query
+        """
+        SELECT collect_list(v) AS r FROM VALUES (1.5D), (2.5D) AS t(v)
+        """
+      Then query result
+        | r          |
+        | [1.5, 2.5] |
+
+    Scenario: decimals keep their scale
+      When query
+        """
+        SELECT collect_list(v) AS r FROM VALUES
+          (CAST(1.50 AS DECIMAL(5, 2))), (CAST(2.00 AS DECIMAL(5, 2)))
+        AS t(v)
+        """
+      Then query result
+        | r            |
+        | [1.50, 2.00] |
+
+    Scenario: booleans
+      When query
+        """
+        SELECT collect_list(v) AS r FROM VALUES (true), (false), (true) AS t(v)
+        """
+      Then query result
+        | r                   |
+        | [true, false, true] |
+
+    Scenario: dates
+      When query
+        """
+        SELECT collect_list(v) AS r FROM VALUES (DATE'2024-01-01'), (DATE'2024-02-02') AS t(v)
+        """
+      Then query result
+        | r                        |
+        | [2024-01-01, 2024-02-02] |
+
+    Scenario: array elements
+      When query
+        """
+        SELECT collect_list(v) AS r FROM VALUES (array(1, 2)), (array(3)) AS t(v)
+        """
+      Then query result
+        | r             |
+        | [[1, 2], [3]] |
+
+    Scenario: struct elements
+      When query
+        """
+        SELECT collect_list(v) AS r FROM VALUES (named_struct('a', 1)), (named_struct('a', 2)) AS t(v)
+        """
+      Then query result
+        | r          |
+        | [{1}, {2}] |
+
+    # collect_list accepts map elements (unlike collect_set, which requires orderable elements).
+    Scenario: map elements
+      When query
+        """
+        SELECT collect_list(v) AS r FROM VALUES (map('a', 1)) AS t(v)
+        """
+      Then query result
+        | r          |
+        | [{a -> 1}] |
+
+  Rule: NULLs are ignored
+
+    Scenario: collect_list drops NULLs and keeps the non-NULL values
+      When query
+        """
+        SELECT collect_list(v) AS r FROM VALUES
+          (1), (CAST(NULL AS INT)), (2), (CAST(NULL AS INT))
+        AS t(v)
+        """
+      Then query result
+        | r      |
+        | [1, 2] |
+
+  Rule: An empty or all-NULL group collects to an empty array, not NULL
+
+    Scenario: collect_list over an all-NULL group
+      When query
+        """
+        SELECT collect_list(v) AS r FROM VALUES
+          (CAST(NULL AS INT)), (CAST(NULL AS INT))
+        AS t(v)
+        """
+      Then query result
+        | r  |
+        | [] |
+
+    Scenario: collect_set over an all-NULL group
+      When query
+        """
+        SELECT collect_set(v) AS r FROM VALUES
+          (CAST(NULL AS INT)), (CAST(NULL AS INT))
+        AS t(v)
+        """
+      Then query result
+        | r  |
+        | [] |
+
+    Scenario: collect_list whose FILTER removes every row
+      When query
+        """
+        SELECT collect_list(v) FILTER (WHERE v > 100) AS r FROM VALUES (1), (2) AS t(v)
+        """
+      Then query result
+        | r  |
+        | [] |
+
+    Scenario: an all-NULL group is an empty array while populated groups keep their values
+      When query
+        """
+        SELECT g, collect_list(v) AS r FROM VALUES
+          ('a', 1),
+          ('a', CAST(NULL AS INT)),
+          ('b', CAST(NULL AS INT))
+        AS t(g, v) GROUP BY g
+        """
+      Then query result
+        | g | r   |
+        | a | [1] |
+        | b | []  |
+
+    # The same empty-collection case as it surfaces through PIVOT: the absent (2013, dotNET)
+    # cell collects to [].
+    Scenario: collect_set in a pivot fills an absent combination with an empty array
+      When query
+        """
+        SELECT * FROM (
+          SELECT year, course, earnings FROM VALUES
+            (2012, 'dotNET', 10),
+            (2012, 'Java', 2),
+            (2013, 'Java', 3)
+          AS courseSales(year, course, earnings)
+        ) PIVOT (
+          collect_set(earnings) FOR (course) IN ('dotNET', 'Java')
+        )
+        """
+      Then query result
+        | year | dotNET | Java |
+        | 2012 | [10]   | [2]  |
+        | 2013 | []     | [3]  |
+
+  Rule: collect_set returns the distinct values, ignoring NULLs
+
+    Scenario: collect_set removes duplicates
+      When query
+        """
+        SELECT sort_array(collect_set(v)) AS r FROM VALUES (1), (2), (1), (3) AS t(v)
+        """
+      Then query result
+        | r         |
+        | [1, 2, 3] |
+
+    Scenario: collect_set drops NULLs
+      When query
+        """
+        SELECT sort_array(collect_set(v)) AS r FROM VALUES (1), (CAST(NULL AS INT)), (1) AS t(v)
+        """
+      Then query result
+        | r   |
+        | [1] |
+
+    Scenario: collect_list with DISTINCT also removes duplicates
+      When query
+        """
+        SELECT sort_array(collect_list(DISTINCT v)) AS r FROM VALUES (1), (2), (1) AS t(v)
+        """
+      Then query result
+        | r      |
+        | [1, 2] |
+
+  Rule: collect_set float equality diverges from Spark
+
+    # Spark's collect_set never treats two NaNs as equal, so duplicate NaNs are all kept.
+    # Sail (DataFusion's distinct array_agg) deduplicates NaN, dropping the repeat -> divergence.
+    @sail-bug
+    Scenario: collect_set keeps duplicate NaN values
+      When query
+        """
+        SELECT sort_array(collect_set(v)) AS r FROM VALUES
+          (CAST('NaN' AS DOUBLE)), (CAST('NaN' AS DOUBLE)), (1.0D)
+        AS t(v)
+        """
+      Then query result
+        | r               |
+        | [1.0, NaN, NaN] |
+
+    # Spark's collect_set treats -0.0 and 0.0 as equal and keeps a single 0.0. Sail keeps both
+    # -> divergence.
+    @sail-bug
+    Scenario: collect_set deduplicates -0.0 and 0.0 to a single 0.0
+      When query
+        """
+        SELECT sort_array(collect_set(v)) AS r FROM VALUES
+          (CAST('0.0' AS DOUBLE)), (CAST('-0.0' AS DOUBLE))
+        AS t(v)
+        """
+      Then query result
+        | r     |
+        | [0.0] |
+
+  Rule: collect_set requires orderable element types
+
+    # Spark rejects collect_set over MAP (unorderable) at analysis time. Sail accepts it and
+    # returns a result -> divergence (Sail is too lenient).
+    @sail-bug
+    Scenario: collect_set over a map raises an analysis error
+      When query
+        """
+        SELECT collect_set(v) AS r FROM VALUES (map('a', 1)) AS t(v)
+        """
+      Then query error .*
+
+  Rule: FILTER restricts the collected rows
+
+    Scenario: collect_list with FILTER WHERE collects only matching rows
+      When query
+        """
+        SELECT collect_list(v) FILTER (WHERE v > 1) AS r FROM VALUES (1), (2), (3) AS t(v)
+        """
+      Then query result
+        | r      |
+        | [2, 3] |

--- a/python/pysail/tests/spark/function/features/pivot.feature
+++ b/python/pysail/tests/spark/function/features/pivot.feature
@@ -1,3 +1,4 @@
+@pivot
 Feature: PIVOT rotates rows into columns
 
   Pivot groups by the remaining (or explicitly grouped) columns and produces one
@@ -157,9 +158,13 @@ Feature: PIVOT rotates rows into columns
         | 2012 | 5000 | 20000 |
         | 2013 | NULL | 30000 |
 
-  Rule: Count aggregate
+  Rule: Count aggregate fills absent combinations with NULL, not 0
 
-    Scenario: pivot count of rows per course
+    # An absent (group, pivot-value) combination is NULL even for count: on the PivotFirst
+    # path Spark only computes the aggregate over (group, value) pairs that occur in the
+    # data, so 2013/dotNET is NULL, not 0. Each cell is gated on whether any row matched the
+    # pivot value, so a group with no matching rows yields NULL.
+    Scenario: pivot count of rows per course (absent combo is NULL, not 0)
       When query
         """
         SELECT * FROM (
@@ -176,4 +181,115 @@ Feature: PIVOT rotates rows into columns
       Then query result
         | year | dotNET | Java |
         | 2012 | 2      | 1    |
-        | 2013 | 0      | 1    |
+        | 2013 | NULL   | 1    |
+
+    # The flip side that pins the semantics: when the (group, value) pair DOES occur but the
+    # counted column is all-NULL, count is 0 (count ignores NULLs) — so 2012/dotNET is 0
+    # while the absent 2013/dotNET is NULL. The gate keeps the 0 (rows matched) and turns
+    # only the truly-absent cell into NULL.
+    Scenario: count over an existing all-NULL group is 0 while an absent group is NULL
+      When query
+        """
+        SELECT * FROM (
+          SELECT year, course, earnings FROM VALUES
+            (2012, 'dotNET', CAST(NULL AS INT)),
+            (2012, 'Java', 20000),
+            (2013, 'Java', 30000)
+          AS courseSales(year, course, earnings)
+        ) PIVOT (
+          count(earnings) FOR (course) IN ('dotNET', 'Java')
+        )
+        """
+      Then query result
+        | year | dotNET | Java |
+        | 2012 | 0      | 1    |
+        | 2013 | NULL   | 1    |
+
+    # count(DISTINCT) is the same counting family: absent combo is NULL, not 0.
+    Scenario: pivot count(DISTINCT) leaves absent combinations NULL
+      When query
+        """
+        SELECT * FROM (
+          SELECT year, course, earnings FROM VALUES
+            (2012, 'dotNET', 10),
+            (2012, 'dotNET', 10),
+            (2012, 'Java', 2),
+            (2013, 'Java', 3)
+          AS courseSales(year, course, earnings)
+        ) PIVOT (
+          count(DISTINCT earnings) FOR (course) IN ('dotNET', 'Java')
+        )
+        """
+      Then query result
+        | year | dotNET | Java |
+        | 2012 | 1      | 1    |
+        | 2013 | NULL   | 1    |
+
+    # approx_count_distinct returns 0 on empty too, so it must also be NULL on an absent
+    # combo (PivotFirst path).
+    Scenario: pivot approx_count_distinct leaves absent combinations NULL
+      When query
+        """
+        SELECT * FROM (
+          SELECT year, course, earnings FROM VALUES
+            (2012, 'dotNET', 10),
+            (2012, 'dotNET', 20),
+            (2012, 'Java', 2),
+            (2013, 'Java', 3)
+          AS courseSales(year, course, earnings)
+        ) PIVOT (
+          approx_count_distinct(earnings) FOR (course) IN ('dotNET', 'Java')
+        )
+        """
+      Then query result
+        | year | dotNET | Java |
+        | 2012 | 2      | 1    |
+        | 2013 | NULL   | 1    |
+
+    # Mixing count with a non-PivotFirst aggregate (a string max) forces Spark's general
+    # path, where count's absent combo is 0 (not NULL). The NULL gate only applies on the
+    # PivotFirst path, so the general-path count must keep 0 here (regression guard for the
+    # fix): 2013/dotNET_c is 0 while the string max for the same absent cell is NULL.
+    Scenario: count on the general path keeps 0 for absent combos
+      When query
+        """
+        SELECT * FROM (
+          SELECT year, course, earnings, note FROM VALUES
+            (2012, 'dotNET', 10, 'p'),
+            (2012, 'dotNET', 20, 'q'),
+            (2012, 'Java', 2, 'r'),
+            (2013, 'Java', 3, 's')
+          AS courseSales(year, course, earnings, note)
+        ) PIVOT (
+          count(earnings) AS c, max(note) AS m
+          FOR (course) IN ('dotNET', 'Java')
+        )
+        """
+      Then query result
+        | year | dotNET_c | dotNET_m | Java_c | Java_m |
+        | 2012 | 2        | q        | 1      | r      |
+        | 2013 | 0        | NULL     | 1      | s      |
+
+  Rule: collect_list/collect_set fill absent combinations with an empty array
+
+    # Spark's general (non-PivotFirst) path computes collect_list over the existing group,
+    # ignoring NULLs, so an absent (group, value) combination is an empty array [], not NULL.
+    # collect_list/collect_set coalesce their empty aggregate to [] (see collect_list.feature),
+    # so this matches Spark.
+    Scenario: pivot collect_list fills an absent combination with an empty array
+      When query
+        """
+        SELECT * FROM (
+          SELECT year, course, earnings FROM VALUES
+            (2012, 'dotNET', 10),
+            (2012, 'Java', 2),
+            (2013, 'Java', 3)
+          AS courseSales(year, course, earnings)
+        ) PIVOT (
+          collect_list(earnings) FOR (course) IN ('dotNET', 'Java')
+        )
+        """
+      Then query result
+        | year | dotNET | Java |
+        | 2012 | [10]   | [2]  |
+        | 2013 | []     | [3]  |


### PR DESCRIPTION
Two related Spark-compatibility fixes for what an aggregate returns over an empty group:

- pivot count of an absent (group, value) combination is now NULL, not 0, by gating each PivotFirst-path cell on `count(1) FILTER(predicate) > 0`.
- collect_list/collect_set now return [] (not NULL) for an empty or all-NULL group, by coalescing DataFusion's array_agg to a typed empty array.

Adds a collect_list/collect_set feature suite and corrects two pre-existing tests whose expected values did not match Spark JVM. Documents three remaining collect_set divergences as @sail-bug.