### PR TITLE
fix: recover Python data source options from table properties

### DIFF
--- a/crates/sail-common-datafusion/src/datasource.rs
+++ b/crates/sail-common-datafusion/src/datasource.rs
@@ -66,7 +66,16 @@ impl OptionLayer {
     /// The returned map can be passed to code that accepts `HashMap<String, String>`.
     pub fn into_opaque_options(self) -> HashMap<String, String> {
         match self {
-            OptionLayer::TablePropertyList { items } => items.into_iter().collect(),
+            OptionLayer::TablePropertyList { items } => items
+                .into_iter()
+                .map(|(key, value)| {
+                    if let Some(key) = key.strip_prefix("option.") {
+                        (key.to_string(), value)
+                    } else {
+                        (key, value)
+                    }
+                })
+                .collect(),
             OptionLayer::OptionList { items } => items.into_iter().collect(),
             OptionLayer::TableLocation { .. }
             | OptionLayer::AsOfTimestamp { .. }

--- a/python/pysail/tests/spark/datasource/test_python.py
+++ b/python/pysail/tests/spark/datasource/test_python.py
@@ -15,6 +15,7 @@ import pyarrow as pa
 import pytest
 
 from pysail.testing.spark.session import spark_session_factory
+from pysail.testing.spark.utils.sql import escape_sql_string_literal
 
 try:
     from pyspark.sql.datasource import (
@@ -1589,7 +1590,7 @@ def test_python_sql_insert_into_python_datasource(spark, tmp_path):
             return SQLInsertReader()
 
         def writer(self, schema, overwrite):
-            return SQLInsertWriter(schema, overwrite, str(state_path))
+            return SQLInsertWriter(schema, overwrite, self.options["state_path"])
 
     class SQLInsertReader(DataSourceReader):
         def partitions(self):
@@ -1603,7 +1604,10 @@ def test_python_sql_insert_into_python_datasource(spark, tmp_path):
             yield batch
 
     spark.dataSource.register(SQLInsertDataSource)
-    spark.sql(f"CREATE TABLE {table_name} USING {table_name}")
+    spark.sql(
+        f"CREATE TABLE {table_name} USING {table_name} "
+        f"OPTIONS (state_path '{escape_sql_string_literal(str(state_path))}')"
+    )
 
     try:
         # Read should work


### PR DESCRIPTION
This fixes an issue found when working on #2202.