### PR TITLE
fix: resolve `next_day` day names per row and stop trimming them

### DIFF
--- a/crates/sail-function/src/scalar/datetime/spark_next_day.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_next_day.rs
@@ -119,53 +119,20 @@ impl ScalarUDFImpl for SparkNextDay {
                 }
             }
             (ColumnarValue::Array(date_array), ColumnarValue::Array(day_of_week_array)) => {
-                let result = match (date_array.data_type(), day_of_week_array.data_type()) {
-                    (
-                        DataType::Date32,
-                        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View,
-                    ) => {
-                        let date_array: &Date32Array = date_array.as_primitive::<Date32Type>();
-                        match day_of_week_array.data_type() {
-                            DataType::Utf8 => {
-                                let day_of_week_array = day_of_week_array.as_string::<i32>();
-                                process_next_day_arrays(
-                                    date_array,
-                                    day_of_week_array,
-                                    self.ansi_mode,
-                                )
-                            }
-                            DataType::LargeUtf8 => {
-                                let day_of_week_array = day_of_week_array.as_string::<i64>();
-                                process_next_day_arrays(
-                                    date_array,
-                                    day_of_week_array,
-                                    self.ansi_mode,
-                                )
-                            }
-                            DataType::Utf8View => {
-                                let day_of_week_array = day_of_week_array.as_string_view();
-                                process_next_day_arrays(
-                                    date_array,
-                                    day_of_week_array,
-                                    self.ansi_mode,
-                                )
-                            }
-                            other => {
-                                exec_err!(
-                                    "Spark `next_day` function: second arg must be string. Got {other:?}"
-                                )
-                            }
-                        }
-                    }
-                    (left, right) => {
-                        exec_err!(
-                            "Spark `next_day` function: first arg must be date, second arg must be string. Got {left:?}, {right:?}"
-                        )
-                    }
-                }?;
-                Ok(ColumnarValue::Array(result))
+                Ok(ColumnarValue::Array(next_day_arrays(
+                    date_array,
+                    day_of_week_array,
+                    self.ansi_mode,
+                )?))
             }
-            _ => exec_err!("Unsupported args {args:?} for Spark function `next_day`"),
+            (ColumnarValue::Scalar(date), ColumnarValue::Array(day_of_week_array)) => {
+                let date_array = date.to_array_of_size(day_of_week_array.len())?;
+                Ok(ColumnarValue::Array(next_day_arrays(
+                    &date_array,
+                    day_of_week_array,
+                    self.ansi_mode,
+                )?))
+            }
         }
     }
 
@@ -212,6 +179,34 @@ impl ScalarUDFImpl for SparkNextDay {
     }
 }
 
+/// Shared by the `(array, array)` and `(scalar, array)` cases: a literal date
+/// combined with a day-of-week column must still resolve row by row.
+fn next_day_arrays(
+    date_array: &ArrayRef,
+    day_of_week_array: &ArrayRef,
+    ansi_mode: bool,
+) -> Result<ArrayRef> {
+    let DataType::Date32 = date_array.data_type() else {
+        return exec_err!(
+            "Spark `next_day` function: first arg must be date. Got {:?}",
+            date_array.data_type()
+        );
+    };
+    let date_array: &Date32Array = date_array.as_primitive::<Date32Type>();
+    match day_of_week_array.data_type() {
+        DataType::Utf8 => {
+            process_next_day_arrays(date_array, day_of_week_array.as_string::<i32>(), ansi_mode)
+        }
+        DataType::LargeUtf8 => {
+            process_next_day_arrays(date_array, day_of_week_array.as_string::<i64>(), ansi_mode)
+        }
+        DataType::Utf8View => {
+            process_next_day_arrays(date_array, day_of_week_array.as_string_view(), ansi_mode)
+        }
+        other => exec_err!("Spark `next_day` function: second arg must be string. Got {other:?}"),
+    }
+}
+
 fn process_next_day_arrays<'a, S>(
     date_array: &Date32Array,
     day_of_week_array: &'a S,
@@ -238,11 +233,14 @@ where
 
 /// Parse a day-of-week string into a `Weekday`. Returns `None` for invalid names.
 ///
