### PR TITLE
fix: spark-compatible xpath — foldable path, first-node semantics, XPath 1.0 numbers

### DIFF
--- a/crates/sail-function/src/scalar/xml/xpath_typed.rs
+++ b/crates/sail-function/src/scalar/xml/xpath_typed.rs
@@ -8,7 +8,7 @@ use datafusion::arrow::datatypes::DataType;
 use datafusion_common::utils::take_function_args;
 use datafusion_common::{DataFusionError, Result, plan_err};
 use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
-use xee_xpath::{Documents, Queries, Query};
+use xee_xpath::{Documents, Item, Queries, Query};
 
 use crate::functions_utils::make_scalar_function;
 
@@ -163,29 +163,59 @@ fn evaluate_xpath_boolean(xml: &str, path: &str) -> Result<Option<bool>> {
     Ok(Some(result))
 }
 
+/// XPath 1.0's number grammar: an optional minus, then digits with an optional fraction, or a bare
+/// fraction. **No exponent and no `INF`** — anything else is NaN. XPath 2.0, which `xee` implements,
+/// would happily read `INF` and `1.5e2`, so Spark and Sail disagree unless the string is parsed by
+/// the 1.0 rules.
+fn xpath1_number(value: &str) -> f64 {
+    let value = value.trim();
+    let digits = value.strip_prefix('-').unwrap_or(value);
+    let well_formed = digits.chars().any(|c| c.is_ascii_digit())
+        && digits.chars().all(|c| c.is_ascii_digit() || c == '.')
+        && digits.matches('.').count() <= 1;
+    if well_formed {
+        value.parse::<f64>().unwrap_or(f64::NAN)
+    } else {
+        f64::NAN
+    }
+}
+
 fn evaluate_xpath_number(xml: &str, path: &str) -> Result<Option<f64>> {
     if xml.is_empty() || path.is_empty() {
         return Ok(None);
     }
-    let wrapped = format!("number({path})");
+    // Spark evaluates the path with XPath 1.0, where a node becomes a number through its string
+    // value (see `xpath1_number`), and where the node-set collapses to its FIRST node — XPath 2.0
+    // would reject a sequence of more than one item with XPTY0004. An atomic result (`sum()`,
+    // `count()`) is already a number and keeps its precision.
+    let wrapped = format!("({path})[1]");
     let mut documents = Documents::new();
     let document = documents
         .add_string_without_uri(xml)
         .map_err(|e| DataFusionError::Execution(format!("Invalid XML document: {e}")))?;
     let query = Queries::default()
-        .one(&wrapped, |_, item| Ok(item.try_into_value::<f64>()?))
+        .option(
+            &wrapped,
+            |documents: &mut Documents, item: &Item| match item {
+                Item::Node(node) => Ok(xpath1_number(&documents.xot().string_value(*node))),
+                _ => Ok(item.try_into_value::<f64>().unwrap_or(f64::NAN)),
+            },
+        )
         .map_err(|e| DataFusionError::Execution(format!("Invalid XPath '{path}': {e}")))?;
     let result = query
         .execute(&mut documents, document)
         .map_err(|e| DataFusionError::Execution(format!("Error evaluating XPath '{path}': {e}")))?;
-    Ok(Some(result))
+    // An empty node-set is NaN in XPath 1.0, not a missing value.
+    Ok(Some(result.unwrap_or(f64::NAN)))
 }
 
 fn evaluate_xpath_string(xml: &str, path: &str) -> Result<Option<String>> {
     if xml.is_empty() || path.is_empty() {
         return Ok(None);
     }
-    let wrapped = format!("string({path})");
+    // As in `evaluate_xpath_number`: XPath 1.0 `string()` takes the first node, XPath 2.0+ errors
+    // on a sequence of more than one item.
+    let wrapped = format!("string(({path})[1])");
     let mut documents = Documents::new();
     let document = documents
         .add_string_without_uri(xml)
@@ -281,7 +311,10 @@ fn build_int16_array(xmls: &StringArray, paths: &StringArray) -> Result<ArrayRef
             builder.append_null();
         } else {
             match evaluate_xpath_number(xmls.value(row), paths.value(row))? {
-                Some(v) => builder.append_value(v as i16),
+                // Spark narrows the double the Java way, `(short) (int) value`: `double -> int`
+                // saturates, and `int -> short` then truncates the bits. Rust's `as i16` would
+                // saturate at 32767 / -32768 instead, so 99999 must come out as -31073.
+                Some(v) => builder.append_value(v as i32 as i16),
                 None => builder.append_null(),
             }
         }

