### PR TITLE
test: cover behaviour-governing arguments passed as a column

### DIFF
--- a/python/pysail/tests/spark/function/features/aes_decrypt.feature
+++ b/python/pysail/tests/spark/function/features/aes_decrypt.feature
@@ -1,0 +1,52 @@
+Feature: aes_decrypt with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: aes_decrypt — the argument may come from a column
+
+    @column_args
+    Scenario: aes_decrypt with the argument as a literal
+      When query
+        """
+        SELECT hex(aes_decrypt(unbase64('2NYmDCjgXTbbxGA3/SnJEfFC/JQ7olk2VQWReIAAFKo='), '1234567890abcdef', 'CBC')) AS result
+        """
+      Then query result ordered
+        | result                   |
+        | 41706163686520537061726B |
+
+    # Sail rejects the column: Sail errors: Spark `aes_decrypt`: Key requires a single value, got StringArray [ "1234567890abcdef", "1...
+    @column_args @sail-bug
+    Scenario: aes_decrypt takes argument 2 from a column
+      When query
+        """
+        SELECT hex(aes_decrypt(unbase64('2NYmDCjgXTbbxGA3/SnJEfFC/JQ7olk2VQWReIAAFKo='), c, 'CBC')) AS result FROM VALUES (1, '1234567890abcdef'), (2, '1234567890abcdef') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result                   |
+        | 41706163686520537061726B |
+        | 41706163686520537061726B |
+
+    # Sail rejects the column: Sail errors: Spark `aes_decrypt`: Mode requires a single value, got StringArray [ "CBC", "CBC", ]
+    @column_args @sail-bug
+    Scenario: aes_decrypt takes argument 3 from a column
+      When query
+        """
+        SELECT hex(aes_decrypt(unbase64('2NYmDCjgXTbbxGA3/SnJEfFC/JQ7olk2VQWReIAAFKo='), '1234567890abcdef', c)) AS result FROM VALUES (1, 'CBC'), (2, 'CBC') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result                   |
+        | 41706163686520537061726B |
+        | 41706163686520537061726B |
+
+    # Sail rejects the column: Sail errors: Spark `aes_decrypt`: AAD requires a single value, got StringArray [ "This is an AAD mixed...
+    @column_args @sail-bug
+    Scenario: aes_decrypt takes argument 5 from a column
+      When query
+        """
+        SELECT hex(aes_decrypt(unbase64('AAAAAAAAAAAAAAAAQiYi+sTLm7KD9UcZ2nlRdYDe/PX4'), 'abcdefghijklmnop12345678ABCDEFGH', 'GCM', 'DEFAULT', c)) AS result FROM VALUES (1, 'This is an AAD mixed into the input'), (2, 'This is an AAD mixed into the input') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result     |
+        | 537061726B |
+        | 537061726B |

--- a/python/pysail/tests/spark/function/features/aes_encrypt.feature
+++ b/python/pysail/tests/spark/function/features/aes_encrypt.feature
@@ -1,0 +1,88 @@
+Feature: aes_encrypt with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: aes_encrypt — the argument may come from a column
+
+    @column_args
+    Scenario: aes_encrypt with the argument as a literal
+      When query
+        """
+        SELECT base64(aes_encrypt('Spark', 'abcdefghijklmnop12345678ABCDEFGH', 'CBC', 'DEFAULT', unhex('00000000000000000000000000000000'))) AS result
+        """
+      Then query result ordered
+        | result                                       |
+        | AAAAAAAAAAAAAAAAAAAAAPSd4mWyMZ5mhvjiAPQJnfg= |
+
+    # Sail rejects the column: Sail errors: Spark `aes_encrypt`: Expr requires a single value, got StringArray [ "Spark", "Spark SQL",...
+    @column_args @sail-bug
+    Scenario: aes_encrypt takes argument 1 from a column holding two different values
+      When query
+        """
+        SELECT base64(aes_encrypt(c, 'abcdefghijklmnop12345678ABCDEFGH', 'CBC', 'DEFAULT', unhex('00000000000000000000000000000000'))) AS result FROM VALUES (1, 'Spark'), (2, 'Spark SQL') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result                                       |
+        | AAAAAAAAAAAAAAAAAAAAAPSd4mWyMZ5mhvjiAPQJnfg= |
+        | AAAAAAAAAAAAAAAAAAAAAFfH3r/2mb/RDzBWeYjUD7c= |
+
+    # Sail rejects the column: Sail errors: Spark `aes_encrypt`: Expr requires a single value, got StringArray [ "Spark", "Spark", ]
+    @column_args @sail-bug
+    Scenario: aes_encrypt takes argument 1 from a column
+      When query
+        """
+        SELECT base64(aes_encrypt(c, 'abcdefghijklmnop12345678ABCDEFGH', 'CBC', 'DEFAULT', unhex('00000000000000000000000000000000'))) AS result FROM VALUES (1, 'Spark'), (2, 'Spark') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result                                       |
+        | AAAAAAAAAAAAAAAAAAAAAPSd4mWyMZ5mhvjiAPQJnfg= |
+        | AAAAAAAAAAAAAAAAAAAAAPSd4mWyMZ5mhvjiAPQJnfg= |
+
+    # Sail rejects the column: Sail errors: Spark `aes_encrypt`: Key requires a single value, got StringArray [ "abcdefghijklmnop12345...
+    @column_args @sail-bug
+    Scenario: aes_encrypt takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT base64(aes_encrypt('Spark', c, 'CBC', 'DEFAULT', unhex('00000000000000000000000000000000'))) AS result FROM VALUES (1, 'abcdefghijklmnop12345678ABCDEFGH'), (2, '0000111122223333') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result                                       |
+        | AAAAAAAAAAAAAAAAAAAAAPSd4mWyMZ5mhvjiAPQJnfg= |
+        | AAAAAAAAAAAAAAAAAAAAADSP83694Ft4gLozkGj72l4= |
+
+    # Sail rejects the column: Sail errors: Spark `aes_encrypt`: Key requires a single value, got StringArray [ "abcdefghijklmnop12345...
+    @column_args @sail-bug
+    Scenario: aes_encrypt takes argument 2 from a column
+      When query
+        """
+        SELECT base64(aes_encrypt('Spark', c, 'CBC', 'DEFAULT', unhex('00000000000000000000000000000000'))) AS result FROM VALUES (1, 'abcdefghijklmnop12345678ABCDEFGH'), (2, 'abcdefghijklmnop12345678ABCDEFGH') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result                                       |
+        | AAAAAAAAAAAAAAAAAAAAAPSd4mWyMZ5mhvjiAPQJnfg= |
+        | AAAAAAAAAAAAAAAAAAAAAPSd4mWyMZ5mhvjiAPQJnfg= |
+
+    # Sail rejects the column: Sail errors: Spark `aes_encrypt`: Mode requires a single value, got StringArray [ "CBC", "CBC", ]
+    @column_args @sail-bug
+    Scenario: aes_encrypt takes argument 3 from a column
+      When query
+        """
+        SELECT base64(aes_encrypt('Spark', 'abcdefghijklmnop12345678ABCDEFGH', c, 'DEFAULT', unhex('00000000000000000000000000000000'))) AS result FROM VALUES (1, 'CBC'), (2, 'CBC') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result                                       |
+        | AAAAAAAAAAAAAAAAAAAAAPSd4mWyMZ5mhvjiAPQJnfg= |
+        | AAAAAAAAAAAAAAAAAAAAAPSd4mWyMZ5mhvjiAPQJnfg= |
+
+    # Sail rejects the column: Sail errors: Spark `aes_encrypt`: AAD requires a single value, got StringArray [ "This is an AAD mixed...
+    @column_args @sail-bug
+    Scenario: aes_encrypt takes argument 6 from a column
+      When query
+        """
+        SELECT base64(aes_encrypt('Spark', 'abcdefghijklmnop12345678ABCDEFGH', 'GCM', 'DEFAULT', unhex('000000000000000000000000'), c)) AS result FROM VALUES (1, 'This is an AAD mixed into the input'), (2, 'This is an AAD mixed into the input') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result                                       |
+        | AAAAAAAAAAAAAAAAQiYi+sTLm7KD9UcZ2nlRdYDe/PX4 |
+        | AAAAAAAAAAAAAAAAQiYi+sTLm7KD9UcZ2nlRdYDe/PX4 |

