### PR TITLE
fix: honor Spark's lambda short-circuit in `exists` and `forall` under ANSI

### DIFF
--- a/crates/sail-function/src/scalar/array/lambda_utils.rs
+++ b/crates/sail-function/src/scalar/array/lambda_utils.rs
@@ -10,12 +10,17 @@
 /// (`index_array`/`offsets_to_indices`).
 use std::sync::Arc;
 
-use datafusion::arrow::array::{Array, ArrayRef, AsArray, Int32Array, OffsetSizeTrait};
+use datafusion::arrow::array::{
+    Array, ArrayRef, AsArray, BooleanArray, BooleanBuilder, Int32Array, OffsetSizeTrait,
+};
 use datafusion::arrow::buffer::OffsetBuffer;
+use datafusion::arrow::compute::take_arrays;
 use datafusion::arrow::datatypes::DataType;
-use datafusion_common::utils::{adjust_offsets_for_slice, list_values, take_function_args};
+use datafusion_common::utils::{
+    adjust_offsets_for_slice, list_values, list_values_row_number, take_function_args,
+};
 use datafusion_common::{Result, ScalarValue, exec_err, plan_err};
-use datafusion_expr::{ColumnarValue, ValueOrLambda};
+use datafusion_expr::{ColumnarValue, LambdaArgument, ValueOrLambda};
 
 use crate::error::generic_exec_err;
 
@@ -95,6 +100,102 @@ pub(crate) fn extract_list_values(
     }
 
     Ok(ListValuesResult::Values(values))
+}
+
+/// Evaluates a boolean lambda element by element, stopping each row at the first
+/// `stop_on` value, and reduces with Spark's three-valued logic.
+///
+/// Spark's `ArrayExists`/`ArrayForAll` walk the elements in order and stop at the
+/// first `true`/`false`, so an element past the stopping point is never evaluated
+/// and can never raise. Evaluating the whole flattened batch at once — which is
+/// what the vectorized path does — raises on elements Spark would have skipped.
+/// This is the recovery path for exactly that case: it costs one lambda
+/// evaluation per element, so callers must only reach it once the vectorized
+/// evaluation has already failed.
+pub(crate) fn short_circuit_boolean_reduce(
+    name: &str,
+    list_array: &ArrayRef,
+    values: &ArrayRef,
+    lambda: &LambdaArgument,
+    stop_on: bool,
+) -> Result<BooleanArray> {
+    let (offsets, nulls) = match list_array.data_type() {
+        DataType::List(_) => {
+            let list = list_array.as_list::<i32>();
+            (
+                offsets_to_usize(&adjust_offsets_for_slice(list)),
+                list.nulls().cloned(),
+            )
+        }
+        DataType::LargeList(_) => {
+            let list = list_array.as_list::<i64>();
+            (
+                offsets_to_usize(&adjust_offsets_for_slice(list)),
+                list.nulls().cloned(),
+            )
+        }
+        other => return exec_err!("{name} expected list, got {other}"),
+    };
+
+    let row_numbers = list_values_row_number(list_array)?;
+    let num_rows = list_array.len();
+    let mut builder = BooleanBuilder::with_capacity(num_rows);
+
+    for row in 0..num_rows {
+        if nulls.as_ref().is_some_and(|n| n.is_null(row)) {
+            builder.append_null();
+            continue;
+        }
+        let mut stopped = false;
+        let mut any_null = false;
+        for index in offsets[row]..offsets[row + 1] {
+            let element = values.slice(index, 1);
+            let element_param = || Ok(Arc::clone(&element));
+            let params: [&dyn Fn() -> Result<ArrayRef>; 1] = [&element_param];
+            let output = lambda.evaluate(&params, |arrays| {
+                Ok(take_arrays(arrays, &row_numbers.slice(index, 1), None)?)
+            })?;
+            match single_boolean(name, &output)? {
+                Some(value) if value == stop_on => {
+                    stopped = true;
+                    break;
+                }
+                Some(_) => {}
+                None => any_null = true,
+            }
+        }
+        if stopped {
+            builder.append_value(stop_on);
+        } else if any_null {
+            builder.append_null();
+        } else {
+            builder.append_value(!stop_on);
+        }
+    }
+
+    Ok(builder.finish())
+}
+
+fn offsets_to_usize<O: OffsetSizeTrait>(offsets: &OffsetBuffer<O>) -> Vec<usize> {
+    offsets.iter().map(|offset| offset.as_usize()).collect()
+}
+
+fn single_boolean(name: &str, output: &ColumnarValue) -> Result<Option<bool>> {
+    if let ColumnarValue::Scalar(ScalarValue::Boolean(value)) = output {
+        return Ok(*value);
+    }
+    let array = output.clone().into_array(1)?;
+    let Some(array) = array.as_any().downcast_ref::<BooleanArray>() else {
+        return exec_err!(
+            "{name} lambda must return boolean, got {}",
+            array.data_type()
+        );
+    };
+    if array.is_null(0) {
+        Ok(None)
+    } else {
+        Ok(Some(array.value(0)))
+    }
 }
 
 /// 0-based per-sublist positions aligned with the flattened values of `list_array`.

