### PR TITLE
fix: codec for data sources

### DIFF
--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -66,6 +66,7 @@ message ExtendedPhysicalPlanNode {
     FileDeleteExecNode file_delete = 51;
     NoopSinkExecNode noop_sink = 52;
     CsvExecNode csv = 53;
+    ParquetExecNode parquet = 54;
   }
 }
 
@@ -585,15 +586,13 @@ message NdJsonExecNode {
 
 message CsvExecNode {
   bytes base_config = 1;
-  CompressionTypeVariant file_compression_type = 2;
-  bool has_header = 3;
-  bytes delimiter = 4;
-  bytes quote = 5;
-  optional bytes escape = 6;
-  optional bytes comment = 7;
-  bool newlines_in_values = 8;
-  bool truncate_rows = 9;
-  optional bytes terminator = 10;
+  bytes options = 2;
+}
+
+message ParquetExecNode {
+  bytes base_config = 1;
+  bytes options = 2;
+  optional bytes predicate = 3;
 }
 
 message ArrowExecNode {

--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -65,6 +65,7 @@ message ExtendedPhysicalPlanNode {
     CoalesceExecNode coalesce = 50;
     FileDeleteExecNode file_delete = 51;
     NoopSinkExecNode noop_sink = 52;
+    CsvExecNode csv = 53;
   }
 }
 
@@ -580,6 +581,19 @@ message ValuesExecNode {
 message NdJsonExecNode {
   bytes base_config = 1;
   CompressionTypeVariant file_compression_type = 2;
+}
+
+message CsvExecNode {
+  bytes base_config = 1;
+  CompressionTypeVariant file_compression_type = 2;
+  bool has_header = 3;
+  bytes delimiter = 4;
+  bytes quote = 5;
+  optional bytes escape = 6;
+  optional bytes comment = 7;
+  bool newlines_in_values = 8;
+  bool truncate_rows = 9;
+  optional bytes terminator = 10;
 }
 
 message ArrowExecNode {

--- a/crates/sail-execution/src/driver/job_scheduler/core.rs
+++ b/crates/sail-execution/src/driver/job_scheduler/core.rs
@@ -23,7 +23,7 @@ use crate::id::{JobId, TaskKey, TaskKeyDisplay, TaskStreamKey};
 use crate::job_graph::{
     InputMode, JobGraph, OutputDistribution, OutputMode, Stage, StageInput, TaskPlacement,
 };
-use crate::proto::encode::{try_encode_physical_expr, try_encode_physical_plan};
+use crate::proto::{encode_remote_physical_expr, encode_remote_physical_plan};
 use crate::task::definition::{
     TaskDefinition, TaskInput, TaskInputKey, TaskInputLocator, TaskOutput, TaskOutputDistribution,
     TaskOutputLocator,
@@ -525,7 +525,7 @@ impl JobScheduler {
             )));
         };
 
-        let plan = try_encode_physical_plan(self.codec.as_ref(), stage.plan.clone())?;
+        let plan = encode_remote_physical_plan(self.codec.as_ref(), stage.plan.clone())?;
         let inputs = stage
             .inputs
             .iter()
@@ -677,7 +677,7 @@ impl JobScheduler {
                 let keys = keys
                     .iter()
                     .map(|expr| {
-                        let expr = try_encode_physical_expr(self.codec.as_ref(), expr)?;
+                        let expr = encode_remote_physical_expr(self.codec.as_ref(), expr)?;
                         Ok(Arc::from(expr))
                     })
                     .collect::<ExecutionResult<Vec<Arc<[u8]>>>>()?;

--- a/crates/sail-execution/src/driver/job_scheduler/mod.rs
+++ b/crates/sail-execution/src/driver/job_scheduler/mod.rs
@@ -14,7 +14,7 @@ pub use state::TaskState;
 use crate::driver::job_scheduler::state::JobDescriptor;
 use crate::driver::output::JobOutputHandle;
 use crate::id::{IdGenerator, JobId, TaskKey, TaskStreamKey};
-use crate::proto::codec::RemoteExecutionCodec;
+use crate::proto::RemoteExecutionCodec;
 use crate::task::scheduling::TaskRegion;
 
 pub struct JobScheduler {

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use datafusion::arrow::compute::SortOptions;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use datafusion::common::config::CsvOptions;
 use datafusion::common::parsers::CompressionTypeVariant;
 use datafusion::common::{
     plan_datafusion_err, plan_err, Constraint, Constraints, JoinSide, Result, ScalarValue,
@@ -13,8 +14,8 @@ use datafusion::common::{
 use datafusion::datasource::file_format::file_compression_type::FileCompressionType;
 use datafusion::datasource::memory::MemorySourceConfig;
 use datafusion::datasource::physical_plan::{
-    ArrowSource, AvroSource, FileScanConfig, FileScanConfigBuilder, FileSink, FileSinkConfig,
-    JsonSource,
+    ArrowSource, AvroSource, CsvSource, FileScanConfig, FileScanConfigBuilder, FileSink,
+    FileSinkConfig, JsonSource,
 };
 use datafusion::datasource::sink::DataSinkExec;
 use datafusion::datasource::source::{DataSource, DataSourceExec};
@@ -247,6 +248,7 @@ use sail_logical_plan::show_string::{ShowStringFormat, ShowStringStyle};
 use sail_physical_plan::barrier::BarrierExec;
 use sail_physical_plan::catalog_command::CatalogCommandExec;
 use sail_physical_plan::coalesce::CoalesceExec;
+use sail_physical_plan::data_source::RemoteDataSourceExec;
 use sail_physical_plan::map_partitions::MapPartitionsExec;
 use sail_physical_plan::merge_cardinality_check::MergeCardinalityCheckExec;
 use sail_physical_plan::monotonic_id::MonotonicIdExec;
@@ -465,6 +467,57 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                     &PhysicalPlanDecodeContext::new(ctx, self),
                     &RemotePhysicalProtoConverter {},
                     Arc::new(JsonSource::new(table_schema)),
+                )?;
+                let source = FileScanConfigBuilder::from(source)
+                    .with_file_compression_type(file_compression_type)
+                    .build();
+                Ok(Arc::new(DataSourceExec::new(Arc::new(source))))
+            }
+            NodeKind::Csv(gen::CsvExecNode {
+                base_config,
+                file_compression_type,
+                has_header,
+                delimiter,
+                quote,
+                escape,
+                comment,
+                newlines_in_values,
+                truncate_rows,
+                terminator,
+            }) => {
+                let file_compression_type: FileCompressionType =
+                    self.try_decode_file_compression_type(file_compression_type)?;
+                let delimiter = self.try_decode_byte(delimiter, "delimiter")?;
+                let quote = self.try_decode_byte(quote, "quote")?;
+                let escape = escape
+                    .map(|bytes| self.try_decode_byte(bytes, "escape"))
+                    .transpose()?;
+                let comment = comment
+                    .map(|bytes| self.try_decode_byte(bytes, "comment"))
+                    .transpose()?;
+                let terminator = terminator
+                    .map(|bytes| self.try_decode_byte(bytes, "terminator"))
+                    .transpose()?;
+                let proto = try_decode_message(&base_config)?;
+                let table_schema = parse_protobuf_file_scan_schema(&proto)?;
+                let csv_options = CsvOptions {
+                    has_header: Some(has_header),
+                    delimiter,
+                    quote,
+                    newlines_in_values: Some(newlines_in_values),
+                    truncated_rows: Some(truncate_rows),
+                    ..Default::default()
+                };
+                let source = CsvSource::new(table_schema)
+                    .with_csv_options(csv_options)
+                    .with_escape(escape)
+                    .with_comment(comment)
+                    .with_terminator(terminator);
+                let source = parse_protobuf_file_scan_config(
+                    &proto,
+                    &PhysicalPlanDecodeContext::new(ctx, self),
+                    &RemotePhysicalProtoConverter {},
+                    Arc::new(source),
                 )?;
                 let source = FileScanConfigBuilder::from(source)
                     .with_file_compression_type(file_compression_type)
@@ -1522,7 +1575,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 input,
                 common_prefix_length,
             })
-        } else if let Some(data_source) = node.downcast_ref::<DataSourceExec>() {
+        } else if let Some(data_source) = node.downcast_ref::<RemoteDataSourceExec>() {
             let source = data_source.data_source();
             if let Some(file_scan) = source.downcast_ref::<FileScanConfig>() {
                 let file_source = file_scan.file_source();
@@ -1550,8 +1603,36 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                         base_config,
                         path_glob_filter: binary_source.path_glob_filter().cloned(),
                     })
+                } else if let Some(csv_source) = file_source.downcast_ref::<CsvSource>() {
+                    let base_config = try_encode_message(serialize_file_scan_config(
+                        file_scan,
+                        self,
+                        &RemotePhysicalProtoConverter {},
+                    )?)?;
+                    let file_compression_type =
+                        self.try_encode_file_compression_type(file_scan.file_compression_type)?;
+                    NodeKind::Csv(gen::CsvExecNode {
+                        base_config,
+                        file_compression_type,
+                        has_header: csv_source.has_header(),
+                        delimiter: self.try_encode_byte(csv_source.delimiter(), "delimiter")?,
+                        quote: self.try_encode_byte(csv_source.quote(), "quote")?,
+                        escape: csv_source
+                            .escape()
+                            .map(|x| self.try_encode_byte(x, "escape"))
+                            .transpose()?,
+                        comment: csv_source
+                            .comment()
+                            .map(|x| self.try_encode_byte(x, "comment"))
+                            .transpose()?,
+                        newlines_in_values: csv_source.newlines_in_values(),
+                        truncate_rows: csv_source.truncate_rows(),
+                        terminator: csv_source
+                            .terminator()
+                            .map(|x| self.try_encode_byte(x, "terminator"))
+                            .transpose()?,
+                    })
                 } else if file_source.is::<JsonSource>() {
-                    // TODO: Check if we still need to have JsonSource: https://github.com/apache/datafusion/pull/14224
                     let base_config = try_encode_message(serialize_file_scan_config(
                         file_scan,
                         self,
@@ -1564,7 +1645,6 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                         file_compression_type,
                     })
                 } else if file_source.is::<ArrowSource>() {
-                    // TODO: Check if we still need to have ArrowSource: https://github.com/apache/datafusion/pull/14224
                     let base_config = try_encode_message(serialize_file_scan_config(
                         file_scan,
                         self,
@@ -1582,7 +1662,6 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                     return plan_err!("unsupported data source node: {data_source:?}");
                 }
             } else if let Some(memory) = source.downcast_ref::<MemorySourceConfig>() {
-                // TODO: Check if we still need to have MemorySourceConfig: https://github.com/apache/datafusion/pull/14224
                 // `memory.schema()` is the schema after projection.
                 // We must use the original schema here.
                 let schema = memory.original_schema();
@@ -3176,6 +3255,17 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
 }
 
 impl RemoteExecutionCodec {
+    fn try_decode_byte(&self, bytes: Vec<u8>, name: &str) -> Result<u8> {
+        match bytes.as_slice() {
+            [x] => Ok(*x),
+            _ => plan_err!("{name} must be a single byte, got: {bytes:?}"),
+        }
+    }
+
+    fn try_encode_byte(&self, value: u8, _name: &str) -> Result<Vec<u8>> {
+        Ok(vec![value])
+    }
+
     #[expect(clippy::type_complexity)]
     fn try_decode_cast_column_expr(
         &self,

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use datafusion::arrow::compute::SortOptions;
 use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit};
-use datafusion::common::config::CsvOptions;
+use datafusion::common::config::{CsvOptions, TableParquetOptions};
 use datafusion::common::parsers::CompressionTypeVariant;
 use datafusion::common::{
     plan_datafusion_err, plan_err, Constraint, Constraints, JoinSide, Result, ScalarValue,
@@ -13,9 +13,10 @@ use datafusion::common::{
 };
 use datafusion::datasource::file_format::file_compression_type::FileCompressionType;
 use datafusion::datasource::memory::MemorySourceConfig;
+use datafusion::datasource::physical_plan::parquet::CachedParquetFileReaderFactory;
 use datafusion::datasource::physical_plan::{
     ArrowSource, AvroSource, CsvSource, FileScanConfig, FileScanConfigBuilder, FileSink,
-    FileSinkConfig, JsonSource,
+    FileSinkConfig, FileSource, JsonSource, ParquetSource,
 };
 use datafusion::datasource::sink::DataSinkExec;
 use datafusion::datasource::source::{DataSource, DataSourceExec};
@@ -47,7 +48,7 @@ use datafusion::physical_plan::{ExecutionPlan, PlanProperties};
 use datafusion_proto::generated::datafusion_common as gen_datafusion_common;
 use datafusion_proto::physical_plan::from_proto::{
     parse_physical_sort_exprs, parse_protobuf_file_scan_config, parse_protobuf_file_scan_schema,
-    parse_protobuf_partitioning,
+    parse_protobuf_partitioning, parse_table_schema_from_proto,
 };
 use datafusion_proto::physical_plan::to_proto::{
     serialize_file_scan_config, serialize_partitioning, serialize_physical_sort_exprs,
@@ -475,44 +476,14 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             }
             NodeKind::Csv(gen::CsvExecNode {
                 base_config,
-                file_compression_type,
-                has_header,
-                delimiter,
-                quote,
-                escape,
-                comment,
-                newlines_in_values,
-                truncate_rows,
-                terminator,
+                options,
             }) => {
-                let file_compression_type: FileCompressionType =
-                    self.try_decode_file_compression_type(file_compression_type)?;
-                let delimiter = self.try_decode_byte(delimiter, "delimiter")?;
-                let quote = self.try_decode_byte(quote, "quote")?;
-                let escape = escape
-                    .map(|bytes| self.try_decode_byte(bytes, "escape"))
-                    .transpose()?;
-                let comment = comment
-                    .map(|bytes| self.try_decode_byte(bytes, "comment"))
-                    .transpose()?;
-                let terminator = terminator
-                    .map(|bytes| self.try_decode_byte(bytes, "terminator"))
-                    .transpose()?;
                 let proto = try_decode_message(&base_config)?;
-                let table_schema = parse_protobuf_file_scan_schema(&proto)?;
-                let csv_options = CsvOptions {
-                    has_header: Some(has_header),
-                    delimiter,
-                    quote,
-                    newlines_in_values: Some(newlines_in_values),
-                    truncated_rows: Some(truncate_rows),
-                    ..Default::default()
-                };
-                let source = CsvSource::new(table_schema)
-                    .with_csv_options(csv_options)
-                    .with_escape(escape)
-                    .with_comment(comment)
-                    .with_terminator(terminator);
+                let table_schema = parse_table_schema_from_proto(&proto)?;
+                let options = try_decode_message::<gen_datafusion_common::CsvOptions>(&options)?;
+                let csv_options: CsvOptions = (&options).try_into()?;
+                let file_compression_type: FileCompressionType = csv_options.compression.into();
+                let source = CsvSource::new(table_schema).with_csv_options(csv_options);
                 let source = parse_protobuf_file_scan_config(
                     &proto,
                     &PhysicalPlanDecodeContext::new(ctx, self),
@@ -522,6 +493,46 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 let source = FileScanConfigBuilder::from(source)
                     .with_file_compression_type(file_compression_type)
                     .build();
+                Ok(Arc::new(DataSourceExec::new(Arc::new(source))))
+            }
+            NodeKind::Parquet(gen::ParquetExecNode {
+                base_config,
+                options,
+                predicate,
+            }) => {
+                let proto = try_decode_message(&base_config)?;
+                let predicate_schema = parse_protobuf_file_scan_schema(&proto)?;
+                let table_schema = parse_table_schema_from_proto(&proto)?;
+                let options =
+                    try_decode_message::<gen_datafusion_common::TableParquetOptions>(&options)?;
+                let options: TableParquetOptions = (&options).try_into()?;
+                let predicate = predicate
+                    .map(|predicate| {
+                        try_decode_physical_expr(ctx, self, &predicate, predicate_schema.as_ref())
+                    })
+                    .transpose()?;
+                let object_store_url = match proto.object_store_url.is_empty() {
+                    false => datafusion::execution::object_store::ObjectStoreUrl::parse(
+                        &proto.object_store_url,
+                    )?,
+                    true => datafusion::execution::object_store::ObjectStoreUrl::local_filesystem(),
+                };
+                let store = ctx.runtime_env().object_store(object_store_url)?;
+                let metadata_cache = ctx.runtime_env().cache_manager.get_file_metadata_cache();
+                let reader_factory =
+                    Arc::new(CachedParquetFileReaderFactory::new(store, metadata_cache));
+                let mut source = ParquetSource::new(table_schema)
+                    .with_parquet_file_reader_factory(reader_factory)
+                    .with_table_parquet_options(options);
+                if let Some(predicate) = predicate {
+                    source = source.with_predicate(predicate);
+                }
+                let source = parse_protobuf_file_scan_config(
+                    &proto,
+                    &PhysicalPlanDecodeContext::new(ctx, self),
+                    &RemotePhysicalProtoConverter {},
+                    Arc::new(source),
+                )?;
                 Ok(Arc::new(DataSourceExec::new(Arc::new(source))))
             }
             NodeKind::Arrow(gen::ArrowExecNode { base_config }) => {
@@ -1609,28 +1620,43 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                         self,
                         &RemotePhysicalProtoConverter {},
                     )?)?;
-                    let file_compression_type =
-                        self.try_encode_file_compression_type(file_scan.file_compression_type)?;
+                    let csv_options = CsvOptions {
+                        has_header: Some(csv_source.has_header()),
+                        delimiter: csv_source.delimiter(),
+                        quote: csv_source.quote(),
+                        terminator: csv_source.terminator(),
+                        escape: csv_source.escape(),
+                        comment: csv_source.comment(),
+                        newlines_in_values: Some(csv_source.newlines_in_values()),
+                        truncated_rows: Some(csv_source.truncate_rows()),
+                        compression: file_scan.file_compression_type.into(),
+                        ..Default::default()
+                    };
+                    let options = try_encode_message(gen_datafusion_common::CsvOptions::try_from(
+                        &csv_options,
+                    )?)?;
                     NodeKind::Csv(gen::CsvExecNode {
                         base_config,
-                        file_compression_type,
-                        has_header: csv_source.has_header(),
-                        delimiter: self.try_encode_byte(csv_source.delimiter(), "delimiter")?,
-                        quote: self.try_encode_byte(csv_source.quote(), "quote")?,
-                        escape: csv_source
-                            .escape()
-                            .map(|x| self.try_encode_byte(x, "escape"))
-                            .transpose()?,
-                        comment: csv_source
-                            .comment()
-                            .map(|x| self.try_encode_byte(x, "comment"))
-                            .transpose()?,
-                        newlines_in_values: csv_source.newlines_in_values(),
-                        truncate_rows: csv_source.truncate_rows(),
-                        terminator: csv_source
-                            .terminator()
-                            .map(|x| self.try_encode_byte(x, "terminator"))
-                            .transpose()?,
+                        options,
+                    })
+                } else if let Some(parquet_source) = file_source.downcast_ref::<ParquetSource>() {
+                    let base_config = try_encode_message(serialize_file_scan_config(
+                        file_scan,
+                        self,
+                        &RemotePhysicalProtoConverter {},
+                    )?)?;
+                    let options = gen_datafusion_common::TableParquetOptions::try_from(
+                        parquet_source.table_parquet_options(),
+                    )?;
+                    let options = try_encode_message(options)?;
+                    let predicate = parquet_source
+                        .filter()
+                        .map(|predicate| try_encode_physical_expr(self, &predicate))
+                        .transpose()?;
+                    NodeKind::Parquet(gen::ParquetExecNode {
+                        base_config,
+                        options,
+                        predicate,
                     })
                 } else if file_source.is::<JsonSource>() {
                     let base_config = try_encode_message(serialize_file_scan_config(
@@ -3255,17 +3281,6 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
 }
 
 impl RemoteExecutionCodec {
-    fn try_decode_byte(&self, bytes: Vec<u8>, name: &str) -> Result<u8> {
-        match bytes.as_slice() {
-            [x] => Ok(*x),
-            _ => plan_err!("{name} must be a single byte, got: {bytes:?}"),
-        }
-    }
-
-    fn try_encode_byte(&self, value: u8, _name: &str) -> Result<Vec<u8>> {
-        Ok(vec![value])
-    }
-
     #[expect(clippy::type_complexity)]
     fn try_decode_cast_column_expr(
         &self,

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -461,10 +461,10 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             }) => {
                 let file_compression_type: FileCompressionType =
                     self.try_decode_file_compression_type(file_compression_type)?;
-                let proto = try_decode_message(&base_config)?;
-                let table_schema = parse_protobuf_file_scan_schema(&proto)?;
+                let base_config = try_decode_message(&base_config)?;
+                let table_schema = parse_table_schema_from_proto(&base_config)?;
                 let source = parse_protobuf_file_scan_config(
-                    &proto,
+                    &base_config,
                     &PhysicalPlanDecodeContext::new(ctx, self),
                     &RemotePhysicalProtoConverter {},
                     Arc::new(JsonSource::new(table_schema)),
@@ -478,14 +478,14 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 base_config,
                 options,
             }) => {
-                let proto = try_decode_message(&base_config)?;
-                let table_schema = parse_table_schema_from_proto(&proto)?;
+                let base_config = try_decode_message(&base_config)?;
+                let table_schema = parse_table_schema_from_proto(&base_config)?;
                 let options = try_decode_message::<gen_datafusion_common::CsvOptions>(&options)?;
                 let csv_options: CsvOptions = (&options).try_into()?;
                 let file_compression_type: FileCompressionType = csv_options.compression.into();
                 let source = CsvSource::new(table_schema).with_csv_options(csv_options);
                 let source = parse_protobuf_file_scan_config(
-                    &proto,
+                    &base_config,
                     &PhysicalPlanDecodeContext::new(ctx, self),
                     &RemotePhysicalProtoConverter {},
                     Arc::new(source),
@@ -500,9 +500,9 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 options,
                 predicate,
             }) => {
-                let proto = try_decode_message(&base_config)?;
-                let predicate_schema = parse_protobuf_file_scan_schema(&proto)?;
-                let table_schema = parse_table_schema_from_proto(&proto)?;
+                let base_config = try_decode_message(&base_config)?;
+                let predicate_schema = parse_protobuf_file_scan_schema(&base_config)?;
+                let table_schema = parse_table_schema_from_proto(&base_config)?;
                 let options =
                     try_decode_message::<gen_datafusion_common::TableParquetOptions>(&options)?;
                 let options: TableParquetOptions = (&options).try_into()?;
@@ -511,9 +511,9 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                         try_decode_physical_expr(ctx, self, &predicate, predicate_schema.as_ref())
                     })
                     .transpose()?;
-                let object_store_url = match proto.object_store_url.is_empty() {
+                let object_store_url = match base_config.object_store_url.is_empty() {
                     false => datafusion::execution::object_store::ObjectStoreUrl::parse(
-                        &proto.object_store_url,
+                        &base_config.object_store_url,
                     )?,
                     true => datafusion::execution::object_store::ObjectStoreUrl::local_filesystem(),
                 };
@@ -528,7 +528,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                     source = source.with_predicate(predicate);
                 }
                 let source = parse_protobuf_file_scan_config(
-                    &proto,
+                    &base_config,
                     &PhysicalPlanDecodeContext::new(ctx, self),
                     &RemotePhysicalProtoConverter {},
                     Arc::new(source),
@@ -536,10 +536,10 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 Ok(Arc::new(DataSourceExec::new(Arc::new(source))))
             }
             NodeKind::Arrow(gen::ArrowExecNode { base_config }) => {
-                let proto = try_decode_message(&base_config)?;
-                let table_schema = parse_protobuf_file_scan_schema(&proto)?;
+                let base_config = try_decode_message(&base_config)?;
+                let table_schema = parse_table_schema_from_proto(&base_config)?;
                 let source = parse_protobuf_file_scan_config(
-                    &proto,
+                    &base_config,
                     &PhysicalPlanDecodeContext::new(ctx, self),
                     &RemotePhysicalProtoConverter {},
                     Arc::new(ArrowSource::new_file_source(table_schema)),
@@ -564,10 +564,10 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                         );
                     }
                 };
-                let proto = try_decode_message(&base_config)?;
-                let table_schema = parse_protobuf_file_scan_schema(&proto)?;
+                let base_config = try_decode_message(&base_config)?;
+                let table_schema = parse_table_schema_from_proto(&base_config)?;
                 let source = parse_protobuf_file_scan_config(
-                    &proto,
+                    &base_config,
                     &PhysicalPlanDecodeContext::new(ctx, self),
                     &RemotePhysicalProtoConverter {},
                     Arc::new(TextSource::new(table_schema, whole_text, line_sep)),
@@ -581,10 +581,10 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 base_config,
                 path_glob_filter,
             }) => {
-                let proto = try_decode_message(&base_config)?;
-                let table_schema = parse_protobuf_file_scan_schema(&proto)?;
+                let base_config = try_decode_message(&base_config)?;
+                let table_schema = parse_table_schema_from_proto(&base_config)?;
                 let source = parse_protobuf_file_scan_config(
-                    &proto,
+                    &base_config,
                     &PhysicalPlanDecodeContext::new(ctx, self),
                     &RemotePhysicalProtoConverter {},
                     Arc::new(BinarySource::new(table_schema, path_glob_filter)),
@@ -593,10 +593,10 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 Ok(Arc::new(DataSourceExec::new(Arc::new(source))))
             }
             NodeKind::Avro(gen::AvroExecNode { base_config }) => {
-                let proto = try_decode_message(&base_config)?;
-                let table_schema = parse_protobuf_file_scan_schema(&proto)?;
+                let base_config = try_decode_message(&base_config)?;
+                let table_schema = parse_table_schema_from_proto(&base_config)?;
                 let source = parse_protobuf_file_scan_config(
-                    &proto,
+                    &base_config,
                     &PhysicalPlanDecodeContext::new(ctx, self),
                     &RemotePhysicalProtoConverter {},
                     Arc::new(AvroSource::new(table_schema)),

--- a/crates/sail-execution/src/proto/converter.rs
+++ b/crates/sail-execution/src/proto/converter.rs
@@ -23,7 +23,7 @@ use crate::plan::gen::{
 use crate::proto::decode::{try_decode_field_ref, try_decode_higher_order_udf};
 use crate::proto::encode::{try_encode_field_ref, try_encode_higher_order_udf};
 
-pub struct RemotePhysicalProtoConverter;
+pub(super) struct RemotePhysicalProtoConverter;
 
 impl Debug for RemotePhysicalProtoConverter {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/crates/sail-execution/src/proto/decode.rs
+++ b/crates/sail-execution/src/proto/decode.rs
@@ -23,7 +23,27 @@ use crate::plan::gen;
 use crate::plan::gen::higher_order_udf::HigherOrderUdfKind;
 use crate::proto::converter::RemotePhysicalProtoConverter;
 
-pub fn try_decode_message<M>(buf: &[u8]) -> Result<M>
+pub fn decode_remote_physical_plan(
+    ctx: &TaskContext,
+    codec: &dyn PhysicalExtensionCodec,
+    buf: &[u8],
+) -> Result<Arc<dyn ExecutionPlan>> {
+    // The remote codec decodes data sources directly into `DataSourceExec`.
+    // `RemoteDataSourceExec` is only used before encoding to bypass DataFusion's
+    // built-in `DataSourceExec` codec.
+    try_decode_physical_plan(ctx, codec, buf)
+}
+
+pub fn decode_remote_physical_expr(
+    ctx: &TaskContext,
+    codec: &dyn PhysicalExtensionCodec,
+    buf: &[u8],
+    schema: &Schema,
+) -> Result<Arc<dyn PhysicalExpr>> {
+    try_decode_physical_expr(ctx, codec, buf, schema)
+}
+
+pub(super) fn try_decode_message<M>(buf: &[u8]) -> Result<M>
 where
     M: Message + Default,
 {
@@ -32,18 +52,18 @@ where
     Ok(message)
 }
 
-pub fn try_decode_schema(buf: &[u8]) -> Result<Schema> {
+pub(super) fn try_decode_schema(buf: &[u8]) -> Result<Schema> {
     let schema = try_decode_message::<gen_datafusion_common::Schema>(buf)?;
     Ok((&schema).try_into()?)
 }
 
-pub fn try_decode_field_ref(buf: &[u8]) -> Result<FieldRef> {
+pub(super) fn try_decode_field_ref(buf: &[u8]) -> Result<FieldRef> {
     let field = try_decode_message::<gen_datafusion_common::Field>(buf)?;
     let field: Field = (&field).try_into()?;
     Ok(Arc::new(field))
 }
 
-pub fn try_decode_physical_plan(
+pub(super) fn try_decode_physical_plan(
     ctx: &TaskContext,
     codec: &dyn PhysicalExtensionCodec,
     buf: &[u8],
@@ -52,7 +72,7 @@ pub fn try_decode_physical_plan(
     proto_to_physical_plan(ctx, codec, &plan)
 }
 
-pub fn proto_to_physical_plan(
+pub(super) fn proto_to_physical_plan(
     ctx: &TaskContext,
     codec: &dyn PhysicalExtensionCodec,
     plan: &PhysicalPlanNode,
@@ -60,7 +80,7 @@ pub fn proto_to_physical_plan(
     plan.try_into_physical_plan_with_converter(ctx, codec, &RemotePhysicalProtoConverter {})
 }
 
-pub fn try_decode_physical_expr(
+pub(super) fn try_decode_physical_expr(
     ctx: &TaskContext,
     codec: &dyn PhysicalExtensionCodec,
     buf: &[u8],
@@ -70,7 +90,7 @@ pub fn try_decode_physical_expr(
     proto_to_physical_expr(ctx, codec, &expr, schema)
 }
 
-pub fn proto_to_physical_expr(
+pub(super) fn proto_to_physical_expr(
     ctx: &TaskContext,
     codec: &dyn PhysicalExtensionCodec,
     expr: &PhysicalExprNode,
@@ -80,7 +100,9 @@ pub fn proto_to_physical_expr(
     converter.proto_to_physical_expr(expr, schema, &PhysicalPlanDecodeContext::new(ctx, codec))
 }
 
-pub fn try_decode_higher_order_udf(udf: &gen::HigherOrderUdf) -> Result<Arc<HigherOrderUDF>> {
+pub(super) fn try_decode_higher_order_udf(
+    udf: &gen::HigherOrderUdf,
+) -> Result<Arc<HigherOrderUDF>> {
     let udf_kind = udf
         .higher_order_udf_kind
         .as_ref()

--- a/crates/sail-execution/src/proto/encode.rs
+++ b/crates/sail-execution/src/proto/encode.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::{FieldRef, Schema};
+use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion::common::{plan_err, Result};
+use datafusion::datasource::source::DataSourceExec;
 use datafusion::physical_expr::{HigherOrderFunctionExpr, PhysicalExpr};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_proto::generated::datafusion_common as gen_datafusion_common;
@@ -14,34 +16,60 @@ use sail_function::scalar::array::spark_array_filter::SparkArrayFilter;
 use sail_function::scalar::array::spark_array_forall::SparkArrayForall;
 use sail_function::scalar::array::spark_array_sort::SparkArraySort;
 use sail_function::scalar::array::spark_array_transform::SparkArrayTransform;
+use sail_physical_plan::data_source::RemoteDataSourceExec;
 
 use crate::plan::gen;
 use crate::plan::gen::higher_order_udf::HigherOrderUdfKind;
 use crate::proto::converter::RemotePhysicalProtoConverter;
 
-pub fn try_encode_message<M>(message: M) -> Result<Vec<u8>>
+pub fn encode_remote_physical_plan(
+    codec: &dyn PhysicalExtensionCodec,
+    plan: Arc<dyn ExecutionPlan>,
+) -> Result<Vec<u8>> {
+    let plan = plan
+        .transform(|node| {
+            if let Some(data_source) = node.downcast_ref::<DataSourceExec>() {
+                let node =
+                    Arc::new(RemoteDataSourceExec::new(data_source)) as Arc<dyn ExecutionPlan>;
+                Ok(Transformed::yes(node))
+            } else {
+                Ok(Transformed::no(node))
+            }
+        })
+        .data()?;
+    try_encode_physical_plan(codec, plan)
+}
+
+pub fn encode_remote_physical_expr(
+    codec: &dyn PhysicalExtensionCodec,
+    expr: &Arc<dyn PhysicalExpr>,
+) -> Result<Vec<u8>> {
+    try_encode_physical_expr(codec, expr)
+}
+
+pub(super) fn try_encode_message<M>(message: M) -> Result<Vec<u8>>
 where
     M: Message,
 {
     Ok(message.encode_to_vec())
 }
 
-pub fn try_encode_schema(schema: &Schema) -> Result<Vec<u8>> {
+pub(super) fn try_encode_schema(schema: &Schema) -> Result<Vec<u8>> {
     try_encode_message::<gen_datafusion_common::Schema>(schema.try_into()?)
 }
 
-pub fn try_encode_field_ref(field: &FieldRef) -> Result<Vec<u8>> {
+pub(super) fn try_encode_field_ref(field: &FieldRef) -> Result<Vec<u8>> {
     try_encode_message::<gen_datafusion_common::Field>(field.as_ref().try_into()?)
 }
 
-pub fn try_encode_physical_plan(
+pub(super) fn try_encode_physical_plan(
     codec: &dyn PhysicalExtensionCodec,
     plan: Arc<dyn ExecutionPlan>,
 ) -> Result<Vec<u8>> {
     try_encode_message(physical_plan_to_proto(codec, plan)?)
 }
 
-pub fn physical_plan_to_proto(
+pub(super) fn physical_plan_to_proto(
     codec: &dyn PhysicalExtensionCodec,
     plan: Arc<dyn ExecutionPlan>,
 ) -> Result<PhysicalPlanNode> {
@@ -52,14 +80,14 @@ pub fn physical_plan_to_proto(
     )
 }
 
-pub fn try_encode_physical_expr(
+pub(super) fn try_encode_physical_expr(
     codec: &dyn PhysicalExtensionCodec,
     expr: &Arc<dyn PhysicalExpr>,
 ) -> Result<Vec<u8>> {
     try_encode_message(physical_expr_to_proto(codec, expr)?)
 }
 
-pub fn physical_expr_to_proto(
+pub(super) fn physical_expr_to_proto(
     codec: &dyn PhysicalExtensionCodec,
     expr: &Arc<dyn PhysicalExpr>,
 ) -> Result<PhysicalExprNode> {
@@ -67,7 +95,9 @@ pub fn physical_expr_to_proto(
     converter.physical_expr_to_proto(expr, codec)
 }
 
-pub fn try_encode_higher_order_udf(hof: &HigherOrderFunctionExpr) -> Result<gen::HigherOrderUdf> {
+pub(super) fn try_encode_higher_order_udf(
+    hof: &HigherOrderFunctionExpr,
+) -> Result<gen::HigherOrderUdf> {
     let udf_inner = hof.fun().inner().as_ref() as &dyn std::any::Any;
     let udf_kind = if let Some(filter) = udf_inner.downcast_ref::<SparkArrayFilter>() {
         HigherOrderUdfKind::Filter(gen::SparkArrayFilterUdf {

--- a/crates/sail-execution/src/proto/mod.rs
+++ b/crates/sail-execution/src/proto/mod.rs
@@ -1,4 +1,8 @@
-pub mod codec;
-pub mod converter;
-pub mod decode;
-pub mod encode;
+mod codec;
+mod converter;
+mod decode;
+mod encode;
+
+pub use codec::RemoteExecutionCodec;
+pub use decode::{decode_remote_physical_expr, decode_remote_physical_plan};
+pub use encode::{encode_remote_physical_expr, encode_remote_physical_plan};

--- a/crates/sail-execution/src/task/definition.rs
+++ b/crates/sail-execution/src/task/definition.rs
@@ -7,7 +7,7 @@ use datafusion_proto::physical_plan::PhysicalExtensionCodec;
 
 use crate::error::{ExecutionError, ExecutionResult};
 use crate::id::{JobId, TaskKey, TaskStreamKey, WorkerId};
-use crate::proto::decode::try_decode_physical_expr;
+use crate::proto::decode_remote_physical_expr;
 use crate::stream::reader::TaskReadLocation;
 use crate::stream::writer::{LocalStreamStorage, TaskWriteLocation};
 use crate::task::gen;
@@ -609,7 +609,7 @@ impl TaskOutput {
                 let keys = keys
                     .iter()
                     .map(|k| {
-                        try_decode_physical_expr(ctx, codec, k.as_ref(), schema)
+                        decode_remote_physical_expr(ctx, codec, k.as_ref(), schema)
                             .map_err(|e| e.into())
                     })
                     .collect::<ExecutionResult<Vec<_>>>()?;

--- a/crates/sail-execution/src/task_runner/core.rs
+++ b/crates/sail-execution/src/task_runner/core.rs
@@ -22,8 +22,7 @@ use crate::driver::TaskStatus;
 use crate::error::{ExecutionError, ExecutionResult};
 use crate::id::{TaskKey, TaskKeyDisplay};
 use crate::plan::{ShuffleReadExec, ShuffleWriteExec, StageInputExec};
-use crate::proto::codec::RemoteExecutionCodec;
-use crate::proto::decode::try_decode_physical_plan;
+use crate::proto::{decode_remote_physical_plan, RemoteExecutionCodec};
 use crate::stream_accessor::{StreamAccessor, StreamAccessorMessage};
 use crate::task::definition::{TaskDefinition, TaskInput, TaskOutput};
 use crate::task_runner::monitor::TaskMonitor;
@@ -84,7 +83,7 @@ impl TaskRunner {
         T::Message: TaskRunnerMessage + StreamAccessorMessage,
     {
         let plan =
-            try_decode_physical_plan(&context, self.codec.as_ref(), definition.plan.as_ref())?;
+            decode_remote_physical_plan(&context, self.codec.as_ref(), definition.plan.as_ref())?;
         let plan = self.rewrite_file_scans(plan)?;
         let plan = self.rewrite_shuffle(
             ctx,

--- a/crates/sail-physical-plan/src/data_source.rs
+++ b/crates/sail-physical-plan/src/data_source.rs
@@ -1,0 +1,71 @@
+use std::fmt;
+use std::sync::Arc;
+
+use datafusion::datasource::source::{DataSource, DataSourceExec};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion_common::{exec_err, internal_err, Result};
+
+/// A [`DataSourceExec`] wrapper for Sail remote codec.
+///
+/// DataFusion's built-in physical plan codec can currently mishandle file
+/// compression metadata for data sources in cluster mode. We wrap
+/// [`DataSourceExec`] before remote plan encoding so our extension codec handles
+/// every supported data source explicitly. The wrapper is not present
+/// in decoded remote plans so it would never be executed.
+#[derive(Clone, Debug)]
+pub struct RemoteDataSourceExec {
+    data_source: Arc<dyn DataSource>,
+    properties: Arc<PlanProperties>,
+}
+
+impl RemoteDataSourceExec {
+    pub fn new(node: &DataSourceExec) -> Self {
+        Self {
+            data_source: Arc::clone(node.data_source()),
+            properties: Arc::clone(node.properties()),
+        }
+    }
+
+    pub fn data_source(&self) -> &Arc<dyn DataSource> {
+        &self.data_source
+    }
+}
+
+impl DisplayAs for RemoteDataSourceExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+impl ExecutionPlan for RemoteDataSourceExec {
+    fn name(&self) -> &str {
+        Self::static_name()
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        Vec::new()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if !children.is_empty() {
+            return internal_err!("{} should not have children", self.name());
+        }
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        exec_err!("{} cannot be executed", self.name())
+    }
+}

--- a/crates/sail-physical-plan/src/lib.rs
+++ b/crates/sail-physical-plan/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod barrier;
 pub mod catalog_command;
 pub mod coalesce;
+pub mod data_source;
 pub mod map_partitions;
 pub mod merge_cardinality_check;
 pub mod monotonic_id;

--- a/python/pysail/tests/spark/datasource/test_binary.py
+++ b/python/pysail/tests/spark/datasource/test_binary.py
@@ -131,3 +131,24 @@ def test_binary_read_projections(spark, tmp_path):
     large_count = large_files.count()
     expected_large = sum(1 for _, content in files.values() if len(content) > min_file_size)
     assert large_count == expected_large
+
+
+def test_binary_read_partition_columns(spark, tmp_path):
+    root = tmp_path / "binary_partitioned"
+    png_dir = root / "kind=image" / "ext=png"
+    bin_dir = root / "kind=data" / "ext=bin"
+    png_dir.mkdir(parents=True)
+    bin_dir.mkdir(parents=True)
+    png_content = b"PNG partition payload"
+    bin_content = b"BIN partition payload"
+    (png_dir / "image.png").write_bytes(png_content)
+    (bin_dir / "payload.bin").write_bytes(bin_content)
+
+    read_df = spark.read.format("binaryFile").load(str(root)).select("path", "length", "content", "kind", "ext")
+
+    rows = {(row.path.split("/")[-1], row.length, bytes(row.content), row.kind, row.ext) for row in read_df.collect()}
+    assert rows == {
+        ("image.png", len(png_content), png_content, "image", "png"),
+        ("payload.bin", len(bin_content), bin_content, "data", "bin"),
+    }
+    assert read_df.filter("kind = 'image'").count() == 1

--- a/python/pysail/tests/spark/datasource/test_text.py
+++ b/python/pysail/tests/spark/datasource/test_text.py
@@ -93,3 +93,25 @@ def test_text_read_projections(spark, sample_df, tmp_path):
     values = [r.value for r in projected_df.collect()]
     expected = [r["col1"] if r["col1"] is not None else "" for r in sample_df.collect()]
     assert sorted(values) == sorted(expected)
+
+
+def test_text_read_partition_columns(spark, tmp_path):
+    root = tmp_path / "text_partitioned"
+    (root / "country=us" / "city=sf").mkdir(parents=True)
+    (root / "country=us" / "city=ny").mkdir(parents=True)
+    (root / "country=ca" / "city=to").mkdir(parents=True)
+    (root / "country=us" / "city=sf" / "part-0.txt").write_text("golden\nbridge\n", encoding="utf-8")
+    (root / "country=us" / "city=ny" / "part-0.txt").write_text("hudson\n", encoding="utf-8")
+    (root / "country=ca" / "city=to" / "part-0.txt").write_text("harbour\n", encoding="utf-8")
+
+    read_df = spark.read.text(str(root)).select("value", "country", "city")
+
+    rows = {(row.value, row.country, row.city) for row in read_df.collect()}
+    assert rows == {
+        ("golden", "us", "sf"),
+        ("bridge", "us", "sf"),
+        ("hudson", "us", "ny"),
+        ("harbour", "ca", "to"),
+    }
+    expected_us_rows = 3
+    assert read_df.filter("country = 'us'").count() == expected_us_rows


### PR DESCRIPTION
1. Fix missing compression in CSV/JSON data source codec. (This is possibly related to #2118.)
2. Move Parquet data source codec from DataFusion to Sail for consistency with other data sources.
3. Fix codec issue around table schema. (The bugs were not active since DataFusion's built-in codec for data sources used to take precedence, but now that we have the `RemoteDataSourceExec` wrapper, the code paths become active.)