--- a/python/pysail/tests/spark/function/features/array_insert.feature
+++ b/python/pysail/tests/spark/function/features/array_insert.feature
@@ -1,0 +1,39 @@
+Feature: array_insert with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: array_insert — the argument may come from a column
+
+    @column_args
+    Scenario: array_insert with the argument as a literal
+      When query
+        """
+        SELECT array_insert(array(1, 2, 3, 4), 5, 5) AS result
+        """
+      Then query result ordered
+        | result          |
+        | [1, 2, 3, 4, 5] |
+
+    # Sail rejects the column: Sail errors: array_insert: the index 0 is invalid. An index shall be either < 0 or > 0 (the first eleme...
+    @column_args @sail-bug
+    Scenario: array_insert takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT array_insert(array(1, 2, 3, 4), c, 5) AS result FROM VALUES (1, 5), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result          |
+        | [1, 2, 3, 4, 5] |
+        | NULL            |
+
+    @column_args
+    Scenario: array_insert takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT array_insert(array(1, 2, 3), c, 9) AS result FROM VALUES (1, 1), (2, 3) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result       |
+        | [9, 1, 2, 3] |
+        | [1, 2, 9, 3] |

--- a/python/pysail/tests/spark/function/features/array_remove.feature
+++ b/python/pysail/tests/spark/function/features/array_remove.feature
@@ -1,0 +1,39 @@
+Feature: array_remove with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: array_remove — the argument may come from a column
+
+    @column_args
+    Scenario: array_remove with the argument as a literal
+      When query
+        """
+        SELECT array_remove(array(1, 2, 3, null, 3), 3) AS result
+        """
+      Then query result ordered
+        | result       |
+        | [1, 2, NULL] |
+
+    # Sail rejects the column: Sail errors: Invalid argument error: Column '#4' is declared as non-nullable but contains null values
+    @column_args @sail-bug
+    Scenario: array_remove takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT array_remove(array(1, 2, 3, null, 3), c) AS result FROM VALUES (1, 3), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result       |
+        | [1, 2, NULL] |
+        | NULL         |
+
+    @column_args
+    Scenario: array_remove takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT array_remove(array(1, 2, 3), c) AS result FROM VALUES (1, 1), (2, 3) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | [2, 3] |
+        | [1, 2] |

--- a/python/pysail/tests/spark/function/features/bround.feature
+++ b/python/pysail/tests/spark/function/features/bround.feature
@@ -331,3 +331,33 @@ Feature: bround comprehensive tests
         | result |
         | 20.0   |
         | 40.0   |
+
+  Rule: bround — the argument must be foldable
+
+    @column_args
+    Scenario: bround with the argument as a literal
+      When query
+        """
+        SELECT bround(25, -1) AS result
+        """
+      Then query result ordered
+        | result |
+        | 20     |
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['20', '25'].
+    @column_args @sail-bug
+    Scenario: bround takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT bround(25, c) AS result FROM VALUES (1, -1), (2, 0) AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['20', '20'].
+    @column_args @sail-bug
+    Scenario: bround takes argument 2 from a column
+      When query
+        """
+        SELECT bround(25, c) AS result FROM VALUES (1, -1), (2, -1) AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT

--- a/python/pysail/tests/spark/function/features/conv.feature
+++ b/python/pysail/tests/spark/function/features/conv.feature
@@ -1,0 +1,52 @@
+Feature: conv with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: conv — the argument may come from a column
+
+    @column_args
+    Scenario: conv with the argument as a literal
+      When query
+        """
+        SELECT conv('100', 2, 10) AS result
+        """
+      Then query result ordered
+        | result |
+        | 4      |
+
+    # Sail rejects the column: Sail errors: Unsupported Data Type: Spark `spark_conv` function expects (Utf8 | Utf8View | LargeUtf8 |...
+    @column_args @sail-bug
+    Scenario: conv takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT conv('100', c, 10) AS result FROM VALUES (1, 2), (2, 16) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | 4      |
+        | 256    |
+
+    # Sail rejects the column: Sail errors: Unsupported Data Type: Spark `spark_conv` function expects (Utf8 | Utf8View | LargeUtf8 |...
+    @column_args @sail-bug
+    Scenario: conv takes argument 2 from a column
+      When query
+        """
+        SELECT conv('100', c, 10) AS result FROM VALUES (1, 2), (2, 2) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | 4      |
+        | 4      |
+
+    # Sail rejects the column: Sail errors: Unsupported Data Type: Spark `spark_conv` function expects (Utf8 | Utf8View | LargeUtf8 |...
+    @column_args @sail-bug
+    Scenario: conv takes argument 3 from a column
+      When query
+        """
+        SELECT conv('100', 2, c) AS result FROM VALUES (1, 10), (2, 10) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | 4      |
+        | 4      |

--- a/python/pysail/tests/spark/function/features/date_format.feature
+++ b/python/pysail/tests/spark/function/features/date_format.feature
@@ -1,0 +1,39 @@
+Feature: date_format with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: date_format — the argument is resolved per row, not taken from the first row
+
+    @column_args
+    Scenario: date_format with the argument as a literal
+      When query
+        """
+        SELECT date_format('2016-04-08', 'y') AS result
+        """
+      Then query result ordered
+        | result |
+        | 2016   |
+
+    # Sail applies the first row's value to every row: Sail returns ['2016', '2016'].
+    @column_args @sail-bug
+    Scenario: date_format takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT date_format('2016-04-08', c) AS result FROM VALUES (1, 'y'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | 2016   |
+        | NULL   |
+
+    @column_args @sail-bug
+    Scenario: date_format takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT date_format(TIMESTAMP '2026-02-02 10:20:30', c) AS result FROM VALUES (1, 'y'), (2, 'MM') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | 2026   |
+        | 02     |

--- a/python/pysail/tests/spark/function/features/date_trunc.feature
+++ b/python/pysail/tests/spark/function/features/date_trunc.feature
@@ -92,3 +92,39 @@ Feature: DATE_TRUNC preserves timestamp type
       Then query result
       | result              |
       | 2026-03-15 18:00:00 |
+
+  Rule: date_trunc — the argument may come from a column
+
+    @column_args
+    Scenario: date_trunc with the argument as a literal
+      When query
+        """
+        SELECT date_trunc('MM', '2015-03-05T09:32:05.359') AS result
+        """
+      Then query result ordered
+        | result              |
+        | 2015-03-01 00:00:00 |
+
+    # Sail rejects the column: Sail errors: Granularity of `date_trunc` must be non-null scalar Utf8
+    @column_args @sail-bug
+    Scenario: date_trunc takes argument 1 from a column holding two different values
+      When query
+        """
+        SELECT date_trunc(c, '2015-03-05T09:32:05.359') AS result FROM VALUES (1, 'YEAR'), (2, 'MM') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result              |
+        | 2015-01-01 00:00:00 |
+        | 2015-03-01 00:00:00 |
+
+    # Sail rejects the column: Sail errors: Granularity of `date_trunc` must be non-null scalar Utf8
+    @column_args @sail-bug
+    Scenario: date_trunc takes argument 1 from a column
+      When query
+        """
+        SELECT date_trunc(c, '2015-03-05T09:32:05.359') AS result FROM VALUES (1, 'YEAR'), (2, 'YEAR') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result              |
+        | 2015-01-01 00:00:00 |
+        | 2015-01-01 00:00:00 |

--- a/python/pysail/tests/spark/function/features/decode.feature
+++ b/python/pysail/tests/spark/function/features/decode.feature
@@ -1,0 +1,40 @@
+Feature: decode with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: decode — the argument may come from a column
+
+    @column_args
+    Scenario: decode with the argument as a literal
+      When query
+        """
+        SELECT decode(encode('abc', 'utf-8'), 'utf-8') AS result
+        """
+      Then query result ordered
+        | result |
+        | abc    |
+
+    # Sail rejects the column: Sail errors: Unsupported args [Scalar(Binary("97,98,99")), Array(StringArray [ "utf-8", null, ])] for S...
+    @column_args @sail-bug
+    Scenario: decode takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT decode(encode('abc', 'utf-8'), c) AS result FROM VALUES (1, 'utf-8'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | abc    |
+        | NULL   |
+
+    # Sail rejects the column: Sail errors: Unsupported args [Scalar(Binary("97,98,99")), Array(StringArray [ "utf-8", "utf-8", ])] fo...
+    @column_args @sail-bug
+    Scenario: decode takes argument 2 from a column
+      When query
+        """
+        SELECT decode(encode('abc', 'utf-8'), c) AS result FROM VALUES (1, 'utf-8'), (2, 'utf-8') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | abc    |
+        | abc    |

