### PR TITLE
fix: support basePath for partition discovery

### DIFF
--- a/crates/sail-data-source/src/listing/planner.rs
+++ b/crates/sail-data-source/src/listing/planner.rs
@@ -21,11 +21,13 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::empty::EmptyExec;
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
 use datafusion_common::stats::Precision;
-use datafusion_common::{Statistics, internal_err, plan_err, project_schema};
-use datafusion_datasource::ListingTableUrl;
+use datafusion_common::{
+    ScalarValue, Statistics, internal_datafusion_err, internal_err, plan_err, project_schema,
+};
 use datafusion_datasource::file_groups::FileGroup;
 use datafusion_datasource::file_scan_config::FileScanConfig;
 use datafusion_datasource::source::DataSourceExec;
+use datafusion_datasource::{ListingTableUrl, PartitionedFile};
 use futures::{Stream, StreamExt, future, stream};
 use object_store::ObjectStore;
 use sail_common_datafusion::datasource::create_sort_order;
@@ -350,12 +352,18 @@ async fn list_files_for_scan<'a>(
         .map(|field| (field.name().clone(), field.data_type().clone()))
         .collect();
 
+    let pruning_filters = if source.config().partition_base_path.is_some() {
+        &[]
+    } else {
+        filters
+    };
+
     let file_list = future::try_join_all(source.config().table_paths.iter().map(|table_path| {
         pruned_partition_list(
             ctx,
             store.as_ref(),
             table_path,
-            filters,
+            pruning_filters,
             "",
             &partition_cols,
         )
@@ -367,7 +375,10 @@ async fn list_files_for_scan<'a>(
 
     let files = file_list
         .map(|part_file| async {
-            let part_file = part_file?;
+            let mut part_file = part_file?;
+            if let Some(base_path) = source.config().partition_base_path.as_ref() {
+                part_file = rewrite_partition_values(part_file, base_path, &partition_cols)?;
+            }
             let (statistics, ordering) = if source.config().collect_stat {
                 do_collect_statistics_and_ordering(source, ctx, &store, &part_file).await?
             } else {
@@ -498,6 +509,61 @@ fn statistics_cache_table_ref(
         "{table}_{:016x}",
         std::hash::Hasher::finish(&hasher)
     ))
+}
+
+fn rewrite_partition_values(
+    mut file: PartitionedFile,
+    partition_base_path: &ListingTableUrl,
+    partition_cols: &[(String, DataType)],
+) -> datafusion_common::Result<PartitionedFile> {
+    if partition_cols.is_empty() {
+        file.partition_values.clear();
+        return Ok(file);
+    }
+
+    file.partition_values = partition_values_from_path(
+        partition_base_path,
+        &file.object_meta.location,
+        partition_cols,
+    )?;
+    Ok(file)
+}
+
+fn partition_values_from_path(
+    partition_base_path: &ListingTableUrl,
+    location: &object_store::path::Path,
+    partition_cols: &[(String, DataType)],
+) -> datafusion_common::Result<Vec<ScalarValue>> {
+    let path_parts = partition_base_path
+        .strip_prefix(location)
+        .ok_or_else(|| {
+            internal_datafusion_err!(
+                "failed to strip partition base path from object location: {}",
+                location
+            )
+        })?
+        .collect::<Vec<_>>();
+
+    let partitions = path_parts
+        .into_iter()
+        .rev()
+        .skip(1)
+        .rev()
+        .filter_map(|part| part.split_once('='))
+        .collect::<Vec<_>>();
+
+    partition_cols
+        .iter()
+        .map(|(name, data_type)| {
+            let value = partitions
+                .iter()
+                .find_map(|(key, value)| (*key == name).then_some(*value));
+            match value {
+                Some(value) => ScalarValue::try_from_string(value.to_string(), data_type),
+                None => ScalarValue::try_new_null(data_type),
+            }
+        })
+        .collect()
 }
 
 async fn get_files_with_limit(

--- a/crates/sail-data-source/src/listing/source.rs
+++ b/crates/sail-data-source/src/listing/source.rs
@@ -158,10 +158,12 @@ impl<T: FormatFactory> TableFormat for ListingTableFormat<T> {
             read_case_sensitive,
         } = info;
 
+        let partition_base_path = resolve_partition_base_path(ctx, &options).await?;
         let read_format = T::read(ctx, options)?;
         let urls = resolve_listing_urls(ctx, paths).await?;
         let sampled_files = sample_listing_files(ctx, &urls).await?;
         let compression = read_format.infer_compression(ctx, &sampled_files).await?;
+        let partition_base_path_ref = partition_base_path.as_ref();
 
         let (schema, partition_fields) = match schema {
             Some(schema) if !schema.fields().is_empty() => {
@@ -189,7 +191,7 @@ impl<T: FormatFactory> TableFormat for ListingTableFormat<T> {
                 // are treated as file columns, and the file reader fails
                 // because the file itself does not contain them.
                 let partition_by = if partition_by.is_empty() {
-                    infer_partitions(&sampled_files)?
+                    infer_partitions(&sampled_files, partition_base_path_ref)?
                         .into_iter()
                         .filter(|name| {
                             schema
@@ -212,7 +214,7 @@ impl<T: FormatFactory> TableFormat for ListingTableFormat<T> {
                 let schema = rewrite_utf8view_fields(schema);
 
                 let partition_by = if partition_by.is_empty() {
-                    infer_partitions(&sampled_files)?
+                    infer_partitions(&sampled_files, partition_base_path_ref)?
                 } else {
                     partition_by
                 };
@@ -227,10 +229,11 @@ impl<T: FormatFactory> TableFormat for ListingTableFormat<T> {
             }
         };
 
-        validate_partitions(&sampled_files, &partition_fields)?;
+        validate_partitions(&sampled_files, partition_base_path_ref, &partition_fields)?;
 
         let source = ListingTableSource::try_new(ListingTableSourceConfig {
             table_paths: urls,
+            partition_base_path,
             schema: TableSchema::new(schema, partition_fields),
             constraints,
             file_sort_order: vec![sort_order],
@@ -297,6 +300,44 @@ impl<T: FormatFactory> TableFormat for ListingTableFormat<T> {
         }))
     }
 }
+
+async fn resolve_partition_base_path(
+    ctx: &dyn Session,
+    options: &[OptionLayer],
+) -> Result<Option<ListingTableUrl>> {
+    let Some(path) = find_option_value(options, &["basePath", "base_path"]) else {
+        return Ok(None);
+    };
+    let urls = resolve_listing_urls(ctx, vec![path.clone()]).await?;
+    let mut urls = urls.into_iter();
+    let Some(url) = urls.next() else {
+        return plan_err!("basePath must resolve to exactly one directory path: {path}");
+    };
+    if urls.next().is_some() || !url.is_collection() {
+        return plan_err!("basePath must resolve to exactly one directory path: {path}");
+    };
+    Ok(Some(url))
+}
+
+fn find_option_value(options: &[OptionLayer], keys: &[&str]) -> Option<String> {
+    for layer in options.iter().rev() {
+        let items = match layer {
+            OptionLayer::OptionList { items } | OptionLayer::TablePropertyList { items } => items,
+            _ => continue,
+        };
+        if let Some(value) = items.iter().find_map(|(key, value)| {
+            keys.iter()
+                .any(|candidate| key.eq_ignore_ascii_case(candidate))
+                .then(|| value.clone())
+        }) {
+            if !value.trim().is_empty() {
+                return Some(value);
+            }
+        }
+    }
+    None
+}
+
 async fn listing_target_exists(ctx: &dyn Session, url: &Url) -> Result<bool> {
     // For file systems, treat the target as existing even if it is an empty directory.
     if url.scheme() == "file"

--- a/crates/sail-data-source/src/listing/table.rs
+++ b/crates/sail-data-source/src/listing/table.rs
@@ -16,6 +16,7 @@ use crate::listing::utils::can_be_evaluated_for_partition_pruning;
 #[derive(Clone, Debug)]
 pub struct ListingTableSourceConfig {
     pub table_paths: Vec<ListingTableUrl>,
+    pub partition_base_path: Option<ListingTableUrl>,
     pub schema: TableSchema,
     pub constraints: Constraints,
     pub file_sort_order: Vec<Vec<Sort>>,
@@ -74,6 +75,9 @@ impl TableSource for ListingTableSource {
         filters
             .iter()
             .map(|filter| {
+                if self.config.partition_base_path.is_some() {
+                    return Ok(TableProviderFilterPushDown::Inexact);
+                }
                 if can_be_evaluated_for_partition_pruning(&partition_column_names, filter) {
                     return Ok(TableProviderFilterPushDown::Exact);
                 }

--- a/crates/sail-data-source/src/listing/utils.rs
+++ b/crates/sail-data-source/src/listing/utils.rs
@@ -110,18 +110,20 @@ pub async fn sample_listing_files<'a>(
 
 pub fn validate_partitions(
     files: &[ListingFileSample<'_>],
+    partition_base_url: Option<&ListingTableUrl>,
     table_partition_fields: &[FieldRef],
 ) -> Result<()> {
     if table_partition_fields.is_empty() {
         return Ok(());
     }
-    let inferred = infer_partitions(files)?;
+    let inferred = infer_partitions(files, partition_base_url)?;
     if inferred.is_empty() {
         return Ok(());
     }
 
     for group in files {
-        if !group.url.is_collection() {
+        let url = partition_base_url.unwrap_or(group.url);
+        if !url.is_collection() {
             return plan_err!(
                 "Can't create a partitioned table backed by a single file, \
             perhaps the URL is missing a trailing slash?"
@@ -155,16 +157,19 @@ pub fn validate_partitions(
     Ok(())
 }
 
-pub fn infer_partitions(files: &[ListingFileSample<'_>]) -> Result<Vec<String>> {
+pub fn infer_partitions(
+    files: &[ListingFileSample<'_>],
+    partition_base_url: Option<&ListingTableUrl>,
+) -> Result<Vec<String>> {
     let mut inferred: Option<Vec<String>> = None;
     for group in files {
         for file in &group.objects {
-            let path_parts = group
-                .url
+            let url = partition_base_url.unwrap_or(group.url);
+            let path_parts = url
                 .strip_prefix(&file.location)
                 .ok_or_else(|| {
                     internal_datafusion_err!(
-                        "failed to strip listing prefix from object location: {}",
+                        "failed to strip partition base path from object location: {}",
                         file.location
                     )
                 })?

--- a/python/pysail/tests/spark/datasource/test_parquet.py
+++ b/python/pysail/tests/spark/datasource/test_parquet.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping
+from datetime import date
 
 import pandas as pd
 import pytest
@@ -386,6 +387,72 @@ def test_parquet_read_uppercase_extension_partitioned_directory_with_schema(spar
         Row(id=2, val="b", part="x"),
         Row(id=3, val="c", part="y"),
     ]
+
+
+def test_parquet_read_partition_subtree_with_base_path_discovers_partition_column(spark, tmp_path):
+    df_in = spark.createDataFrame(
+        [
+            ("row1", 1, date(2026, 1, 1)),
+            ("row2", 2, date(2026, 12, 15)),
+        ],
+        "id STRING, value INT, delivery_date DATE",
+    )
+    src = tmp_path / "src"
+    df_in.write.partitionBy("delivery_date").parquet(str(src), mode="overwrite")
+
+    df = (
+        spark.read.format("parquet")
+        .option("basePath", str(src))
+        .load(str(src / "delivery_date=2026-01-01"))
+    )
+
+    assert df.columns == ["id", "value", "delivery_date"]
+    assert df.schema["delivery_date"].dataType.simpleString() == "string"
+    assert df.collect() == [Row(id="row1", value=1, delivery_date="2026-01-01")]
+
+
+def test_parquet_read_partition_subtree_with_base_path_and_schema_uses_schema_type(spark, tmp_path):
+    df_in = spark.createDataFrame(
+        [
+            ("row1", 1, date(2026, 1, 1)),
+            ("row2", 2, date(2026, 12, 15)),
+        ],
+        "id STRING, value INT, delivery_date DATE",
+    )
+    src = tmp_path / "src"
+    df_in.write.partitionBy("delivery_date").parquet(str(src), mode="overwrite")
+
+    df = (
+        spark.read.format("parquet")
+        .schema("id STRING, value INT, delivery_date DATE")
+        .option("basePath", str(src))
+        .load(str(src / "delivery_date=2026-01-01"))
+    )
+
+    assert df.columns == ["id", "value", "delivery_date"]
+    assert df.schema["delivery_date"].dataType.simpleString() == "date"
+    assert df.collect() == [Row(id="row1", value=1, delivery_date=date(2026, 1, 1))]
+
+
+def test_parquet_read_nested_partition_subtree_with_base_path(spark, tmp_path):
+    df_in = spark.createDataFrame(
+        [
+            (1, "female", "CN"),
+            (2, "female", "US"),
+            (3, "male", "CN"),
+        ],
+        "id INT, gender STRING, country STRING",
+    )
+    src = tmp_path / "src"
+    df_in.write.partitionBy("gender", "country").parquet(str(src), mode="overwrite")
+
+    df = (
+        spark.read.format("parquet")
+        .option("basePath", str(src))
+        .load(str(src / "gender=female" / "country=CN"))
+    )
+
+    assert df.collect() == [Row(id=1, gender="female", country="CN")]
 
 
 def test_parquet_hidden_files_are_excluded(spark, sample_df, tmp_path):


### PR DESCRIPTION
 ## What Changed

  Fixes partition discovery when reading a partition subtree with the Spark `basePath` option.

  Previously, Sail inferred partition columns relative to the selected read path. For a read like:

  ```python
  spark.read.option("basePath", table_path).parquet(f"{table_path}/delivery_date=2026-01-01")
  ```
  the delivery_date partition segment was treated as part of the scan root and was not exposed as a partition column.

  This change resolves basePath / base_path in the listing data source and uses it as the partition root for:

  - schema-time partition inference
  - explicit-schema partition validation
  - scan-time partition value construction

  ## Tests

  Added PySpark DataFrame API tests covering:

  - reading a partition subtree with basePath
  - preserving explicit partition schema types, including DATE
  - nested partition discovery from a selected subtree

  Local validation:

  cargo fmt --check
  cargo check -p sail-data-source
  cargo check -p sail-data-source --tests
  python -m py_compile python/pysail/tests/spark/datasource/test_parquet.py

  Full Spark runtime tests are left to CI due local environment constraints.

  Fixes #2107.