--- a/crates/sail-function/src/scalar/array/spark_array_exists.rs
+++ b/crates/sail-function/src/scalar/array/spark_array_exists.rs
@@ -24,7 +24,9 @@ use datafusion_expr::{
     HigherOrderUDFImpl, LambdaParametersProgress, ValueOrLambda, Volatility,
 };
 
-use super::lambda_utils::{coerce_single_list_arg, value_lambda_pair};
+use super::lambda_utils::{
+    coerce_single_list_arg, short_circuit_boolean_reduce, value_lambda_pair,
+};
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct SparkArrayExists {
@@ -86,10 +88,19 @@ impl HigherOrderUDFImpl for SparkArrayExists {
 
         let values_param = || Ok(Arc::clone(&values));
         let params: [&dyn Fn() -> Result<ArrayRef>; 1] = [&values_param];
-        let predicate_output = lambda.evaluate(&params, |arrays| {
+        let predicate_output = match lambda.evaluate(&params, |arrays| {
             let indices = list_values_row_number(&list_array)?;
             Ok(take_arrays(arrays, &indices, None)?)
-        })?;
+        }) {
+            Ok(output) => output,
+            // Evaluating every element at once can raise on an element that Spark
+            // would never reach; retry in Spark's order before giving up.
+            Err(_) => {
+                let result =
+                    short_circuit_boolean_reduce(self.name(), &list_array, &values, lambda, true)?;
+                return Ok(ColumnarValue::Array(Arc::new(result)));
+            }
+        };
 
         let result = match list_array.data_type() {
             DataType::List(_) => {

--- a/crates/sail-function/src/scalar/array/spark_array_forall.rs
+++ b/crates/sail-function/src/scalar/array/spark_array_forall.rs
@@ -23,7 +23,9 @@ use datafusion_expr::{
     HigherOrderUDFImpl, LambdaParametersProgress, ValueOrLambda, Volatility,
 };
 
-use super::lambda_utils::{coerce_single_list_arg, value_lambda_pair};
+use super::lambda_utils::{
+    coerce_single_list_arg, short_circuit_boolean_reduce, value_lambda_pair,
+};
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct SparkArrayForall {
@@ -85,10 +87,19 @@ impl HigherOrderUDFImpl for SparkArrayForall {
 
         let values_param = || Ok(Arc::clone(&values));
         let params: [&dyn Fn() -> Result<ArrayRef>; 1] = [&values_param];
-        let predicate_output = lambda.evaluate(&params, |arrays| {
+        let predicate_output = match lambda.evaluate(&params, |arrays| {
             let indices = list_values_row_number(&list_array)?;
             Ok(take_arrays(arrays, &indices, None)?)
-        })?;
+        }) {
+            Ok(output) => output,
+            // Evaluating every element at once can raise on an element that Spark
+            // would never reach; retry in Spark's order before giving up.
+            Err(_) => {
+                let result =
+                    short_circuit_boolean_reduce(self.name(), &list_array, &values, lambda, false)?;
+                return Ok(ColumnarValue::Array(Arc::new(result)));
+            }
+        };
 
         let result = match list_array.data_type() {
             DataType::List(_) => {

--- a/python/pysail/tests/spark/function/features/exists.feature
+++ b/python/pysail/tests/spark/function/features/exists.feature
@@ -313,7 +313,6 @@ Feature: exists higher-order function
 
   Rule: ANSI mode inside the predicate
 
-    @sail-bug
     Scenario: short-circuit avoids division by zero under ANSI on
       Given config spark.sql.ansi.enabled = true
       When query
@@ -342,3 +341,202 @@ Feature: exists higher-order function
         SELECT exists(array(1, 2, 3), x -> x + 1) AS result
         """
       Then query error .*
+
+    @sail-bug
+    Scenario: a constant boolean is accepted in place of a lambda
+      When query
+        """
+        SELECT exists(array(1, 2), true) AS result
+        """
+      Then query result
+        | result |
+        | true   |
+
+  Rule: Array borne by a column rather than a literal
+
+    Scenario: distinct arrays per row are not broadcast from the first row
+      When query
+        """
+        SELECT exists(c, x -> x > 2) AS result
+        FROM VALUES (array(5)), (array(1)), (array(3)) AS t(c)
+        """
+      Then query result ordered
+        | result |
+        | true   |
+        | false  |
+        | true   |
+
+    Scenario: non-empty, empty and NULL arrays in the same batch
+      When query
+        """
+        SELECT exists(c, x -> x > 2) AS result
+        FROM VALUES (array(1, 2)), (array(3, 4)), (CAST(NULL AS ARRAY<INT>)), (array()) AS t(c)
+        """
+      Then query result ordered
+        | result |
+        | false  |
+        | true   |
+        | NULL   |
+        | false  |
+
+    Scenario: three-valued logic resolved per row
+      When query
+        """
+        SELECT exists(c, x -> x > 2) AS result
+        FROM VALUES (array(1, NULL)), (array(3, NULL)), (array(NULL)) AS t(c)
+        """
+      Then query result ordered
+        | result |
+        | NULL   |
+        | true   |
+        | NULL   |
+
+    Scenario: every row is a NULL array
+      When query
+        """
+        SELECT exists(c, x -> x > 2) AS result
+        FROM VALUES (CAST(NULL AS ARRAY<INT>)), (CAST(NULL AS ARRAY<INT>)) AS t(c)
+        """
+      Then query result ordered
+        | result |
+        | NULL   |
+        | NULL   |
+
+    Scenario: every row is an empty array
+      When query
+        """
+        SELECT exists(c, x -> x > 2) AS result
+        FROM VALUES (array()), (array()) AS t(c)
+        """
+      Then query result ordered
+        | result |
+        | false  |
+        | false  |
+
+    Scenario: the captured column changes the predicate per row
+      When query
+        """
+        SELECT exists(c, x -> x > v) AS result
+        FROM VALUES (array(1, 2), 0), (array(1, 2), 5) AS t(c, v)
+        """
+      Then query result ordered
+        | result |
+        | true   |
+        | false  |
+
+  Rule: Short-circuit order under ANSI
+
+    Scenario: an element before the first true is still evaluated under ANSI on
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT exists(array(0, 1, 2), x -> 10 / x > 4) AS result
+        """
+      Then query error Division by zero
+
+    Scenario: an element before the first true is still evaluated under ANSI off
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT exists(array(0, 1, 2), x -> 10 / x > 4) AS result
+        """
+      Then query result
+        | result |
+        | true   |
+
+    Scenario: no element is true so every element is evaluated under ANSI on
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT exists(array(1, 0, 2), x -> 10 / x > 100) AS result
+        """
+      Then query error Division by zero
+
+    Scenario: no element is true so every element is evaluated under ANSI off
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT exists(array(1, 0, 2), x -> 10 / x > 100) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: a true after the failing element does not save it under ANSI on
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT exists(array(5, 0, 1), x -> 10 / x > 4) AS result
+        """
+      Then query error Division by zero
+
+    Scenario: a true after the failing element does not save it under ANSI off
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT exists(array(5, 0, 1), x -> 10 / x > 4) AS result
+        """
+      Then query result
+        | result |
+        | true   |
+
+    Scenario: one row short-circuits while another does not under ANSI on
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT exists(c, x -> 10 / x > 4) AS result
+        FROM VALUES (array(1, 0)), (array(5, 5)) AS t(c)
+        """
+      Then query result ordered
+        | result |
+        | true   |
+        | false  |
+
+    Scenario: one row short-circuits while another does not under ANSI off
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT exists(c, x -> 10 / x > 4) AS result
+        FROM VALUES (array(1, 0)), (array(5, 5)) AS t(c)
+        """
+      Then query result ordered
+        | result |
+        | true   |
+        | false  |
+
+  Rule: Output schema
+
+    @sail-bug
+    Scenario: a non-null array literal yields a non-nullable boolean
+      When query
+        """
+        SELECT exists(array(1, 2), x -> x > 1) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: boolean (nullable = false)
+        """
+
+    Scenario: a typed NULL array literal yields a nullable boolean
+      When query
+        """
+        SELECT exists(CAST(NULL AS ARRAY<INT>), x -> x > 1) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: boolean (nullable = true)
+        """
+
+    Scenario: a nullable array column yields a nullable boolean
+      When query
+        """
+        SELECT exists(c, x -> x > 1) AS result
+        FROM VALUES (array(1)), (CAST(NULL AS ARRAY<INT>)) AS t(c)
+        """
+      Then query schema
+        """
+        root
+         |-- result: boolean (nullable = true)
+        """

--- a/python/pysail/tests/spark/function/features/forall.feature
+++ b/python/pysail/tests/spark/function/features/forall.feature
@@ -314,3 +314,193 @@ Feature: forall higher-order function
         SELECT forall(array(1, 2, 3), x -> x + 1) AS result
         """
       Then query error .*
+
+    @sail-bug
+    Scenario: a constant boolean is accepted in place of a lambda
+      When query
+        """
+        SELECT forall(array(1, 2), true) AS result
+        """
+      Then query result
+        | result |
+        | true   |
+
+  Rule: Array borne by a column rather than a literal
+
+    Scenario: distinct arrays per row are not broadcast from the first row
+      When query
+        """
+        SELECT forall(c, x -> x > 2) AS result
+        FROM VALUES (array(5)), (array(1)), (array(3)) AS t(c)
+        """
+      Then query result ordered
+        | result |
+        | true   |
+        | false  |
+        | true   |
+
+    Scenario: non-empty, empty and NULL arrays in the same batch
+      When query
+        """
+        SELECT forall(c, x -> x > 2) AS result
+        FROM VALUES (array(3, 4)), (array(1, 2)), (CAST(NULL AS ARRAY<INT>)), (array()) AS t(c)
+        """
+      Then query result ordered
+        | result |
+        | true   |
+        | false  |
+        | NULL   |
+        | true   |
+
+    Scenario: three-valued logic resolved per row
+      When query
+        """
+        SELECT forall(c, x -> x > 2) AS result
+        FROM VALUES (array(3, NULL)), (array(1, NULL)), (array(NULL)) AS t(c)
+        """
+      Then query result ordered
+        | result |
+        | NULL   |
+        | false  |
+        | NULL   |
+
+    Scenario: every row is a NULL array
+      When query
+        """
+        SELECT forall(c, x -> x > 2) AS result
+        FROM VALUES (CAST(NULL AS ARRAY<INT>)), (CAST(NULL AS ARRAY<INT>)) AS t(c)
+        """
+      Then query result ordered
+        | result |
+        | NULL   |
+        | NULL   |
+
+    Scenario: every row is an empty array
+      When query
+        """
+        SELECT forall(c, x -> x > 2) AS result
+        FROM VALUES (array()), (array()) AS t(c)
+        """
+      Then query result ordered
+        | result |
+        | true   |
+        | true   |
+
+    Scenario: the captured column changes the predicate per row
+      When query
+        """
+        SELECT forall(c, x -> x > v) AS result
+        FROM VALUES (array(1, 2), 0), (array(1, 2), 5) AS t(c, v)
+        """
+      Then query result ordered
+        | result |
+        | true   |
+        | false  |
+
+  Rule: Short-circuit order under ANSI
+
+    Scenario: a false before the failing element stops evaluation under ANSI on
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT forall(array(100, 0, 2), x -> 10 / x > 4) AS result
+        """
+      Then query result
+        | result |
+        | false  |
+
+    Scenario: a false before the failing element stops evaluation under ANSI off
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT forall(array(100, 0, 2), x -> 10 / x > 4) AS result
+        """
+      Then query result
+        | result |
+        | false  |
+
+    Scenario: the failing element comes first so it is evaluated under ANSI on
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT forall(array(0, 100), x -> 10 / x > 4) AS result
+        """
+      Then query error Division by zero
+
+    Scenario: the failing element comes first so it is evaluated under ANSI off
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT forall(array(0, 100), x -> 10 / x > 4) AS result
+        """
+      Then query result
+        | result |
+        | false  |
+
+    Scenario: a false only after the failing element does not save it under ANSI on
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT forall(array(1, 0, 100), x -> 10 / x > 4) AS result
+        """
+      Then query error Division by zero
+
+    Scenario: a false only after the failing element does not save it under ANSI off
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT forall(array(1, 0, 100), x -> 10 / x > 4) AS result
+        """
+      Then query result
+        | result |
+        | false  |
+
+    Scenario: one row stops early while another does not under ANSI on
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT forall(c, x -> 10 / x > 4) AS result
+        FROM VALUES (array(100, 0)), (array(1, 2)) AS t(c)
+        """
+      Then query result ordered
+        | result |
+        | false  |
+        | true   |
+
+    Scenario: one row stops early while another does not under ANSI off
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT forall(c, x -> 10 / x > 4) AS result
+        FROM VALUES (array(100, 0)), (array(1, 2)) AS t(c)
+        """
+      Then query result ordered
+        | result |
+        | false  |
+        | true   |
+
+  Rule: Output schema
+
+    @sail-bug
+    Scenario: a non-null array literal yields a non-nullable boolean
+      When query
+        """
+        SELECT forall(array(1, 2), x -> x > 1) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: boolean (nullable = false)
+        """
+
+    Scenario: a nullable array column yields a nullable boolean
+      When query
+        """
+        SELECT forall(c, x -> x > 1) AS result
+        FROM VALUES (array(1)), (CAST(NULL AS ARRAY<INT>)) AS t(c)
+        """
+      Then query schema
+        """
+        root
+         |-- result: boolean (nullable = true)
+        """


### PR DESCRIPTION
Spark's `ArrayExists`/`ArrayForAll` walk the elements in order and stop at the
first `true`/`false`, so an element past the stopping point is never evaluated
and can never raise. Sail evaluates the whole flattened batch in one vectorized
pass, so it raises on elements Spark would have skipped:

```
SELECT exists(array(1, 0, 2), x -> 10 / x > 4)   -- ANSI on
-- Spark: true (stops at the first element, never divides by the 0)
-- Sail:  ERROR Division by zero
```

Add `short_circuit_boolean_reduce` to `lambda_utils`, shared by both functions
and parameterized by the stopping value, and fall back to it only when the
vectorized evaluation returns an error. The happy path is unchanged, and the
recovery path reproduces Spark's evaluation order exactly, one element at a
time, per row.

The fallback needs no ANSI plumbing and no proto change: with
`spark.sql.ansi.enabled = false` the predicate yields NULL instead of raising,
so the vectorized pass succeeds and the fallback is never reached. The error
itself is the gate, and it carries no state that would have to reach a worker —
the recovery lives entirely inside `invoke_with_args`.

Sail's errors were a superset of Spark's and the values never differed — the
reduce only reads the prefix up to the stopping point — so recovering from the
error is a complete fix rather than a partial one.

Cover both functions with column-borne arrays, which neither feature file
exercised before (every scenario used an array literal, so the multi-row
columnar kernel was never hit), and pin the short-circuit order with ANSI
on/off pairs asserting opposite outcomes for the same query. Five of the new
scenarios assert that the query still fails with Spark's own message, so a
fallback that swallowed legitimate errors would not pass.

exists: 35 -> 54 scenarios, forall: 33 -> 50, all verified against Spark JVM.