### PR TITLE
test: skip Spark 3 Writer V2 provider test

### DIFF
--- a/scripts/spark-tests/plugins/spark.py
+++ b/scripts/spark-tests/plugins/spark.py
@@ -423,6 +423,14 @@ SKIPPED_SPARK_TESTS = [
         reason="Spark 3.x doctest uses the JVM-dependent RDD API",
         spark_major_version_less_than=4,
     ),
+    TestMarker(
+        keywords=["test_parity_readwriter.py", "test_create_without_provider"],
+        reason=(
+            "Spark 3 requires Hive when no provider is specified, while Spark 4 uses the default provider; "
+            "Sail follows Spark 4"
+        ),
+        spark_major_version_less_than=4,
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

Skip the Spark 3 `test_create_without_provider` compatibility test because Sail intentionally follows Spark 4 behavior when Writer V2 table creation omits a provider.

## Why

[Spark 3.5.7 expects](https://github.com/apache/spark/blob/v3.5.7/python/pyspark/sql/tests/test_readwriter.py#L249-L257) `df.writeTo("test_table").create()` to raise `NOT_SUPPORTED_COMMAND_WITHOUT_HIVE_SUPPORT`. In Spark 3.5.7, [`spark.sql.legacy.createHiveTableByDefault` defaults to `true`](https://github.com/apache/spark/blob/v3.5.7/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L4161-L4168), so omitting the provider selects the legacy Hive path.

[Spark 4.0 expects](https://github.com/apache/spark/blob/v4.0.0/python/pyspark/sql/tests/test_readwriter.py#L314-L318) the same call to create the table successfully. Spark 4 changed the legacy setting to [default to `false`](https://github.com/apache/spark/blob/v4.0.0/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L5016-L5023), so provider-less creation uses [`spark.sql.sources.default`, which defaults to Parquet](https://github.com/apache/spark/blob/v4.0.0/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala#L1599-L1604).

Sail must choose one behavior for both compatibility suites. Its existing behavior matches Spark 4 by using the configured default table format, so the Spark 3-only expectation is skipped rather than changing Sail to the legacy behavior.