--- a/python/pysail/tests/spark/function/features/encode.feature
+++ b/python/pysail/tests/spark/function/features/encode.feature
@@ -1,0 +1,51 @@
+Feature: encode with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: encode — the argument may come from a column
+
+    @column_args
+    Scenario: encode with the argument as a literal
+      When query
+        """
+        SELECT hex(encode('abc', 'utf-8')) AS result
+        """
+      Then query result ordered
+        | result |
+        | 616263 |
+
+    # Sail rejects the column: Sail errors: Unsupported args [Scalar(Utf8("abc")), Array(StringArray [ "utf-8", null, ])] for Spark fu...
+    @column_args @sail-bug
+    Scenario: encode takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT hex(encode('abc', c)) AS result FROM VALUES (1, 'utf-8'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | 616263 |
+        | NULL   |
+
+    # Sail rejects the column: Sail errors: Unsupported args [Scalar(Utf8("abc")), Array(StringArray [ "utf-8", "utf-8", ])] for Spark...
+    @column_args @sail-bug
+    Scenario: encode takes argument 2 from a column
+      When query
+        """
+        SELECT hex(encode('abc', c)) AS result FROM VALUES (1, 'utf-8'), (2, 'utf-8') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | 616263 |
+        | 616263 |
+
+    @column_args @sail-bug
+    Scenario: encode takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT hex(encode('ab', c)) AS result FROM VALUES (1, 'utf-8'), (2, 'utf-16') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result       |
+        | 6162         |
+        | FEFF00610062 |

--- a/python/pysail/tests/spark/function/features/from_unixtime.feature
+++ b/python/pysail/tests/spark/function/features/from_unixtime.feature
@@ -1,0 +1,39 @@
+Feature: from_unixtime with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: from_unixtime — the argument is resolved per row, not taken from the first row
+
+    @column_args
+    Scenario: from_unixtime with the argument as a literal
+      When query
+        """
+        SELECT from_unixtime(0, 'yyyy-MM-dd HH:mm:ss') AS result
+        """
+      Then query result ordered
+        | result              |
+        | 1970-01-01 00:00:00 |
+
+    # Sail applies the first row's value to every row: Sail returns ['1970-01-01 01:00:00', '1970-01-01 01:00:00'].
+    @column_args @sail-bug
+    Scenario: from_unixtime takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT from_unixtime(0, c) AS result FROM VALUES (1, 'yyyy-MM-dd HH:mm:ss'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result              |
+        | 1970-01-01 00:00:00 |
+        | NULL                |
+
+    @column_args @sail-bug
+    Scenario: from_unixtime takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT from_unixtime(0, c) AS result FROM VALUES (1, 'yyyy'), (2, 'MM') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | 1970   |
+        | 01     |

--- a/python/pysail/tests/spark/function/features/get.feature
+++ b/python/pysail/tests/spark/function/features/get.feature
@@ -1,0 +1,39 @@
+Feature: get with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: get — the argument is resolved per row, not taken from the first row
+
+    @column_args
+    Scenario: get with the argument as a literal
+      When query
+        """
+        SELECT get(array(1, 2, 3), 0) AS result
+        """
+      Then query result ordered
+        | result |
+        | 1      |
+
+    # Sail applies the first row's value to every row: Sail returns ['1', '1'].
+    @column_args @sail-bug
+    Scenario: get takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT get(array(1, 2, 3), c) AS result FROM VALUES (1, 0), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | 1      |
+        | NULL   |
+
+    @column_args
+    Scenario: get takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT get(array(10, 20, 30), c) AS result FROM VALUES (1, 0), (2, 2) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | 10     |
+        | 30     |

--- a/python/pysail/tests/spark/function/features/get_json_object.feature
+++ b/python/pysail/tests/spark/function/features/get_json_object.feature
@@ -203,3 +203,51 @@ Feature: get_json_object extracts values via a Spark JSONPath
       Then query result
         | result |
         | NULL   |
+
+  Rule: get_json_object — the argument is resolved per row, not taken from the first row
+
+    @column_args
+    Scenario: get_json_object with the argument as a literal
+      When query
+        """
+        SELECT get_json_object('[{"a":"b"},{"a":"c"}]', '$[0].a') AS result
+        """
+      Then query result ordered
+        | result |
+        | b      |
+
+    # Sail returns the wrong value on the column path: Sail returns NULL for every row.
+    @column_args @sail-bug
+    Scenario: get_json_object takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT get_json_object('[{"a":"b"},{"a":"c"}]', c) AS result FROM VALUES (1, '$[0].a'), (2, '$.a') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | b      |
+        | NULL   |
+
+    # Sail returns the wrong value on the column path: Sail returns NULL for every row.
+    @column_args @sail-bug
+    Scenario: get_json_object takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT get_json_object('[{"a":"b"},{"a":"c"}]', c) AS result FROM VALUES (1, '$[0].a'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | b      |
+        | NULL   |
+
+    # Sail returns the wrong value on the column path: Sail returns NULL for every row.
+    @column_args @sail-bug
+    Scenario: get_json_object takes argument 2 from a column
+      When query
+        """
+        SELECT get_json_object('[{"a":"b"},{"a":"c"}]', c) AS result FROM VALUES (1, '$[0].a'), (2, '$[0].a') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | b      |
+        | b      |

--- a/python/pysail/tests/spark/function/features/json_tuple.feature
+++ b/python/pysail/tests/spark/function/features/json_tuple.feature
@@ -1,0 +1,75 @@
+Feature: json_tuple with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: json_tuple — the argument may come from a column
+
+    @column_args
+    Scenario: json_tuple with the argument as a literal
+      When query
+        """
+        SELECT json_tuple('{"a":1, "b":2}', 'a', 'b')
+        """
+      Then query result ordered
+        | c0 | c1 |
+        | 1  | 2  |
+
+    # Sail rejects the column: Sail errors: invalid argument: json_tuple field names must be string literals
+    @column_args @sail-bug
+    Scenario: json_tuple takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT json_tuple('{"a":1, "b":2}', c, 'b') FROM VALUES (1, 'a'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | c0   | c1 |
+        | 1    | 2  |
+        | NULL | 2  |
+
+    # Sail rejects the column: Sail errors: invalid argument: json_tuple field names must be string literals
+    @column_args @sail-bug
+    Scenario: json_tuple takes argument 2 from a column
+      When query
+        """
+        SELECT json_tuple('{"a":1, "b":2}', c, 'b') FROM VALUES (1, 'a'), (2, 'a') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | c0 | c1 |
+        | 1  | 2  |
+        | 1  | 2  |
+
+    # Sail rejects the column: Sail errors: invalid argument: json_tuple field names must be string literals
+    @column_args @sail-bug
+    Scenario: json_tuple takes argument 3 from a column containing NULL
+      When query
+        """
+        SELECT json_tuple('{"a":1, "b":2}', 'a', c) FROM VALUES (1, 'b'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | c0 | c1   |
+        | 1  | 2    |
+        | 1  | NULL |
+
+    # Sail rejects the column: Sail errors: invalid argument: json_tuple field names must be string literals
+    @column_args @sail-bug
+    Scenario: json_tuple takes argument 3 from a column
+      When query
+        """
+        SELECT json_tuple('{"a":1, "b":2}', 'a', c) FROM VALUES (1, 'b'), (2, 'b') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | c0 | c1 |
+        | 1  | 2  |
+        | 1  | 2  |
+
+    @column_args @sail-bug
+    Scenario: json_tuple takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT json_tuple('{"a":1, "b":2}', c, 'b') FROM VALUES (1, 'a'), (2, 'b') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | c0 | c1 |
+        | 1  | 2  |
+        | 2  | 2  |

--- a/python/pysail/tests/spark/function/features/next_day.feature
+++ b/python/pysail/tests/spark/function/features/next_day.feature
@@ -276,3 +276,50 @@ Feature: next_day comprehensive tests
       Then query result
         | result     |
         | 2025-01-01 |
+
+  Rule: next_day — the argument may come from a column
+
+    @column_args
+    Scenario: next_day with the argument as a literal
+      When query
+        """
+        SELECT next_day('2015-01-14', 'TU') AS result
+        """
+      Then query result ordered
+        | result     |
+        | 2015-01-20 |
+
+    # Sail rejects the column: Sail errors: Unsupported args [Scalar(Date32("2015-01-14")), Array(StringArray [ "TU", null, ])] for Sp...
+    @column_args @sail-bug
+    Scenario: next_day takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT next_day('2015-01-14', c) AS result FROM VALUES (1, 'TU'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result     |
+        | 2015-01-20 |
+        | NULL       |
+
+    # Sail rejects the column: Sail errors: Unsupported args [Scalar(Date32("2015-01-14")), Array(StringArray [ "TU", "TU", ])] for Sp...
+    @column_args @sail-bug
+    Scenario: next_day takes argument 2 from a column
+      When query
+        """
+        SELECT next_day('2015-01-14', c) AS result FROM VALUES (1, 'TU'), (2, 'TU') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result     |
+        | 2015-01-20 |
+        | 2015-01-20 |
+
+    @column_args @sail-bug
+    Scenario: next_day takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT next_day(DATE '2015-01-14', c) AS result FROM VALUES (1, 'TU'), (2, 'FR') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result     |
+        | 2015-01-20 |
+        | 2015-01-16 |

--- a/python/pysail/tests/spark/function/features/round.feature
+++ b/python/pysail/tests/spark/function/features/round.feature
@@ -1,0 +1,34 @@
+Feature: round with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: round — the argument must be foldable
+
+    @column_args
+    Scenario: round with the argument as a literal
+      When query
+        """
+        SELECT round(2.5, 0) AS result
+        """
+      Then query result ordered
+        | result |
+        | 3      |
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', 'NULL'].
+    @column_args @sail-bug
+    Scenario: round takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT round(2.5, c) AS result FROM VALUES (1, 0), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', '3.0'].
+    @column_args @sail-bug
+    Scenario: round takes argument 2 from a column
+      When query
+        """
+        SELECT round(2.5, c) AS result FROM VALUES (1, 0), (2, 0) AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT

--- a/python/pysail/tests/spark/function/features/sha2.feature
+++ b/python/pysail/tests/spark/function/features/sha2.feature
@@ -1,0 +1,39 @@
+Feature: sha2 with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: sha2 — the argument may come from a column
+
+    @column_args
+    Scenario: sha2 with the argument as a literal
+      When query
+        """
+        SELECT sha2('Spark', 256) AS result
+        """
+      Then query result ordered
+        | result                                                           |
+        | 529bc3b07127ecb7e53a4dcf1991d9152c24537d919178022b2c42657f79a26b |
+
+    # Sail rejects the column: Sail errors: invalid argument: The second argument of sha2 must be a literal integer.
+    @column_args @sail-bug
+    Scenario: sha2 takes argument 2 from a column
+      When query
+        """
+        SELECT sha2('Spark', c) AS result FROM VALUES (1, 256), (2, 256) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result                                                           |
+        | 529bc3b07127ecb7e53a4dcf1991d9152c24537d919178022b2c42657f79a26b |
+        | 529bc3b07127ecb7e53a4dcf1991d9152c24537d919178022b2c42657f79a26b |
+
+    @column_args @sail-bug
+    Scenario: sha2 takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT sha2('Spark', c) AS result FROM VALUES (1, 256), (2, 512) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result                                                                                                                           |
+        | 529bc3b07127ecb7e53a4dcf1991d9152c24537d919178022b2c42657f79a26b                                                                 |
+        | 44844a586c54c9a212da1dbfe05c5f1705de1af5fda1f0d36297623249b279fd8f0ccec03f888f4fb13bf7cd83fdad58591c797f81121a23cfdd5e0897795238 |

--- a/python/pysail/tests/spark/function/features/slice.feature
+++ b/python/pysail/tests/spark/function/features/slice.feature
@@ -1,0 +1,51 @@
+Feature: slice with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: slice — the argument may come from a column
+
+    @column_args
+    Scenario: slice with the argument as a literal
+      When query
+        """
+        SELECT slice(array(1, 2, 3, 4), 2, 2) AS result
+        """
+      Then query result ordered
+        | result |
+        | [2, 3] |
+
+    # Sail rejects the column: Sail errors: Invalid argument error: Non-nullable field of ListArray "item" cannot contain nulls
+    @column_args @sail-bug
+    Scenario: slice takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT slice(array(1, 2, 3, 4), c, 2) AS result FROM VALUES (1, 2), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | [2, 3] |
+        | NULL   |
+
+    # Sail rejects the column: Sail errors: Invalid argument error: Non-nullable field of ListArray "item" cannot contain nulls
+    @column_args @sail-bug
+    Scenario: slice takes argument 3 from a column containing NULL
+      When query
+        """
+        SELECT slice(array(1, 2, 3, 4), 2, c) AS result FROM VALUES (1, 2), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | [2, 3] |
+        | NULL   |
+
+    @column_args
+    Scenario: slice takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT slice(array(1, 2, 3, 4), c, 2) AS result FROM VALUES (1, 1), (2, 3) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | [1, 2] |
+        | [3, 4] |

--- a/python/pysail/tests/spark/function/features/to_char.feature
+++ b/python/pysail/tests/spark/function/features/to_char.feature
@@ -1,0 +1,54 @@
+Feature: to_char with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: to_char — the argument must be foldable
+
+    @column_args
+    Scenario: to_char with the argument as a literal
+      When query
+        """
+        SELECT to_char(454, '999') AS result
+        """
+      Then query result ordered
+        | result |
+        | 454    |
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['454', '454'].
+    @column_args @sail-bug
+    Scenario: to_char takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT to_char(454, c) AS result FROM VALUES (1, '999'), (2, '000D00') AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['454', '454'].
+    @column_args @sail-bug
+    Scenario: to_char takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT to_char(454, c) AS result FROM VALUES (1, '999'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['454', '454'].
+    @column_args @sail-bug
+    Scenario: to_char takes argument 2 from a column
+      When query
+        """
+        SELECT to_char(454, c) AS result FROM VALUES (1, '999'), (2, '999') AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    @column_args @sail-bug
+    Scenario: to_char takes the date format from a column holding two different values
+      When query
+        """
+        SELECT to_char(DATE '2026-02-02', c) AS result FROM VALUES (1, 'y'), (2, 'MM') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | 2026   |
+        | 02     |

--- a/python/pysail/tests/spark/function/features/to_char.feature
+++ b/python/pysail/tests/spark/function/features/to_char.feature
@@ -3,7 +3,7 @@ Feature: to_char with an argument coming from a column
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
   # through a column. All expected values were captured on Spark JVM 4.1.1.
 
-  Rule: to_char — the argument must be foldable
+  Rule: to_char — a numeric format must be foldable
 
     @column_args
     Scenario: to_char with the argument as a literal
@@ -42,6 +42,12 @@ Feature: to_char with an argument coming from a column
         """
       Then query error NON_FOLDABLE_INPUT
 
+  # With a DATE or TIMESTAMP input, Spark resolves `to_char` to `DateFormatClass`, which accepts a
+  # non-foldable format and applies it row by row. So the foldable rule above is specific to the
+  # numeric format; here the column is legal and each row must use its own format.
+  Rule: to_char — a date format is resolved per row
+
+    # Sail applies the first row's value to every row: Sail returns ['2026', '2026'].
     @column_args @sail-bug
     Scenario: to_char takes the date format from a column holding two different values
       When query

--- a/python/pysail/tests/spark/function/features/to_date.feature
+++ b/python/pysail/tests/spark/function/features/to_date.feature
@@ -1,0 +1,28 @@
+Feature: to_date with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: to_date — the argument may come from a column
+
+    @column_args
+    Scenario: to_date with the argument as a literal
+      When query
+        """
+        SELECT to_date('2016-12-31', 'yyyy-MM-dd') AS result
+        """
+      Then query result ordered
+        | result     |
+        | 2016-12-31 |
+
+    # Sail rejects the column: Sail errors: Unsupported data type Array(StringArray [ "%Y-%m-%d", "%Y-%m-%d", ]) for function to_date,...
+    @column_args @sail-bug
+    Scenario: to_date takes argument 2 from a column
+      When query
+        """
+        SELECT to_date('2016-12-31', c) AS result FROM VALUES (1, 'yyyy-MM-dd'), (2, 'yyyy-MM-dd') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result     |
+        | 2016-12-31 |
+        | 2016-12-31 |

--- a/python/pysail/tests/spark/function/features/to_unix_timestamp.feature
+++ b/python/pysail/tests/spark/function/features/to_unix_timestamp.feature
@@ -1,0 +1,28 @@
+Feature: to_unix_timestamp with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: to_unix_timestamp — the argument may come from a column
+
+    @column_args
+    Scenario: to_unix_timestamp with the argument as a literal
+      When query
+        """
+        SELECT to_unix_timestamp('2016-04-08', 'yyyy-MM-dd') AS result
+        """
+      Then query result ordered
+        | result     |
+        | 1460073600 |
+
+    # Sail rejects the column: Sail errors: Unsupported data type Array(StringArray [ "%Y-%m-%d", "%Y-%m-%d", ]) for function to_times...
+    @column_args @sail-bug
+    Scenario: to_unix_timestamp takes argument 2 from a column
+      When query
+        """
+        SELECT to_unix_timestamp('2016-04-08', c) AS result FROM VALUES (1, 'yyyy-MM-dd'), (2, 'yyyy-MM-dd') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result     |
+        | 1460073600 |
+        | 1460073600 |

--- a/python/pysail/tests/spark/function/features/to_varchar.feature
+++ b/python/pysail/tests/spark/function/features/to_varchar.feature
@@ -3,7 +3,7 @@ Feature: to_varchar with an argument coming from a column
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
   # through a column. All expected values were captured on Spark JVM 4.1.1.
 
-  Rule: to_varchar — the argument must be foldable
+  Rule: to_varchar — a numeric format must be foldable
 
     @column_args
     Scenario: to_varchar with the argument as a literal
@@ -41,3 +41,20 @@ Feature: to_varchar with an argument coming from a column
         SELECT to_varchar(454, c) AS result FROM VALUES (1, '999'), (2, '999') AS t(i, c) ORDER BY i
         """
       Then query error NON_FOLDABLE_INPUT
+
+  # With a DATE or TIMESTAMP input, Spark resolves `to_varchar` to `DateFormatClass`, which accepts a
+  # non-foldable format and applies it row by row. So the foldable rule above is specific to the
+  # numeric format; here the column is legal and each row must use its own format.
+  Rule: to_varchar — a date format is resolved per row
+
+    # Sail applies the first row's value to every row: Sail returns ['2026', '2026'].
+    @column_args @sail-bug
+    Scenario: to_varchar takes the date format from a column holding two different values
+      When query
+        """
+        SELECT to_varchar(DATE '2026-02-02', c) AS result FROM VALUES (1, 'y'), (2, 'MM') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | 2026   |
+        | 02     |

--- a/python/pysail/tests/spark/function/features/to_varchar.feature
+++ b/python/pysail/tests/spark/function/features/to_varchar.feature
@@ -1,0 +1,43 @@
+Feature: to_varchar with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: to_varchar — the argument must be foldable
+
+    @column_args
+    Scenario: to_varchar with the argument as a literal
+      When query
+        """
+        SELECT to_varchar(454, '999') AS result
+        """
+      Then query result ordered
+        | result |
+        | 454    |
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['454', '454'].
+    @column_args @sail-bug
+    Scenario: to_varchar takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT to_varchar(454, c) AS result FROM VALUES (1, '999'), (2, '000D00') AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['454', '454'].
+    @column_args @sail-bug
+    Scenario: to_varchar takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT to_varchar(454, c) AS result FROM VALUES (1, '999'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['454', '454'].
+    @column_args @sail-bug
+    Scenario: to_varchar takes argument 2 from a column
+      When query
+        """
+        SELECT to_varchar(454, c) AS result FROM VALUES (1, '999'), (2, '999') AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT

--- a/python/pysail/tests/spark/function/features/trunc.feature
+++ b/python/pysail/tests/spark/function/features/trunc.feature
@@ -1,0 +1,40 @@
+Feature: trunc with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: trunc — the argument may come from a column
+
+    @column_args
+    Scenario: trunc with the argument as a literal
+      When query
+        """
+        SELECT trunc('2009-02-12', 'MM') AS result
+        """
+      Then query result ordered
+        | result     |
+        | 2009-02-01 |
+
+    # Sail rejects the column: Sail errors: Granularity of `date_trunc` must be non-null scalar Utf8
+    @column_args @sail-bug
+    Scenario: trunc takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT trunc('2009-02-12', c) AS result FROM VALUES (1, 'MM'), (2, 'week') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result     |
+        | 2009-02-01 |
+        | 2009-02-09 |
+
+    # Sail rejects the column: Sail errors: Granularity of `date_trunc` must be non-null scalar Utf8
+    @column_args @sail-bug
+    Scenario: trunc takes argument 2 from a column
+      When query
+        """
+        SELECT trunc('2019-08-04', c) AS result FROM VALUES (1, 'week'), (2, 'week') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result     |
+        | 2019-07-29 |
+        | 2019-07-29 |

--- a/python/pysail/tests/spark/function/features/try_aes_decrypt.feature
+++ b/python/pysail/tests/spark/function/features/try_aes_decrypt.feature
@@ -1,0 +1,64 @@
+Feature: try_aes_decrypt with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: try_aes_decrypt — the argument is resolved per row, not taken from the first row
+
+    @column_args
+    Scenario: try_aes_decrypt with the argument as a literal
+      When query
+        """
+        SELECT hex(try_aes_decrypt(unhex('6E7CA17BBB468D3084B5744BCA729FB7B2B7BCB8E4472847D02670489D95FA97DBBA7D3210'), '0000111122223333', 'GCM')) AS result
+        """
+      Then query result ordered
+        | result             |
+        | 537061726B2053514C |
+
+    # Sail returns the wrong value on the column path: Sail returns NULL for every row.
+    @column_args @sail-bug
+    Scenario: try_aes_decrypt takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT hex(try_aes_decrypt(unhex('6E7CA17BBB468D3084B5744BCA729FB7B2B7BCB8E4472847D02670489D95FA97DBBA7D3210'), c, 'GCM')) AS result FROM VALUES (1, '0000111122223333'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result             |
+        | 537061726B2053514C |
+        | NULL               |
+
+    # Sail returns the wrong value on the column path: Sail returns NULL for every row.
+    @column_args @sail-bug
+    Scenario: try_aes_decrypt takes argument 2 from a column
+      When query
+        """
+        SELECT hex(try_aes_decrypt(unhex('6E7CA17BBB468D3084B5744BCA729FB7B2B7BCB8E4472847D02670489D95FA97DBBA7D3210'), c, 'GCM')) AS result FROM VALUES (1, '0000111122223333'), (2, '0000111122223333') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result             |
+        | 537061726B2053514C |
+        | 537061726B2053514C |
+
+    # Sail returns the wrong value on the column path: Sail returns NULL for every row.
+    @column_args @sail-bug
+    Scenario: try_aes_decrypt takes argument 3 from a column containing NULL
+      When query
+        """
+        SELECT hex(try_aes_decrypt(unhex('6E7CA17BBB468D3084B5744BCA729FB7B2B7BCB8E4472847D02670489D95FA97DBBA7D3210'), '0000111122223333', c)) AS result FROM VALUES (1, 'GCM'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result             |
+        | 537061726B2053514C |
+        | NULL               |
+
+    # Sail returns the wrong value on the column path: Sail returns NULL for every row.
+    @column_args @sail-bug
+    Scenario: try_aes_decrypt takes argument 3 from a column
+      When query
+        """
+        SELECT hex(try_aes_decrypt(unhex('6E7CA17BBB468D3084B5744BCA729FB7B2B7BCB8E4472847D02670489D95FA97DBBA7D3210'), '0000111122223333', c)) AS result FROM VALUES (1, 'GCM'), (2, 'GCM') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result             |
+        | 537061726B2053514C |
+        | 537061726B2053514C |

--- a/python/pysail/tests/spark/function/features/try_to_binary.feature
+++ b/python/pysail/tests/spark/function/features/try_to_binary.feature
@@ -1,0 +1,57 @@
+Feature: try_to_binary with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: try_to_binary — the argument is resolved per row, not taken from the first row
+
+    @column_args
+    Scenario: try_to_binary with the argument as a literal
+      When query
+        """
+        SELECT hex(try_to_binary('abc', 'utf-8')) AS result
+        """
+      Then query result ordered
+        | result |
+        | 616263 |
+
+    # Sail returns the wrong value on the column path: Sail returns NULL for every row.
+    @column_args @sail-bug
+    Scenario: try_to_binary takes argument 1 from a column holding two different values
+      When query
+        """
+        select hex(try_to_binary(c, 'base64')) AS result FROM VALUES (1, 'a!'), (2, 'abc') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result |
+        | NULL   |
+        | 69B7   |
+
+  Rule: try_to_binary — the argument must be foldable
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns NULL for every row.
+    @column_args @sail-bug
+    Scenario: try_to_binary takes argument 2 from a column holding two different values
+      When query
+        """
+        select try_to_binary('a!', c) AS result FROM VALUES (1, 'base64'), (2, 'utf-8') AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns NULL for every row.
+    @column_args @sail-bug
+    Scenario: try_to_binary takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT try_to_binary('abc', c) AS result FROM VALUES (1, 'utf-8'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns NULL for every row.
+    @column_args @sail-bug
+    Scenario: try_to_binary takes argument 2 from a column
+      When query
+        """
+        SELECT try_to_binary('abc', c) AS result FROM VALUES (1, 'utf-8'), (2, 'utf-8') AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT

--- a/python/pysail/tests/spark/function/features/try_variant_get.feature
+++ b/python/pysail/tests/spark/function/features/try_variant_get.feature
@@ -1,0 +1,40 @@
+Feature: try_variant_get with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: try_variant_get — the argument may come from a column
+
+    @column_args
+    Scenario: try_variant_get with the argument as a literal
+      When query
+        """
+        SELECT try_variant_get(parse_json('[1, "hello"]'), '$[1]') AS result
+        """
+      Then query result ordered
+        | result  |
+        | "hello" |
+
+    # Sail rejects the column: Sail errors: Spark `try_variant_get` function: path must be a constant string
+    @column_args @sail-bug
+    Scenario: try_variant_get takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT try_variant_get(parse_json('[1, "hello"]'), c) AS result FROM VALUES (1, '$[1]'), (2, '$.a') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result  |
+        | "hello" |
+        | NULL    |
+
+    # Sail rejects the column: Sail errors: Spark `try_variant_get` function: path must be a constant string
+    @column_args @sail-bug
+    Scenario: try_variant_get takes argument 2 from a column
+      When query
+        """
+        SELECT try_variant_get(parse_json('[1, "hello"]'), c) AS result FROM VALUES (1, '$[1]'), (2, '$[1]') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result  |
+        | "hello" |
+        | "hello" |

--- a/python/pysail/tests/spark/function/features/unix_timestamp.feature
+++ b/python/pysail/tests/spark/function/features/unix_timestamp.feature
@@ -1,0 +1,28 @@
+Feature: unix_timestamp with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: unix_timestamp — the argument may come from a column
+
+    @column_args
+    Scenario: unix_timestamp with the argument as a literal
+      When query
+        """
+        SELECT unix_timestamp('2016-04-08', 'yyyy-MM-dd') AS result
+        """
+      Then query result ordered
+        | result     |
+        | 1460073600 |
+
+    # Sail rejects the column: Sail errors: Unsupported data type Array(StringArray [ "%Y-%m-%d", "%Y-%m-%d", ]) for function to_times...
+    @column_args @sail-bug
+    Scenario: unix_timestamp takes argument 2 from a column
+      When query
+        """
+        SELECT unix_timestamp('2016-04-08', c) AS result FROM VALUES (1, 'yyyy-MM-dd'), (2, 'yyyy-MM-dd') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result     |
+        | 1460073600 |
+        | 1460073600 |

--- a/python/pysail/tests/spark/function/features/variant_get.feature
+++ b/python/pysail/tests/spark/function/features/variant_get.feature
@@ -1,0 +1,40 @@
+Feature: variant_get with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: variant_get — the argument may come from a column
+
+    @column_args
+    Scenario: variant_get with the argument as a literal
+      When query
+        """
+        SELECT variant_get(parse_json('[1, "hello"]'), '$[1]') AS result
+        """
+      Then query result ordered
+        | result  |
+        | "hello" |
+
+    # Sail rejects the column: Sail errors: Spark `variant_get` function: path must be a constant string
+    @column_args @sail-bug
+    Scenario: variant_get takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT variant_get(parse_json('[1, "hello"]'), c) AS result FROM VALUES (1, '$[1]'), (2, '$.a') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result  |
+        | "hello" |
+        | NULL    |
+
+    # Sail rejects the column: Sail errors: Spark `variant_get` function: path must be a constant string
+    @column_args @sail-bug
+    Scenario: variant_get takes argument 2 from a column
+      When query
+        """
+        SELECT variant_get(parse_json('[1, "hello"]'), c) AS result FROM VALUES (1, '$[1]'), (2, '$[1]') AS t(i, c) ORDER BY i
+        """
+      Then query result ordered
+        | result  |
+        | "hello" |
+        | "hello" |

--- a/python/pysail/tests/spark/function/features/xpath.feature
+++ b/python/pysail/tests/spark/function/features/xpath.feature
@@ -68,3 +68,42 @@ Feature: xpath() extracts XML nodes with Spark-compatible semantics
         SELECT xpath('<a><b>1</b></a>', 'sum(a/b)') AS result
         """
       Then query error (?s).*NodeList.*
+
+  Rule: xpath — the argument must be foldable
+
+    @column_args
+    Scenario: xpath with the argument as a literal
+      When query
+        """
+        SELECT xpath('<a><b>b1</b><b>b2</b><b>b3</b><c>c1</c><c>c2</c></a>','a/b') AS result
+        """
+      Then query result ordered
+        | result             |
+        | [NULL, NULL, NULL] |
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ["['b1', 'b2', 'b3']", '[None, None, None]'].
+    @column_args @sail-bug
+    Scenario: xpath takes argument 2 from a column holding two different values
+      When query
+        """
+        SELECT xpath('<a><b>b1</b><b>b2</b><b>b3</b><c>c1</c><c>c2</c></a>', c) AS result FROM VALUES (1, 'a/b/text()'), (2, 'a/b') AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['[None, None, None]', 'NULL'].
+    @column_args @sail-bug
+    Scenario: xpath takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT xpath('<a><b>b1</b><b>b2</b><b>b3</b><c>c1</c><c>c2</c></a>', c) AS result FROM VALUES (1, 'a/b'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['[None, None, None]', '[None, None, None]'].
+    @column_args @sail-bug
+    Scenario: xpath takes argument 2 from a column
+      When query
+        """
+        SELECT xpath('<a><b>b1</b><b>b2</b><b>b3</b><c>c1</c><c>c2</c></a>', c) AS result FROM VALUES (1, 'a/b'), (2, 'a/b') AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT

--- a/python/pysail/tests/spark/function/features/xpath_boolean.feature
+++ b/python/pysail/tests/spark/function/features/xpath_boolean.feature
@@ -1,0 +1,34 @@
+Feature: xpath_boolean with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: xpath_boolean — the argument must be foldable
+
+    @column_args
+    Scenario: xpath_boolean with the argument as a literal
+      When query
+        """
+        SELECT xpath_boolean('<a><b>1</b></a>','a/b') AS result
+        """
+      Then query result ordered
+        | result |
+        | true   |
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['True', 'NULL'].
+    @column_args @sail-bug
+    Scenario: xpath_boolean takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT xpath_boolean('<a><b>1</b></a>', c) AS result FROM VALUES (1, 'a/b'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['True', 'True'].
+    @column_args @sail-bug
+    Scenario: xpath_boolean takes argument 2 from a column
+      When query
+        """
+        SELECT xpath_boolean('<a><b>1</b></a>', c) AS result FROM VALUES (1, 'a/b'), (2, 'a/b') AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT

--- a/python/pysail/tests/spark/function/features/xpath_double.feature
+++ b/python/pysail/tests/spark/function/features/xpath_double.feature
@@ -1,0 +1,34 @@
+Feature: xpath_double with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: xpath_double — the argument must be foldable
+
+    @column_args
+    Scenario: xpath_double with the argument as a literal
+      When query
+        """
+        SELECT xpath_double('<a><b>1</b><b>2</b></a>', 'sum(a/b)') AS result
+        """
+      Then query result ordered
+        | result |
+        | 3.0    |
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', 'NULL'].
+    @column_args @sail-bug
+    Scenario: xpath_double takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT xpath_double('<a><b>1</b><b>2</b></a>', c) AS result FROM VALUES (1, 'sum(a/b)'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', '3.0'].
+    @column_args @sail-bug
+    Scenario: xpath_double takes argument 2 from a column
+      When query
+        """
+        SELECT xpath_double('<a><b>1</b><b>2</b></a>', c) AS result FROM VALUES (1, 'sum(a/b)'), (2, 'sum(a/b)') AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT

--- a/python/pysail/tests/spark/function/features/xpath_float.feature
+++ b/python/pysail/tests/spark/function/features/xpath_float.feature
@@ -1,0 +1,34 @@
+Feature: xpath_float with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: xpath_float — the argument must be foldable
+
+    @column_args
+    Scenario: xpath_float with the argument as a literal
+      When query
+        """
+        SELECT xpath_float('<a><b>1</b><b>2</b></a>', 'sum(a/b)') AS result
+        """
+      Then query result ordered
+        | result |
+        | 3.0    |
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', 'NULL'].
+    @column_args @sail-bug
+    Scenario: xpath_float takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT xpath_float('<a><b>1</b><b>2</b></a>', c) AS result FROM VALUES (1, 'sum(a/b)'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', '3.0'].
+    @column_args @sail-bug
+    Scenario: xpath_float takes argument 2 from a column
+      When query
+        """
+        SELECT xpath_float('<a><b>1</b><b>2</b></a>', c) AS result FROM VALUES (1, 'sum(a/b)'), (2, 'sum(a/b)') AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT

--- a/python/pysail/tests/spark/function/features/xpath_int.feature
+++ b/python/pysail/tests/spark/function/features/xpath_int.feature
@@ -1,0 +1,34 @@
+Feature: xpath_int with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: xpath_int — the argument must be foldable
+
+    @column_args
+    Scenario: xpath_int with the argument as a literal
+      When query
+        """
+        SELECT xpath_int('<a><b>1</b><b>2</b></a>', 'sum(a/b)') AS result
+        """
+      Then query result ordered
+        | result |
+        | 3      |
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', 'NULL'].
+    @column_args @sail-bug
+    Scenario: xpath_int takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT xpath_int('<a><b>1</b><b>2</b></a>', c) AS result FROM VALUES (1, 'sum(a/b)'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', '3'].
+    @column_args @sail-bug
+    Scenario: xpath_int takes argument 2 from a column
+      When query
+        """
+        SELECT xpath_int('<a><b>1</b><b>2</b></a>', c) AS result FROM VALUES (1, 'sum(a/b)'), (2, 'sum(a/b)') AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT

--- a/python/pysail/tests/spark/function/features/xpath_long.feature
+++ b/python/pysail/tests/spark/function/features/xpath_long.feature
@@ -1,0 +1,34 @@
+Feature: xpath_long with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: xpath_long — the argument must be foldable
+
+    @column_args
+    Scenario: xpath_long with the argument as a literal
+      When query
+        """
+        SELECT xpath_long('<a><b>1</b><b>2</b></a>', 'sum(a/b)') AS result
+        """
+      Then query result ordered
+        | result |
+        | 3      |
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', 'NULL'].
+    @column_args @sail-bug
+    Scenario: xpath_long takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT xpath_long('<a><b>1</b><b>2</b></a>', c) AS result FROM VALUES (1, 'sum(a/b)'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', '3'].
+    @column_args @sail-bug
+    Scenario: xpath_long takes argument 2 from a column
+      When query
+        """
+        SELECT xpath_long('<a><b>1</b><b>2</b></a>', c) AS result FROM VALUES (1, 'sum(a/b)'), (2, 'sum(a/b)') AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT

--- a/python/pysail/tests/spark/function/features/xpath_number.feature
+++ b/python/pysail/tests/spark/function/features/xpath_number.feature
@@ -1,0 +1,34 @@
+Feature: xpath_number with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: xpath_number — the argument must be foldable
+
+    @column_args
+    Scenario: xpath_number with the argument as a literal
+      When query
+        """
+        SELECT xpath_number('<a><b>1</b><b>2</b></a>', 'sum(a/b)') AS result
+        """
+      Then query result ordered
+        | result |
+        | 3.0    |
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', 'NULL'].
+    @column_args @sail-bug
+    Scenario: xpath_number takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT xpath_number('<a><b>1</b><b>2</b></a>', c) AS result FROM VALUES (1, 'sum(a/b)'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', '3.0'].
+    @column_args @sail-bug
+    Scenario: xpath_number takes argument 2 from a column
+      When query
+        """
+        SELECT xpath_number('<a><b>1</b><b>2</b></a>', c) AS result FROM VALUES (1, 'sum(a/b)'), (2, 'sum(a/b)') AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT

--- a/python/pysail/tests/spark/function/features/xpath_short.feature
+++ b/python/pysail/tests/spark/function/features/xpath_short.feature
@@ -1,0 +1,34 @@
+Feature: xpath_short with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: xpath_short — the argument must be foldable
+
+    @column_args
+    Scenario: xpath_short with the argument as a literal
+      When query
+        """
+        SELECT xpath_short('<a><b>1</b><b>2</b></a>', 'sum(a/b)') AS result
+        """
+      Then query result ordered
+        | result |
+        | 3      |
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', 'NULL'].
+    @column_args @sail-bug
+    Scenario: xpath_short takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT xpath_short('<a><b>1</b><b>2</b></a>', c) AS result FROM VALUES (1, 'sum(a/b)'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', '3'].
+    @column_args @sail-bug
+    Scenario: xpath_short takes argument 2 from a column
+      When query
+        """
+        SELECT xpath_short('<a><b>1</b><b>2</b></a>', c) AS result FROM VALUES (1, 'sum(a/b)'), (2, 'sum(a/b)') AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT

--- a/python/pysail/tests/spark/function/features/xpath_string.feature
+++ b/python/pysail/tests/spark/function/features/xpath_string.feature
@@ -1,0 +1,34 @@
+Feature: xpath_string with an argument coming from a column
+  # A behaviour-governing argument given as a literal is constant-folded, so the literal
+  # scenarios never exercise the columnar kernel. These scenarios pass the same argument
+  # through a column. All expected values were captured on Spark JVM 4.1.1.
+
+  Rule: xpath_string — the argument must be foldable
+
+    @column_args
+    Scenario: xpath_string with the argument as a literal
+      When query
+        """
+        SELECT xpath_string('<a><b>b</b><c>cc</c></a>','a/c') AS result
+        """
+      Then query result ordered
+        | result |
+        | cc     |
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['cc', 'NULL'].
+    @column_args @sail-bug
+    Scenario: xpath_string takes argument 2 from a column containing NULL
+      When query
+        """
+        SELECT xpath_string('<a><b>b</b><c>cc</c></a>', c) AS result FROM VALUES (1, 'a/c'), (2, NULL) AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT
+
+    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['cc', 'cc'].
+    @column_args @sail-bug
+    Scenario: xpath_string takes argument 2 from a column
+      When query
+        """
+        SELECT xpath_string('<a><b>b</b><c>cc</c></a>', c) AS result FROM VALUES (1, 'a/c'), (2, 'a/c') AS t(i, c) ORDER BY i
+        """
+      Then query error NON_FOLDABLE_INPUT


### PR DESCRIPTION
Our Spark-semantics fixes live in the plan builder and match on `Expr::Literal`. When the same value arrives as a column, that code never runs and the query falls through to the raw DataFusion function, which usually demands a scalar. Literals are also constant-folded, so a scenario written with a literal often never exercises the columnar kernel at all -- the path production actually takes.

The scenarios are derived from Spark's own `DESCRIBE FUNCTION EXTENDED` examples, with one literal argument at a time lifted into a two-row column. Every expected value was captured on Spark JVM 4.1.1, and every divergence was re-checked with the argument inlined as a literal, so that a plain value divergence is not misreported as a column bug.

Adds 129 scenarios over 37 feature files, all tagged `@column_args`. Each function also gets an untagged literal control that is green on both engines, so the file itself shows the gap: the literal passes, the column does not. The 88 divergent scenarios are tagged `@sail-bug` and carry a comment stating what Sail does today: 8 apply the first row's argument to every row (wrong data, no error), 3 return NULL for every row, 18 reject the column outright, and 14 accept a column where Spark requires a foldable argument.

No production code is changed.