### PR TITLE
feat: reject multiple TABLE arguments in UDTFs unless explicitly enabled

### DIFF
--- a/crates/sail-plan/src/config.rs
+++ b/crates/sail-plan/src/config.rs
@@ -36,6 +36,10 @@ pub struct PlanConfig {
     /// The maximum number of distinct values collected for a pivot without an explicit
     /// value list (`spark.sql.pivotMaxValues`, default 10000). Exceeding it is an error.
     pub pivot_max_values: usize,
+    /// Whether a table-valued function may receive more than one `TABLE (...)` argument
+    /// (`spark.sql.tvf.allowMultipleTableArguments.enabled`, default false). Multiple table
+    /// arguments produce the cartesian product of their rows.
+    pub tvf_allow_multiple_table_arguments: bool,
 }
 
 impl PlanConfig {
@@ -61,6 +65,7 @@ impl Default for PlanConfig {
             cross_join_enabled: true,
             case_sensitive: false,
             pivot_max_values: 10000,
+            tvf_allow_multiple_table_arguments: false,
         }
     }
 }

--- a/crates/sail-plan/src/resolver/query/udtf.rs
+++ b/crates/sail-plan/src/resolver/query/udtf.rs
@@ -96,7 +96,7 @@ impl PlanResolver<'_> {
                 "[TABLE_VALUED_FUNCTION_TOO_MANY_TABLE_ARGUMENTS] There are too many table \
                  arguments for table-valued function. It allows one table argument, but got: \
                  {table_argument_count}. If you want to allow it, please set \
-                 \"spark.sql.allowMultipleTableArguments.enabled\" to \"true\""
+                 \"spark.sql.tvf.allowMultipleTableArguments.enabled\" to \"true\""
             )));
         }
 

--- a/crates/sail-plan/src/resolver/query/udtf.rs
+++ b/crates/sail-plan/src/resolver/query/udtf.rs
@@ -87,6 +87,19 @@ impl PlanResolver<'_> {
             })
             .collect::<datafusion_common::Result<Vec<_>>>()?;
 
+        let table_argument_count = argument_is_tables
+            .iter()
+            .filter(|is_table| **is_table)
+            .count();
+        if table_argument_count > 1 && !self.config.tvf_allow_multiple_table_arguments {
+            return Err(PlanError::analysis(format!(
+                "[TABLE_VALUED_FUNCTION_TOO_MANY_TABLE_ARGUMENTS] There are too many table \
+                 arguments for table-valued function. It allows one table argument, but got: \
+                 {table_argument_count}. If you want to allow it, please set \
+                 \"spark.sql.allowMultipleTableArguments.enabled\" to \"true\""
+            )));
+        }
+
         let kind = match function.eval_type {
             spec::PySparkUdfType::Table => PySparkUdtfKind::Table,
             spec::PySparkUdfType::ArrowTable | spec::PySparkUdfType::ArrowUdtf => {

--- a/crates/sail-spark-connect/src/config.rs
+++ b/crates/sail-spark-connect/src/config.rs
@@ -15,7 +15,7 @@ use crate::spark::config::{
     SPARK_SQL_LEGACY_EXECUTION_PYTHON_UDF_PANDAS_CONVERSION_ENABLED,
     SPARK_SQL_LEGACY_EXECUTION_PYTHON_UDTF_PANDAS_CONVERSION_ENABLED, SPARK_SQL_PIVOT_MAX_VALUES,
     SPARK_SQL_SESSION_TIME_ZONE, SPARK_SQL_SOURCES_DEFAULT, SPARK_SQL_TIMESTAMP_TYPE,
-    SPARK_SQL_WAREHOUSE_DIR,
+    SPARK_SQL_TVF_ALLOW_MULTIPLE_TABLE_ARGUMENTS_ENABLED, SPARK_SQL_WAREHOUSE_DIR,
 };
 use crate::spark::connect;
 
@@ -296,6 +296,14 @@ impl TryFrom<&SparkRuntimeConfig> for PlanConfig {
             .transpose()?
         {
             output.pivot_max_values = value;
+        }
+
+        if let Some(value) = config
+            .get(SPARK_SQL_TVF_ALLOW_MULTIPLE_TABLE_ARGUMENTS_ENABLED)?
+            .map(|x| x.to_lowercase().parse::<bool>())
+            .transpose()?
+        {
+            output.tvf_allow_multiple_table_arguments = value;
         }
 
         output.pyspark_udf_config = Arc::new(PySparkUdfConfig::try_from(config)?);


### PR DESCRIPTION
Honor `spark.sql.tvf.allowMultipleTableArguments.enabled` (default false): a table-valued function receiving more than one `TABLE (...)` argument now raises AnalysisException [TABLE_VALUED_FUNCTION_TOO_MANY_TABLE_ARGUMENTS] at plan time, matching Spark. When enabled, the existing cross-join produces the cartesian product of the tables.

The check lives in `resolve_python_udtf_plan`, the single point reached by the inline, lateral and SQL-registered UDTF paths, reusing the already-computed `argument_is_tables`.

Fixes test_udtf_with_table_argument_multiple (base/Legacy/Arrow parity).