### PR TITLE
fix: measure BINARY in bytes for length, octet_length and bit_length

### DIFF
--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -73,6 +73,7 @@ use datafusion_spark::function::math::hex::SparkHex;
 use datafusion_spark::function::math::width_bucket::SparkWidthBucket;
 use datafusion_spark::function::string::elt::SparkElt;
 use datafusion_spark::function::string::format_string::FormatStringFunc;
+use datafusion_spark::function::string::length::SparkLengthFunc;
 use datafusion_spark::function::string::luhn_check::SparkLuhnCheck;
 use datafusion_spark::function::url::try_url_decode::TryUrlDecode;
 use datafusion_spark::function::url::url_decode::UrlDecode;
@@ -213,6 +214,7 @@ use sail_function::scalar::string::soundex::Soundex;
 use sail_function::scalar::string::spark_base64::{SparkBase64, SparkUnbase64};
 use sail_function::scalar::string::spark_concat_ws::SparkConcatWs;
 use sail_function::scalar::string::spark_encode_decode::{SparkDecode, SparkEncode};
+use sail_function::scalar::string::spark_length::{SparkBitLength, SparkOctetLength};
 use sail_function::scalar::string::spark_mask::SparkMask;
 use sail_function::scalar::string::spark_quote::SparkQuote;
 use sail_function::scalar::string::spark_regexp_extract_all::{
@@ -2460,8 +2462,11 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             "format_string" => Ok(Arc::new(ScalarUDF::from(FormatStringFunc::new()))),
             "greatest" => Ok(Arc::new(ScalarUDF::from(GreatestFunc::new()))),
             "least" => Ok(Arc::new(ScalarUDF::from(LeastFunc::new()))),
+            "length" => Ok(Arc::new(ScalarUDF::from(SparkLengthFunc::new()))),
             "levenshtein" => Ok(Arc::new(ScalarUDF::from(Levenshtein::new()))),
             "make_valid_utf8" => Ok(Arc::new(ScalarUDF::from(MakeValidUtf8::new()))),
+            "spark_bit_length" => Ok(Arc::new(ScalarUDF::from(SparkBitLength::new()))),
+            "spark_octet_length" => Ok(Arc::new(ScalarUDF::from(SparkOctetLength::new()))),
             "map_entries" => Ok(Arc::new(ScalarUDF::from(SparkMapEntries::new()))),
             "map_from_arrays" => Ok(Arc::new(ScalarUDF::from(MapFromArrays::new()))),
             "map_from_entries" => Ok(Arc::new(ScalarUDF::from(MapFromEntries::new()))),
@@ -2644,6 +2649,9 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node_inner.is::<StGeomFromWKB>()
             || node_inner.is::<StGeogFromWKB>()
             || node_inner.is::<MakeValidUtf8>()
+            || node_inner.is::<SparkLengthFunc>()
+            || node_inner.is::<SparkBitLength>()
+            || node_inner.is::<SparkOctetLength>()
             || node_inner.is::<SparkMapEntries>()
             || node_inner.is::<MapFromArrays>()
             || node_inner.is::<MapFromEntries>()

--- a/crates/sail-function/src/scalar/string/mod.rs
+++ b/crates/sail-function/src/scalar/string/mod.rs
@@ -7,6 +7,7 @@ pub mod soundex;
 pub mod spark_base64;
 pub mod spark_concat_ws;
 pub mod spark_encode_decode;
+pub mod spark_length;
 pub mod spark_mask;
 pub mod spark_quote;
 pub mod spark_regexp_extract_all;

--- a/crates/sail-function/src/scalar/string/spark_length.rs
+++ b/crates/sail-function/src/scalar/string/spark_length.rs
@@ -1,0 +1,99 @@
+use std::sync::Arc;
+
+use datafusion::arrow::array::{Array, ArrayRef, AsArray, PrimitiveArray};
+use datafusion::arrow::compute::kernels::length::{bit_length, length};
+use datafusion::arrow::datatypes::{DataType, Field, FieldRef, Int32Type, Int64Type};
+use datafusion_common::Result;
+use datafusion_expr::{
+    ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion_functions::utils::make_scalar_function;
+
+use crate::error::generic_internal_err;
+
+/// Spark measures the byte length of both string and binary data, unlike DataFusion's
+/// `octet_length` and `bit_length`, whose signatures accept string data only. Feeding them
+/// binary data coerces it to UTF-8 first, which rejects data that is not valid UTF-8.
+///
+/// The Arrow kernels already measure both, from the offset buffer alone, and already wrap
+/// on overflow the way Spark does. They return `Int64` for the large variants, whereas Spark
+/// always returns `Int32`.
+macro_rules! define_length_udf {
+    ($udf:ident, $name:expr_2021, $kernel:expr_2021) => {
+        #[derive(Debug, PartialEq, Eq, Hash)]
+        pub struct $udf {
+            signature: Signature,
+        }
+
+        impl Default for $udf {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl $udf {
+            pub fn new() -> Self {
+                Self {
+                    signature: Signature::uniform(
+                        1,
+                        vec![
+                            DataType::Utf8,
+                            DataType::LargeUtf8,
+                            DataType::Utf8View,
+                            DataType::Binary,
+                            DataType::LargeBinary,
+                            DataType::BinaryView,
+                        ],
+                        Volatility::Immutable,
+                    ),
+                }
+            }
+        }
+
+        impl ScalarUDFImpl for $udf {
+            fn name(&self) -> &str {
+                $name
+            }
+
+            fn signature(&self) -> &Signature {
+                &self.signature
+            }
+
+            fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+                Err(generic_internal_err(
+                    $name,
+                    "`return_type` should not be called, call `return_field_from_args` instead",
+                ))
+            }
+
+            fn return_field_from_args(&self, args: ReturnFieldArgs) -> Result<FieldRef> {
+                let nullable = args.arg_fields.iter().any(|f| f.is_nullable());
+                Ok(Arc::new(Field::new(self.name(), DataType::Int32, nullable)))
+            }
+
+            fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+                make_scalar_function(|args: &[ArrayRef]| into_int32($kernel(&args[0])?), vec![])(
+                    &args.args,
+                )
+            }
+        }
+    };
+}
+
+define_length_udf!(SparkOctetLength, "spark_octet_length", length);
+define_length_udf!(SparkBitLength, "spark_bit_length", bit_length);
+
+/// The large variants measure into `Int64`; Spark returns `Int32` for every input type.
+/// The conversion truncates rather than nullifying, so a value whose length overflows
+/// `Int32` wraps, which is what Spark does.
+fn into_int32(lengths: ArrayRef) -> Result<ArrayRef> {
+    match lengths.data_type() {
+        DataType::Int64 => {
+            let lengths: PrimitiveArray<Int32Type> = lengths
+                .as_primitive::<Int64Type>()
+                .unary(|length| length as i32);
+            Ok(Arc::new(lengths))
+        }
+        _ => Ok(lengths),
+    }
+}

--- a/crates/sail-plan/src/function/scalar/string.rs
+++ b/crates/sail-plan/src/function/scalar/string.rs
@@ -10,7 +10,9 @@ use datafusion_spark::function::math::expr_fn as math_fn;
 use datafusion_spark::function::string::elt::SparkElt;
 use datafusion_spark::function::string::expr_fn as string_fn;
 use datafusion_spark::function::string::format_string::FormatStringFunc;
+use datafusion_spark::function::string::length::SparkLengthFunc;
 use sail_common_datafusion::utils::items::ItemTaker;
+use sail_function::scalar::spark_to_string::SparkToUtf8;
 use sail_function::scalar::string::format_number::FormatNumber;
 use sail_function::scalar::string::levenshtein::Levenshtein;
 use sail_function::scalar::string::make_valid_utf8::MakeValidUtf8;
@@ -19,6 +21,7 @@ use sail_function::scalar::string::soundex::Soundex;
 use sail_function::scalar::string::spark_base64::{SparkBase64, SparkUnbase64};
 use sail_function::scalar::string::spark_concat_ws::SparkConcatWs;
 use sail_function::scalar::string::spark_encode_decode::{SparkDecode, SparkEncode};
+use sail_function::scalar::string::spark_length::{SparkBitLength, SparkOctetLength};
 use sail_function::scalar::string::spark_mask::SparkMask;
 use sail_function::scalar::string::spark_quote::SparkQuote;
 use sail_function::scalar::string::spark_regexp_extract_all::{
@@ -162,12 +165,53 @@ fn contains(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     in_str_str_out_bool(expr_fn::contains)(input)
 }
 
+/// Spark measures the character length of string data and the byte length of binary data,
+/// so binary must reach the function as-is. Any other type is measured as its string form,
+/// via the Spark-compatible cast rather than the Arrow one, which renders a timestamp with
+/// a time zone suffix. Collections have no string form in Spark and are rejected.
+fn length_argument(input: ScalarFunctionInput, name: &str) -> PlanResult<expr::Expr> {
+    let ScalarFunctionInput {
+        arguments,
+        function_context,
+    } = input;
+    let arg = arguments.one()?;
+    let data_type = arg.get_type(function_context.schema)?;
+    match data_type {
+        DataType::Utf8
+        | DataType::LargeUtf8
+        | DataType::Utf8View
+        | DataType::Binary
+        | DataType::LargeBinary
+        | DataType::BinaryView => Ok(arg),
+        DataType::FixedSizeBinary(_) => Ok(cast(arg, DataType::Binary)),
+        DataType::Null => Ok(cast(arg, DataType::Utf8)),
+        DataType::List(_)
+        | DataType::LargeList(_)
+        | DataType::ListView(_)
+        | DataType::LargeListView(_)
+        | DataType::FixedSizeList(_, _)
+        | DataType::Struct(_)
+        | DataType::Map(_, _)
+        | DataType::Union(_, _) => Err(PlanError::invalid(format!(
+            "`{name}` does not support {data_type} input"
+        ))),
+        _ => Ok(ScalarUDF::from(SparkToUtf8::new()).call(vec![arg])),
+    }
+}
+
+fn length(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
+    let arg = length_argument(input, "length")?;
+    Ok(ScalarUDF::from(SparkLengthFunc::new()).call(vec![arg]))
+}
+
 fn bit_length(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
-    in_str_out_i32(expr_fn::bit_length)(input)
+    let arg = length_argument(input, "bit_length")?;
+    Ok(ScalarUDF::from(SparkBitLength::new()).call(vec![arg]))
 }
 
 fn octet_length(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
-    in_str_out_i32(expr_fn::octet_length)(input)
+    let arg = length_argument(input, "octet_length")?;
+    Ok(ScalarUDF::from(SparkOctetLength::new()).call(vec![arg]))
 }
 
 fn ascii(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
@@ -297,8 +341,8 @@ pub(super) fn list_built_in_string_functions() -> Vec<(&'static str, ScalarFunct
         ("bit_length", F::custom(bit_length)),
         ("btrim", F::var_arg(expr_fn::btrim)),
         ("char", F::unary(expr_fn::chr)),
-        ("char_length", F::unary(expr_fn::char_length)),
-        ("character_length", F::unary(expr_fn::char_length)),
+        ("char_length", F::custom(length)),
+        ("character_length", F::custom(length)),
         ("chr", F::unary(expr_fn::chr)),
         ("collate", F::unknown("collate")),
         ("collation", F::unknown("collation")),
@@ -316,8 +360,8 @@ pub(super) fn list_built_in_string_functions() -> Vec<(&'static str, ScalarFunct
         ("is_valid_utf8", F::custom(is_valid_utf8)),
         ("lcase", F::custom(lower)),
         ("left", F::binary(expr_fn::left)),
-        ("len", F::unary(expr_fn::length)),
-        ("length", F::unary(expr_fn::length)),
+        ("len", F::custom(length)),
+        ("length", F::custom(length)),
         ("levenshtein", F::udf(Levenshtein::new())),
         ("locate", F::custom(position)),
         ("lower", F::custom(lower)),

--- a/python/pysail/tests/spark/__snapshots__/test_clickbench.plan.yaml
+++ b/python/pysail/tests/spark/__snapshots__/test_clickbench.plan.yaml
@@ -366,11 +366,11 @@ data:
     ProjectionExec: expr=[#105@0 as CounterID, #106@1 as l, #107@2 as c]
       SortPreservingMergeExec: [#106@1 DESC NULLS LAST], fetch=25
         SortExec: TopK(fetch=25), expr=[#106@1 DESC NULLS LAST], preserve_partitioning=[true]
-          ProjectionExec: expr=[#6@0 as #105, avg(character_length(hits.#13))@1 as #106, count(Int64(1))@2 as #107]
+          ProjectionExec: expr=[#6@0 as #105, avg(length(hits.#13))@1 as #106, count(Int64(1))@2 as #107]
             FilterExec: count(Int64(1))@2 > 100000
-              AggregateExec: mode=FinalPartitioned, gby=[#6@0 as #6], aggr=[avg(character_length(hits.#13)), count(Int64(1))]
+              AggregateExec: mode=FinalPartitioned, gby=[#6@0 as #6], aggr=[avg(length(hits.#13)), count(Int64(1))]
                 RepartitionExec: partitioning=Hash([#6@0], 4), input_partitions=4
-                  AggregateExec: mode=Partial, gby=[#6@0 as #6], aggr=[avg(character_length(hits.#13)), count(Int64(1))]
+                  AggregateExec: mode=Partial, gby=[#6@0 as #6], aggr=[avg(length(hits.#13)), count(Int64(1))]
                     ProjectionExec: expr=[CounterID@0 as #6, URL@1 as #13]
                       FilterExec: URL@1 != <eol>
                         RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
@@ -385,11 +385,11 @@ data:
         RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1, maintains_sort_order=true
           SortPreservingMergeExec: [#106@1 DESC NULLS LAST], fetch=25
             SortExec: TopK(fetch=25), expr=[#106@1 DESC NULLS LAST], preserve_partitioning=[true]
-              ProjectionExec: expr=[k@0 as #105, avg(character_length(hits.#14))@1 as #106, count(Int64(1))@2 as #107, min(hits.#14)@3 as #108]
+              ProjectionExec: expr=[k@0 as #105, avg(length(hits.#14))@1 as #106, count(Int64(1))@2 as #107, min(hits.#14)@3 as #108]
                 FilterExec: count(Int64(1))@2 > 100000
-                  AggregateExec: mode=FinalPartitioned, gby=[k@0 as k], aggr=[avg(character_length(hits.#14)), count(Int64(1)), min(hits.#14)]
+                  AggregateExec: mode=FinalPartitioned, gby=[k@0 as k], aggr=[avg(length(hits.#14)), count(Int64(1)), min(hits.#14)]
                     RepartitionExec: partitioning=Hash([k@0], 4), input_partitions=4
-                      AggregateExec: mode=Partial, gby=[regexp_replace(CAST(#14@0 AS LargeUtf8), ^https?:/(?:www.)?([^/]+)/.*$, $1, g) as k], aggr=[avg(character_length(hits.#14)), count(Int64(1)), min(hits.#14)]
+                      AggregateExec: mode=Partial, gby=[regexp_replace(CAST(#14@0 AS LargeUtf8), ^https?:/(?:www.)?([^/]+)/.*$, $1, g) as k], aggr=[avg(length(hits.#14)), count(Int64(1)), min(hits.#14)]
                         ProjectionExec: expr=[Referer@0 as #14]
                           FilterExec: Referer@0 != <eol>
                             RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1

--- a/python/pysail/tests/spark/function/features/length.feature
+++ b/python/pysail/tests/spark/function/features/length.feature
@@ -1,0 +1,362 @@
+@length
+Feature: length() returns character length for strings and byte length for binary
+
+  Rule: Character length for string data
+
+    Scenario: length counts characters including trailing spaces
+      When query
+        """
+        SELECT length('Spark SQL ') AS result
+        """
+      Then query result
+        | result |
+        | 10     |
+
+    Scenario: length of the empty string is zero
+      When query
+        """
+        SELECT length('') AS result
+        """
+      Then query result
+        | result |
+        | 0      |
+
+    Scenario: length counts characters not bytes for multi-byte text
+      When query
+        """
+        SELECT length('josé') AS accented, length('中文') AS cjk, length('😀') AS emoji
+        """
+      Then query result
+        | accented | cjk | emoji |
+        | 4        | 2   | 1     |
+
+  Rule: Byte length for binary data
+
+    Scenario: length of binary counts bytes not characters
+      When query
+        """
+        SELECT length(CAST('josé' AS BINARY)) AS result
+        """
+      Then query result
+        | result |
+        | 5      |
+
+    Scenario: length of binary that is not valid UTF-8
+      When query
+        """
+        SELECT length(X'DEADBEEF') AS result
+        """
+      Then query result
+        | result |
+        | 4      |
+
+    Scenario: length of empty binary is zero
+      When query
+        """
+        SELECT length(X'') AS result
+        """
+      Then query result
+        | result |
+        | 0      |
+
+    Scenario: length of binary counts every UTF-8 byte of an emoji
+      When query
+        """
+        SELECT length(CAST('😀' AS BINARY)) AS result
+        """
+      Then query result
+        | result |
+        | 4      |
+
+    Scenario: aliases len, char_length and character_length also count binary bytes
+      When query
+        """
+        SELECT len(X'DEADBEEF') AS a, char_length(X'DEADBEEF') AS b, character_length(X'DEADBEEF') AS c
+        """
+      Then query result
+        | a | b | c |
+        | 4 | 4 | 4 |
+
+    Scenario: length of binary includes binary zeros
+      When query
+        """
+        SELECT length(X'00010203') AS result
+        """
+      Then query result
+        | result |
+        | 4      |
+
+    Scenario: length of a single byte that is not valid UTF-8 on its own
+      When query
+        """
+        SELECT length(unhex('FF')) AS result
+        """
+      Then query result
+        | result |
+        | 1      |
+
+    Scenario: length of UTF-16 encoded binary counts the BOM and the NUL bytes
+      When query
+        """
+        SELECT length(encode('ab', 'UTF-16')) AS result
+        """
+      Then query result
+        | result |
+        | 6      |
+
+    Scenario: length of a binary column mixes valid UTF-8, NULL and raw bytes
+      When query
+        """
+        SELECT length(b) AS result FROM VALUES (CAST('josé' AS BINARY)), (NULL), (X'00') AS t(b)
+        """
+      Then query result
+        | result |
+        | 5      |
+        | NULL   |
+        | 1      |
+
+    Scenario: binary byte lengths can be aggregated
+      When query
+        """
+        SELECT sum(length(b)) AS result FROM VALUES (X'AABB'), (X'CC'), (NULL) AS t(b)
+        """
+      Then query result
+        | result |
+        | 3      |
+
+    Scenario: length of large binary counts every byte
+      When query
+        """
+        SELECT length(CAST(repeat('é', 10000) AS BINARY)) AS result
+        """
+      Then query result
+        | result |
+        | 20000  |
+
+  Rule: octet_length and bit_length measure bytes and bits
+
+    Scenario: octet_length and bit_length of binary that is not valid UTF-8
+      When query
+        """
+        SELECT octet_length(X'DEADBEEF') AS octets, bit_length(X'DEADBEEF') AS bits
+        """
+      Then query result
+        | octets | bits |
+        | 4      | 32   |
+
+    Scenario: octet_length and bit_length of binary count bytes not characters
+      When query
+        """
+        SELECT octet_length(CAST('josé' AS BINARY)) AS octets, bit_length(CAST('josé' AS BINARY)) AS bits
+        """
+      Then query result
+        | octets | bits |
+        | 5      | 40   |
+
+    Scenario: octet_length and bit_length of UTF-16 encoded binary
+      When query
+        """
+        SELECT octet_length(encode('ab', 'UTF-16')) AS octets, bit_length(encode('ab', 'UTF-16')) AS bits
+        """
+      Then query result
+        | octets | bits |
+        | 6      | 48   |
+
+    Scenario: octet_length and bit_length of empty binary are zero
+      When query
+        """
+        SELECT octet_length(X'') AS octets, bit_length(X'') AS bits
+        """
+      Then query result
+        | octets | bits |
+        | 0      | 0    |
+
+    Scenario: octet_length and bit_length of strings measure UTF-8 bytes not characters
+      When query
+        """
+        SELECT octet_length('josé') AS accented_octets, bit_length('josé') AS accented_bits, octet_length('😀') AS emoji_octets, bit_length('😀') AS emoji_bits
+        """
+      Then query result
+        | accented_octets | accented_bits | emoji_octets | emoji_bits |
+        | 5               | 40            | 4            | 32         |
+
+    Scenario: octet_length and bit_length of NULL binary are NULL
+      When query
+        """
+        SELECT octet_length(CAST(NULL AS BINARY)) AS octets, bit_length(CAST(NULL AS BINARY)) AS bits
+        """
+      Then query result
+        | octets | bits |
+        | NULL   | NULL |
+
+  Rule: NULL propagation
+
+    Scenario: length of a NULL string is NULL
+      When query
+        """
+        SELECT length(CAST(NULL AS STRING)) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: length of a NULL binary is NULL
+      When query
+        """
+        SELECT length(CAST(NULL AS BINARY)) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: length of an untyped NULL is NULL
+      When query
+        """
+        SELECT length(NULL) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+  Rule: Implicit coercion of non-string input to its string form
+
+    Scenario: numeric and boolean input is measured as its string form
+      When query
+        """
+        SELECT length(12345) AS int_in, length(1.5) AS double_in, length(true) AS bool_in, length(CAST(1.0 AS DECIMAL(10,2))) AS decimal_in
+        """
+      Then query result
+        | int_in | double_in | bool_in | decimal_in |
+        | 5      | 3         | 4       | 4          |
+
+    Scenario: date and timestamp input is measured as its string form
+      When query
+        """
+        SELECT length(DATE '2024-01-15') AS date_in, length(TIMESTAMP '2024-01-15 12:00:00') AS ts_in
+        """
+      Then query result
+        | date_in | ts_in |
+        | 10      | 19    |
+
+    Scenario: a timestamp with microseconds keeps its fractional part, with or without a time zone
+      When query
+        """
+        SELECT length(TIMESTAMP '2024-01-15 12:00:00.123456') AS ts_in, length(TIMESTAMP_NTZ '2024-01-15 12:00:00.123456') AS ntz_in
+        """
+      Then query result
+        | ts_in | ntz_in |
+        | 26    | 26     |
+
+    Scenario: octet_length of a timestamp measures its string form, without a time zone suffix
+      When query
+        """
+        SELECT octet_length(TIMESTAMP '2024-01-15 12:00:00') AS result
+        """
+      Then query result
+        | result |
+        | 19     |
+
+    Scenario: time input is measured as its string form
+      When query
+        """
+        SELECT length(TIME '23:59:59.999999') AS result
+        """
+      Then query result
+        | result |
+        | 15     |
+
+    Scenario: char input is not padded to its declared length
+      When query
+        """
+        SELECT length(CAST('ab' AS CHAR(10))) AS char_in, length(CAST('ab' AS VARCHAR(10))) AS varchar_in
+        """
+      Then query result
+        | char_in | varchar_in |
+        | 2       | 2          |
+
+  Rule: The result is always a non-nullable-preserving 32-bit integer
+
+    # Spark's Length/OctetLength/BitLength always return INT, never BIGINT, whatever the
+    # width of the input's offsets, and they propagate the nullability of their input.
+
+    Scenario: length of a string literal is a non-nullable integer
+      When query
+        """
+        SELECT length('josé') AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: integer (nullable = false)
+        """
+
+    Scenario: length of a binary literal is a non-nullable integer
+      When query
+        """
+        SELECT length(X'DEADBEEF') AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: integer (nullable = false)
+        """
+
+    Scenario: octet_length and bit_length also return integers
+      When query
+        """
+        SELECT octet_length(X'DEADBEEF') AS octets, bit_length(X'DEADBEEF') AS bits
+        """
+      Then query schema
+        """
+        root
+         |-- octets: integer (nullable = false)
+         |-- bits: integer (nullable = false)
+        """
+
+    Scenario: length of a nullable input is a nullable integer
+      When query
+        """
+        SELECT length(b) AS result FROM VALUES (X'00'), (NULL) AS t(b)
+        """
+      Then query schema
+        """
+        root
+         |-- result: integer (nullable = true)
+        """
+
+  Rule: Types whose string form Sail renders differently from Spark
+
+    # These measure correctly — they measure the string form Sail produces, and that
+    # string form is what diverges. The root cause is Sail's CAST-to-string formatter,
+    # not the length family: Sail renders a double in scientific notation as `1e18`
+    # where Spark renders `1.0E18`, and a day interval as `INTERVAL '1 00:00:00' DAY TO
+    # SECOND` where Spark renders `INTERVAL '1' DAY`. Fixing the formatter fixes these.
+
+    @sail-bug
+    Scenario: a double in scientific notation is measured as Spark renders it
+      When query
+        """
+        SELECT length(CAST(1e18 AS DOUBLE)) AS big, length(CAST(1e-7 AS DOUBLE)) AS small
+        """
+      Then query result
+        | big | small |
+        | 6   | 6     |
+
+    @sail-bug
+    Scenario: an interval is measured as Spark renders it
+      When query
+        """
+        SELECT length(INTERVAL 1 DAY) AS result
+        """
+      Then query result
+        | result |
+        | 16     |
+
+  Rule: Collections are rejected
+
+    Scenario: length of an array is an error
+      When query
+        """
+        SELECT length(array(1, 2, 3)) AS result
+        """
+      Then query error .*


### PR DESCRIPTION
Spark measures the character length of string data and the byte length of binary data. Sail routed `length`/`len`/`char_length`/`character_length` to DataFusion's `CharacterLengthFunc` and `octet_length`/`bit_length` through an explicit UTF-8 validation, both of which accept string data only. Binary input was therefore coerced to UTF-8 first, which silently counted characters instead of bytes (`length(CAST('josé' AS BINARY))` returned 4, Spark returns 5) and rejected outright any binary that is not valid UTF-8 (`length(X'DEADBEEF')`), including binary columns and aggregates over them.

Dispatch on the argument type in the plan builder instead: binary reaches the function untouched, collections are rejected as Spark rejects them (they were silently stringified — `length(array(1, 2, 3))` returned 9), and any other type is measured as its string form through `SparkToUtf8`. Casting through Arrow, as before, renders a timestamp with a time zone suffix, so `length` measured 25 characters where Spark measures 19, even though Sail's own `CAST(ts AS STRING)` is correct.

`length` and its aliases now use datafusion-spark's `SparkLengthFunc`, which measures binary and always returns INT. DataFusion has no binary-aware `octet_length`/`bit_length`, so add both, delegating to the Arrow kernels, which measure from the offset buffer and already wrap on overflow the way Spark does (the bit length of more than 2^28 bytes wraps to i32::MIN in both engines). The kernels return BIGINT for large offsets, so normalize to INT, truncating rather than nullifying to preserve that wrap.

Every expected value is validated against Spark JVM. The feature also pins the output schema, which a values-only test cannot see: Spark returns INT for every input type, whatever the width of the input's offsets.

The two remaining divergences are pinned as `@sail-bug`: the string form Sail renders for a double in scientific notation and for an interval differs from Spark, so `length` measures the right thing about the wrong string. The root cause is the CAST-to-string formatter, not this family; the strict xfail will XPASS and force the markers off once that is fixed.