--- a/crates/sail-plan/src/function/scalar/xml.rs
+++ b/crates/sail-plan/src/function/scalar/xml.rs
@@ -1,3 +1,4 @@
+use datafusion_common::ScalarValue;
 use datafusion_expr::{Expr, ScalarUDF, expr};
 use sail_common_datafusion::literal::LiteralEvaluator;
 use sail_common_datafusion::utils::items::ItemTaker;
@@ -6,11 +7,43 @@ use sail_function::scalar::xml::to_xml::SparkToXml;
 use sail_function::scalar::xml::xpath::Xpath;
 use sail_function::scalar::xml::xpath_typed::{XpathTyped, XpathTypedKind};
 
-use crate::error::PlanResult;
+use crate::error::{PlanError, PlanResult};
 use crate::function::common::{ScalarFunction, ScalarFunctionInput};
+
+/// Spark compiles the XPath once, when it analyzes the query, so it requires the `path` argument
+/// to be **foldable** and rejects a per-row path with `DATATYPE_MISMATCH.NON_FOLDABLE_INPUT`. Only
+/// the path is gated: the XML itself is an ordinary column.
+///
+/// Foldable is not the same as literal. Spark's rule is that the expression references no column
+/// and is deterministic, so `concat('a', '/b')` and `substring('zza/b', 3)` are both accepted. Do
+/// not decide this by trying to evaluate the expression: evaluation needs the argument types to be
+/// coerced first, so a perfectly foldable `substring('zza/b', 3)` (whose position arrives as
+/// `Int32` against an `Int64` signature) would fail and be rejected.
+///
+/// So gate on the rule, and fold only as a bonus: folding here keeps the plan readable and hands
+/// the function a literal, and when it does not work the optimizer's constant folding gets there
+/// later anyway.
+fn foldable_path(name: &str, path: Expr) -> PlanResult<Expr> {
+    if path.any_column_refs() || path.is_volatile() {
+        return Err(PlanError::AnalysisError(format!(
+            "[DATATYPE_MISMATCH.NON_FOLDABLE_INPUT] Cannot resolve `{name}` due to data type mismatch: the input `path` should be a foldable \"STRING\" expression; however, got a non-foldable expression."
+        )));
+    }
+    if matches!(path, Expr::Literal(_, _)) {
+        return Ok(path);
+    }
+    match LiteralEvaluator::new().evaluate(&path) {
+        Ok(ScalarValue::Utf8View(v) | ScalarValue::LargeUtf8(v)) => {
+            Ok(Expr::Literal(ScalarValue::Utf8(v), None))
+        }
+        Ok(scalar) => Ok(Expr::Literal(scalar, None)),
+        Err(_) => Ok(path),
+    }
+}
 
 fn xpath(input: ScalarFunctionInput) -> PlanResult<Expr> {
     let (xml, path) = input.arguments.two()?;
+    let path = foldable_path("xpath", path)?;
     let func = Xpath::new();
     Ok(Expr::ScalarFunction(expr::ScalarFunction {
         func: std::sync::Arc::new(ScalarUDF::from(func)),
@@ -18,9 +51,13 @@ fn xpath(input: ScalarFunctionInput) -> PlanResult<Expr> {
     }))
 }
 
-fn xpath_typed(kind: XpathTypedKind) -> impl Fn(ScalarFunctionInput) -> PlanResult<Expr> {
+fn xpath_typed(
+    name: &'static str,
+    kind: XpathTypedKind,
+) -> impl Fn(ScalarFunctionInput) -> PlanResult<Expr> {
     move |input: ScalarFunctionInput| {
         let (xml, path) = input.arguments.two()?;
+        let path = foldable_path(name, path)?;
         let func = XpathTyped::new(kind);
         Ok(Expr::ScalarFunction(expr::ScalarFunction {
             func: std::sync::Arc::new(ScalarUDF::from(func)),
@@ -69,23 +106,35 @@ pub(super) fn list_built_in_xml_functions() -> Vec<(&'static str, ScalarFunction
         ("xpath", F::custom(xpath)),
         (
             "xpath_boolean",
-            F::custom(xpath_typed(XpathTypedKind::Boolean)),
+            F::custom(xpath_typed("xpath_boolean", XpathTypedKind::Boolean)),
         ),
         (
             "xpath_double",
-            F::custom(xpath_typed(XpathTypedKind::Double)),
+            F::custom(xpath_typed("xpath_double", XpathTypedKind::Double)),
         ),
-        ("xpath_float", F::custom(xpath_typed(XpathTypedKind::Float))),
-        ("xpath_int", F::custom(xpath_typed(XpathTypedKind::Int))),
-        ("xpath_long", F::custom(xpath_typed(XpathTypedKind::Long))),
+        (
+            "xpath_float",
+            F::custom(xpath_typed("xpath_float", XpathTypedKind::Float)),
+        ),
+        (
+            "xpath_int",
+            F::custom(xpath_typed("xpath_int", XpathTypedKind::Int)),
+        ),
+        (
+            "xpath_long",
+            F::custom(xpath_typed("xpath_long", XpathTypedKind::Long)),
+        ),
         (
             "xpath_number",
-            F::custom(xpath_typed(XpathTypedKind::Number)),
+            F::custom(xpath_typed("xpath_number", XpathTypedKind::Number)),
         ),
-        ("xpath_short", F::custom(xpath_typed(XpathTypedKind::Short))),
+        (
+            "xpath_short",
+            F::custom(xpath_typed("xpath_short", XpathTypedKind::Short)),
+        ),
         (
             "xpath_string",
-            F::custom(xpath_typed(XpathTypedKind::String)),
+            F::custom(xpath_typed("xpath_string", XpathTypedKind::String)),
         ),
     ]
 }

--- a/python/pysail/tests/spark/function/__snapshots__/features/xpath.yaml
+++ b/python/pysail/tests/spark/function/__snapshots__/features/xpath.yaml
@@ -1,0 +1,17 @@
+# serializer version: 1
+---
+name: "test_the_plan_folds_a_constant_expression_into_a_literal_path"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#2@0 as result]
+      ProjectionExec: expr=[xpath_string(column1@0, a/b) as #2]
+        DataSourceExec: partitions=1, partition_sizes=[1]
+---
+name: "test_the_plan_for_a_literal_path"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#2@0 as result]
+      ProjectionExec: expr=[xpath_string(column1@0, a/b) as #2]
+        DataSourceExec: partitions=1, partition_sizes=[1]

--- a/python/pysail/tests/spark/function/features/xpath.feature
+++ b/python/pysail/tests/spark/function/features/xpath.feature
@@ -1,3 +1,4 @@
+@xpath
 Feature: xpath() extracts XML nodes with Spark-compatible semantics
 
   Rule: Node selection returns arrays of string-like values
@@ -81,8 +82,7 @@ Feature: xpath() extracts XML nodes with Spark-compatible semantics
         | result             |
         | [NULL, NULL, NULL] |
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ["['b1', 'b2', 'b3']", '[None, None, None]'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath takes argument 2 from a column holding two different values
       When query
         """
@@ -90,8 +90,7 @@ Feature: xpath() extracts XML nodes with Spark-compatible semantics
         """
       Then query error NON_FOLDABLE_INPUT
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['[None, None, None]', 'NULL'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath takes argument 2 from a column containing NULL
       When query
         """
@@ -99,11 +98,64 @@ Feature: xpath() extracts XML nodes with Spark-compatible semantics
         """
       Then query error NON_FOLDABLE_INPUT
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['[None, None, None]', '[None, None, None]'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath takes argument 2 from a column
       When query
         """
         SELECT xpath('<a><b>b1</b><b>b2</b><b>b3</b><c>c1</c><c>c2</c></a>', c) AS result FROM VALUES (1, 'a/b'), (2, 'a/b') AS t(i, c) ORDER BY i
         """
       Then query error NON_FOLDABLE_INPUT
+
+  Rule: the plan folds the path
+
+    # The plan is Sail's, so it cannot be compared against Spark. These snapshots pin the invariant
+    # the foldability gate creates: the path reaches the function as a LITERAL, whether the user
+    # wrote a literal or a constant expression. Anything relying on a constant path -- compiling the
+    # XPath once per batch, for instance -- depends on this holding.
+    @sail-only
+    Scenario: the plan for a literal path
+      When query
+        """
+        EXPLAIN SELECT xpath_string(c, 'a/b') AS result FROM VALUES ('<a><b>x</b></a>') AS t(c)
+        """
+      Then query plan matches snapshot
+
+    @sail-only
+    Scenario: the plan folds a constant expression into a literal path
+      When query
+        """
+        EXPLAIN SELECT xpath_string(c, concat('a', '/b')) AS result FROM VALUES ('<a><b>x</b></a>') AS t(c)
+        """
+      Then query plan matches snapshot
+
+  Rule: xpath — a foldable path is accepted, a non-foldable one is not
+
+    # Spark requires the path to be FOLDABLE, which is not the same as literal: any expression
+    # without column references and without non-determinism qualifies.
+
+    Scenario: xpath accepts a path built by a constant expression
+      When query
+        """
+        SELECT xpath_string('<a><b>x</b></a>', substring('zza/b', 3)) AS result
+        """
+      Then query result
+        | result |
+        | x      |
+
+    Scenario: xpath rejects a non-deterministic path
+      When query
+        """
+        SELECT xpath_string('<a><b>x</b></a>', CASE WHEN rand() > 2 THEN 'a/b' ELSE 'a/b' END) AS result
+        """
+      Then query error (?s).*(NON_FOLDABLE|non-foldable).*
+
+    # Sail returns an empty array.
+    @sail-bug
+    Scenario: xpath matches through a default namespace
+      When query
+        """
+        SELECT xpath('<a xmlns="http://x"><b>v</b></a>', 'a/b/text()') AS result
+        """
+      Then query result
+        | result |
+        | [v]    |

--- a/python/pysail/tests/spark/function/features/xpath_boolean.feature
+++ b/python/pysail/tests/spark/function/features/xpath_boolean.feature
@@ -1,3 +1,4 @@
+@xpath
 Feature: xpath_boolean with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -15,8 +16,7 @@ Feature: xpath_boolean with an argument coming from a column
         | result |
         | true   |
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['True', 'NULL'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath_boolean takes argument 2 from a column containing NULL
       When query
         """
@@ -24,8 +24,7 @@ Feature: xpath_boolean with an argument coming from a column
         """
       Then query error NON_FOLDABLE_INPUT
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['True', 'True'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath_boolean takes argument 2 from a column
       When query
         """

--- a/python/pysail/tests/spark/function/features/xpath_double.feature
+++ b/python/pysail/tests/spark/function/features/xpath_double.feature
@@ -1,3 +1,4 @@
+@xpath
 Feature: xpath_double with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -15,8 +16,7 @@ Feature: xpath_double with an argument coming from a column
         | result |
         | 3.0    |
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', 'NULL'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath_double takes argument 2 from a column containing NULL
       When query
         """
@@ -24,8 +24,7 @@ Feature: xpath_double with an argument coming from a column
         """
       Then query error NON_FOLDABLE_INPUT
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', '3.0'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath_double takes argument 2 from a column
       When query
         """

--- a/python/pysail/tests/spark/function/features/xpath_float.feature
+++ b/python/pysail/tests/spark/function/features/xpath_float.feature
@@ -1,3 +1,4 @@
+@xpath
 Feature: xpath_float with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -15,8 +16,7 @@ Feature: xpath_float with an argument coming from a column
         | result |
         | 3.0    |
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', 'NULL'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath_float takes argument 2 from a column containing NULL
       When query
         """
@@ -24,8 +24,7 @@ Feature: xpath_float with an argument coming from a column
         """
       Then query error NON_FOLDABLE_INPUT
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', '3.0'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath_float takes argument 2 from a column
       When query
         """

--- a/python/pysail/tests/spark/function/features/xpath_int.feature
+++ b/python/pysail/tests/spark/function/features/xpath_int.feature
@@ -1,3 +1,4 @@
+@xpath
 Feature: xpath_int with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -15,8 +16,7 @@ Feature: xpath_int with an argument coming from a column
         | result |
         | 3      |
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', 'NULL'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath_int takes argument 2 from a column containing NULL
       When query
         """
@@ -24,8 +24,7 @@ Feature: xpath_int with an argument coming from a column
         """
       Then query error NON_FOLDABLE_INPUT
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', '3'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath_int takes argument 2 from a column
       When query
         """

--- a/python/pysail/tests/spark/function/features/xpath_long.feature
+++ b/python/pysail/tests/spark/function/features/xpath_long.feature
@@ -1,3 +1,4 @@
+@xpath
 Feature: xpath_long with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -15,8 +16,7 @@ Feature: xpath_long with an argument coming from a column
         | result |
         | 3      |
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', 'NULL'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath_long takes argument 2 from a column containing NULL
       When query
         """
@@ -24,8 +24,7 @@ Feature: xpath_long with an argument coming from a column
         """
       Then query error NON_FOLDABLE_INPUT
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', '3'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath_long takes argument 2 from a column
       When query
         """

--- a/python/pysail/tests/spark/function/features/xpath_number.feature
+++ b/python/pysail/tests/spark/function/features/xpath_number.feature
@@ -1,3 +1,4 @@
+@xpath
 Feature: xpath_number with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -15,8 +16,7 @@ Feature: xpath_number with an argument coming from a column
         | result |
         | 3.0    |
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', 'NULL'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath_number takes argument 2 from a column containing NULL
       When query
         """
@@ -24,8 +24,7 @@ Feature: xpath_number with an argument coming from a column
         """
       Then query error NON_FOLDABLE_INPUT
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', '3.0'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath_number takes argument 2 from a column
       When query
         """

--- a/python/pysail/tests/spark/function/features/xpath_short.feature
+++ b/python/pysail/tests/spark/function/features/xpath_short.feature
@@ -1,3 +1,4 @@
+@xpath
 Feature: xpath_short with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -15,8 +16,7 @@ Feature: xpath_short with an argument coming from a column
         | result |
         | 3      |
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', 'NULL'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath_short takes argument 2 from a column containing NULL
       When query
         """
@@ -24,8 +24,7 @@ Feature: xpath_short with an argument coming from a column
         """
       Then query error NON_FOLDABLE_INPUT
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', '3'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath_short takes argument 2 from a column
       When query
         """

--- a/python/pysail/tests/spark/function/features/xpath_string.feature
+++ b/python/pysail/tests/spark/function/features/xpath_string.feature
@@ -1,3 +1,4 @@
+@xpath
 Feature: xpath_string with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -15,8 +16,7 @@ Feature: xpath_string with an argument coming from a column
         | result |
         | cc     |
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['cc', 'NULL'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath_string takes argument 2 from a column containing NULL
       When query
         """
@@ -24,8 +24,7 @@ Feature: xpath_string with an argument coming from a column
         """
       Then query error NON_FOLDABLE_INPUT
 
-    # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['cc', 'cc'].
-    @column_args @sail-bug
+    @column_args
     Scenario: xpath_string takes argument 2 from a column
       When query
         """

--- a/python/pysail/tests/spark/function/features/xpath_typed.feature
+++ b/python/pysail/tests/spark/function/features/xpath_typed.feature
@@ -1,3 +1,4 @@
+@xpath
 Feature: xpath_boolean/double/float/int/long/number/short/string extract typed values from XML
 
   Rule: xpath_boolean evaluates XPath to a boolean
@@ -190,12 +191,15 @@ Feature: xpath_boolean/double/float/int/long/number/short/string extract typed v
 
   Rule: Invalid XML or XPath fails
 
+    # Both engines reject the document, with different wording: Spark says "Error loading
+    # expression", Sail says "Invalid XML document". Accept either, but still require the error
+    # to be about the document.
     Scenario: typed xpath fails on invalid XML
       When query
         """
         SELECT xpath_int('<a><b>1</b>', 'a/b') AS result
         """
-      Then query error (?s).*Invalid XML.*
+      Then query error (?s).*(Invalid XML|Error loading expression).*
 
     Scenario: typed xpath fails on invalid XPath
       When query
@@ -203,3 +207,214 @@ Feature: xpath_boolean/double/float/int/long/number/short/string extract typed v
         SELECT xpath_int('<a><b>1</b></a>', '!!!') AS result
         """
       Then query error (?s).*Invalid XPath.*
+
+  Rule: a path matching several nodes takes the first one
+
+    Scenario: xpath_string on a single element node
+      When query
+        """
+        SELECT xpath_string('<a><b>b1</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | b1     |
+
+    Scenario: xpath_string on several element nodes takes the first
+      When query
+        """
+        SELECT xpath_string('<a><b>b1</b><b>b2</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | b1     |
+
+    Scenario: xpath_int on several element nodes takes the first
+      When query
+        """
+        SELECT xpath_int('<a><b>7</b><b>8</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | 7      |
+
+    Scenario: xpath_double on several element nodes takes the first
+      When query
+        """
+        SELECT xpath_double('<a><b>1.5</b><b>2</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | 1.5    |
+
+    Scenario: xpath_boolean on several element nodes tests the node-set
+      When query
+        """
+        SELECT xpath_boolean('<a><b>1</b><b>2</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | true   |
+
+  Rule: narrowing to a SHORT wraps, it does not saturate
+
+    Scenario: xpath_short wraps a value above the short range
+      When query
+        """
+        SELECT xpath_short('<a><b>99999</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | -31073 |
+
+    Scenario: xpath_short wraps at the exact upper boundary
+      When query
+        """
+        SELECT xpath_short('<a><b>32768</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | -32768 |
+
+    Scenario: xpath_short wraps a value below the short range
+      When query
+        """
+        SELECT xpath_short('<a><b>-40000</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | 25536  |
+
+    Scenario: xpath_int saturates a value above the int range
+      When query
+        """
+        SELECT xpath_int('<a><b>99999999999</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result     |
+        | 2147483647 |
+
+  Rule: a number outside XPath 1.0's lexical space is NaN
+
+    # Spark evaluates the path with XPath 1.0, whose number grammar is only [-]digits[.digits]:
+    # no exponent, no INF. Anything else is NaN. Sail uses XPath 2.0 (xee), which accepts both.
+
+    Scenario: xpath_double of INF is NaN
+      When query
+        """
+        SELECT xpath_double('<a><b>INF</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | NaN    |
+
+    Scenario: xpath_double of -INF is NaN
+      When query
+        """
+        SELECT xpath_double('<a><b>-INF</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | NaN    |
+
+    Scenario: xpath_double of scientific notation is NaN
+      When query
+        """
+        SELECT xpath_double('<a><b>1.5e2</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | NaN    |
+
+    Scenario: xpath_double of an exponent that overflows is NaN
+      When query
+        """
+        SELECT xpath_double('<a><b>1e400</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | NaN    |
+
+    Scenario: xpath_float of an exponent is NaN
+      When query
+        """
+        SELECT xpath_float('<a><b>1e300</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | NaN    |
+
+    Scenario: xpath_int of INF is zero
+      When query
+        """
+        SELECT xpath_int('<a><b>INF</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | 0      |
+
+    Scenario: xpath_long of INF is zero
+      When query
+        """
+        SELECT xpath_long('<a><b>INF</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | 0      |
+
+    Scenario: xpath_short of INF is zero
+      When query
+        """
+        SELECT xpath_short('<a><b>INF</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | 0      |
+
+    Scenario: xpath_boolean of INF tests the node, not the number
+      When query
+        """
+        SELECT xpath_boolean('<a><b>INF</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | true   |
+
+  Rule: a default namespace does not hide the nodes
+
+    # Spark parses the document WITHOUT namespace awareness, so an unprefixed path still matches a
+    # node in a default namespace. Sail evaluates with XPath 2.0 (xee), which honours the namespace:
+    # `a/b` matches nothing and the result comes back empty (or 0, or an empty array).
+    #
+    # This is not a laboratory case: any real-world document carrying an `xmlns` -- SOAP, RSS, SVG,
+    # Atom, most industry schemas -- returns empty in Sail today.
+    #
+    # Deferred rather than patched, because none of the ways out is free:
+    #   - Rewrite the path (`a/b` -> `*:a/*:b`, "any namespace" in XPath 2.0). Emulates Spark well,
+    #     but it means parsing the XPath expression to rewrite only the name tests, leaving string
+    #     literals and function names alone.
+    #   - Strip the `xmlns` declarations from the document before parsing. Simple, but it breaks
+    #     documents that use prefixes, and it changes what the user actually passed in.
+    #   - Accept the divergence and document it.
+    # It needs a decision, so it gets its own PR.
+
+    # Sail returns an empty string.
+    @sail-bug
+    Scenario: xpath_string matches through a default namespace
+      When query
+        """
+        SELECT xpath_string('<a xmlns="http://x"><b>v</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | v      |
+
+    # Sail returns 0.
+    @sail-bug
+    Scenario: xpath_int matches through a default namespace
+      When query
+        """
+        SELECT xpath_int('<a xmlns="http://x"><b>7</b></a>', 'a/b') AS result
+        """
+      Then query result
+        | result |
+        | 7      |


### PR DESCRIPTION
The xpath family diverged from Spark in five ways. All expected values were captured on Spark JVM 4.1.1, and an 81-probe sweep of the family now agrees with Spark on 80 of them (the remaining one is namespaces, see below).

1. The path must be foldable. Spark compiles the XPath once, when it analyzes the query, so it requires `path` to be a foldable expression and rejects a per-row one with DATATYPE_MISMATCH.NON_FOLDABLE_INPUT. Sail accepted a column and evaluated it row by row. Note that foldable is not the same as literal: Spark's rule is "no column references, and deterministic", so `concat('a', '/b')` and `substring('zza/b', 3)` are both valid. Gating on `Expr::Literal` -- or on "can I evaluate it right now", which fails whenever the argument types still need coercion -- would reject queries Spark accepts. Only the path is gated; the XML is an ordinary column.

2. A path matching several nodes now takes the first one. `xpath_string('<a><b>b1</b><b>b2</b></a>', 'a/b')` errored with XPTY0004: XPath 2.0 rejects a sequence of more than one item, while Spark evaluates with XPath 1.0 and takes the first node. Same for xpath_int / xpath_double / xpath_float / xpath_number.

3. xpath_short wraps instead of saturating. Spark narrows the double the Java way, `(short) (int) value`: double -> int saturates, and int -> short then truncates the bits, so 99999 comes out as -31073. Rust's `as i16` was saturating at 32767. xpath_int and xpath_long already agreed (both saturate).

4. Numbers follow XPath 1.0's lexical space. XPath 1.0's number grammar is only [-]digits[.digits]: no exponent, no INF. Anything else is NaN. Sail read `INF` as Infinity and `1.5e2` as 150.0, because xee implements XPath 2.0. The integer variants inherit it: in Spark `xpath_int('<a><b>INF</b></a>', 'a/b')` is 0, because the value is NaN and Java's (int) NaN is 0. A node is now converted through its string value and parsed by the 1.0 rules, while an atomic result (`sum()`, `count()`) stays a number and keeps its precision.

5. A pre-existing test asserted Sail's own error wording ("Invalid XML") and so failed against Spark JVM. It now accepts either engine's wording, while still requiring the error to be about the document.

Tests: 40 new scenarios across the family, all validated against Spark JVM 4.1.1 -- 78 pass there, and on Sail 77 pass with 3 xfail. Plus two Sail-only plan snapshots pinning the invariant the gate creates: the path reaches the function as a literal, whether the user wrote a literal or a constant expression.

Known divergence, left as @sail-bug with its own follow-up: Spark parses the document without namespace awareness, so an unprefixed path still matches a node in a default namespace, while Sail (XPath 2.0) honours it and comes back empty. Every real-world document carrying an `xmlns` -- SOAP, RSS, SVG, Atom -- is affected, and none of the ways out is free (rewriting the path to `*:a/*:b` means parsing the XPath expression; stripping the xmlns breaks prefixed documents), so it needs a decision of its own.