+/// Matching is case-insensitive but NOT whitespace-insensitive: Spark treats a
+/// padded name such as `"MON "` as invalid, so the input must not be trimmed.
+///
 /// Invalid-name handling is ANSI-mode-dependent — callers must translate the
 /// `None` into either an error (ANSI=true) or a NULL result (ANSI=false)
 /// via [`illegal_day_of_week_err`].
 fn parse_day_of_week(day_of_week: &str) -> Option<Weekday> {
-    let upper = day_of_week.trim().to_uppercase();
+    let upper = day_of_week.to_uppercase();
     match upper.as_str() {
         "MO" | "MON" | "MONDAY" => Some(Weekday::Mon),
         "TU" | "TUE" | "TUESDAY" => Some(Weekday::Tue),

--- a/python/pysail/tests/spark/function/features/next_day.feature
+++ b/python/pysail/tests/spark/function/features/next_day.feature
@@ -1,3 +1,4 @@
+@next_day
 Feature: next_day comprehensive tests
 
   Rule: Argument count validation
@@ -166,6 +167,64 @@ Feature: next_day comprehensive tests
         | result     |
         | 2024-01-15 |
 
+    # Spark applies toUpperCase(Locale.ROOT), i.e. full Unicode case folding, so a
+    # non-ASCII letter that upper-cases into a day-name letter is valid. Exactly two
+    # codepoints are reachable: U+0131 (dotless i) -> 'I' and U+017F (long s) -> 'S'.
+    # These two scenarios pin that behaviour. An ASCII-only compare
+    # (eq_ignore_ascii_case) to save the parser's per-row allocation must therefore
+    # stay behind an `is_ascii()` guard, or it silently diverges from Spark here.
+    Scenario: next_day matches a day name containing a dotless i
+      When query
+        """
+        SELECT next_day(DATE'2024-01-10', 'frıday') AS result
+        """
+      Then query result
+        | result     |
+        | 2024-01-12 |
+
+    Scenario: next_day matches a day name containing a long s
+      When query
+        """
+        SELECT next_day(DATE'2024-01-10', 'ſunday') AS result
+        """
+      Then query result
+        | result     |
+        | 2024-01-14 |
+
+    # Case folding is not normalisation: full-width letters do not fold to ASCII.
+    Scenario: next_day rejects a full-width day name under ANSI false
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT next_day(DATE'2024-01-10', 'ＭＯＮＤＡＹ') AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+  Rule: Surrounding whitespace is not trimmed
+
+    # Spark is case-insensitive but does NOT trim the day name: surrounding
+    # whitespace makes it invalid, exactly like an unknown name.
+
+    Scenario: next_day ANSI=true errors on a padded day name
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT next_day(DATE'2024-01-10', 'Monday ') AS result
+        """
+      Then query error .*Illegal input for day of week.*
+
+    Scenario: next_day ANSI=false returns NULL on a padded day name
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT next_day(DATE'2024-01-10', '  Monday  ') AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
   Rule: String date input coercion
 
     Scenario: next_day with string date
@@ -289,8 +348,7 @@ Feature: next_day comprehensive tests
         | result     |
         | 2015-01-20 |
 
-    # Sail rejects the column: Sail errors: Unsupported args [Scalar(Date32("2015-01-14")), Array(StringArray [ "TU", null, ])] for Sp...
-    @column_args @sail-bug
+    @column_args
     Scenario: next_day takes argument 2 from a column containing NULL
       When query
         """
@@ -301,8 +359,7 @@ Feature: next_day comprehensive tests
         | 2015-01-20 |
         | NULL       |
 
-    # Sail rejects the column: Sail errors: Unsupported args [Scalar(Date32("2015-01-14")), Array(StringArray [ "TU", "TU", ])] for Sp...
-    @column_args @sail-bug
+    @column_args
     Scenario: next_day takes argument 2 from a column
       When query
         """
@@ -313,7 +370,7 @@ Feature: next_day comprehensive tests
         | 2015-01-20 |
         | 2015-01-20 |
 
-    @column_args @sail-bug
+    @column_args
     Scenario: next_day takes argument 2 from a column holding two different values
       When query
         """


### PR DESCRIPTION
next_day handled (scalar,scalar), (array,scalar) and (array,array) but not (scalar,array), so a literal date with the day name in a column fell through to a catch-all error leaking Rust Debug output. Share the array path between both cases, which also makes the match exhaustive and removes the catch-all.

parse_day_of_week trimmed the day name; Spark does not, so 'MON ' must be invalid like any unknown name. Matching stays case-insensitive.