### PR TITLE
[DO NOT MERGE] keep catalog command in a single driver stage

### DIFF
--- a/crates/sail-execution/src/job_graph/planner.rs
+++ b/crates/sail-execution/src/job_graph/planner.rs
@@ -268,7 +268,13 @@ fn plan_job_graph_stages(
     }
 
     if let Some(barrier) = plan.downcast_ref::<BarrierExec>() {
-        return build_barrier_job_graph(barrier, usage, graph, scalar_context);
+        return build_barrier_job_graph(
+            barrier,
+            usage,
+            graph,
+            driver_stage_handling,
+            scalar_context,
+        );
     }
 
     // Recursively build the job graph for the children first
@@ -552,6 +558,7 @@ fn build_barrier_job_graph(
     barrier: &BarrierExec,
     usage: PartitionUsage,
     graph: &mut JobGraph,
+    driver_stage_handling: DriverStageHandling,
     scalar_context: Option<ScalarSubqueryContext<'_>>,
 ) -> ExecutionResult<PlannedSubtree> {
     let preconditions = barrier
@@ -597,9 +604,13 @@ fn build_barrier_job_graph(
     let barrier = Arc::new(BarrierExec::new(preconditions, plan.plan)) as Arc<dyn ExecutionPlan>;
     let barrier = PlannedSubtree::new(barrier, barrier_has_pending_scalar_subquery_expr);
     if plan_is_driver_stage {
-        Ok(PlannedSubtree::without_pending_scalar_subquery_expr(
-            create_driver_stage(barrier, graph, scalar_context)?,
-        ))
+        if matches!(driver_stage_handling, DriverStageHandling::PreserveRoot) {
+            Ok(barrier)
+        } else {
+            Ok(PlannedSubtree::without_pending_scalar_subquery_expr(
+                create_driver_stage(barrier, graph, scalar_context)?,
+            ))
+        }
     } else {
         Ok(barrier)
     }
@@ -608,6 +619,9 @@ fn build_barrier_job_graph(
 fn is_driver_stage_plan(plan: &Arc<dyn ExecutionPlan>) -> bool {
     if let Some(cooperative) = plan.downcast_ref::<CooperativeExec>() {
         return is_driver_stage_plan(cooperative.input());
+    }
+    if let Some(barrier) = plan.downcast_ref::<BarrierExec>() {
+        return is_driver_stage_plan(barrier.plan());
     }
 
     plan.is::<SystemTableExec>()
@@ -927,6 +941,7 @@ mod tests {
     use datafusion::physical_plan::coop::CooperativeExec;
     use datafusion::physical_plan::empty::EmptyExec;
     use datafusion::physical_plan::filter::FilterExec;
+    use datafusion::physical_plan::projection::ProjectionExec;
     use datafusion::physical_plan::repartition::RepartitionExec;
     use datafusion::physical_plan::scalar_subquery::{ScalarSubqueryExec, ScalarSubqueryLink};
     use datafusion::physical_plan::union::UnionExec;
@@ -1039,7 +1054,7 @@ mod tests {
         let graph =
             JobGraph::try_new(Arc::new(BarrierExec::new(vec![precondition], command))).unwrap();
 
-        assert_eq!(graph.stages().len(), 3);
+        assert_eq!(graph.stages().len(), 2);
         assert_eq!(graph.stages()[1].placement, TaskPlacement::Driver);
         #[expect(clippy::expect_used)]
         let barrier = graph.stages()[1]
@@ -1059,6 +1074,32 @@ mod tests {
                 mode: InputMode::Shuffle,
             }]
         ));
+    }
+
+    #[test]
+    fn test_job_graph_creates_driver_stage_for_nested_driver_barrier() {
+        let precondition = Arc::new(
+            RepartitionExec::try_new(empty_plan(), Partitioning::RoundRobinBatch(1)).unwrap(),
+        );
+        let command = Arc::new(CatalogCommandExec::new(
+            CatalogCommand::CurrentCatalog,
+            schema(),
+        ));
+        let command = Arc::new(CooperativeExec::new(command));
+        let barrier = Arc::new(BarrierExec::new(vec![precondition], command));
+        let projection = Arc::new(
+            ProjectionExec::try_new(
+                vec![(col("id", schema().as_ref()).unwrap(), "id".to_string())],
+                barrier,
+            )
+            .unwrap(),
+        );
+
+        let graph = JobGraph::try_new(projection).unwrap();
+
+        assert_eq!(graph.stages().len(), 3);
+        assert_eq!(graph.stages()[1].placement, TaskPlacement::Driver);
+        assert!(graph.stages()[1].plan.is::<BarrierExec>());
         assert!(matches!(
             graph.stages()[2].inputs.as_slice(),
             [StageInput {

--- a/crates/sail-execution/src/job_graph/planner.rs
+++ b/crates/sail-execution/src/job_graph/planner.rs
@@ -46,7 +46,19 @@ impl JobGraph {
             stages: vec![],
             schema: plan.schema(),
         };
-        let last = build_job_graph(plan, PartitionUsage::Once, &mut graph)?.plan;
+        let last = plan_job_graph_stages(
+            plan,
+            PartitionUsage::Once,
+            &mut graph,
+            DriverStageHandling::PreserveRoot,
+            None,
+        )?
+        .plan;
+        let placement = if is_driver_stage_plan(&last) {
+            TaskPlacement::Driver
+        } else {
+            TaskPlacement::Worker
+        };
         let (last, inputs) = rewrite_inputs(last)?;
         graph.stages.push(Stage {
             inputs,
@@ -54,7 +66,7 @@ impl JobGraph {
             group: String::new(),
             mode: OutputMode::Pipelined,
             distribution: OutputDistribution::RoundRobin { channels: 1 },
-            placement: TaskPlacement::Worker,
+            placement,
         });
         Ok(graph)
     }
@@ -244,14 +256,6 @@ impl RebuiltSubtree {
 }
 
 /// Recursively splits an execution plan into stages at shuffle boundaries and adds them to the job graph.
-fn build_job_graph(
-    plan: Arc<dyn ExecutionPlan>,
-    usage: PartitionUsage,
-    graph: &mut JobGraph,
-) -> ExecutionResult<PlannedSubtree> {
-    plan_job_graph_stages(plan, usage, graph, DriverStageHandling::CreateStage, None)
-}
-
 fn plan_job_graph_stages(
     plan: Arc<dyn ExecutionPlan>,
     usage: PartitionUsage,
@@ -1006,6 +1010,20 @@ mod tests {
                 mode: InputMode::Rescale,
             }]
         ));
+    }
+
+    #[test]
+    fn test_job_graph_keeps_root_catalog_command_on_driver() {
+        let command = Arc::new(CatalogCommandExec::new(
+            CatalogCommand::CurrentCatalog,
+            schema(),
+        ));
+        let graph = JobGraph::try_new(command).unwrap();
+
+        assert_eq!(graph.stages().len(), 1);
+        assert_eq!(graph.stages()[0].placement, TaskPlacement::Driver);
+        assert!(graph.stages()[0].inputs.is_empty());
+        assert!(graph.stages()[0].plan.is::<CatalogCommandExec>());
     }
 
     #[test]


### PR DESCRIPTION
If the physical plan is only a catalog command, we should have a single driver stage to avoid the roundtrip between driver and worker.

But this PR has its own issue. It somehow causes tests to hang (e.g., `env SAIL_MODE=local-cluster hatch run pytest -k "test_delta_io.py"`). The root cause is unknown.

I feel we can have a proper implementation after certain refactoring on the job graph planning logic which has been getting complex over time.