### PR TITLE
fix: return fields for struct function

### DIFF
--- a/crates/sail-function/src/scalar/struct_function.rs
+++ b/crates/sail-function/src/scalar/struct_function.rs
@@ -104,13 +104,17 @@ impl ScalarUDFImpl for StructFunction {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs {
-            args, arg_fields, ..
+            args, return_field, ..
         } = args;
+        let arg_fields = match return_field.data_type() {
+            DataType::Struct(fields) => fields.iter().cloned().collect::<Vec<_>>(),
+            other => return exec_err!("struct: expected struct return field, got {}", other),
+        };
         let arrays = ColumnarValue::values_to_arrays(&args)?;
         Ok(ColumnarValue::Array(to_struct_array(
             arrays.as_slice(),
             self.field_names.as_slice(),
-            &arg_fields,
+            arg_fields.as_slice(),
         )?))
     }
 }


### PR DESCRIPTION
This issue was surfaced when running tests in cluster mode.

Here is the analysis by Codex.

> Root cause: `StructFunction` planned its return type with Spark field metadata, but at execution it rebuilt the actual `StructArray` fields from `arg_fields`. In cluster mode, nested-field `arg_fields` can arrive without that metadata, so DataFusion saw a mismatch between the promised return type and the produced array type. The fix makes execution derive the struct child fields from the planned `return_field`, keeping metadata consistent.

Here is how we test this.

```bash
hatch run maturin develop
env SAIL_MODE=local-cluster hatch run pytest -k "test_struct_wildcard_on_struct_column"
```
