### PR TITLE
test: fix Delta location for Windows

### DIFF
--- a/python/pysail/tests/spark/execution/features/lakehouse_commit.feature
+++ b/python/pysail/tests/spark/execution/features/lakehouse_commit.feature
@@ -11,7 +11,7 @@ Feature: Lakehouse commits in distributed execution
         """
         CREATE TABLE distributed_delta_commit (id BIGINT)
         USING delta
-        LOCATION {{ location.uri }}
+        LOCATION {{ location.sql }}
         """
 
     Scenario: Delta commit runs on the driver after parallel file writing


### PR DESCRIPTION
It seems that for BDD tests we need `LOCATION {{ location.sql }}` for Delta tables but `LOCATION {{ location.uri }}` for Iceberg tables.