### PR TITLE
test: cover the DataFrame coalesce doctest scenario

### DIFF
--- a/python/pysail/tests/spark/dataframe/test_repartition.py
+++ b/python/pysail/tests/spark/dataframe/test_repartition.py
@@ -100,6 +100,19 @@ def test_explicit_coalesce(spark):
     assert partition_count(spark.range(0, 10, 1, 4).coalesce(2)) == 2  # noqa: PLR2004
 
 
+def test_coalesce_reduces_visible_partition_ids(spark):
+    # Mirrors the ``DataFrame.coalesce`` PySpark doctest: a three-partition range
+    # exposes partition ids {0, 1, 2}, and coalescing to one partition leaves {0}.
+    def visible_partition_ids(df):
+        return sorted(
+            row["partition"] for row in df.select(F.spark_partition_id().alias("partition")).distinct().collect()
+        )
+
+    base = spark.range(0, 10, 1, 3)
+    assert visible_partition_ids(base) == [0, 1, 2]
+    assert visible_partition_ids(base.coalesce(1)) == [0]
+
+
 def test_coalesce_hint(spark):
     df = spark.range(0, 12, 1, 4).select("id", (F.col("id") % 3).alias("group"))
 


### PR DESCRIPTION
The `DataFrame.coalesce` PySpark doctest already passes against Sail, since range partitioning, `coalesce`, and `spark_partition_id` are all supported. This adds a focused regression test that pins the exact doctest behavior through the user-facing surface: a three-partition range exposes partition ids {0, 1, 2} via `spark_partition_id`, and coalescing to a single partition leaves only {0}. Existing tests verify partition counts through `mapInPandas` but not this path.

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)