### PR TITLE
fix: delta nested column mapping fix

### DIFF
--- a/crates/sail-common-datafusion/src/array/record_batch.rs
+++ b/crates/sail-common-datafusion/src/array/record_batch.rs
@@ -108,7 +108,7 @@ where
     ))
 }
 
-fn cast_array_recursively(src: &ArrayRef, target_type: &DataType) -> Result<ArrayRef> {
+pub fn cast_array_recursively(src: &ArrayRef, target_type: &DataType) -> Result<ArrayRef> {
     let src_type = src.data_type();
     if src_type == target_type {
         return Ok(src.clone());

--- a/crates/sail-common-datafusion/src/schema_evolution.rs
+++ b/crates/sail-common-datafusion/src/schema_evolution.rs
@@ -10,6 +10,7 @@ use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::tree_node::{Transformed, TransformedResult, TreeNode};
 use datafusion::common::{DataFusionError, Result, ScalarValue, exec_err};
 use datafusion::functions::core::getfield::GetFieldFunc;
+use datafusion::parquet::arrow::PARQUET_FIELD_ID_META_KEY;
 use datafusion::physical_expr::expressions::{self, Column, Literal};
 use datafusion::physical_expr::{PhysicalExpr, ScalarFunctionExpr};
 use datafusion::physical_expr_adapter::{PhysicalExprAdapter, PhysicalExprAdapterFactory};
@@ -17,7 +18,16 @@ use datafusion::physical_plan::ColumnarValue;
 use datafusion_common::format::DEFAULT_CAST_OPTIONS;
 use parquet_variant_compute::{VariantArray, unshred_variant};
 
+use crate::array::record_batch::cast_array_recursively;
 use crate::variant::{is_binary_variant_field, is_variant_arrow_field, is_variant_storage_type};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum StructFieldMatching {
+    #[default]
+    Name,
+    PhysicalName,
+    FieldId,
+}
 
 #[derive(Debug)]
 pub struct SchemaEvolutionPhysicalExprAdapterFactory {}
@@ -28,16 +38,50 @@ impl PhysicalExprAdapterFactory for SchemaEvolutionPhysicalExprAdapterFactory {
         logical_file_schema: SchemaRef,
         physical_file_schema: SchemaRef,
     ) -> Result<Arc<dyn PhysicalExprAdapter>> {
-        let (column_mapping, default_values) =
-            create_column_mapping(&logical_file_schema, &physical_file_schema);
-
-        Ok(Arc::new(SchemaEvolutionPhysicalExprAdapter {
+        create_schema_evolution_adapter(
             logical_file_schema,
             physical_file_schema,
-            column_mapping,
-            default_values,
-        }))
+            StructFieldMatching::Name,
+        )
     }
+}
+
+#[derive(Debug)]
+pub struct SchemaEvolutionPhysicalExprAdapterFactoryWithMatching {
+    matching: StructFieldMatching,
+}
+
+impl SchemaEvolutionPhysicalExprAdapterFactoryWithMatching {
+    pub fn new(matching: StructFieldMatching) -> Self {
+        Self { matching }
+    }
+}
+
+impl PhysicalExprAdapterFactory for SchemaEvolutionPhysicalExprAdapterFactoryWithMatching {
+    fn create(
+        &self,
+        logical_file_schema: SchemaRef,
+        physical_file_schema: SchemaRef,
+    ) -> Result<Arc<dyn PhysicalExprAdapter>> {
+        create_schema_evolution_adapter(logical_file_schema, physical_file_schema, self.matching)
+    }
+}
+
+fn create_schema_evolution_adapter(
+    logical_file_schema: SchemaRef,
+    physical_file_schema: SchemaRef,
+    matching: StructFieldMatching,
+) -> Result<Arc<dyn PhysicalExprAdapter>> {
+    let (column_mapping, default_values) =
+        create_column_mapping(&logical_file_schema, &physical_file_schema);
+
+    Ok(Arc::new(SchemaEvolutionPhysicalExprAdapter {
+        logical_file_schema,
+        physical_file_schema,
+        column_mapping,
+        default_values,
+        matching,
+    }))
 }
 
 fn create_column_mapping(
@@ -80,6 +124,7 @@ struct SchemaEvolutionPhysicalExprAdapter {
     physical_file_schema: SchemaRef,
     column_mapping: Vec<Option<usize>>,
     default_values: Vec<Option<ScalarValue>>,
+    matching: StructFieldMatching,
 }
 
 impl PhysicalExprAdapter for SchemaEvolutionPhysicalExprAdapter {
@@ -89,6 +134,7 @@ impl PhysicalExprAdapter for SchemaEvolutionPhysicalExprAdapter {
             physical_file_schema: &self.physical_file_schema,
             column_mapping: &self.column_mapping,
             default_values: &self.default_values,
+            matching: self.matching,
         };
         expr.transform(|expr| rewriter.rewrite_expr(Arc::clone(&expr)))
             .data()
@@ -100,6 +146,7 @@ struct SchemaEvolutionPhysicalExprRewriter<'a> {
     physical_file_schema: &'a Schema,
     column_mapping: &'a [Option<usize>],
     default_values: &'a [Option<ScalarValue>],
+    matching: StructFieldMatching,
 }
 
 impl<'a> SchemaEvolutionPhysicalExprRewriter<'a> {
@@ -157,13 +204,6 @@ impl<'a> SchemaEvolutionPhysicalExprRewriter<'a> {
             DataType::Struct(fields) => fields,
             _ => return Ok(None),
         };
-        if physical_struct_fields
-            .iter()
-            .any(|f| f.name() == field_name)
-        {
-            return Ok(None);
-        }
-
         let logical_field = match self.logical_file_schema.field_with_name(column.name()) {
             Ok(field) => field,
             Err(_) => return Ok(None),
@@ -179,6 +219,12 @@ impl<'a> SchemaEvolutionPhysicalExprRewriter<'a> {
             Some(field) => field,
             None => return Ok(None),
         };
+        if find_matching_struct_field(physical_struct_fields, logical_struct_field, self.matching)
+            .is_some()
+        {
+            return Ok(None);
+        }
+
         let null_value = ScalarValue::Null.cast_to(logical_struct_field.data_type())?;
         Ok(Some(Arc::new(Literal::new(null_value))))
     }
@@ -274,7 +320,7 @@ impl<'a> SchemaEvolutionPhysicalExprRewriter<'a> {
         logical_field: &Field,
         physical_field: &Field,
     ) -> Result<Transformed<Arc<dyn PhysicalExpr>>> {
-        if !can_cast_field_with_schema_evolution(physical_field, logical_field)? {
+        if !can_cast_field_with_schema_evolution(physical_field, logical_field, self.matching)? {
             return exec_err!(
                 "Cannot cast column '{}' from '{}' (physical) to '{}' (logical)",
                 logical_field.name(),
@@ -284,17 +330,22 @@ impl<'a> SchemaEvolutionPhysicalExprRewriter<'a> {
         }
 
         Ok(Transformed::yes(Arc::new(
-            SchemaEvolutionCastColumnExpr::new(
+            SchemaEvolutionCastColumnExpr::new_with_matching(
                 column_expr,
                 Arc::new(physical_field.clone()),
                 Arc::new(logical_field.clone()),
                 None,
+                self.matching,
             ),
         )))
     }
 }
 
-fn can_cast_field_with_schema_evolution(source: &Field, target: &Field) -> Result<bool> {
+fn can_cast_field_with_schema_evolution(
+    source: &Field,
+    target: &Field,
+    matching: StructFieldMatching,
+) -> Result<bool> {
     if source.data_type() == &DataType::Null {
         return Ok(target.is_nullable());
     }
@@ -313,14 +364,14 @@ fn can_cast_field_with_schema_evolution(source: &Field, target: &Field) -> Resul
 
     match (source.data_type(), target.data_type()) {
         (DataType::Struct(from_fields), DataType::Struct(to_fields)) => {
-            validate_struct_compatibility_with_variant(from_fields, to_fields)?;
+            validate_struct_compatibility_with_variant(from_fields, to_fields, matching)?;
             Ok(true)
         }
         (DataType::List(from_elem), DataType::List(to_elem)) => {
-            can_cast_field_with_schema_evolution(from_elem, to_elem)
+            can_cast_field_with_schema_evolution(from_elem, to_elem, matching)
         }
         (DataType::LargeList(from_elem), DataType::LargeList(to_elem)) => {
-            can_cast_field_with_schema_evolution(from_elem, to_elem)
+            can_cast_field_with_schema_evolution(from_elem, to_elem, matching)
         }
         (
             DataType::FixedSizeList(from_elem, from_len),
@@ -329,24 +380,72 @@ fn can_cast_field_with_schema_evolution(source: &Field, target: &Field) -> Resul
             if from_len != to_len {
                 return Ok(false);
             }
-            can_cast_field_with_schema_evolution(from_elem, to_elem)
+            can_cast_field_with_schema_evolution(from_elem, to_elem, matching)
         }
         (DataType::Map(from_entries, _), DataType::Map(to_entries, _)) => {
-            can_cast_field_with_schema_evolution(from_entries, to_entries)
+            validate_map_entries_compatibility(from_entries, to_entries, matching)?;
+            Ok(true)
         }
         _ => Ok(can_cast_types(source.data_type(), target.data_type())),
+    }
+}
+
+const DELTA_COLUMN_MAPPING_PHYSICAL_NAME_METADATA_KEY: &str = "delta.columnMapping.physicalName";
+// Delta kernel schemas, Arrow Parquet readers, and Delta's physical schema builder use
+// different field-ID metadata spellings, all of which represent the same identity.
+const STRUCT_FIELD_ID_METADATA_KEYS: [&str; 3] = [
+    "delta.columnMapping.id",
+    PARQUET_FIELD_ID_META_KEY,
+    "parquet.field.id",
+];
+
+fn struct_field_id(field: &Field) -> Option<&str> {
+    STRUCT_FIELD_ID_METADATA_KEYS
+        .iter()
+        .find_map(|key| field.metadata().get(*key).map(String::as_str))
+}
+
+fn find_matching_struct_field<'a>(
+    source_fields: &'a [Arc<Field>],
+    target_field: &Field,
+    matching: StructFieldMatching,
+) -> Option<(usize, &'a Arc<Field>)> {
+    match matching {
+        StructFieldMatching::Name => source_fields
+            .iter()
+            .enumerate()
+            .find(|(_, source)| source.name() == target_field.name()),
+        StructFieldMatching::PhysicalName => {
+            // Synthetic list/map wrappers are matched by their container handlers; only
+            // actual Delta struct fields with physicalName metadata reach this branch.
+            let physical_name = target_field
+                .metadata()
+                .get(DELTA_COLUMN_MAPPING_PHYSICAL_NAME_METADATA_KEY)?;
+            source_fields
+                .iter()
+                .enumerate()
+                .find(|(_, source)| source.name() == physical_name)
+        }
+        StructFieldMatching::FieldId => {
+            let target_id = struct_field_id(target_field)?;
+            source_fields
+                .iter()
+                .enumerate()
+                .find(|(_, source)| struct_field_id(source) == Some(target_id))
+        }
     }
 }
 
 fn validate_struct_compatibility_with_variant(
     source_fields: &[Arc<Field>],
     target_fields: &[Arc<Field>],
+    matching: StructFieldMatching,
 ) -> Result<()> {
-    if !target_fields.iter().any(|target| {
-        source_fields
+    if matching == StructFieldMatching::Name
+        && !target_fields
             .iter()
-            .any(|source| source.name() == target.name())
-    }) {
+            .any(|target| find_matching_struct_field(source_fields, target, matching).is_some())
+    {
         return exec_err!(
             "Cannot cast struct with {} fields to {} fields because there is no field name overlap",
             source_fields.len(),
@@ -355,12 +454,9 @@ fn validate_struct_compatibility_with_variant(
     }
 
     for target_field in target_fields {
-        match source_fields
-            .iter()
-            .find(|source| source.name() == target_field.name())
-        {
-            Some(source_field) => {
-                if !can_cast_field_with_schema_evolution(source_field, target_field)? {
+        match find_matching_struct_field(source_fields, target_field, matching) {
+            Some((_, source_field)) => {
+                if !can_cast_field_with_schema_evolution(source_field, target_field, matching)? {
                     return exec_err!(
                         "Cannot cast struct field '{}' from type {} to type {}",
                         target_field.name(),
@@ -383,12 +479,54 @@ fn validate_struct_compatibility_with_variant(
     Ok(())
 }
 
+fn validate_map_entries_compatibility(
+    source_entries: &Field,
+    target_entries: &Field,
+    matching: StructFieldMatching,
+) -> Result<()> {
+    let (DataType::Struct(source_fields), DataType::Struct(target_fields)) =
+        (source_entries.data_type(), target_entries.data_type())
+    else {
+        return exec_err!("map entries must use struct types");
+    };
+
+    for target_field in target_fields {
+        // Arrow map key/value fields are structural wrappers without column-mapping metadata.
+        match source_fields
+            .iter()
+            .find(|source| source.name() == target_field.name())
+        {
+            Some(source_field)
+                if can_cast_field_with_schema_evolution(source_field, target_field, matching)? => {}
+            Some(source_field) => {
+                return exec_err!(
+                    "Cannot cast map entry '{}' from type {} to type {}",
+                    target_field.name(),
+                    source_field.data_type(),
+                    target_field.data_type()
+                );
+            }
+            None if target_field.is_nullable() => {}
+            None => {
+                return exec_err!(
+                    "Cannot cast map: target entry '{}' is non-nullable but missing from source. \
+                     Cannot fill with NULL.",
+                    target_field.name()
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
 #[derive(Debug, Clone, Eq)]
 pub struct SchemaEvolutionCastColumnExpr {
     expr: Arc<dyn PhysicalExpr>,
     input_field: Arc<Field>,
     target_field: Arc<Field>,
     cast_options: CastOptions<'static>,
+    matching: StructFieldMatching,
 }
 
 impl PartialEq for SchemaEvolutionCastColumnExpr {
@@ -397,6 +535,7 @@ impl PartialEq for SchemaEvolutionCastColumnExpr {
             && self.input_field.eq(&other.input_field)
             && self.target_field.eq(&other.target_field)
             && self.cast_options.eq(&other.cast_options)
+            && self.matching.eq(&other.matching)
     }
 }
 
@@ -406,6 +545,7 @@ impl std::hash::Hash for SchemaEvolutionCastColumnExpr {
         self.input_field.hash(state);
         self.target_field.hash(state);
         self.cast_options.hash(state);
+        self.matching.hash(state);
     }
 }
 
@@ -427,11 +567,28 @@ impl SchemaEvolutionCastColumnExpr {
         target_field: Arc<Field>,
         cast_options: Option<CastOptions<'static>>,
     ) -> Self {
+        Self::new_with_matching(
+            expr,
+            input_field,
+            target_field,
+            cast_options,
+            StructFieldMatching::Name,
+        )
+    }
+
+    pub fn new_with_matching(
+        expr: Arc<dyn PhysicalExpr>,
+        input_field: Arc<Field>,
+        target_field: Arc<Field>,
+        cast_options: Option<CastOptions<'static>>,
+        matching: StructFieldMatching,
+    ) -> Self {
         Self {
             expr,
             input_field,
             target_field,
             cast_options: cast_options.unwrap_or(DEFAULT_CAST_OPTIONS),
+            matching,
         }
     }
 
@@ -441,6 +598,10 @@ impl SchemaEvolutionCastColumnExpr {
 
     pub fn target_field(&self) -> &Arc<Field> {
         &self.target_field
+    }
+
+    pub const fn matching(&self) -> StructFieldMatching {
+        self.matching
     }
 }
 
@@ -461,6 +622,7 @@ impl PhysicalExpr for SchemaEvolutionCastColumnExpr {
                     &array,
                     self.target_field.as_ref(),
                     &self.cast_options,
+                    self.matching,
                 )?))
             }
             ColumnarValue::Scalar(scalar) => {
@@ -469,6 +631,7 @@ impl PhysicalExpr for SchemaEvolutionCastColumnExpr {
                     &as_array,
                     self.target_field.as_ref(),
                     &self.cast_options,
+                    self.matching,
                 )?;
                 Ok(ColumnarValue::Scalar(ScalarValue::try_from_array(
                     casted.as_ref(),
@@ -494,11 +657,12 @@ impl PhysicalExpr for SchemaEvolutionCastColumnExpr {
         let child = children.pop().ok_or_else(|| {
             DataFusionError::Plan("SchemaEvolutionCastColumnExpr requires a child".to_string())
         })?;
-        Ok(Arc::new(Self::new(
+        Ok(Arc::new(Self::new_with_matching(
             child,
             Arc::clone(&self.input_field),
             Arc::clone(&self.target_field),
             Some(self.cast_options.clone()),
+            self.matching,
         )))
     }
 
@@ -507,19 +671,54 @@ impl PhysicalExpr for SchemaEvolutionCastColumnExpr {
     }
 }
 
-fn cast_array_with_schema_evolution(
+pub fn cast_array_with_schema_evolution(
     source: &ArrayRef,
     target_field: &Field,
     cast_options: &CastOptions,
+    matching: StructFieldMatching,
 ) -> Result<ArrayRef> {
+    cast_array_with_schema_evolution_inner(source, target_field, cast_options, matching, false)
+}
+
+pub fn cast_array_with_schema_evolution_relaxed_tz(
+    source: &ArrayRef,
+    target_field: &Field,
+    cast_options: &CastOptions,
+    matching: StructFieldMatching,
+) -> Result<ArrayRef> {
+    cast_array_with_schema_evolution_inner(source, target_field, cast_options, matching, true)
+}
+
+fn cast_array_with_schema_evolution_inner(
+    source: &ArrayRef,
+    target_field: &Field,
+    cast_options: &CastOptions,
+    matching: StructFieldMatching,
+    relaxed_timezone: bool,
+) -> Result<ArrayRef> {
+    if relaxed_timezone
+        && let (DataType::Timestamp(source_unit, _), DataType::Timestamp(target_unit, _)) =
+            (source.data_type(), target_field.data_type())
+    {
+        let source_without_timezone = DataType::Timestamp(*source_unit, None);
+        let source = cast_array_recursively(source, &source_without_timezone)?;
+        let target_without_timezone = DataType::Timestamp(*target_unit, None);
+        let scaled = cast_with_options(&source, &target_without_timezone, cast_options)?;
+        return cast_array_recursively(&scaled, target_field.data_type());
+    }
+
     if is_variant_arrow_field(target_field) && is_variant_storage_type(source.data_type()) {
         return cast_variant_array_with_schema_evolution(source, target_field, cast_options);
     }
 
     match target_field.data_type() {
-        DataType::Struct(target_fields) => {
-            cast_struct_array_with_schema_evolution(source, target_fields, cast_options)
-        }
+        DataType::Struct(target_fields) => cast_struct_array_with_schema_evolution(
+            source,
+            target_fields,
+            cast_options,
+            matching,
+            relaxed_timezone,
+        ),
         DataType::List(target_elem) => {
             let Some(source_list) = source.as_any().downcast_ref::<ListArray>() else {
                 return exec_err!(
@@ -527,10 +726,12 @@ fn cast_array_with_schema_evolution(
                     source.data_type()
                 );
             };
-            let casted_values = cast_array_with_schema_evolution(
+            let casted_values = cast_array_with_schema_evolution_inner(
                 source_list.values(),
                 target_elem.as_ref(),
                 cast_options,
+                matching,
+                relaxed_timezone,
             )?;
             Ok(Arc::new(ListArray::new(
                 Arc::clone(target_elem),
@@ -546,10 +747,12 @@ fn cast_array_with_schema_evolution(
                     source.data_type()
                 );
             };
-            let casted_values = cast_array_with_schema_evolution(
+            let casted_values = cast_array_with_schema_evolution_inner(
                 source_list.values(),
                 target_elem.as_ref(),
                 cast_options,
+                matching,
+                relaxed_timezone,
             )?;
             Ok(Arc::new(LargeListArray::new(
                 Arc::clone(target_elem),
@@ -573,10 +776,12 @@ fn cast_array_with_schema_evolution(
                     target_len
                 );
             }
-            let casted_values = cast_array_with_schema_evolution(
+            let casted_values = cast_array_with_schema_evolution_inner(
                 source_list.values(),
                 target_elem.as_ref(),
                 cast_options,
+                matching,
+                relaxed_timezone,
             )?;
             Ok(Arc::new(FixedSizeListArray::new(
                 Arc::clone(target_elem),
@@ -605,12 +810,15 @@ fn cast_array_with_schema_evolution(
             let mut kv_fields: Vec<Arc<Field>> = Vec::with_capacity(target_kv_fields.len());
 
             for target_child in target_kv_fields {
+                // Match the synthetic key/value wrapper by name, then apply mapping recursively.
                 kv_fields.push(Arc::clone(target_child));
                 match source_map.entries().column_by_name(target_child.name()) {
-                    Some(source_child) => kv_arrays.push(cast_array_with_schema_evolution(
+                    Some(source_child) => kv_arrays.push(cast_array_with_schema_evolution_inner(
                         source_child,
                         target_child.as_ref(),
                         cast_options,
+                        matching,
+                        relaxed_timezone,
                     )?),
                     None => kv_arrays.push(new_null_array(target_child.data_type(), num_entries)),
                 }
@@ -647,13 +855,21 @@ fn cast_variant_array_with_schema_evolution(
     let variant = VariantArray::try_new(source.as_ref())?;
     let unshredded = unshred_variant(&variant)?;
     let unshredded = Arc::new(unshredded.into_inner()) as ArrayRef;
-    cast_struct_array_to_fields(&unshredded, target_fields, cast_options)
+    cast_struct_array_to_fields(
+        &unshredded,
+        target_fields,
+        cast_options,
+        StructFieldMatching::Name,
+        false,
+    )
 }
 
 fn cast_struct_array_with_schema_evolution(
     source: &ArrayRef,
     target_fields: &[Arc<Field>],
     cast_options: &CastOptions,
+    matching: StructFieldMatching,
+    relaxed_timezone: bool,
 ) -> Result<ArrayRef> {
     if source.data_type() == &DataType::Null
         || (!source.is_empty() && source.null_count() == source.len())
@@ -670,14 +886,22 @@ fn cast_struct_array_with_schema_evolution(
             source.data_type()
         );
     };
-    validate_struct_compatibility_with_variant(source_struct.fields(), target_fields)?;
-    cast_struct_array_to_fields(source, target_fields, cast_options)
+    validate_struct_compatibility_with_variant(source_struct.fields(), target_fields, matching)?;
+    cast_struct_array_to_fields(
+        source,
+        target_fields,
+        cast_options,
+        matching,
+        relaxed_timezone,
+    )
 }
 
 fn cast_struct_array_to_fields(
     source: &ArrayRef,
     target_fields: &[Arc<Field>],
     cast_options: &CastOptions,
+    matching: StructFieldMatching,
+    relaxed_timezone: bool,
 ) -> Result<ArrayRef> {
     let Some(source_struct) = source.as_any().downcast_ref::<StructArray>() else {
         return exec_err!(
@@ -691,12 +915,14 @@ fn cast_struct_array_to_fields(
 
     for target_child in target_fields {
         fields.push(Arc::clone(target_child));
-        match source_struct.column_by_name(target_child.name()) {
-            Some(source_child) => {
-                arrays.push(cast_array_with_schema_evolution(
-                    source_child,
+        match find_matching_struct_field(source_struct.fields(), target_child, matching) {
+            Some((source_index, _)) => {
+                arrays.push(cast_array_with_schema_evolution_inner(
+                    source_struct.column(source_index),
                     target_child.as_ref(),
                     cast_options,
+                    matching,
+                    relaxed_timezone,
                 )?);
             }
             None => arrays.push(new_null_array(target_child.data_type(), num_rows)),
@@ -713,8 +939,14 @@ fn cast_struct_array_to_fields(
 #[cfg(test)]
 #[expect(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
-    use datafusion::arrow::array::{BinaryViewArray, Int64Array, StringArray};
+    use std::collections::HashMap;
+
+    use datafusion::arrow::array::{
+        BinaryViewArray, Int64Array, StringArray, TimestampMicrosecondArray,
+        TimestampMillisecondArray,
+    };
     use datafusion::arrow::buffer::OffsetBuffer;
+    use datafusion::arrow::datatypes::TimeUnit;
     use parquet_variant_compute::{VariantType, json_to_variant, shred_variant, variant_to_json};
 
     use super::*;
@@ -732,6 +964,379 @@ mod tests {
             true,
         )
         .with_extension_type(VariantType)
+    }
+
+    fn field_with_id(name: &str, metadata_key: &str, id: i64) -> Arc<Field> {
+        Arc::new(
+            Field::new(name, DataType::Int64, true)
+                .with_metadata(HashMap::from([(metadata_key.to_string(), id.to_string())])),
+        )
+    }
+
+    #[test]
+    fn cast_struct_fields_by_column_id() -> Result<()> {
+        let source_fields = vec![
+            field_with_id("col-a", PARQUET_FIELD_ID_META_KEY, 1),
+            field_with_id("col-b", PARQUET_FIELD_ID_META_KEY, 2),
+        ];
+        let source = Arc::new(StructArray::new(
+            source_fields.into(),
+            vec![
+                Arc::new(Int64Array::from(vec![Some(10)])),
+                Arc::new(Int64Array::from(vec![Some(20)])),
+            ],
+            None,
+        )) as ArrayRef;
+        let target_fields = vec![
+            field_with_id("logical_b", "delta.columnMapping.id", 2),
+            field_with_id("logical_a", "delta.columnMapping.id", 1),
+        ];
+        let target_field = Field::new("root", DataType::Struct(target_fields.clone().into()), true);
+
+        assert!(can_cast_field_with_schema_evolution(
+            &Field::new("root", source.data_type().clone(), true),
+            &target_field,
+            StructFieldMatching::FieldId,
+        )?);
+        let casted = cast_array_with_schema_evolution(
+            &source,
+            &target_field,
+            &DEFAULT_CAST_OPTIONS,
+            StructFieldMatching::FieldId,
+        )?;
+        let casted = casted
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("struct array");
+
+        assert!(casted.fields().iter().eq(target_fields.iter()));
+        assert_eq!(
+            casted
+                .column_by_name("logical_b")
+                .expect("logical_b")
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("int64")
+                .value(0),
+            20,
+        );
+        assert_eq!(
+            casted
+                .column_by_name("logical_a")
+                .expect("logical_a")
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("int64")
+                .value(0),
+            10,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn generic_default_matches_nested_fields_by_name() -> Result<()> {
+        let source_by_name = field_with_id("logical", PARQUET_FIELD_ID_META_KEY, 2);
+        let source_by_id = field_with_id("old_name", PARQUET_FIELD_ID_META_KEY, 1);
+        let source = Arc::new(StructArray::new(
+            vec![source_by_name, source_by_id].into(),
+            vec![
+                Arc::new(Int64Array::from(vec![Some(20)])),
+                Arc::new(Int64Array::from(vec![Some(10)])),
+            ],
+            None,
+        )) as ArrayRef;
+        let target_child = field_with_id("logical", "delta.columnMapping.id", 1);
+        let target_field = Field::new("root", DataType::Struct(vec![target_child].into()), true);
+
+        let casted = cast_array_with_schema_evolution(
+            &source,
+            &target_field,
+            &DEFAULT_CAST_OPTIONS,
+            StructFieldMatching::default(),
+        )?;
+        let casted = casted
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("struct array");
+        assert_eq!(
+            casted
+                .column_by_name("logical")
+                .expect("logical")
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("int64")
+                .value(0),
+            20,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn generic_name_mode_rejects_structs_without_field_overlap() {
+        let source = Arc::new(StructArray::new(
+            vec![Arc::new(Field::new("old", DataType::Int64, true))].into(),
+            vec![Arc::new(Int64Array::from(vec![Some(10)]))],
+            None,
+        )) as ArrayRef;
+        let target_field = Field::new(
+            "root",
+            DataType::Struct(vec![Arc::new(Field::new("new", DataType::Int64, true))].into()),
+            true,
+        );
+
+        let error = cast_array_with_schema_evolution(
+            &source,
+            &target_field,
+            &DEFAULT_CAST_OPTIONS,
+            StructFieldMatching::Name,
+        )
+        .expect_err("zero-overlap name-based structs must fail");
+
+        assert!(error.to_string().contains("no field name overlap"));
+    }
+
+    #[test]
+    fn relaxed_timezone_cast_scales_without_shifting_values() -> Result<()> {
+        let source = Arc::new(TimestampMillisecondArray::from(vec![Some(1_000)])) as ArrayRef;
+        let target = Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, Some(Arc::from("Europe/Amsterdam"))),
+            true,
+        );
+
+        let casted = cast_array_with_schema_evolution_relaxed_tz(
+            &source,
+            &target,
+            &DEFAULT_CAST_OPTIONS,
+            StructFieldMatching::Name,
+        )?;
+        let timestamp = casted
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .expect("timestamp");
+
+        assert_eq!(timestamp.value(0), 1_000_000);
+        assert_eq!(timestamp.data_type(), target.data_type());
+        Ok(())
+    }
+
+    #[test]
+    fn relaxed_timezone_cast_recurses_into_structs() -> Result<()> {
+        let source_child = Arc::new(Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Millisecond, Some(Arc::from("UTC"))),
+            true,
+        ));
+        let source = Arc::new(StructArray::new(
+            vec![Arc::clone(&source_child)].into(),
+            vec![Arc::new(
+                TimestampMillisecondArray::from(vec![Some(1_000)]).with_timezone("UTC"),
+            )],
+            None,
+        )) as ArrayRef;
+        let target_child = Arc::new(Field::new(
+            "ts",
+            DataType::Timestamp(TimeUnit::Microsecond, Some(Arc::from("Europe/Amsterdam"))),
+            true,
+        ));
+        let target = Field::new(
+            "root",
+            DataType::Struct(vec![Arc::clone(&target_child)].into()),
+            true,
+        );
+
+        let casted = cast_array_with_schema_evolution_relaxed_tz(
+            &source,
+            &target,
+            &DEFAULT_CAST_OPTIONS,
+            StructFieldMatching::Name,
+        )?;
+        let casted = casted
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("struct");
+        let timestamp = casted
+            .column(0)
+            .as_any()
+            .downcast_ref::<TimestampMicrosecondArray>()
+            .expect("timestamp");
+
+        assert_eq!(timestamp.value(0), 1_000_000);
+        assert_eq!(timestamp.data_type(), target_child.data_type());
+        Ok(())
+    }
+
+    #[test]
+    fn name_mode_does_not_fallback_to_id_or_logical_name() -> Result<()> {
+        let source_child = field_with_id("logical", PARQUET_FIELD_ID_META_KEY, 1);
+        let source = Arc::new(StructArray::new(
+            vec![source_child].into(),
+            vec![Arc::new(Int64Array::from(vec![Some(10)]))],
+            None,
+        )) as ArrayRef;
+        let target_child = Arc::new(Field::new("logical", DataType::Int64, true).with_metadata(
+            HashMap::from([
+                (
+                    DELTA_COLUMN_MAPPING_PHYSICAL_NAME_METADATA_KEY.to_string(),
+                    "different-physical-name".to_string(),
+                ),
+                ("delta.columnMapping.id".to_string(), "1".to_string()),
+            ]),
+        ));
+        let target_field = Field::new("root", DataType::Struct(vec![target_child].into()), true);
+
+        let casted = cast_array_with_schema_evolution(
+            &source,
+            &target_field,
+            &DEFAULT_CAST_OPTIONS,
+            StructFieldMatching::PhysicalName,
+        )?;
+        let casted = casted
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("struct array");
+
+        assert!(casted.column(0).is_null(0));
+        Ok(())
+    }
+
+    #[test]
+    fn missing_non_nullable_mapped_field_is_rejected() {
+        let source = Arc::new(StructArray::new(
+            vec![Arc::new(Field::new("other", DataType::Int64, true))].into(),
+            vec![Arc::new(Int64Array::from(vec![Some(10)]))],
+            None,
+        )) as ArrayRef;
+        let target_child = Arc::new(
+            Field::new("required", DataType::Int64, false).with_metadata(HashMap::from([(
+                DELTA_COLUMN_MAPPING_PHYSICAL_NAME_METADATA_KEY.to_string(),
+                "required-physical".to_string(),
+            )])),
+        );
+        let target_field = Field::new("root", DataType::Struct(vec![target_child].into()), true);
+
+        let error = cast_array_with_schema_evolution(
+            &source,
+            &target_field,
+            &DEFAULT_CAST_OPTIONS,
+            StructFieldMatching::PhysicalName,
+        )
+        .expect_err("missing non-nullable field must fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("target field 'required' is non-nullable")
+        );
+    }
+
+    #[test]
+    fn map_entry_wrappers_match_by_name_in_physical_name_mode() -> Result<()> {
+        let source_value = Arc::new(Field::new(
+            "value",
+            DataType::Struct(vec![Arc::new(Field::new("col-a", DataType::Int64, true))].into()),
+            true,
+        ));
+        let source = Field::new(
+            "attrs",
+            DataType::Map(
+                Arc::new(Field::new(
+                    "entries",
+                    DataType::Struct(
+                        vec![
+                            Arc::new(Field::new("key", DataType::Utf8, false)),
+                            source_value,
+                        ]
+                        .into(),
+                    ),
+                    false,
+                )),
+                false,
+            ),
+            true,
+        );
+
+        let target_value_child = Arc::new(Field::new("a", DataType::Int64, true).with_metadata(
+            HashMap::from([(
+                DELTA_COLUMN_MAPPING_PHYSICAL_NAME_METADATA_KEY.to_string(),
+                "col-a".to_string(),
+            )]),
+        ));
+        let target = Field::new(
+            "attrs",
+            DataType::Map(
+                Arc::new(Field::new(
+                    "entries",
+                    DataType::Struct(
+                        vec![
+                            Arc::new(Field::new("key", DataType::Utf8, false)),
+                            Arc::new(Field::new(
+                                "value",
+                                DataType::Struct(vec![target_value_child].into()),
+                                true,
+                            )),
+                        ]
+                        .into(),
+                    ),
+                    false,
+                )),
+                false,
+            ),
+            true,
+        );
+
+        assert!(can_cast_field_with_schema_evolution(
+            &source,
+            &target,
+            StructFieldMatching::PhysicalName,
+        )?);
+        Ok(())
+    }
+
+    #[test]
+    fn cast_struct_field_by_physical_name_before_logical_name() -> Result<()> {
+        let source = Arc::new(StructArray::new(
+            vec![
+                Arc::new(Field::new("rate", DataType::Int64, true)),
+                Arc::new(Field::new("col-rate", DataType::Int64, true)),
+            ]
+            .into(),
+            vec![
+                Arc::new(Int64Array::from(vec![Some(10)])),
+                Arc::new(Int64Array::from(vec![Some(20)])),
+            ],
+            None,
+        )) as ArrayRef;
+        let target_child = Arc::new(Field::new("rate", DataType::Int64, true).with_metadata(
+            HashMap::from([(
+                DELTA_COLUMN_MAPPING_PHYSICAL_NAME_METADATA_KEY.to_string(),
+                "col-rate".to_string(),
+            )]),
+        ));
+        let target_field = Field::new("root", DataType::Struct(vec![target_child].into()), true);
+
+        let casted = cast_array_with_schema_evolution(
+            &source,
+            &target_field,
+            &DEFAULT_CAST_OPTIONS,
+            StructFieldMatching::PhysicalName,
+        )?;
+        let casted = casted
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("struct array");
+
+        assert_eq!(
+            casted
+                .column_by_name("rate")
+                .expect("rate")
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .expect("int64")
+                .value(0),
+            20,
+        );
+        Ok(())
     }
 
     #[test]
@@ -752,10 +1357,15 @@ mod tests {
 
         assert!(can_cast_field_with_schema_evolution(
             &source_field,
-            &target_field
+            &target_field,
+            StructFieldMatching::PhysicalName,
         )?);
-        let casted =
-            cast_array_with_schema_evolution(&source, &target_field, &DEFAULT_CAST_OPTIONS)?;
+        let casted = cast_array_with_schema_evolution(
+            &source,
+            &target_field,
+            &DEFAULT_CAST_OPTIONS,
+            StructFieldMatching::PhysicalName,
+        )?;
 
         assert_eq!(casted.data_type(), target_field.data_type());
         let json = variant_to_json(&casted)?;
@@ -790,8 +1400,12 @@ mod tests {
         let target_payload = Arc::new(variant_field("payload"));
         let target_field = Field::new("root", DataType::Struct(vec![target_payload].into()), true);
 
-        let casted =
-            cast_array_with_schema_evolution(&source, &target_field, &DEFAULT_CAST_OPTIONS)?;
+        let casted = cast_array_with_schema_evolution(
+            &source,
+            &target_field,
+            &DEFAULT_CAST_OPTIONS,
+            StructFieldMatching::Name,
+        )?;
         let casted_struct = casted
             .as_any()
             .downcast_ref::<StructArray>()
@@ -828,8 +1442,12 @@ mod tests {
             true,
         );
 
-        let casted =
-            cast_array_with_schema_evolution(&source, &target_field, &DEFAULT_CAST_OPTIONS)?;
+        let casted = cast_array_with_schema_evolution(
+            &source,
+            &target_field,
+            &DEFAULT_CAST_OPTIONS,
+            StructFieldMatching::Name,
+        )?;
         let casted_list = casted
             .as_any()
             .downcast_ref::<ListArray>()

--- a/crates/sail-delta-lake/src/datasource/expressions.rs
+++ b/crates/sail-delta-lake/src/datasource/expressions.rs
@@ -19,16 +19,21 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use datafusion::arrow::datatypes::{DataType as ArrowDataType, FieldRef, Schema as ArrowSchema};
 use datafusion::catalog::Session;
 use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
-use datafusion::common::{Column, DFSchema, Result};
+use datafusion::common::{Column, DFSchema, Result, ScalarValue};
+use datafusion::functions::core::getfield::GetFieldFunc;
 use datafusion::logical_expr::simplify::SimplifyContextBuilder;
 use datafusion::logical_expr::{BinaryExpr, Expr, Operator, TableProviderFilterPushDown};
 use datafusion::optimizer::simplify_expressions::ExprSimplifier;
-use datafusion::physical_expr::PhysicalExpr;
-use datafusion::physical_plan::expressions::Column as PhysicalColumn;
+use datafusion::physical_expr::{PhysicalExpr, ScalarFunctionExpr};
+use datafusion::physical_plan::expressions::{
+    Column as PhysicalColumn, Literal as PhysicalLiteral,
+};
 
-use crate::spec::DeltaResult;
+use crate::schema::arrow_field_physical_name;
+use crate::spec::{ColumnMappingMode, DeltaResult};
 
 // [Credit]: <https://github.com/delta-io/delta-rs/blob/3607c314cbdd2ad06c6ee0677b92a29f695c71f3/crates/core/src/delta_datafusion/mod.rs>
 
@@ -111,6 +116,122 @@ fn expr_is_exact_predicate_for_cols(partition_cols: &[String], expr: &Expr) -> b
     is_applicable
 }
 
+/// Rewrite column references in a parquet pushdown predicate from logical names to the
+/// physical names used in the data files of column-mapped tables. Nested struct field
+/// accesses (`get_field`) are rewritten as well, using the column mapping metadata carried
+/// by the logical schema. Partition columns are exposed to the file scan as virtual columns
+/// under their logical names and are left untouched.
+pub fn rewrite_predicate_for_column_mapping(
+    expr: Arc<dyn PhysicalExpr>,
+    logical_schema: &ArrowSchema,
+    mode: ColumnMappingMode,
+    partition_cols: &[String],
+) -> Result<Arc<dyn PhysicalExpr>> {
+    if mode == ColumnMappingMode::None {
+        return Ok(expr);
+    }
+    Ok(rewrite_expr_for_column_mapping(expr, logical_schema, mode, partition_cols)?.0)
+}
+
+/// Recursively rewrite an expression, returning the rewritten expression along with the
+/// logical schema field it resolves to (when the expression is a column or a chain of
+/// struct field accesses rooted at a column).
+fn rewrite_expr_for_column_mapping(
+    expr: Arc<dyn PhysicalExpr>,
+    logical_schema: &ArrowSchema,
+    mode: ColumnMappingMode,
+    partition_cols: &[String],
+) -> Result<(Arc<dyn PhysicalExpr>, Option<FieldRef>)> {
+    if let Some(column) = expr.downcast_ref::<PhysicalColumn>() {
+        if partition_cols.iter().any(|col| col == column.name()) {
+            return Ok((expr, None));
+        }
+        let Some((_, field)) = logical_schema.fields().find(column.name()) else {
+            return Ok((expr, None));
+        };
+        let physical_name = arrow_field_physical_name(field, mode);
+        let rewritten: Arc<dyn PhysicalExpr> = if physical_name == column.name() {
+            Arc::clone(&expr)
+        } else {
+            // Column mapping changes names, not file order, so the logical index remains valid.
+            Arc::new(PhysicalColumn::new(physical_name, column.index()))
+        };
+        return Ok((rewritten, Some(Arc::clone(field))));
+    }
+
+    if ScalarFunctionExpr::try_downcast_func::<GetFieldFunc>(expr.as_ref()).is_some() {
+        let children = expr.children();
+        let Some((source_expr, path_exprs)) = children.split_first() else {
+            return Ok((expr, None));
+        };
+        let (new_source, source_field) = rewrite_expr_for_column_mapping(
+            Arc::clone(source_expr),
+            logical_schema,
+            mode,
+            partition_cols,
+        )?;
+        let mut current_field = source_field;
+        // Rewriters preserve the original Arc when unchanged, making pointer identity sufficient.
+        let mut changed = !Arc::ptr_eq(&new_source, source_expr);
+        let mut new_children = Vec::with_capacity(children.len());
+        new_children.push(new_source);
+
+        for path_expr in path_exprs {
+            let field_name = path_expr
+                .downcast_ref::<PhysicalLiteral>()
+                .and_then(|lit| lit.value().try_as_str().flatten());
+            let child_field = match (&current_field, field_name) {
+                (Some(source_field), Some(name)) => match source_field.data_type() {
+                    ArrowDataType::Struct(children) => {
+                        children.iter().find(|f| f.name() == name).cloned()
+                    }
+                    _ => None,
+                },
+                _ => None,
+            };
+            let rewritten_path = child_field.as_ref().and_then(|child| {
+                let physical_name = arrow_field_physical_name(child, mode);
+                (physical_name != child.name().as_str()).then(|| {
+                    Arc::new(PhysicalLiteral::new(ScalarValue::Utf8(Some(
+                        physical_name.to_string(),
+                    )))) as Arc<dyn PhysicalExpr>
+                })
+            });
+            changed |= rewritten_path.is_some();
+            new_children.push(rewritten_path.unwrap_or_else(|| Arc::clone(path_expr)));
+            current_field = child_field;
+        }
+
+        if changed {
+            let rewritten = Arc::clone(&expr).with_new_children(new_children)?;
+            return Ok((rewritten, current_field));
+        }
+        return Ok((expr, current_field));
+    }
+
+    let children = expr.children();
+    if children.is_empty() {
+        return Ok((expr, None));
+    }
+    let mut new_children = Vec::with_capacity(children.len());
+    let mut changed = false;
+    for child in children {
+        let (new_child, _) = rewrite_expr_for_column_mapping(
+            Arc::clone(child),
+            logical_schema,
+            mode,
+            partition_cols,
+        )?;
+        changed |= !Arc::ptr_eq(&new_child, child);
+        new_children.push(new_child);
+    }
+    if changed {
+        Ok((Arc::clone(&expr).with_new_children(new_children)?, None))
+    } else {
+        Ok((expr, None))
+    }
+}
+
 /// Extract column names referenced by a `PhysicalExpr`.
 pub fn collect_physical_columns(expr: &Arc<dyn PhysicalExpr>) -> HashSet<String> {
     let mut columns = HashSet::<String>::new();
@@ -148,6 +269,81 @@ impl PredicateProperties {
             .iter()
             .all(|col| self.partition_columns.contains(col));
 
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used)]
+mod tests {
+    use std::collections::HashMap;
+
+    use datafusion::common::config::ConfigOptions;
+    use datafusion::physical_expr::expressions::{
+        Column as PhysicalColumn, Literal as PhysicalLiteral,
+    };
+
+    use super::*;
+
+    fn mapped_field(name: &str, physical_name: &str, data_type: ArrowDataType) -> FieldRef {
+        Arc::new(
+            datafusion::arrow::datatypes::Field::new(name, data_type, true).with_metadata(
+                HashMap::from([(
+                    "delta.columnMapping.physicalName".to_string(),
+                    physical_name.to_string(),
+                )]),
+            ),
+        )
+    }
+
+    #[test]
+    fn rewrites_every_segment_of_flattened_get_field_path() -> Result<()> {
+        let inner = mapped_field("inner", "col-inner", ArrowDataType::Int64);
+        let outer = mapped_field(
+            "outer",
+            "col-outer",
+            ArrowDataType::Struct(vec![inner].into()),
+        );
+        let root = mapped_field(
+            "root",
+            "col-root",
+            ArrowDataType::Struct(vec![outer].into()),
+        );
+        let schema = ArrowSchema::new(vec![root]);
+        let args: Vec<Arc<dyn PhysicalExpr>> = vec![
+            Arc::new(PhysicalColumn::new("root", 0)),
+            Arc::new(PhysicalLiteral::new(ScalarValue::Utf8(Some(
+                "outer".to_string(),
+            )))),
+            Arc::new(PhysicalLiteral::new(ScalarValue::Utf8(Some(
+                "inner".to_string(),
+            )))),
+        ];
+        let expr = Arc::new(ScalarFunctionExpr::try_new(
+            datafusion::functions::core::get_field(),
+            args,
+            &schema,
+            Arc::new(ConfigOptions::default()),
+        )?) as Arc<dyn PhysicalExpr>;
+
+        let rewritten =
+            rewrite_predicate_for_column_mapping(expr, &schema, ColumnMappingMode::Name, &[])?;
+        let children = rewritten.children();
+
+        let root = children[0]
+            .downcast_ref::<PhysicalColumn>()
+            .expect("root column");
+        assert_eq!(root.name(), "col-root");
+        let path = children[1..]
+            .iter()
+            .map(|child| {
+                child
+                    .downcast_ref::<PhysicalLiteral>()
+                    .and_then(|literal| literal.value().try_as_str().flatten())
+                    .expect("literal path")
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(path, ["col-outer", "col-inner"]);
         Ok(())
     }
 }

--- a/crates/sail-delta-lake/src/datasource/mod.rs
+++ b/crates/sail-delta-lake/src/datasource/mod.rs
@@ -45,7 +45,8 @@ pub mod schema;
 // Re-exports
 pub use actions::{adds_to_remove_actions, partitioned_file_from_action};
 pub use expressions::{
-    PredicateProperties, collect_physical_columns, get_pushdown_filters, simplify_expr,
+    PredicateProperties, collect_physical_columns, get_pushdown_filters,
+    rewrite_predicate_for_column_mapping, simplify_expr,
 };
 pub use pruning::{PruningResult, prune_files};
 pub use scan::build_file_scan_config;

--- a/crates/sail-delta-lake/src/datasource/scan.rs
+++ b/crates/sail-delta-lake/src/datasource/scan.rs
@@ -35,7 +35,9 @@ use datafusion::datasource::physical_plan::{
 use datafusion::datasource::table_schema::TableSchema;
 use datafusion::physical_expr::{LexOrdering, PhysicalExpr};
 use object_store::path::Path;
-use sail_common_datafusion::schema_evolution::SchemaEvolutionPhysicalExprAdapterFactory;
+use sail_common_datafusion::schema_evolution::{
+    SchemaEvolutionPhysicalExprAdapterFactoryWithMatching, StructFieldMatching,
+};
 
 use crate::conversion::ScalarConverter;
 use crate::datasource::{DeltaScanConfig, create_object_store_url, partitioned_file_from_action};
@@ -364,7 +366,15 @@ pub fn build_file_scan_config(
         .with_statistics(stats)
         .with_projection_indices(params.projection.cloned())?
         .with_limit(params.limit)
-        .with_expr_adapter(Some(Arc::new(SchemaEvolutionPhysicalExprAdapterFactory {})))
+        .with_expr_adapter(Some(Arc::new(
+            SchemaEvolutionPhysicalExprAdapterFactoryWithMatching::new(
+                match snapshot.effective_column_mapping_mode() {
+                    crate::spec::ColumnMappingMode::None => StructFieldMatching::Name,
+                    crate::spec::ColumnMappingMode::Name => StructFieldMatching::PhysicalName,
+                    crate::spec::ColumnMappingMode::Id => StructFieldMatching::FieldId,
+                },
+            ),
+        )))
         .build();
 
     Ok(file_scan_config)

--- a/crates/sail-delta-lake/src/physical/scan_planner.rs
+++ b/crates/sail-delta-lake/src/physical/scan_planner.rs
@@ -18,7 +18,9 @@ use sail_data_source::options::ResolveOptions;
 use crate::datasource::scan::{
     FileScanParams, TableStatsMode, build_file_scan_config, file_scan_projection_for_schema,
 };
-use crate::datasource::{DeltaScanConfig, df_logical_schema, simplify_expr};
+use crate::datasource::{
+    DeltaScanConfig, df_logical_schema, rewrite_predicate_for_column_mapping, simplify_expr,
+};
 use crate::delta_log::LogStoreRef;
 use crate::options::r#gen::DeltaWriteOptions;
 use crate::physical_plan::planner::metadata_predicate::{
@@ -27,7 +29,7 @@ use crate::physical_plan::planner::metadata_predicate::{
 use crate::physical_plan::planner::utils::LogReplayOptions;
 use crate::physical_plan::planner::{DeltaPlannerConfig, PlannerContext};
 use crate::physical_plan::{DeltaDiscoveryExec, DeltaScanByAddsExec, RelaxedTzCastExec};
-use crate::schema::get_physical_schema;
+use crate::schema::{attach_column_mapping_metadata, get_physical_schema};
 use crate::spec::{Add, ColumnMappingMode, StructType};
 use crate::table::DeltaSnapshot;
 
@@ -41,15 +43,24 @@ pub(crate) async fn plan_delta_scan(
     filters: &[Expr],
     limit: Option<usize>,
 ) -> Result<Arc<dyn ExecutionPlan>> {
-    let config = config.clone();
+    let mut config = config.clone();
     snapshot
         .ensure_data_read_supported()
         .map_err(|e| datafusion::common::DataFusionError::External(Box::new(e)))?;
 
-    let schema = config
-        .schema
-        .clone()
-        .unwrap_or_else(|| Arc::new(snapshot.schema().clone()));
+    let kmode = snapshot.effective_column_mapping_mode();
+    let schema = match config.schema.clone() {
+        Some(requested) if kmode != ColumnMappingMode::None => {
+            let schema = Arc::new(attach_column_mapping_metadata(
+                requested.as_ref(),
+                snapshot.schema(),
+            ));
+            config.schema = Some(Arc::clone(&schema));
+            schema
+        }
+        Some(requested) => requested,
+        None => Arc::new(snapshot.schema().clone()),
+    };
 
     let full_logical_schema = df_logical_schema(
         snapshot,
@@ -175,10 +186,9 @@ pub(crate) async fn plan_delta_scan(
     };
 
     // Build physical file schema (non-partition columns)
-    let kmode: ColumnMappingMode = snapshot.effective_column_mapping_mode();
     let kschema_arc = snapshot.schema();
     let logical_kernel = StructType::try_from(kschema_arc)?;
-    let physical_arrow: ArrowSchema = get_physical_schema(&logical_kernel, kmode);
+    let physical_arrow: ArrowSchema = get_physical_schema(&logical_kernel, kmode)?;
     let physical_partition_cols: HashSet<String> = snapshot
         .physical_partition_columns()
         .into_iter()
@@ -209,6 +219,18 @@ pub(crate) async fn plan_delta_scan(
     } else {
         None
     };
+    // The parquet scan resolves predicate columns against the physical file schema,
+    // so column-mapped tables need the predicate rewritten from logical to physical names.
+    let pushdown_filter = pushdown_filter
+        .map(|expr| {
+            rewrite_predicate_for_column_mapping(
+                expr,
+                snapshot.schema(),
+                kmode,
+                &table_partition_cols,
+            )
+        })
+        .transpose()?;
 
     // When the table protocol declares the deletionVectors feature, always use the
     // metadata-as-data path (DeltaScanByAddsExec) which loads a fresh snapshot and
@@ -276,9 +298,11 @@ pub(crate) async fn plan_delta_scan(
             input_field.data_type() != field.data_type()
         });
         if needs_wrapping {
-            return Ok(
-                Arc::new(RelaxedTzCastExec::new(renamed, output_schema)) as Arc<dyn ExecutionPlan>
-            );
+            return Ok(Arc::new(RelaxedTzCastExec::new_with_column_mapping(
+                renamed,
+                output_schema,
+                kmode,
+            )) as Arc<dyn ExecutionPlan>);
         }
         return Ok(renamed);
     }

--- a/crates/sail-delta-lake/src/physical_plan/relaxed_tz_exec.rs
+++ b/crates/sail-delta-lake/src/physical_plan/relaxed_tz_exec.rs
@@ -14,16 +14,27 @@ use sail_common_datafusion::array::record_batch::cast_record_batch_relaxed_tz;
 use sail_common_datafusion::utils::items::ItemTaker;
 
 use crate::datasource::scan::map_statistics_to_schema;
+use crate::schema::restore_logical_record_batch;
+use crate::spec::ColumnMappingMode;
 
 #[derive(Debug, Clone)]
 pub struct RelaxedTzCastExec {
     input: Arc<dyn ExecutionPlan>,
     schema: SchemaRef,
+    column_mapping_mode: ColumnMappingMode,
     properties: Arc<PlanProperties>,
 }
 
 impl RelaxedTzCastExec {
     pub fn new(input: Arc<dyn ExecutionPlan>, schema: SchemaRef) -> Self {
+        Self::new_with_column_mapping(input, schema, ColumnMappingMode::None)
+    }
+
+    pub fn new_with_column_mapping(
+        input: Arc<dyn ExecutionPlan>,
+        schema: SchemaRef,
+        column_mapping_mode: ColumnMappingMode,
+    ) -> Self {
         let properties = Arc::new(PlanProperties::new(
             EquivalenceProperties::new(schema.clone()),
             input.output_partitioning().clone(),
@@ -33,12 +44,17 @@ impl RelaxedTzCastExec {
         Self {
             input,
             schema,
+            column_mapping_mode,
             properties,
         }
     }
 
     pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
         &self.input
+    }
+
+    pub const fn column_mapping_mode(&self) -> ColumnMappingMode {
+        self.column_mapping_mode
     }
 
     fn aligned_timestamp_columns(&self) -> Vec<String> {
@@ -116,7 +132,11 @@ impl ExecutionPlan for RelaxedTzCastExec {
         let input = children.one().map_err(|_| {
             internal_datafusion_err!("RelaxedTzCastExec must have exactly one child")
         })?;
-        Ok(Arc::new(Self::new(input, Arc::clone(&self.schema))))
+        Ok(Arc::new(Self::new_with_column_mapping(
+            input,
+            Arc::clone(&self.schema),
+            self.column_mapping_mode,
+        )))
     }
 
     fn execute(
@@ -125,10 +145,16 @@ impl ExecutionPlan for RelaxedTzCastExec {
         context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
         let schema = Arc::clone(&self.schema);
+        let column_mapping_mode = self.column_mapping_mode;
         let stream = self.input.execute(partition, context)?;
         let stream = stream.map(move |batch| {
             let schema = Arc::clone(&schema);
-            batch.and_then(|batch| cast_record_batch_relaxed_tz(&batch, &schema))
+            batch.and_then(|batch| match column_mapping_mode {
+                ColumnMappingMode::None => cast_record_batch_relaxed_tz(&batch, &schema),
+                ColumnMappingMode::Name | ColumnMappingMode::Id => {
+                    restore_logical_record_batch(&batch, &schema, column_mapping_mode)
+                }
+            })
         });
 
         Ok(Box::pin(RecordBatchStreamAdapter::new(

--- a/crates/sail-delta-lake/src/physical_plan/scan_by_adds_exec.rs
+++ b/crates/sail-delta-lake/src/physical_plan/scan_by_adds_exec.rs
@@ -29,7 +29,6 @@ use datafusion::physical_plan::{
 use datafusion_common::{DataFusionError, Result, Statistics, internal_err};
 use datafusion_physical_expr::{Distribution, EquivalenceProperties, PhysicalExpr};
 use futures::stream::{self, StreamExt, TryStreamExt};
-use sail_common_datafusion::array::record_batch::cast_record_batch_relaxed_tz;
 use sail_common_datafusion::catalog::LakehouseExecutionContext;
 use sail_common_datafusion::extension::SessionExtensionAccessor;
 use sail_common_datafusion::rename::physical_plan::rename_physical_plan;
@@ -43,7 +42,7 @@ use crate::datasource::{DeltaScanConfig, build_file_scan_config};
 use crate::deletion_vector::DeletionVectorBitmap;
 use crate::delta_log::LogStoreRef;
 use crate::physical_plan::{COL_ACTION, decode_adds_from_batch, meta_adds};
-use crate::schema::{arrow_field_physical_name, get_physical_schema};
+use crate::schema::{arrow_field_physical_name, get_physical_schema, restore_logical_record_batch};
 use crate::session_extension::{DeltaTableCache, load_table_uncached, load_table_with_config};
 use crate::snapshot::{CatalogManagedCommitSet, DeltaSnapshotConfig};
 use crate::spec::StructType;
@@ -183,7 +182,7 @@ impl ScanByAddsStreamState {
         let kschema_arc = snapshot_state.schema();
         let logical_kernel = StructType::try_from(kschema_arc)
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
-        let physical_arrow = get_physical_schema(&logical_kernel, kmode);
+        let physical_arrow = get_physical_schema(&logical_kernel, kmode)?;
         let physical_partition_cols: std::collections::HashSet<String> = table_partition_cols
             .iter()
             .map(|col| {
@@ -239,6 +238,7 @@ impl ScanByAddsStreamState {
             .snapshot
             .as_deref()
             .ok_or_else(|| DataFusionError::Internal("missing snapshot".into()))?;
+        let column_mapping_mode = snapshot.effective_column_mapping_mode();
         let log_store = self
             .log_store
             .as_ref()
@@ -323,8 +323,11 @@ impl ScanByAddsStreamState {
                 .and_then(move |batch| {
                     let output_schema = Arc::clone(&output_schema);
                     async move {
-                        let casted = cast_record_batch_relaxed_tz(&batch, &output_schema)
-                            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+                        let casted = restore_logical_record_batch(
+                            &batch,
+                            &output_schema,
+                            column_mapping_mode,
+                        )?;
                         Ok(casted)
                     }
                 });
@@ -403,8 +406,8 @@ impl ScanByAddsStreamState {
             .and_then(move |batch| {
                 let output_schema = Arc::clone(&output_schema);
                 async move {
-                    let casted = cast_record_batch_relaxed_tz(&batch, &output_schema)
-                        .map_err(|e| DataFusionError::External(Box::new(e)))?;
+                    let casted =
+                        restore_logical_record_batch(&batch, &output_schema, column_mapping_mode)?;
                     Ok(casted)
                 }
             });

--- a/crates/sail-delta-lake/src/physical_plan/write_context.rs
+++ b/crates/sail-delta-lake/src/physical_plan/write_context.rs
@@ -121,7 +121,7 @@ impl DeltaWriteContext {
             Ok(Arc::new(get_physical_schema(
                 logical_kernel,
                 self.effective_column_mapping_mode,
-            )))
+            )?))
         }
     }
 }
@@ -576,4 +576,62 @@ fn validate_schema_compatibility(table_schema: &Schema, input_schema: &Schema) -
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, clippy::panic)]
+mod tests {
+    use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
+
+    use super::*;
+    use crate::spec::{DataType, MetadataValue, StructField};
+
+    fn mapped_field(name: &str, physical_name: &str, id: i64, data_type: DataType) -> StructField {
+        StructField::new(name, data_type, true).with_metadata([
+            ("delta.columnMapping.id", MetadataValue::Number(id)),
+            (
+                "delta.columnMapping.physicalName",
+                MetadataValue::String(physical_name.to_string()),
+            ),
+        ])
+    }
+
+    #[test]
+    fn writer_schema_preserves_nested_parquet_field_ids() -> Result<()> {
+        let nested = StructType::try_new(vec![mapped_field("rate", "col-rate", 2, DataType::LONG)])
+            .expect("nested schema");
+        let logical = StructType::try_new(vec![mapped_field(
+            "details",
+            "col-details",
+            1,
+            DataType::Struct(Box::new(nested)),
+        )])
+        .expect("logical schema");
+        let context = DeltaWriteContext {
+            commit_context: DeltaCommitContext::default(),
+            final_schema: logical.clone(),
+            effective_column_mapping_mode: ColumnMappingMode::Name,
+            initial_actions: Vec::new(),
+            schema_actions: Vec::new(),
+            operation: None,
+            logical_kernel_for_mapping: Some(logical),
+            physical_partition_columns: Vec::new(),
+        };
+
+        let writer_schema = context.writer_schema()?;
+        let details = writer_schema.field_with_name("col-details")?;
+        let datafusion::arrow::datatypes::DataType::Struct(children) = details.data_type() else {
+            panic!("details must be a struct");
+        };
+        let rate = children.first().expect("nested rate field");
+
+        assert_eq!(rate.name(), "col-rate");
+        assert_eq!(
+            rate.metadata()
+                .get(PARQUET_FIELD_ID_META_KEY)
+                .map(String::as_str),
+            Some("2")
+        );
+        Ok(())
+    }
 }

--- a/crates/sail-delta-lake/src/physical_plan/writer_exec.rs
+++ b/crates/sail-delta-lake/src/physical_plan/writer_exec.rs
@@ -46,6 +46,7 @@ use datafusion::physical_plan::{
 use datafusion_common::{DataFusionError, Result, internal_err};
 use datafusion_physical_expr::{Distribution, EquivalenceProperties};
 use futures::stream::{StreamExt, once};
+use sail_common_datafusion::array::record_batch::cast_array_recursively;
 use sail_common_datafusion::catalog::LakehouseExecutionContext;
 use sail_common_datafusion::datasource::{
     MERGE_SOURCE_METRIC_COLUMN, OPERATION_COLUMN, PhysicalSinkMode, RowLevelOperationType,
@@ -58,9 +59,9 @@ use crate::physical_plan::writer_options::DeltaWriterExecOptions;
 use crate::physical_plan::{
     DeltaWriteContext, ExecCommitMeta, delta_action_schema, encode_actions,
 };
+use crate::schema::adapt_array_to_physical_field;
 use crate::spec::{
-    Action, ColumnMappingMode, DeltaOperation, Metadata, Protocol, StructType, TableFeature,
-    TableProperties,
+    Action, ColumnMappingMode, DeltaOperation, Metadata, Protocol, TableFeature, TableProperties,
 };
 use crate::transaction::OperationMetrics;
 use crate::writer::variant_shredding::{VariantShreddingConfig, variant_top_level_columns};
@@ -293,21 +294,68 @@ pub struct DeltaWriterExec {
     cache: Arc<PlanProperties>,
 }
 
-impl DeltaWriterExec {
-    /// Build a map from physical field name to logical name for top-level columns
-    fn build_physical_to_logical_map(
-        logical_kernel: &StructType,
-        column_mapping_mode: ColumnMappingMode,
-    ) -> HashMap<String, String> {
-        let mut map = HashMap::new();
-        for kf in logical_kernel.fields() {
-            map.insert(
-                kf.physical_name(column_mapping_mode).to_string(),
-                kf.name().clone(),
-            );
-        }
-        map
+fn matching_nested_types(source: &DataType, target: &DataType) -> bool {
+    matches!(
+        (source, target),
+        (DataType::Struct(_), DataType::Struct(_))
+            | (DataType::List(_), DataType::List(_))
+            | (DataType::LargeList(_), DataType::LargeList(_))
+            | (DataType::FixedSizeList(_, _), DataType::FixedSizeList(_, _))
+            | (DataType::Map(_, _), DataType::Map(_, _))
+    )
+}
+
+fn validate_cast_safety_recursively(
+    source: &DataType,
+    target: &DataType,
+    path: &str,
+) -> Result<()> {
+    if source == target {
+        return Ok(());
     }
+
+    match (source, target) {
+        (DataType::Struct(source_fields), DataType::Struct(target_fields)) => {
+            for target_field in target_fields {
+                if let Some(source_field) = source_fields
+                    .iter()
+                    .find(|field| field.name() == target_field.name())
+                {
+                    validate_cast_safety_recursively(
+                        source_field.data_type(),
+                        target_field.data_type(),
+                        &format!("{path}.{}", target_field.name()),
+                    )?;
+                }
+            }
+            Ok(())
+        }
+        (DataType::List(source), DataType::List(target))
+        | (DataType::LargeList(source), DataType::LargeList(target)) => {
+            validate_cast_safety_recursively(
+                source.data_type(),
+                target.data_type(),
+                &format!("{path}[]"),
+            )
+        }
+        (
+            DataType::FixedSizeList(source, source_len),
+            DataType::FixedSizeList(target, target_len),
+        ) if source_len == target_len => validate_cast_safety_recursively(
+            source.data_type(),
+            target.data_type(),
+            &format!("{path}[]"),
+        ),
+        (DataType::Map(source, _), DataType::Map(target, _)) => validate_cast_safety_recursively(
+            source.data_type(),
+            target.data_type(),
+            &format!("{path}{{}}"),
+        ),
+        _ => DeltaTypeConverter::validate_cast_safety(source, target, path),
+    }
+}
+
+impl DeltaWriterExec {
     #[expect(clippy::too_many_arguments)]
     pub fn new(
         input: Arc<dyn ExecutionPlan>,
@@ -690,12 +738,12 @@ impl DeltaWriterExec {
             let writer_path = object_store::path::Path::from(table_url.path());
             let mut writer = DeltaWriter::new(object_store.clone(), writer_path, writer_config);
 
-            // Compute physical-to-logical mapping once before the loop
-            let phys_to_logical = logical_kernel_for_mapping.as_ref().map(|logical_kernel| {
-                let map = Self::build_physical_to_logical_map(logical_kernel, kernel_mode);
-                log::trace!("phys_to_logical: {:?}", map);
-                map
-            });
+            let logical_schema_for_mapping = logical_kernel_for_mapping
+                .as_ref()
+                .map(Schema::try_from)
+                .transpose()
+                .map_err(|e| DataFusionError::External(Box::new(e)))?
+                .map(Arc::new);
 
             let mut total_rows = 0u64;
             let mut data = stream;
@@ -735,7 +783,8 @@ impl DeltaWriterExec {
                 let validated_batch = Self::validate_and_adapt_batch(
                     batch,
                     &writer_schema,
-                    phys_to_logical.as_ref(),
+                    logical_schema_for_mapping.as_ref(),
+                    kernel_mode,
                     timezone.as_deref(),
                 )?;
 
@@ -963,45 +1012,70 @@ impl DeltaWriterExec {
     fn validate_and_adapt_batch(
         batch: RecordBatch,
         final_schema: &SchemaRef,
-        phys_to_logical: Option<&HashMap<String, String>>,
+        logical_schema: Option<&SchemaRef>,
+        column_mapping_mode: ColumnMappingMode,
         timezone: Option<&str>,
     ) -> Result<RecordBatch> {
         let batch_schema = batch.schema();
+        if column_mapping_mode != ColumnMappingMode::None {
+            let logical_schema = logical_schema.ok_or_else(|| {
+                DataFusionError::Internal(
+                    "column-mapped Delta write is missing its logical schema".to_string(),
+                )
+            })?;
+            if logical_schema.fields().len() != final_schema.fields().len() {
+                return Err(DataFusionError::Plan(format!(
+                    "logical writer schema field count {} differs from physical field count {}",
+                    logical_schema.fields().len(),
+                    final_schema.fields().len()
+                )));
+            }
+        }
 
         // If schemas are identical, no adaptation needed
-        if batch_schema.as_ref() == final_schema.as_ref() {
+        if batch_schema.as_ref() == final_schema.as_ref()
+            && batch
+                .columns()
+                .iter()
+                .zip(final_schema.fields())
+                .all(|(column, field)| column.data_type() == field.data_type())
+        {
             return Ok(batch);
         }
 
         // Check if all required fields are present and types are compatible
         let mut adapted_columns = Vec::with_capacity(final_schema.fields().len());
 
-        for final_field in final_schema.fields() {
-            // For physical writer schema, final_field.name() is physical. Map to logical if provided
-            let lookup_name: &str = if let Some(map) = phys_to_logical {
-                map.get(final_field.name().as_str())
-                    .map(|s| s.as_str())
-                    .unwrap_or(final_field.name())
-            } else {
-                final_field.name()
-            };
+        for (final_index, final_field) in final_schema.fields().iter().enumerate() {
+            let logical_field = logical_schema.and_then(|schema| schema.fields().get(final_index));
+            let lookup_name = logical_field
+                .map(|field| field.name().as_str())
+                .unwrap_or_else(|| final_field.name());
 
             match batch_schema.column_with_name(lookup_name) {
-                Some((batch_index, batch_field)) => {
+                Some((batch_index, _)) => {
                     let batch_column = batch.column(batch_index);
+                    let validation_field = logical_field.unwrap_or(final_field);
+                    validate_cast_safety_recursively(
+                        batch_column.data_type(),
+                        validation_field.data_type(),
+                        validation_field.name(),
+                    )?;
 
-                    if batch_field.data_type() == final_field.data_type() {
+                    if column_mapping_mode != ColumnMappingMode::None
+                        && let Some(logical_field) = logical_field
+                        && matching_nested_types(logical_field.data_type(), final_field.data_type())
+                    {
+                        adapted_columns.push(adapt_array_to_physical_field(
+                            batch_column,
+                            logical_field,
+                            final_field,
+                        )?);
+                    } else if batch_column.data_type() == final_field.data_type() {
                         adapted_columns.push(batch_column.clone());
                     } else {
-                        // Types don't match, validate cast safety and attempt casting
-                        DeltaTypeConverter::validate_cast_safety(
-                            batch_field.data_type(),
-                            final_field.data_type(),
-                            final_field.name(),
-                        )?;
-
                         let casted_column =
-                            match (batch_field.data_type(), final_field.data_type(), timezone) {
+                            match (batch_column.data_type(), final_field.data_type(), timezone) {
                                 (
                                     DataType::Timestamp(unit_from, Some(_)),
                                     DataType::Timestamp(unit_to, Some(target_tz)),
@@ -1053,11 +1127,7 @@ impl DeltaWriterExec {
                                     )
                                     .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?
                                 }
-                                _ => datafusion::arrow::compute::cast(
-                                    batch_column,
-                                    final_field.data_type(),
-                                )
-                                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?,
+                                _ => cast_array_recursively(batch_column, final_field.data_type())?,
                             };
                         adapted_columns.push(casted_column);
                     }
@@ -1127,5 +1197,123 @@ impl DisplayAs for DeltaWriterExec {
                 write!(f, "table_path={}", self.table_url)
             }
         }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use std::collections::HashMap;
+
+    use datafusion::arrow::array::{Array, ArrayRef, Int32Array, StructArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::record_batch::RecordBatchOptions;
+    use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
+
+    use super::*;
+
+    fn field_with_id(name: &str, metadata_key: &str, id: i64) -> Arc<Field> {
+        Arc::new(
+            Field::new(name, DataType::Int32, true)
+                .with_metadata(HashMap::from([(metadata_key.to_string(), id.to_string())])),
+        )
+    }
+
+    #[test]
+    fn adapt_batch_replaces_nested_field_metadata() -> Result<()> {
+        let source_fields = vec![
+            field_with_id("rate", PARQUET_FIELD_ID_META_KEY, 1),
+            field_with_id("exponent", PARQUET_FIELD_ID_META_KEY, 2),
+        ];
+        let details = Arc::new(StructArray::new(
+            source_fields.into(),
+            vec![
+                Arc::new(Int32Array::from(vec![Some(10)])),
+                Arc::new(Int32Array::from(vec![Some(2)])),
+            ],
+            None,
+        )) as ArrayRef;
+        let logical_fields = vec![
+            field_with_id("rate", "delta.columnMapping.id", 2),
+            field_with_id("exponent", "delta.columnMapping.id", 3),
+        ];
+        let logical_schema = Arc::new(Schema::new(vec![Field::new(
+            "details",
+            DataType::Struct(logical_fields.into()),
+            true,
+        )]));
+        let target_fields = vec![
+            field_with_id("col-rate", PARQUET_FIELD_ID_META_KEY, 2),
+            field_with_id("col-exponent", PARQUET_FIELD_ID_META_KEY, 3),
+        ];
+        let final_schema = Arc::new(Schema::new(vec![Field::new(
+            "col-details",
+            DataType::Struct(target_fields.clone().into()),
+            true,
+        )]));
+        let batch = RecordBatch::try_new_with_options(
+            logical_schema.clone(),
+            vec![details],
+            &RecordBatchOptions::new().with_match_field_names(false),
+        )?;
+
+        let adapted = DeltaWriterExec::validate_and_adapt_batch(
+            batch,
+            &final_schema,
+            Some(&logical_schema),
+            ColumnMappingMode::Name,
+            None,
+        )?;
+        let details = adapted
+            .column(0)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .unwrap();
+
+        assert_eq!(adapted.schema(), final_schema);
+        RecordBatch::try_new(adapted.schema(), adapted.columns().to_vec())?;
+        assert!(details.fields().iter().eq(target_fields.iter()));
+        assert_eq!(
+            details
+                .column_by_name("col-rate")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .value(0),
+            10,
+        );
+        assert_eq!(
+            details
+                .column_by_name("col-exponent")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Int32Array>()
+                .unwrap()
+                .value(0),
+            2,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn nested_cast_validation_rejects_unsafe_leaf_cast() {
+        let source = DataType::Struct(
+            vec![Field::new("value", DataType::Decimal128(20, 4), true)]
+                .into_iter()
+                .map(Arc::new)
+                .collect(),
+        );
+        let target = DataType::Struct(
+            vec![Field::new("value", DataType::Decimal128(10, 2), true)]
+                .into_iter()
+                .map(Arc::new)
+                .collect(),
+        );
+
+        let error = validate_cast_safety_recursively(&source, &target, "details")
+            .expect_err("narrowing nested cast must fail");
+
+        assert!(error.to_string().contains("details.value"));
     }
 }

--- a/crates/sail-delta-lake/src/schema/converter.rs
+++ b/crates/sail-delta-lake/src/schema/converter.rs
@@ -1,8 +1,19 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
+use datafusion::arrow::array::{
+    Array, ArrayRef, FixedSizeListArray, LargeListArray, ListArray, MapArray, StructArray,
+    new_null_array,
+};
+use datafusion::arrow::buffer::NullBuffer;
 use datafusion::arrow::datatypes::{
     DataType as ArrowDataType, Field, Fields, Schema as ArrowSchema, SchemaRef,
+};
+use datafusion::arrow::record_batch::{RecordBatch, RecordBatchOptions};
+use datafusion_common::{DataFusionError, Result, exec_err};
+use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
+use sail_common_datafusion::array::record_batch::cast_array_recursively;
+use sail_common_datafusion::schema_evolution::{
+    StructFieldMatching, cast_array_with_schema_evolution_relaxed_tz,
 };
 
 use crate::spec::{
@@ -36,19 +47,26 @@ pub fn arrow_schema_from_struct_type(
     Ok(Arc::new(ArrowSchema::new(fields)))
 }
 
-pub fn get_physical_arrow_schema(logical: &StructType, mode: ColumnMappingMode) -> ArrowSchema {
+/// Build the physical Arrow schema used for Delta Parquet data files.
+///
+/// Name mode strips Delta-side field ID metadata, then re-adds each ID under Arrow's
+/// `PARQUET:field_id` key so nested IDs reach the Parquet footer.
+pub fn get_physical_arrow_schema(
+    logical: &StructType,
+    mode: ColumnMappingMode,
+) -> DeltaResult<ArrowSchema> {
+    // Build the stripped Delta physical schema first, then restore IDs only for Parquet.
     let physical_kernel = logical.make_physical(mode);
-    let physical_arrow: ArrowSchema =
-        ArrowSchema::try_from(&physical_kernel).unwrap_or_else(|_| ArrowSchema::empty());
+    let physical_arrow = ArrowSchema::try_from(&physical_kernel)?;
     match mode {
         ColumnMappingMode::Name | ColumnMappingMode::Id => {
             enrich_arrow_with_parquet_field_ids(&physical_arrow, logical)
         }
-        ColumnMappingMode::None => physical_arrow,
+        ColumnMappingMode::None => Ok(physical_arrow),
     }
 }
 
-/// Apply Delta column mapping to an Arrow schema, renaming logical→physical column names.
+/// Build a physical schema for metadata and statistics without Parquet footer field IDs.
 ///
 /// This is the Arrow-native equivalent of `StructType::make_physical`. It reads the
 /// `delta.columnMapping.physicalName` metadata from each Arrow field and renames the
@@ -62,6 +80,83 @@ pub fn make_physical_arrow_schema(logical: &ArrowSchema, mode: ColumnMappingMode
     ArrowSchema::new(new_fields).with_metadata(logical.metadata().clone())
 }
 
+pub fn attach_column_mapping_metadata(requested: &ArrowSchema, table: &ArrowSchema) -> ArrowSchema {
+    let fields = requested
+        .fields()
+        .iter()
+        .map(|requested| {
+            table
+                .field_with_name(requested.name())
+                .map(|table| attach_field_mapping_metadata(requested, table))
+                .unwrap_or_else(|_| requested.as_ref().clone())
+        })
+        .collect::<Vec<_>>();
+    ArrowSchema::new(fields).with_metadata(requested.metadata().clone())
+}
+
+fn attach_field_mapping_metadata(requested: &Field, table: &Field) -> Field {
+    let mut metadata = requested.metadata().clone();
+    for key in [
+        ColumnMetadataKey::ColumnMappingPhysicalName.as_ref(),
+        ColumnMetadataKey::ColumnMappingId.as_ref(),
+        ColumnMetadataKey::ParquetFieldId.as_ref(),
+        PARQUET_FIELD_ID_META_KEY,
+    ] {
+        if let Some(value) = table.metadata().get(key) {
+            metadata.insert(key.to_string(), value.clone());
+        }
+    }
+
+    requested
+        .clone()
+        .with_data_type(attach_data_type_mapping_metadata(
+            requested.data_type(),
+            table.data_type(),
+        ))
+        .with_metadata(metadata)
+}
+
+fn attach_data_type_mapping_metadata(
+    requested: &ArrowDataType,
+    table: &ArrowDataType,
+) -> ArrowDataType {
+    match (requested, table) {
+        (ArrowDataType::Struct(requested), ArrowDataType::Struct(table)) => {
+            let fields = requested
+                .iter()
+                .map(|requested| {
+                    table
+                        .iter()
+                        .find(|table| table.name() == requested.name())
+                        .map(|table| attach_field_mapping_metadata(requested, table))
+                        .unwrap_or_else(|| requested.as_ref().clone())
+                })
+                .collect::<Vec<_>>();
+            ArrowDataType::Struct(fields.into())
+        }
+        (ArrowDataType::List(requested), ArrowDataType::List(table)) => {
+            ArrowDataType::List(Arc::new(attach_field_mapping_metadata(requested, table)))
+        }
+        (ArrowDataType::LargeList(requested), ArrowDataType::LargeList(table)) => {
+            ArrowDataType::LargeList(Arc::new(attach_field_mapping_metadata(requested, table)))
+        }
+        (
+            ArrowDataType::FixedSizeList(requested, requested_len),
+            ArrowDataType::FixedSizeList(table, _),
+        ) => ArrowDataType::FixedSizeList(
+            Arc::new(attach_field_mapping_metadata(requested, table)),
+            *requested_len,
+        ),
+        (ArrowDataType::Map(requested, sorted), ArrowDataType::Map(table, _)) => {
+            ArrowDataType::Map(
+                Arc::new(attach_field_mapping_metadata(requested, table)),
+                *sorted,
+            )
+        }
+        _ => requested.clone(),
+    }
+}
+
 /// Get the physical name of an Arrow field under a given column mapping mode.
 ///
 /// This is the Arrow-native equivalent of `StructField::physical_name`.
@@ -73,6 +168,246 @@ pub fn arrow_field_physical_name(field: &Field, mode: ColumnMappingMode) -> &str
             .get(ColumnMetadataKey::ColumnMappingPhysicalName.as_ref())
             .map(|s| s.as_str())
             .unwrap_or_else(|| field.name().as_str()),
+    }
+}
+
+pub fn restore_logical_record_batch(
+    batch: &RecordBatch,
+    target_schema: &SchemaRef,
+    mode: ColumnMappingMode,
+) -> Result<RecordBatch> {
+    let matching = match mode {
+        ColumnMappingMode::None => StructFieldMatching::Name,
+        ColumnMappingMode::Name => StructFieldMatching::PhysicalName,
+        ColumnMappingMode::Id => StructFieldMatching::FieldId,
+    };
+    let source_schema = batch.schema();
+    let columns = target_schema
+        .fields()
+        .iter()
+        .map(|target| match source_schema.index_of(target.name()) {
+            Ok(index) => cast_array_with_schema_evolution_relaxed_tz(
+                batch.column(index),
+                target.as_ref(),
+                &datafusion_common::format::DEFAULT_CAST_OPTIONS,
+                matching,
+            ),
+            Err(_) if target.is_nullable() => {
+                Ok(new_null_array(target.data_type(), batch.num_rows()))
+            }
+            Err(_) => Err(DataFusionError::Plan(format!(
+                "missing required column '{}' while restoring Delta logical schema",
+                target.name()
+            ))),
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    if columns.is_empty() {
+        Ok(RecordBatch::try_new_with_options(
+            Arc::clone(target_schema),
+            columns,
+            &RecordBatchOptions::new().with_row_count(Some(batch.num_rows())),
+        )?)
+    } else {
+        Ok(RecordBatch::try_new(Arc::clone(target_schema), columns)?)
+    }
+}
+
+pub(crate) fn adapt_array_to_physical_field(
+    source: &ArrayRef,
+    logical_field: &Field,
+    physical_field: &Field,
+) -> Result<ArrayRef> {
+    adapt_array_to_physical_field_inner(source, logical_field, physical_field, None)
+}
+
+fn adapt_array_to_physical_field_inner(
+    source: &ArrayRef,
+    logical_field: &Field,
+    physical_field: &Field,
+    parent_nulls: Option<&NullBuffer>,
+) -> Result<ArrayRef> {
+    if !physical_field.is_nullable()
+        && (0..source.len()).any(|index| {
+            parent_nulls.is_none_or(|nulls| nulls.is_valid(index))
+                && (source.data_type() == &ArrowDataType::Null || source.is_null(index))
+        })
+    {
+        return exec_err!(
+            "required field '{}' contains null values",
+            logical_field.name()
+        );
+    }
+
+    if source.data_type() == &ArrowDataType::Null
+        || (!source.is_empty() && source.null_count() == source.len())
+    {
+        return Ok(new_null_array(physical_field.data_type(), source.len()));
+    }
+
+    match (logical_field.data_type(), physical_field.data_type()) {
+        (ArrowDataType::Struct(logical_fields), ArrowDataType::Struct(physical_fields)) => {
+            let Some(source_struct) = source.as_any().downcast_ref::<StructArray>() else {
+                return exec_err!("expected struct array for field '{}'", logical_field.name());
+            };
+            if logical_fields.len() != physical_fields.len() {
+                return exec_err!(
+                    "cannot adapt struct field '{}': logical field count {} differs from physical field count {}",
+                    logical_field.name(),
+                    logical_fields.len(),
+                    physical_fields.len()
+                );
+            }
+            let arrays = logical_fields
+                .iter()
+                .zip(physical_fields)
+                .map(
+                    |(logical, physical)| match source_struct.column_by_name(logical.name()) {
+                        Some(source) => adapt_array_to_physical_field_inner(
+                            source,
+                            logical.as_ref(),
+                            physical.as_ref(),
+                            source_struct.nulls(),
+                        ),
+                        None if physical.is_nullable()
+                            || source_struct
+                                .nulls()
+                                .is_some_and(|nulls| nulls.null_count() == source_struct.len()) =>
+                        {
+                            Ok(new_null_array(physical.data_type(), source_struct.len()))
+                        }
+                        None => exec_err!(
+                            "required nested field '{}' is missing from input",
+                            logical.name()
+                        ),
+                    },
+                )
+                .collect::<Result<Vec<_>>>()?;
+            Ok(Arc::new(StructArray::new(
+                physical_fields.clone(),
+                arrays,
+                source_struct.nulls().cloned(),
+            )))
+        }
+        (ArrowDataType::List(logical), ArrowDataType::List(physical)) => {
+            let Some(source_list) = source.as_any().downcast_ref::<ListArray>() else {
+                return exec_err!("expected list array for field '{}'", logical_field.name());
+            };
+            let values =
+                adapt_array_to_physical_field_inner(source_list.values(), logical, physical, None)?;
+            Ok(Arc::new(ListArray::new(
+                Arc::clone(physical),
+                source_list.offsets().clone(),
+                values,
+                source_list.nulls().cloned(),
+            )))
+        }
+        (ArrowDataType::LargeList(logical), ArrowDataType::LargeList(physical)) => {
+            let Some(source_list) = source.as_any().downcast_ref::<LargeListArray>() else {
+                return exec_err!(
+                    "expected large list array for field '{}'",
+                    logical_field.name()
+                );
+            };
+            let values =
+                adapt_array_to_physical_field_inner(source_list.values(), logical, physical, None)?;
+            Ok(Arc::new(LargeListArray::new(
+                Arc::clone(physical),
+                source_list.offsets().clone(),
+                values,
+                source_list.nulls().cloned(),
+            )))
+        }
+        (
+            ArrowDataType::FixedSizeList(logical, logical_len),
+            ArrowDataType::FixedSizeList(physical, physical_len),
+        ) => {
+            let Some(source_list) = source.as_any().downcast_ref::<FixedSizeListArray>() else {
+                return exec_err!(
+                    "expected fixed-size list array for field '{}'",
+                    logical_field.name()
+                );
+            };
+            if logical_len != physical_len || source_list.value_length() != *physical_len {
+                return exec_err!(
+                    "cannot adapt fixed-size list field '{}' from length {} to {}",
+                    logical_field.name(),
+                    source_list.value_length(),
+                    physical_len
+                );
+            }
+            let values =
+                adapt_array_to_physical_field_inner(source_list.values(), logical, physical, None)?;
+            Ok(Arc::new(FixedSizeListArray::new(
+                Arc::clone(physical),
+                *physical_len,
+                values,
+                source_list.nulls().cloned(),
+            )))
+        }
+        (ArrowDataType::Map(logical, _), ArrowDataType::Map(physical, sorted)) => {
+            let Some(source_map) = source.as_any().downcast_ref::<MapArray>() else {
+                return exec_err!("expected map array for field '{}'", logical_field.name());
+            };
+            let (ArrowDataType::Struct(logical_entries), ArrowDataType::Struct(physical_entries)) =
+                (logical.data_type(), physical.data_type())
+            else {
+                return exec_err!("map field '{}' has invalid entries", logical_field.name());
+            };
+            if logical_entries.len() != 2 || physical_entries.len() != 2 {
+                return exec_err!(
+                    "cannot adapt map field '{}': expected key/value entries, got {} logical and {} physical entries",
+                    logical_field.name(),
+                    logical_entries.len(),
+                    physical_entries.len()
+                );
+            }
+            let arrays = physical_entries
+                .iter()
+                .map(|physical| {
+                    if !matches!(physical.name().as_str(), "key" | "value") {
+                        return exec_err!(
+                            "map field '{}' has unexpected physical entry '{}'",
+                            logical_field.name(),
+                            physical.name()
+                        );
+                    }
+                    let logical = logical_entries
+                        .iter()
+                        .find(|logical| logical.name() == physical.name())
+                        .ok_or_else(|| {
+                            DataFusionError::Plan(format!(
+                                "map entry '{}' is missing from logical schema",
+                                physical.name()
+                            ))
+                        })?;
+                    let source = source_map
+                        .entries()
+                        .column_by_name(logical.name())
+                        .ok_or_else(|| {
+                            DataFusionError::Plan(format!(
+                                "map entry '{}' is missing from input",
+                                logical.name()
+                            ))
+                        })?;
+                    adapt_array_to_physical_field_inner(
+                        source,
+                        logical.as_ref(),
+                        physical.as_ref(),
+                        source_map.entries().nulls(),
+                    )
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let entries = StructArray::new(physical_entries.clone(), arrays, None);
+            Ok(Arc::new(MapArray::try_new(
+                Arc::clone(physical),
+                source_map.offsets().clone(),
+                entries,
+                source_map.nulls().cloned(),
+                *sorted,
+            )?))
+        }
+        _ => cast_array_recursively(source, physical_field.data_type()),
     }
 }
 
@@ -120,6 +455,52 @@ fn make_physical_arrow_data_type(dt: &ArrowDataType, mode: ColumnMappingMode) ->
                 .map(|f| Arc::new(make_physical_arrow_field(f.as_ref(), mode)))
                 .collect();
             ArrowDataType::Struct(new_fields)
+        }
+        ArrowDataType::List(field) => ArrowDataType::List(Arc::new(
+            field
+                .as_ref()
+                .clone()
+                .with_data_type(make_physical_arrow_data_type(field.data_type(), mode)),
+        )),
+        ArrowDataType::LargeList(field) => ArrowDataType::LargeList(Arc::new(
+            field
+                .as_ref()
+                .clone()
+                .with_data_type(make_physical_arrow_data_type(field.data_type(), mode)),
+        )),
+        ArrowDataType::FixedSizeList(field, len) => ArrowDataType::FixedSizeList(
+            Arc::new(
+                field
+                    .as_ref()
+                    .clone()
+                    .with_data_type(make_physical_arrow_data_type(field.data_type(), mode)),
+            ),
+            *len,
+        ),
+        ArrowDataType::Map(entries, sorted) => {
+            let ArrowDataType::Struct(fields) = entries.data_type() else {
+                return dt.clone();
+            };
+            let fields: Fields = fields
+                .iter()
+                .map(|field| {
+                    Arc::new(
+                        field
+                            .as_ref()
+                            .clone()
+                            .with_data_type(make_physical_arrow_data_type(field.data_type(), mode)),
+                    )
+                })
+                .collect();
+            ArrowDataType::Map(
+                Arc::new(
+                    entries
+                        .as_ref()
+                        .clone()
+                        .with_data_type(ArrowDataType::Struct(fields)),
+                ),
+                *sorted,
+            )
         }
         other => other.clone(),
     }
@@ -182,157 +563,467 @@ fn wrap_partition_type(data_type: &ArrowDataType) -> ArrowDataType {
     }
 }
 
-pub fn enrich_arrow_with_parquet_field_ids(
+fn enrich_arrow_with_parquet_field_ids(
     physical_arrow: &ArrowSchema,
     logical_kernel: &StructType,
-) -> ArrowSchema {
-    fn build_path_map(
-        st: &StructType,
-        path: &mut Vec<String>,
-        out: &mut HashMap<Vec<String>, (Option<i64>, String)>,
-    ) {
-        for f in st.fields() {
-            let phys = match f.get_config_value(&ColumnMetadataKey::ColumnMappingPhysicalName) {
-                Some(MetadataValue::String(s)) => s.clone(),
-                _ => f.name().clone(),
-            };
-            path.push(phys);
-            let id = match f.get_config_value(&ColumnMetadataKey::ColumnMappingId) {
-                Some(MetadataValue::Number(fid)) => Some(*fid),
-                _ => None,
-            };
-            out.insert(path.clone(), (id, f.name().clone()));
-
-            match f.data_type() {
-                DataType::Struct(nst) => build_path_map(nst.as_ref(), path, out),
-                DataType::Array(at) => {
-                    if let DataType::Struct(nst) = at.element_type() {
-                        build_path_map(nst.as_ref(), path, out)
-                    }
+) -> DeltaResult<ArrowSchema> {
+    fn enrich_data_type(
+        physical: &ArrowDataType,
+        logical: &DataType,
+    ) -> DeltaResult<ArrowDataType> {
+        match (physical, logical) {
+            (ArrowDataType::Struct(physical_fields), DataType::Struct(logical_fields)) => {
+                let logical_fields = logical_fields.fields().collect::<Vec<_>>();
+                if physical_fields.len() != logical_fields.len() {
+                    return Err(DeltaTableError::schema(format!(
+                        "physical struct field count {} differs from logical field count {}",
+                        physical_fields.len(),
+                        logical_fields.len()
+                    )));
                 }
-                DataType::Map(mt) => {
-                    if let DataType::Struct(nst) = mt.value_type() {
-                        build_path_map(nst.as_ref(), path, out)
-                    }
-                }
-                _ => {}
+                Ok(ArrowDataType::Struct(
+                    physical_fields
+                        .iter()
+                        .zip(logical_fields)
+                        .map(|(physical, logical)| {
+                            enrich_field(physical.as_ref(), logical).map(Arc::new)
+                        })
+                        .collect::<DeltaResult<Fields>>()?,
+                ))
             }
-            path.pop();
-        }
-    }
-
-    fn enrich_field(
-        af: &datafusion::arrow::datatypes::Field,
-        path: &mut Vec<String>,
-        map: &HashMap<Vec<String>, (Option<i64>, String)>,
-        rename_current: bool,
-    ) -> datafusion::arrow::datatypes::Field {
-        let mut meta = af.metadata().clone();
-        let mut new_name = af.name().clone();
-        if let Some((maybe_id, logical_name)) = map.get(path) {
-            if let Some(fid) = maybe_id {
-                meta.insert("PARQUET:field_id".to_string(), fid.to_string());
+            (ArrowDataType::List(physical), DataType::Array(logical)) => Ok(ArrowDataType::List(
+                Arc::new(physical.as_ref().clone().with_data_type(enrich_data_type(
+                    physical.data_type(),
+                    logical.element_type(),
+                )?)),
+            )),
+            (ArrowDataType::LargeList(physical), DataType::Array(logical)) => Ok(
+                ArrowDataType::LargeList(Arc::new(physical.as_ref().clone().with_data_type(
+                    enrich_data_type(physical.data_type(), logical.element_type())?,
+                ))),
+            ),
+            (ArrowDataType::FixedSizeList(physical, len), DataType::Array(logical)) => {
+                Ok(ArrowDataType::FixedSizeList(
+                    Arc::new(physical.as_ref().clone().with_data_type(enrich_data_type(
+                        physical.data_type(),
+                        logical.element_type(),
+                    )?)),
+                    *len,
+                ))
             }
-            if rename_current {
-                new_name = logical_name.clone();
-            }
-        }
-
-        let new_dt = match af.data_type() {
-            datafusion::arrow::datatypes::DataType::Struct(children) => {
-                let new_children: Vec<datafusion::arrow::datatypes::Field> = children
-                    .iter()
-                    .map(|child| {
-                        path.push(child.name().clone());
-                        let updated = enrich_field(child, path, map, true);
-                        path.pop();
-                        updated
-                    })
-                    .collect();
-                datafusion::arrow::datatypes::DataType::Struct(new_children.into())
-            }
-            datafusion::arrow::datatypes::DataType::List(elem) => {
-                let updated_elem = enrich_field(elem.as_ref(), path, map, false);
-                datafusion::arrow::datatypes::DataType::List(Arc::new(updated_elem))
-            }
-            datafusion::arrow::datatypes::DataType::LargeList(elem) => {
-                let updated_elem = enrich_field(elem.as_ref(), path, map, false);
-                datafusion::arrow::datatypes::DataType::LargeList(Arc::new(updated_elem))
-            }
-            datafusion::arrow::datatypes::DataType::FixedSizeList(elem, len) => {
-                let updated_elem = enrich_field(elem.as_ref(), path, map, false);
-                datafusion::arrow::datatypes::DataType::FixedSizeList(Arc::new(updated_elem), *len)
-            }
-            datafusion::arrow::datatypes::DataType::Map(kv, is_sorted) => {
-                let kv_struct = match kv.data_type() {
-                    datafusion::arrow::datatypes::DataType::Struct(children) => children,
-                    _ => {
-                        return datafusion::arrow::datatypes::Field::new(
-                            af.name(),
-                            af.data_type().clone(),
-                            af.is_nullable(),
-                        )
-                        .with_metadata(meta);
-                    }
+            (ArrowDataType::Map(physical, sorted), DataType::Map(logical)) => {
+                let ArrowDataType::Struct(physical_entries) = physical.data_type() else {
+                    return Err(DeltaTableError::schema(
+                        "physical map entries must be a struct",
+                    ));
                 };
-                let mut new_kv_children: Vec<datafusion::arrow::datatypes::Field> =
-                    Vec::with_capacity(2);
-                for child in kv_struct.iter() {
-                    if child.name() == "value" {
-                        let value_dt = match child.data_type() {
-                            datafusion::arrow::datatypes::DataType::Struct(value_children) => {
-                                let new_value_children: Vec<datafusion::arrow::datatypes::Field> =
-                                    value_children
-                                        .iter()
-                                        .map(|grandchild| {
-                                            path.push(grandchild.name().clone());
-                                            let updated = enrich_field(grandchild, path, map, true);
-                                            path.pop();
-                                            updated
-                                        })
-                                        .collect();
-                                datafusion::arrow::datatypes::DataType::Struct(
-                                    new_value_children.into(),
-                                )
-                            }
-                            _ => child.data_type().clone(),
-                        };
-                        let updated = datafusion::arrow::datatypes::Field::new(
-                            "value",
-                            value_dt,
-                            child.is_nullable(),
-                        )
-                        .with_metadata(child.metadata().clone());
-                        new_kv_children.push(updated);
-                    } else {
-                        new_kv_children.push(child.as_ref().clone());
-                    }
+                if physical_entries.len() != 2 {
+                    return Err(DeltaTableError::schema(format!(
+                        "physical map must contain key/value entries, got {}",
+                        physical_entries.len()
+                    )));
                 }
-                let new_kv = datafusion::arrow::datatypes::Field::new(
-                    kv.name(),
-                    datafusion::arrow::datatypes::DataType::Struct(new_kv_children.into()),
-                    kv.is_nullable(),
-                );
-                datafusion::arrow::datatypes::DataType::Map(Arc::new(new_kv), *is_sorted)
+                let entries = physical_entries
+                    .iter()
+                    .map(|entry| {
+                        let logical_type = match entry.name().as_str() {
+                            "key" => logical.key_type(),
+                            "value" => logical.value_type(),
+                            name => {
+                                return Err(DeltaTableError::schema(format!(
+                                    "unexpected physical map entry '{name}'"
+                                )));
+                            }
+                        };
+                        Ok(Arc::new(entry.as_ref().clone().with_data_type(
+                            enrich_data_type(entry.data_type(), logical_type)?,
+                        )))
+                    })
+                    .collect::<DeltaResult<Fields>>()?;
+                Ok(ArrowDataType::Map(
+                    Arc::new(
+                        physical
+                            .as_ref()
+                            .clone()
+                            .with_data_type(ArrowDataType::Struct(entries)),
+                    ),
+                    *sorted,
+                ))
             }
-            _ => af.data_type().clone(),
-        };
-
-        datafusion::arrow::datatypes::Field::new(&new_name, new_dt, af.is_nullable())
-            .with_metadata(meta)
+            _ => Ok(physical.clone()),
+        }
     }
 
-    let mut path_to_info: HashMap<Vec<String>, (Option<i64>, String)> = HashMap::new();
-    build_path_map(logical_kernel, &mut Vec::new(), &mut path_to_info);
+    fn enrich_field(physical: &Field, logical: &StructField) -> DeltaResult<Field> {
+        let mut metadata = physical.metadata().clone();
+        if let Some(MetadataValue::Number(id)) =
+            logical.get_config_value(&ColumnMetadataKey::ColumnMappingId)
+        {
+            metadata.insert(PARQUET_FIELD_ID_META_KEY.to_string(), id.to_string());
+        }
+        Ok(Field::new(
+            physical.name(),
+            enrich_data_type(physical.data_type(), logical.data_type())?,
+            physical.is_nullable(),
+        )
+        .with_metadata(metadata))
+    }
 
-    let new_fields: Vec<datafusion::arrow::datatypes::Field> = physical_arrow
+    let logical_fields = logical_kernel.fields().collect::<Vec<_>>();
+    if physical_arrow.fields().len() != logical_fields.len() {
+        return Err(DeltaTableError::schema(format!(
+            "physical schema field count {} differs from logical field count {}",
+            physical_arrow.fields().len(),
+            logical_fields.len()
+        )));
+    }
+    let new_fields = physical_arrow
         .fields()
         .iter()
-        .map(|af| {
-            let mut path = vec![af.name().clone()];
-            enrich_field(af, &mut path, &path_to_info, false)
-        })
-        .collect();
+        .zip(logical_fields)
+        .map(|(physical, logical)| enrich_field(physical.as_ref(), logical))
+        .collect::<DeltaResult<Vec<_>>>()?;
 
-    ArrowSchema::new(new_fields)
+    Ok(ArrowSchema::new(new_fields))
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, clippy::panic)]
+mod tests {
+    use std::collections::HashMap;
+
+    use datafusion::arrow::array::{Int64Array, NullArray};
+    use datafusion::arrow::buffer::NullBuffer;
+    use datafusion::arrow::record_batch::RecordBatchOptions;
+
+    use super::*;
+    use crate::spec::{ArrayType, MapType};
+
+    fn mapped_field(name: &str, physical_name: &str, id: i64, data_type: DataType) -> StructField {
+        StructField::new(name, data_type, true).with_metadata([
+            ("delta.columnMapping.id", MetadataValue::Number(id)),
+            (
+                "delta.columnMapping.physicalName",
+                MetadataValue::String(physical_name.to_string()),
+            ),
+        ])
+    }
+
+    #[test]
+    fn explicit_schema_inherits_nested_column_mapping_metadata() {
+        let physical_name_key = ColumnMetadataKey::ColumnMappingPhysicalName.as_ref();
+        let table_value = Arc::new(
+            Field::new("value", ArrowDataType::Int64, true).with_metadata(HashMap::from([(
+                physical_name_key.to_string(),
+                "col-value".to_string(),
+            )])),
+        );
+        let table_level = Arc::new(
+            Field::new(
+                "level",
+                ArrowDataType::Struct(vec![table_value].into()),
+                true,
+            )
+            .with_metadata(HashMap::from([(
+                physical_name_key.to_string(),
+                "col-level".to_string(),
+            )])),
+        );
+        let table = ArrowSchema::new(vec![
+            Field::new(
+                "payload",
+                ArrowDataType::Struct(vec![table_level].into()),
+                true,
+            )
+            .with_metadata(HashMap::from([(
+                physical_name_key.to_string(),
+                "col-payload".to_string(),
+            )])),
+        ]);
+        let requested = ArrowSchema::new(vec![Field::new(
+            "payload",
+            ArrowDataType::Struct(
+                vec![Arc::new(Field::new(
+                    "level",
+                    ArrowDataType::Struct(
+                        vec![Arc::new(Field::new("value", ArrowDataType::Int64, true))].into(),
+                    ),
+                    true,
+                ))]
+                .into(),
+            ),
+            true,
+        )]);
+
+        let attached = attach_column_mapping_metadata(&requested, &table);
+        let payload = attached.field_with_name("payload").expect("payload");
+        assert_eq!(
+            payload
+                .metadata()
+                .get(physical_name_key)
+                .map(String::as_str),
+            Some("col-payload")
+        );
+        let ArrowDataType::Struct(payload_fields) = payload.data_type() else {
+            panic!("payload must be struct");
+        };
+        let level = payload_fields.first().expect("level");
+        assert_eq!(
+            level.metadata().get(physical_name_key).map(String::as_str),
+            Some("col-level")
+        );
+        let ArrowDataType::Struct(level_fields) = level.data_type() else {
+            panic!("level must be struct");
+        };
+        assert_eq!(
+            level_fields[0]
+                .metadata()
+                .get(physical_name_key)
+                .map(String::as_str),
+            Some("col-value")
+        );
+    }
+
+    #[test]
+    fn physical_name_schema_enriches_nested_field_ids() {
+        let nested = StructType::try_new(vec![mapped_field("rate", "col-rate", 2, DataType::LONG)])
+            .expect("nested schema");
+        let logical = StructType::try_new(vec![mapped_field(
+            "details",
+            "col-details",
+            1,
+            DataType::Struct(Box::new(nested)),
+        )])
+        .expect("logical schema");
+
+        let physical =
+            get_physical_arrow_schema(&logical, ColumnMappingMode::Name).expect("physical schema");
+        let details = physical
+            .field_with_name("col-details")
+            .expect("physical details field");
+        let ArrowDataType::Struct(children) = details.data_type() else {
+            panic!("details must be a struct");
+        };
+        let rate = children.first().expect("nested rate field");
+
+        assert_eq!(rate.name(), "col-rate");
+        assert_eq!(
+            rate.metadata()
+                .get(PARQUET_FIELD_ID_META_KEY)
+                .map(String::as_str),
+            Some("2")
+        );
+    }
+
+    #[test]
+    fn physical_schema_recurses_through_arrays_and_maps() {
+        let event =
+            StructType::try_new(vec![mapped_field("code", "col-code", 2, DataType::STRING)])
+                .expect("event schema");
+        let amount = StructType::try_new(vec![mapped_field(
+            "amount",
+            "col-amount",
+            4,
+            DataType::LONG,
+        )])
+        .expect("amount schema");
+        let logical = StructType::try_new(vec![
+            mapped_field(
+                "events",
+                "col-events",
+                1,
+                DataType::Array(Box::new(ArrayType::new(
+                    DataType::Struct(Box::new(event)),
+                    true,
+                ))),
+            ),
+            mapped_field(
+                "lookup",
+                "col-lookup",
+                3,
+                DataType::Map(Box::new(MapType::new(
+                    DataType::STRING,
+                    DataType::Struct(Box::new(amount)),
+                    true,
+                ))),
+            ),
+        ])
+        .expect("logical schema");
+
+        let physical =
+            get_physical_arrow_schema(&logical, ColumnMappingMode::Name).expect("physical schema");
+        let events = physical
+            .field_with_name("col-events")
+            .expect("events field");
+        assert_eq!(
+            events.metadata().get(PARQUET_FIELD_ID_META_KEY),
+            Some(&"1".to_string())
+        );
+        let ArrowDataType::List(element) = events.data_type() else {
+            panic!("events must be a list");
+        };
+        let ArrowDataType::Struct(event_fields) = element.data_type() else {
+            panic!("events element must be a struct");
+        };
+        let code = event_fields.first().expect("code field");
+        assert_eq!(code.name(), "col-code");
+        assert_eq!(
+            code.metadata().get(PARQUET_FIELD_ID_META_KEY),
+            Some(&"2".to_string())
+        );
+
+        let lookup = physical
+            .field_with_name("col-lookup")
+            .expect("lookup field");
+        let ArrowDataType::Map(entries, _) = lookup.data_type() else {
+            panic!("lookup must be a map");
+        };
+        let ArrowDataType::Struct(entries) = entries.data_type() else {
+            panic!("map entries must be a struct");
+        };
+        let value = entries
+            .iter()
+            .find(|field| field.name() == "value")
+            .expect("map value");
+        let ArrowDataType::Struct(value_fields) = value.data_type() else {
+            panic!("map value must be a struct");
+        };
+        let amount = value_fields.first().expect("amount field");
+        assert_eq!(amount.name(), "col-amount");
+        assert_eq!(
+            amount.metadata().get(PARQUET_FIELD_ID_META_KEY),
+            Some(&"4".to_string())
+        );
+    }
+
+    #[test]
+    fn restore_missing_nullable_column_as_nulls() {
+        let batch = RecordBatch::try_new_with_options(
+            Arc::new(ArrowSchema::empty()),
+            vec![],
+            &RecordBatchOptions::new().with_row_count(Some(2)),
+        )
+        .expect("batch");
+        let target = Arc::new(ArrowSchema::new(vec![Field::new(
+            "optional",
+            ArrowDataType::Int64,
+            true,
+        )]));
+
+        let restored = restore_logical_record_batch(&batch, &target, ColumnMappingMode::Name)
+            .expect("restore");
+
+        assert_eq!(restored.column(0).null_count(), 2);
+    }
+
+    #[test]
+    fn restore_missing_required_column_fails() {
+        let batch = RecordBatch::try_new_with_options(
+            Arc::new(ArrowSchema::empty()),
+            vec![],
+            &RecordBatchOptions::new().with_row_count(Some(1)),
+        )
+        .expect("batch");
+        let target = Arc::new(ArrowSchema::new(vec![Field::new(
+            "required",
+            ArrowDataType::Int64,
+            false,
+        )]));
+
+        let error = restore_logical_record_batch(&batch, &target, ColumnMappingMode::Name)
+            .expect_err("missing required column must fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("missing required column 'required'")
+        );
+    }
+
+    #[test]
+    fn parquet_field_id_enrichment_rejects_field_count_mismatch() {
+        let physical = ArrowSchema::new(vec![Field::new("physical", ArrowDataType::Int64, true)]);
+        let logical = StructType::try_new([
+            StructField::new("first", DataType::LONG, true),
+            StructField::new("second", DataType::LONG, true),
+        ])
+        .expect("logical schema");
+
+        let error = enrich_arrow_with_parquet_field_ids(&physical, &logical)
+            .expect_err("field count mismatch must fail");
+
+        assert!(error.to_string().contains("field count"));
+    }
+
+    #[test]
+    fn physical_adaptation_rejects_required_child_null_under_valid_parent() {
+        let logical_child = Arc::new(Field::new("child", ArrowDataType::Int64, true));
+        let physical_child = Arc::new(Field::new("col-child", ArrowDataType::Int64, false));
+        let source = Arc::new(StructArray::new(
+            vec![Arc::clone(&logical_child)].into(),
+            vec![Arc::new(Int64Array::from(vec![None]))],
+            None,
+        )) as ArrayRef;
+        let logical = Field::new(
+            "parent",
+            ArrowDataType::Struct(vec![logical_child].into()),
+            true,
+        );
+        let physical = Field::new(
+            "col-parent",
+            ArrowDataType::Struct(vec![physical_child].into()),
+            true,
+        );
+
+        let error = adapt_array_to_physical_field(&source, &logical, &physical)
+            .expect_err("required child null must fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("required field 'child' contains null")
+        );
+    }
+
+    #[test]
+    fn physical_adaptation_rejects_all_null_required_field() {
+        let source = Arc::new(NullArray::new(1)) as ArrayRef;
+        let logical = Field::new("required", ArrowDataType::Int64, true);
+        let physical = Field::new("col-required", ArrowDataType::Int64, false);
+
+        let error = adapt_array_to_physical_field(&source, &logical, &physical)
+            .expect_err("required field must reject nulls");
+
+        assert!(
+            error
+                .to_string()
+                .contains("required field 'required' contains null")
+        );
+    }
+
+    #[test]
+    fn physical_adaptation_allows_required_child_under_null_parent() {
+        let logical_child = Arc::new(Field::new("child", ArrowDataType::Int64, true));
+        let physical_child = Arc::new(Field::new("col-child", ArrowDataType::Int64, false));
+        let source = Arc::new(StructArray::new(
+            vec![Arc::clone(&logical_child)].into(),
+            vec![Arc::new(Int64Array::from(vec![None]))],
+            Some(NullBuffer::from(vec![false])),
+        )) as ArrayRef;
+        let logical = Field::new(
+            "parent",
+            ArrowDataType::Struct(vec![logical_child].into()),
+            true,
+        );
+        let physical = Field::new(
+            "col-parent",
+            ArrowDataType::Struct(vec![physical_child].into()),
+            true,
+        );
+
+        let adapted =
+            adapt_array_to_physical_field(&source, &logical, &physical).expect("adaptation");
+
+        assert_eq!(adapted.null_count(), 1);
+    }
 }

--- a/crates/sail-delta-lake/src/schema/mapping.rs
+++ b/crates/sail-delta-lake/src/schema/mapping.rs
@@ -13,7 +13,11 @@
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicI64, Ordering};
 
-use crate::spec::{ArrayType, DataType, MapType, MetadataValue, StructField, StructType};
+use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
+
+use crate::spec::{
+    ArrayType, ColumnMetadataKey, DataType, MapType, MetadataValue, StructField, StructType,
+};
 
 /// Annotate a logical kernel schema with column mapping metadata (id + physicalName)
 /// using a sequential id assignment. Intended only for new table creation (name mode).
@@ -115,8 +119,14 @@ fn column_mapping_physical_name(field: &StructField) -> Option<&str> {
         })
 }
 
+fn strip_parquet_field_id_metadata(metadata: &mut HashMap<String, MetadataValue>) {
+    metadata.remove(PARQUET_FIELD_ID_META_KEY);
+    metadata.remove(ColumnMetadataKey::ParquetFieldId.as_ref());
+}
+
 fn merge_metadata(prev: &StructField, new: &StructField) -> HashMap<String, MetadataValue> {
     let mut merged = prev.metadata().clone();
+    strip_parquet_field_id_metadata(&mut merged);
 
     for (key, value) in new.metadata() {
         let is_column_mapping_key =
@@ -125,7 +135,9 @@ fn merge_metadata(prev: &StructField, new: &StructField) -> HashMap<String, Meta
         if is_column_mapping_key {
             // Preserve existing column mapping metadata if present; otherwise add it.
             merged.entry(key.clone()).or_insert_with(|| value.clone());
-        } else {
+        } else if key != PARQUET_FIELD_ID_META_KEY
+            && key != ColumnMetadataKey::ParquetFieldId.as_ref()
+        {
             // For non-column-mapping keys, prefer the value from the new field (to keep user-added metadata).
             merged.insert(key.clone(), value.clone());
         }
@@ -137,7 +149,9 @@ fn merge_metadata(prev: &StructField, new: &StructField) -> HashMap<String, Meta
 fn annotate_field(field: &StructField, counter: &AtomicI64) -> StructField {
     let next_id = counter.fetch_add(1, Ordering::Relaxed);
     let physical_name = format!("col-{}", uuid::Uuid::new_v4());
-    let annotated = field.clone().add_metadata([
+    let mut annotated = field.clone();
+    strip_parquet_field_id_metadata(&mut annotated.metadata);
+    let annotated = annotated.add_metadata([
         ("delta.columnMapping.id", MetadataValue::Number(next_id)),
         (
             "delta.columnMapping.physicalName",
@@ -268,4 +282,42 @@ fn merge_struct(existing: &StructType, candidate: &StructType, counter: &AtomicI
 fn empty_struct_type() -> StructType {
     StructType::try_new(Vec::<StructField>::new())
         .unwrap_or_else(|_| unreachable!("empty struct type is always valid"))
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn annotation_strips_transient_parquet_field_ids() {
+        let rate = StructField::new("rate", DataType::LONG, true).with_metadata([
+            (PARQUET_FIELD_ID_META_KEY, MetadataValue::Number(30)),
+            (
+                ColumnMetadataKey::ParquetFieldId.as_ref(),
+                MetadataValue::Number(30),
+            ),
+        ]);
+        let nested = StructType::try_new(vec![rate]).expect("nested schema");
+        let details = StructField::new("details", DataType::Struct(Box::new(nested)), true)
+            .with_metadata([(PARQUET_FIELD_ID_META_KEY, MetadataValue::Number(20))]);
+        let schema = StructType::try_new(vec![details]).expect("schema");
+
+        let annotated = annotate_schema_for_column_mapping(&schema);
+        let details = annotated.field("details").expect("details field");
+        let DataType::Struct(nested) = details.data_type() else {
+            panic!("details must be a struct");
+        };
+        let rate = nested.field("rate").expect("rate field");
+
+        for field in [details, rate] {
+            assert!(!field.metadata().contains_key(PARQUET_FIELD_ID_META_KEY));
+            assert!(
+                !field
+                    .metadata()
+                    .contains_key(ColumnMetadataKey::ParquetFieldId.as_ref())
+            );
+            assert!(field.metadata().contains_key("delta.columnMapping.id"));
+        }
+    }
 }

--- a/crates/sail-delta-lake/src/schema/mod.rs
+++ b/crates/sail-delta-lake/src/schema/mod.rs
@@ -17,9 +17,11 @@ pub mod mapping;
 pub mod normalize;
 pub mod type_widening;
 
+pub(crate) use converter::adapt_array_to_physical_field;
 pub use converter::{
     arrow_field_physical_name, arrow_schema_from_struct_type, arrow_schema_reorder_partitions,
-    get_physical_arrow_schema as get_physical_schema, make_physical_arrow_schema,
+    attach_column_mapping_metadata, get_physical_arrow_schema as get_physical_schema,
+    make_physical_arrow_schema, restore_logical_record_batch,
 };
 pub use manager::{
     evolve_schema, metadata_for_create_with_struct_type, protocol_for_create,

--- a/crates/sail-delta-lake/src/spec/schema.rs
+++ b/crates/sail-delta-lake/src/spec/schema.rs
@@ -460,10 +460,7 @@ impl Display for StructField {
 }
 
 fn make_physical_field(field: &StructField, column_mapping_mode: ColumnMappingMode) -> StructField {
-    let data_type = match &field.data_type {
-        DataType::Struct(inner) => DataType::from(inner.make_physical(column_mapping_mode)),
-        other => other.clone(),
-    };
+    let data_type = make_physical_data_type(&field.data_type, column_mapping_mode);
 
     let mut metadata = field.metadata().clone();
     let physical_name_key = ColumnMetadataKey::ColumnMappingPhysicalName.as_ref();
@@ -500,6 +497,25 @@ fn make_physical_field(field: &StructField, column_mapping_mode: ColumnMappingMo
         data_type,
         nullable: field.nullable,
         metadata,
+    }
+}
+
+fn make_physical_data_type(
+    data_type: &DataType,
+    column_mapping_mode: ColumnMappingMode,
+) -> DataType {
+    match data_type {
+        DataType::Struct(inner) => DataType::from(inner.make_physical(column_mapping_mode)),
+        DataType::Array(array) => DataType::Array(Box::new(ArrayType::new(
+            make_physical_data_type(array.element_type(), column_mapping_mode),
+            array.contains_null(),
+        ))),
+        DataType::Map(map) => DataType::Map(Box::new(MapType::new(
+            make_physical_data_type(map.key_type(), column_mapping_mode),
+            make_physical_data_type(map.value_type(), column_mapping_mode),
+            map.value_contains_null(),
+        ))),
+        other => other.clone(),
     }
 }
 

--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -79,9 +79,16 @@ message ExtendedPhysicalExprNode {
   }
 }
 
+enum StructFieldMatching {
+  STRUCT_FIELD_MATCHING_NAME = 0;
+  STRUCT_FIELD_MATCHING_PHYSICAL_NAME = 1;
+  STRUCT_FIELD_MATCHING_FIELD_ID = 2;
+}
+
 message CastColumnExprNode {
   bytes input_schema = 1;
   bytes target_schema = 2;
+  StructFieldMatching struct_field_matching = 3;
 }
 
 message LambdaExprNode {
@@ -863,6 +870,7 @@ message CoalesceExecNode {
 message RelaxedTzCastExecNode {
   bytes input = 1;
   bytes schema = 2;
+  DeltaColumnMappingMode column_mapping_mode = 3;
 }
 
 message JoinOn {

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -85,7 +85,9 @@ use sail_common_datafusion::catalog::{
     CatalogPartitionField, LakehouseExecutionContext, PartitionTransform,
 };
 use sail_common_datafusion::datasource::PhysicalSinkMode;
-use sail_common_datafusion::schema_evolution::SchemaEvolutionCastColumnExpr;
+use sail_common_datafusion::schema_evolution::{
+    SchemaEvolutionCastColumnExpr, StructFieldMatching,
+};
 use sail_common_datafusion::system::catalog::SystemTable;
 use sail_common_datafusion::udf::StreamUDF;
 use sail_data_source::formats::binary::source::BinarySource;
@@ -1147,10 +1149,20 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 try_decode_physical_plan(ctx, self, &input)?,
                 usize::try_from(output_partitions).map_err(|e| plan_datafusion_err!("{e}"))?,
             ))),
-            NodeKind::RelaxedTzCast(r#gen::RelaxedTzCastExecNode { input, schema }) => {
+            NodeKind::RelaxedTzCast(r#gen::RelaxedTzCastExecNode {
+                input,
+                schema,
+                column_mapping_mode,
+            }) => {
                 let input = try_decode_physical_plan(ctx, self, &input)?;
                 let schema = Arc::new(try_decode_schema(&schema)?);
-                Ok(Arc::new(RelaxedTzCastExec::new(input, schema)))
+                let column_mapping_mode =
+                    self.try_decode_delta_column_mapping_mode(column_mapping_mode)?;
+                Ok(Arc::new(RelaxedTzCastExec::new_with_column_mapping(
+                    input,
+                    schema,
+                    column_mapping_mode,
+                )))
             }
             NodeKind::DeletionVectorWriter(r#gen::DeletionVectorWriterExecNode {
                 input,
@@ -2021,7 +2033,13 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
         } else if let Some(relaxed_tz_cast) = node.downcast_ref::<RelaxedTzCastExec>() {
             let input = try_encode_physical_plan(self, relaxed_tz_cast.input().clone())?;
             let schema = try_encode_schema(relaxed_tz_cast.schema().as_ref())?;
-            NodeKind::RelaxedTzCast(r#gen::RelaxedTzCastExecNode { input, schema })
+            let column_mapping_mode =
+                Self::try_encode_delta_column_mapping_mode(relaxed_tz_cast.column_mapping_mode())?;
+            NodeKind::RelaxedTzCast(r#gen::RelaxedTzCastExecNode {
+                input,
+                schema,
+                column_mapping_mode,
+            })
         } else if let Some(dv_writer_exec) = node.downcast_ref::<DeletionVectorWriterExec>() {
             let input = try_encode_physical_plan(self, dv_writer_exec.input().clone())?;
             let condition = try_encode_physical_expr(self, dv_writer_exec.condition())?;
@@ -3264,16 +3282,14 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             .ok_or_else(|| plan_datafusion_err!("missing physical expr node"))?;
         match expr_kind {
             ExprKind::SchemaEvolutionCast(node) => {
-                let (input, input_field, target_field) = self.try_decode_cast_column_expr(
-                    &node,
-                    inputs,
-                    "SchemaEvolutionCastColumnExpr",
-                )?;
-                Ok(Arc::new(SchemaEvolutionCastColumnExpr::new(
+                let (input, input_field, target_field, matching) = self
+                    .try_decode_cast_column_expr(&node, inputs, "SchemaEvolutionCastColumnExpr")?;
+                Ok(Arc::new(SchemaEvolutionCastColumnExpr::new_with_matching(
                     input,
                     input_field,
                     target_field,
                     None,
+                    matching,
                 )))
             }
             // Lambdas are handled in converter.rs, but we leave it here for defensive programming.
@@ -3306,6 +3322,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             let node = self.try_encode_cast_column_expr(
                 cast.input_field().as_ref(),
                 cast.target_field().as_ref(),
+                cast.matching(),
             )?;
             ExprKind::SchemaEvolutionCast(node)
         } else if let Some(lambda) = node.downcast_ref::<LambdaExpr>() {
@@ -3337,10 +3354,16 @@ impl RemoteExecutionCodec {
         node: &CastColumnExprNode,
         inputs: &[Arc<dyn PhysicalExpr>],
         expr_name: &str,
-    ) -> Result<(Arc<dyn PhysicalExpr>, Arc<Field>, Arc<Field>)> {
+    ) -> Result<(
+        Arc<dyn PhysicalExpr>,
+        Arc<Field>,
+        Arc<Field>,
+        StructFieldMatching,
+    )> {
         let CastColumnExprNode {
             input_schema,
             target_schema,
+            struct_field_matching,
         } = node;
         if inputs.len() != 1 {
             return plan_err!(
@@ -3369,6 +3392,7 @@ impl RemoteExecutionCodec {
             inputs[0].clone(),
             Arc::new(input_field),
             Arc::new(target_field),
+            Self::try_decode_struct_field_matching(*struct_field_matching)?,
         ))
     }
 
@@ -3376,6 +3400,7 @@ impl RemoteExecutionCodec {
         &self,
         input_field: &Field,
         target_field: &Field,
+        matching: StructFieldMatching,
     ) -> Result<CastColumnExprNode> {
         let input_schema = Schema::new(vec![input_field.clone()]);
         let input_schema = try_encode_schema(&input_schema)?;
@@ -3384,7 +3409,26 @@ impl RemoteExecutionCodec {
         Ok(CastColumnExprNode {
             input_schema,
             target_schema,
+            struct_field_matching: Self::try_encode_struct_field_matching(matching),
         })
+    }
+
+    fn try_decode_struct_field_matching(mode: i32) -> Result<StructFieldMatching> {
+        match r#gen::StructFieldMatching::try_from(mode)
+            .map_err(|_| plan_datafusion_err!("invalid struct field matching mode"))?
+        {
+            r#gen::StructFieldMatching::Name => Ok(StructFieldMatching::Name),
+            r#gen::StructFieldMatching::PhysicalName => Ok(StructFieldMatching::PhysicalName),
+            r#gen::StructFieldMatching::FieldId => Ok(StructFieldMatching::FieldId),
+        }
+    }
+
+    fn try_encode_struct_field_matching(mode: StructFieldMatching) -> i32 {
+        (match mode {
+            StructFieldMatching::Name => r#gen::StructFieldMatching::Name,
+            StructFieldMatching::PhysicalName => r#gen::StructFieldMatching::PhysicalName,
+            StructFieldMatching::FieldId => r#gen::StructFieldMatching::FieldId,
+        }) as i32
     }
 
     fn try_decode_physical_sink_mode(
@@ -4375,6 +4419,30 @@ mod tests {
         let mut buf = vec![];
         codec.try_encode_udwf(udwf.as_ref(), &mut buf)?;
         codec.try_decode_udwf(&name, &buf)
+    }
+
+    #[test]
+    fn test_struct_field_matching_proto_round_trip_and_default() -> Result<()> {
+        for mode in [
+            StructFieldMatching::Name,
+            StructFieldMatching::PhysicalName,
+            StructFieldMatching::FieldId,
+        ] {
+            let encoded = RemoteExecutionCodec::try_encode_struct_field_matching(mode);
+            assert_eq!(
+                RemoteExecutionCodec::try_decode_struct_field_matching(encoded)?,
+                mode
+            );
+        }
+
+        assert_eq!(
+            RemoteExecutionCodec::try_decode_struct_field_matching(
+                r#gen::CastColumnExprNode::default().struct_field_matching,
+            )?,
+            StructFieldMatching::Name
+        );
+        assert!(RemoteExecutionCodec::try_decode_struct_field_matching(i32::MAX).is_err());
+        Ok(())
     }
 
     #[test]

--- a/python/pysail/testing/spark/utils/jvm.py
+++ b/python/pysail/testing/spark/utils/jvm.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import contextlib
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+# Delta 4.1 embeds the Spark minor in its artifact name, while earlier releases
+# use the Scala binary version only.
+DELTA_SPARK_COORDINATES: dict[str, str] = {
+    "3.5": "io.delta:delta-spark_2.12:3.3.2",
+    "4.0": "io.delta:delta-spark_2.13:4.0.1",
+    "4.1": "io.delta:delta-spark_4.1_2.13:4.1.0",
+}
+
+
+def delta_spark_maven_coordinate(spark_version: str) -> str:
+    spark_minor = ".".join(spark_version.split(".")[:2])
+    try:
+        return DELTA_SPARK_COORDINATES[spark_minor]
+    except KeyError as error:
+        message = f"No Delta Maven coordinate mapping for Spark {spark_version}"
+        raise RuntimeError(message) from error
+
+
+@contextlib.contextmanager
+def classic_spark_mode() -> Generator[None, None, None]:
+    old_api_mode = os.environ.get("SPARK_API_MODE")
+    old_remote = os.environ.pop("SPARK_REMOTE", None)
+    old_connect_mode = os.environ.pop("SPARK_CONNECT_MODE_ENABLED", None)
+    os.environ["SPARK_API_MODE"] = "classic"
+    try:
+        yield
+    finally:
+        if old_api_mode is None:
+            os.environ.pop("SPARK_API_MODE", None)
+        else:
+            os.environ["SPARK_API_MODE"] = old_api_mode
+        if old_remote is not None:
+            os.environ["SPARK_REMOTE"] = old_remote
+        if old_connect_mode is not None:
+            os.environ["SPARK_CONNECT_MODE_ENABLED"] = old_connect_mode

--- a/python/pysail/tests/spark/catalog/hms/conftest.py
+++ b/python/pysail/tests/spark/catalog/hms/conftest.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import contextlib
 import hashlib
 import os
 import re
@@ -20,6 +19,7 @@ from testcontainers.core.network import Network
 from testcontainers.core.waiting_utils import wait_for_logs
 
 from pysail.testing.spark.session import spark_connect_server, spark_session_factory
+from pysail.testing.spark.utils.jvm import classic_spark_mode, delta_spark_maven_coordinate
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -109,25 +109,6 @@ def _spark_s3_options(endpoint: str) -> dict[str, str]:
         "spark.hadoop.fs.s3a.secret.key": _MINIO_PASSWORD,
         "spark.hadoop.fs.s3a.aws.credentials.provider": ("org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider"),
     }
-
-
-@contextlib.contextmanager
-def _classic_spark_mode() -> Generator[None, None, None]:
-    old_api_mode = os.environ.get("SPARK_API_MODE")
-    old_remote = os.environ.pop("SPARK_REMOTE", None)
-    old_connect_mode = os.environ.pop("SPARK_CONNECT_MODE_ENABLED", None)
-    os.environ["SPARK_API_MODE"] = "classic"
-    try:
-        yield
-    finally:
-        if old_api_mode is None:
-            os.environ.pop("SPARK_API_MODE", None)
-        else:
-            os.environ["SPARK_API_MODE"] = old_api_mode
-        if old_remote is not None:
-            os.environ["SPARK_REMOTE"] = old_remote
-        if old_connect_mode is not None:
-            os.environ["SPARK_CONNECT_MODE_ENABLED"] = old_connect_mode
 
 
 def _wait_for_port(host: str, port: int, timeout: float) -> None:
@@ -371,29 +352,10 @@ _SPARK_VERSION = _pyspark.__version__
 _SPARK_MAJOR, _SPARK_MINOR_PART = _SPARK_VERSION.split(".")[:2]
 _SCALA_BINARY = "2.12" if _SPARK_MAJOR == "3" else "2.13"
 _SPARK_MINOR = f"{_SPARK_MAJOR}.{_SPARK_MINOR_PART}"
-# Delta Maven coordinates per Spark minor version. Delta renamed its artifact at
-# 4.1.0 to embed the Spark minor (``delta-spark_<spark-minor>_<scala>``); earlier
-# releases (3.3.x, 4.0.x) keep the legacy ``delta-spark_<scala>`` name. The previous
-# ``delta-spark_{minor}_{scala}`` rule for every Spark 4.x produced a 404 for 4.0
-# (``delta-spark_4.0_2.13`` does not exist at 4.0.1), so pin the full coordinate
-# explicitly per Spark version: a future Delta rename then cannot silently break
-# the JVM classpath. Each row was verified against Maven Central:
-#   Spark 3.5 -> io.delta:delta-spark_2.12:3.3.2
-#   Spark 4.0 -> io.delta:delta-spark_2.13:4.0.1   (legacy name; 4.0 minor not embedded)
-#   Spark 4.1 -> io.delta:delta-spark_4.1_2.13:4.1.0 (new name introduced at Delta 4.1.0)
-_DELTA_SPARK_COORDINATES: dict[str, tuple[str, str, str]] = {
-    "3.5": ("io.delta", "delta-spark_2.12", "3.3.2"),
-    "4.0": ("io.delta", "delta-spark_2.13", "4.0.1"),
-    "4.1": ("io.delta", "delta-spark_4.1_2.13", "4.1.0"),
-}
-if _SPARK_MINOR not in _DELTA_SPARK_COORDINATES:
-    pytest.skip(
-        reason=f"No Delta Maven coordinate mapping for Spark {_SPARK_VERSION}; "
-        "add an entry to _DELTA_SPARK_COORDINATES in "
-        "python/pysail/tests/spark/catalog/hms/conftest.py."
-    )
-_DELTA_GROUP, _DELTA_ARTIFACT, _DELTA_VERSION = _DELTA_SPARK_COORDINATES[_SPARK_MINOR]
-_DELTA_SPARK_PACKAGE = f"{_DELTA_GROUP}:{_DELTA_ARTIFACT}:{_DELTA_VERSION}"
+try:
+    _DELTA_SPARK_PACKAGE = delta_spark_maven_coordinate(_SPARK_VERSION)
+except RuntimeError as error:
+    pytest.skip(reason=str(error))
 # Avro is a built-in but *external* datasource in Spark 2.4+: the runtime jar must
 # be on the classpath for `USING AVRO`.
 _AVRO_SPARK_PACKAGE = f"org.apache.spark:spark-avro_{_SCALA_BINARY}:{_SPARK_VERSION}"
@@ -450,7 +412,7 @@ def jvm_spark(
         _ICEBERG_SPARK_PACKAGE,
     ]
 
-    with _classic_spark_mode():
+    with classic_spark_mode():
         builder = (
             SparkSession.builder.master("local[1]")
             .appName("hms-jvm-unified")

--- a/python/pysail/tests/spark/delta/conftest.py
+++ b/python/pysail/tests/spark/delta/conftest.py
@@ -1,9 +1,46 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pyspark
 import pytest
+from pyspark.sql import SparkSession
 
 from pysail.testing.spark.utils.common import is_jvm_spark
+from pysail.testing.spark.utils.jvm import classic_spark_mode, delta_spark_maven_coordinate
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 
 @pytest.fixture(scope="session", autouse=True)
 def skip_if_jvm_spark():
     if is_jvm_spark():
         pytest.skip("Delta Lake tests for JVM Spark")
+
+
+@pytest.fixture(scope="session")
+def delta_jvm_spark(tmp_path_factory: pytest.TempPathFactory) -> Generator[SparkSession, None, None]:
+    warehouse_dir = tmp_path_factory.mktemp("delta-jvm-warehouse")
+    try:
+        delta_package = delta_spark_maven_coordinate(pyspark.__version__)
+    except RuntimeError as error:
+        pytest.skip(str(error))
+    with classic_spark_mode():
+        spark = (
+            SparkSession.builder.master("local[1]")
+            .appName("delta-column-mapping-interop")
+            .config("spark.jars.packages", delta_package)
+            .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+            .config(
+                "spark.sql.catalog.spark_catalog",
+                "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+            )
+            .config("spark.sql.warehouse.dir", str(warehouse_dir))
+            .getOrCreate()
+        )
+        spark.conf.set("spark.sql.session.timeZone", "UTC")
+
+    yield spark
+
+    spark.stop()

--- a/python/pysail/tests/spark/delta/test_delta_column_mapping.py
+++ b/python/pysail/tests/spark/delta/test_delta_column_mapping.py
@@ -2,12 +2,18 @@ from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
 from pyspark.sql import Row
 from pyspark.sql import functions as F  # noqa: N812
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from pyspark.sql import SparkSession
 
 
 def _latest_metadata(base: Path) -> dict:
@@ -28,6 +34,69 @@ def _physical_name_for_column(metadata: dict, column_name: str) -> str:
             return field.get("metadata", {}).get("delta.columnMapping.physicalName", column_name)
     message = f"column {column_name!r} not found in schema"
     raise AssertionError(message)
+
+
+def _latest_added_parquet_files(base: Path) -> list[Path]:
+    for log_file in sorted((base / "_delta_log").glob("*.json"), reverse=True):
+        added = []
+        with log_file.open("r", encoding="utf-8") as f:
+            for line in f:
+                action = json.loads(line)
+                if "add" in action and action["add"]["path"].endswith(".parquet"):
+                    added.append(base / unquote(action["add"]["path"]))
+        if added:
+            return added
+    return []
+
+
+def _assert_parquet_struct_matches_delta(
+    arrow_type: pa.Schema | pa.StructType,
+    delta_type: dict,
+) -> None:
+    for delta_field in delta_type["fields"]:
+        metadata = delta_field["metadata"]
+        physical_name = metadata["delta.columnMapping.physicalName"]
+        arrow_field = arrow_type.field(physical_name)
+        arrow_metadata = {key.decode(): value.decode() for key, value in (arrow_field.metadata or {}).items()}
+        assert arrow_metadata["PARQUET:field_id"] == str(metadata["delta.columnMapping.id"])
+
+        nested_type = delta_field["type"]
+        if not isinstance(nested_type, dict):
+            continue
+        if nested_type["type"] == "struct":
+            _assert_parquet_struct_matches_delta(arrow_field.type, nested_type)
+        elif nested_type["type"] == "array" and isinstance(nested_type["elementType"], dict):
+            element_type = nested_type["elementType"]
+            if element_type["type"] == "struct":
+                _assert_parquet_struct_matches_delta(
+                    arrow_field.type.value_type,
+                    element_type,
+                )
+        elif nested_type["type"] == "map":
+            key_type = nested_type["keyType"]
+            value_type = nested_type["valueType"]
+            if isinstance(key_type, dict) and key_type["type"] == "struct":
+                _assert_parquet_struct_matches_delta(arrow_field.type.key_type, key_type)
+            if isinstance(value_type, dict) and value_type["type"] == "struct":
+                _assert_parquet_struct_matches_delta(
+                    arrow_field.type.item_type,
+                    value_type,
+                )
+
+
+def _assert_parquet_files_match_delta_schema(
+    base: Path,
+    *,
+    latest_only: bool = False,
+) -> None:
+    delta_schema = json.loads(_latest_metadata(base)["schemaString"])
+    parquet_files = _latest_added_parquet_files(base) if latest_only else list(base.rglob("*.parquet"))
+    assert parquet_files
+    for parquet_file in parquet_files:
+        _assert_parquet_struct_matches_delta(
+            pq.ParquetFile(parquet_file).schema_arrow,
+            delta_schema,
+        )
 
 
 def test_create_table_with_column_mapping_name(spark, tmp_path: Path):
@@ -186,16 +255,90 @@ def test_merge_nested_struct_in_name_mode(spark, tmp_path: Path):
     ]
 
 
+def test_column_mapping_nested_struct_round_trip(spark, tmp_path: Path):
+    source_path = tmp_path / "delta_cm_nested_round_trip_source"
+    output_path = tmp_path / "delta_cm_nested_round_trip_output"
+    source_rows = [
+        Row(
+            id=1,
+            code="USD",
+            original_details=Row(amount=10, active=True),
+        )
+    ]
+
+    (
+        spark.createDataFrame(source_rows)
+        .write.format("delta")
+        .mode("overwrite")
+        .option("delta.columnMapping.mode", "name")
+        .save(str(source_path))
+    )
+
+    loaded = spark.read.format("delta").load(str(source_path))
+    assert [row.asDict(recursive=True) for row in loaded.collect()] == [
+        {
+            "id": 1,
+            "code": "USD",
+            "original_details": {"amount": 10, "active": True},
+        }
+    ]
+    assert loaded.select("original_details.amount").collect() == [Row(amount=10)]
+    _assert_parquet_files_match_delta_schema(source_path)
+
+    rebuilt = loaded.select(F.struct(F.col("id"), F.col("code")).alias("details"))
+    (rebuilt.write.format("delta").mode("overwrite").option("delta.columnMapping.mode", "name").save(str(output_path)))
+
+    result = spark.read.format("delta").load(str(output_path))
+    assert [row.asDict(recursive=True) for row in result.collect()] == [{"details": {"id": 1, "code": "USD"}}]
+    _assert_parquet_files_match_delta_schema(output_path)
+    target_schema = _latest_metadata(output_path)["schemaString"]
+    assert "PARQUET:field_id" not in target_schema
+    assert "parquet.field.id" not in target_schema
+
+
+def test_deep_nested_predicate_with_explicit_schema(spark, tmp_path: Path):
+    base = tmp_path / "delta_cm_deep_predicate"
+    rows = [
+        Row(id=1, payload=Row(level=Row(value=10))),
+        Row(id=2, payload=Row(level=Row(value=20))),
+    ]
+    source = spark.createDataFrame(rows)
+    (source.write.format("delta").mode("overwrite").option("delta.columnMapping.mode", "name").save(str(base)))
+
+    loaded = spark.read.schema(source.schema).format("delta").load(str(base))
+    filtered = loaded.where(F.col("payload.level.value") > F.lit(10)).collect()
+
+    assert [row.asDict(recursive=True) for row in filtered] == [{"id": 2, "payload": {"level": {"value": 20}}}]
+
+
+def test_nested_mapping_with_metadata_as_data_read(spark, tmp_path: Path):
+    base = tmp_path / "delta_cm_metadata_as_data"
+    rows = [
+        Row(id=1, payload=Row(level=Row(value=10))),
+        Row(id=2, payload=Row(level=Row(value=20))),
+    ]
+    source = spark.createDataFrame(rows)
+    (source.write.format("delta").mode("overwrite").option("delta.columnMapping.mode", "name").save(str(base)))
+
+    loaded = spark.read.format("delta").option("metadataAsDataRead", "true").load(str(base)).orderBy("id")
+
+    assert [row.asDict(recursive=True) for row in loaded.collect()] == [
+        {"id": 1, "payload": {"level": {"value": 10}}},
+        {"id": 2, "payload": {"level": {"value": 20}}},
+    ]
+
+
 def test_merge_array_of_struct_in_name_mode(spark, tmp_path: Path):
     base = tmp_path / "delta_cm_array_struct"
     df = spark.createDataFrame([Row(events=[Row(ts=1)])])
-    df.write.format("delta").mode("overwrite").option("column_mapping_mode", "name").save(str(base))
+    (df.write.format("delta").mode("overwrite").option("delta.columnMapping.mode", "name").save(str(base)))
 
     df2 = spark.createDataFrame([Row(events=[Row(ts=2, kind="x")])])
     df2.write.format("delta").mode("append").option("mergeSchema", "true").save(str(base))
 
     rows = [r.asDict(recursive=True) for r in spark.read.format("delta").load(str(base)).collect()]
-    assert any("kind" in ev for row in rows for ev in row.get("events", []) or [])
+    assert {"ts": 2, "kind": "x"} in [event for row in rows for event in row["events"]]
+    _assert_parquet_files_match_delta_schema(base, latest_only=True)
 
 
 def test_add_new_array_struct_field(spark, tmp_path: Path):
@@ -213,8 +356,8 @@ def test_add_new_array_struct_field(spark, tmp_path: Path):
     assert rows[1]["id"] == 2  # noqa: PLR2004
     assert isinstance(rows[1]["items"], list)
     assert len(rows[1]["items"]) == 1
-    # Do not assert nested field logical name to avoid coupling to physicalName mapping
-    assert list(rows[1]["items"][0].values()) == [10]
+    assert rows[1]["items"][0] == {"a": 10}
+    _assert_parquet_files_match_delta_schema(base, latest_only=True)
 
 
 def test_merge_map_value_struct(spark, tmp_path: Path):
@@ -225,8 +368,9 @@ def test_merge_map_value_struct(spark, tmp_path: Path):
     df2 = spark.createDataFrame([Row(attrs={"k": Row(a=2, b=3)})])
     df2.write.format("delta").mode("append").option("mergeSchema", "true").save(str(base))
 
-    row = spark.read.format("delta").load(str(base)).collect()[0].asDict(recursive=True)
-    assert "b" in row["attrs"]["k"]
+    rows = [row.asDict(recursive=True) for row in spark.read.format("delta").load(str(base)).collect()]
+    assert {"k": {"a": 2, "b": 3}} in [row["attrs"] for row in rows]
+    _assert_parquet_files_match_delta_schema(base, latest_only=True)
 
 
 def test_partitioned_table_with_column_mapping_name(spark, tmp_path: Path):
@@ -378,3 +522,190 @@ def test_column_mapping_supports_special_characters_in_column_names(spark, tmp_p
 
     projected = out.selectExpr("`first.name`", "`name with space`", "`a,b`").collect()
     assert [row.asDict() for row in projected] == rows
+
+
+RENAMED_EXPECTED_ROWS = [
+    {"id": 1, "code": "alpha", "details": {"total": 10, "active": True}},
+    {"id": 2, "code": "beta", "details": {"total": 20, "active": False}},
+    {"id": 3, "code": "gamma", "details": {"total": 30, "active": True}},
+]
+
+
+def _collect_rows(df) -> list[dict]:
+    return sorted(
+        (row.asDict(recursive=True) for row in df.collect()),
+        key=lambda row: row["id"],
+    )
+
+
+def _rename_schema(schema: dict) -> dict:
+    renamed = json.loads(json.dumps(schema))
+    for field in renamed["fields"]:
+        if field["name"] == "label":
+            field["name"] = "code"
+        if field["name"] == "details":
+            for child in field["type"]["fields"]:
+                if child["name"] == "amount":
+                    child["name"] = "total"
+    return renamed
+
+
+def _append_metadata_only_rename(table_path: Path) -> None:
+    metadata = _latest_metadata(table_path)
+    original_schema = json.loads(metadata["schemaString"])
+    renamed_schema = _rename_schema(original_schema)
+
+    original_fields = {field["name"]: field["metadata"] for field in original_schema["fields"]}
+    renamed_fields = {field["name"]: field["metadata"] for field in renamed_schema["fields"]}
+    assert renamed_fields["code"] == original_fields["label"]
+    original_details = {field["name"]: field["metadata"] for field in original_schema["fields"][2]["type"]["fields"]}
+    renamed_details = {field["name"]: field["metadata"] for field in renamed_schema["fields"][2]["type"]["fields"]}
+    assert renamed_details["total"] == original_details["amount"]
+
+    log_dir = table_path / "_delta_log"
+    version = max(int(path.stem) for path in log_dir.glob("*.json")) + 1
+    renamed_metadata = {
+        **metadata,
+        "schemaString": json.dumps(renamed_schema, separators=(",", ":")),
+    }
+    actions = [
+        {
+            "commitInfo": {
+                "operation": "RENAME COLUMN",
+                "operationParameters": {
+                    "oldColumnPath": "label,details.amount",
+                    "newColumnPath": "code,details.total",
+                },
+                "readVersion": version - 1,
+                "isBlindAppend": True,
+            }
+        },
+        {"metaData": renamed_metadata},
+    ]
+    log_file = log_dir / f"{version:020}.json"
+    log_file.write_text(
+        "".join(f"{json.dumps(action, separators=(',', ':'))}\n" for action in actions),
+        encoding="utf-8",
+    )
+
+
+def _change_nested_physical_name(table_path: Path) -> None:
+    metadata = _latest_metadata(table_path)
+    schema = json.loads(metadata["schemaString"])
+    details = next(field for field in schema["fields"] if field["name"] == "details")
+    amount = next(field for field in details["type"]["fields"] if field["name"] == "amount")
+    amount["metadata"]["delta.columnMapping.physicalName"] = "missing-physical-name"
+
+    log_dir = table_path / "_delta_log"
+    version = max(int(path.stem) for path in log_dir.glob("*.json")) + 1
+    changed_metadata = {
+        **metadata,
+        "schemaString": json.dumps(schema, separators=(",", ":")),
+    }
+    actions = [
+        {
+            "commitInfo": {
+                "operation": "SET TBLPROPERTIES",
+                "readVersion": version - 1,
+                "isBlindAppend": True,
+            }
+        },
+        {"metaData": changed_metadata},
+    ]
+    (log_dir / f"{version:020}.json").write_text(
+        "".join(f"{json.dumps(action, separators=(',', ':'))}\n" for action in actions),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def renamed_table(spark: SparkSession, tmp_path: Path) -> Path:
+    table_path = tmp_path / "renamed_column_mapping"
+    initial_rows = [
+        Row(id=1, label="alpha", details=Row(amount=10, active=True)),
+        Row(id=2, label="beta", details=Row(amount=20, active=False)),
+    ]
+    (
+        spark.createDataFrame(initial_rows)
+        .write.format("delta")
+        .mode("overwrite")
+        .option("delta.columnMapping.mode", "name")
+        .save(str(table_path))
+    )
+    _append_metadata_only_rename(table_path)
+
+    appended = [Row(id=3, code="gamma", details=Row(total=30, active=True))]
+    spark.createDataFrame(appended).write.format("delta").mode("append").save(str(table_path))
+    return table_path
+
+
+def test_reads_files_written_before_and_after_rename(
+    spark: SparkSession,
+    renamed_table: Path,
+):
+    df = spark.read.format("delta").load(str(renamed_table))
+
+    assert _collect_rows(df) == RENAMED_EXPECTED_ROWS
+    assert sorted(row.total for row in df.select("details.total").collect()) == [
+        10,
+        20,
+        30,
+    ]
+
+
+def test_append_preserves_renamed_nested_mapping(
+    spark: SparkSession,
+    renamed_table: Path,
+):
+    row = [Row(id=4, code="delta", details=Row(total=40, active=False))]
+    spark.createDataFrame(row).write.format("delta").mode("append").save(str(renamed_table))
+
+    assert _collect_rows(spark.read.format("delta").load(str(renamed_table))) == [
+        *RENAMED_EXPECTED_ROWS,
+        {"id": 4, "code": "delta", "details": {"total": 40, "active": False}},
+    ]
+    schema_string = _latest_metadata(renamed_table)["schemaString"]
+    assert "PARQUET:field_id" not in schema_string
+    assert "parquet.field.id" not in schema_string
+
+
+def test_overwrite_preserves_renamed_nested_mapping(
+    spark: SparkSession,
+    renamed_table: Path,
+):
+    original_schema = _latest_metadata(renamed_table)["schemaString"]
+    loaded = spark.read.format("delta").load(str(renamed_table))
+
+    loaded.where("id < 3").write.format("delta").mode("overwrite").save(str(renamed_table))
+
+    assert _collect_rows(spark.read.format("delta").load(str(renamed_table))) == RENAMED_EXPECTED_ROWS[:2]
+    assert _latest_metadata(renamed_table)["schemaString"] == original_schema
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        ("name", None),
+        ("id", 10),
+    ],
+)
+def test_nested_resolution_uses_only_the_configured_identity(
+    spark: SparkSession,
+    tmp_path: Path,
+    mode: str,
+    expected: int | None,
+):
+    table_path = tmp_path / f"nested_resolution_{mode}"
+    rows = [Row(id=1, details=Row(amount=10))]
+    (
+        spark.createDataFrame(rows)
+        .write.format("delta")
+        .mode("overwrite")
+        .option("delta.columnMapping.mode", mode)
+        .save(str(table_path))
+    )
+    _change_nested_physical_name(table_path)
+
+    row = spark.read.format("delta").load(str(table_path)).collect()[0]
+
+    assert row.details.amount == expected

--- a/python/pysail/tests/spark/delta/test_delta_column_mapping_delta_spark.py
+++ b/python/pysail/tests/spark/delta/test_delta_column_mapping_delta_spark.py
@@ -1,0 +1,157 @@
+# ruff: noqa: S608
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from pyspark.sql import Row
+from pyspark.sql.types import BooleanType, IntegerType, StructField, StructType
+
+from pysail.testing.spark.utils.sql import escape_sql_identifier
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from pyspark.sql import SparkSession
+
+pytestmark = pytest.mark.integration
+
+
+def _nested_schema(value_field: str) -> StructType:
+    return StructType(
+        [
+            StructField("id", IntegerType(), nullable=True),
+            StructField(
+                "details",
+                StructType(
+                    [
+                        StructField(value_field, IntegerType(), nullable=True),
+                        StructField("active", BooleanType(), nullable=True),
+                    ]
+                ),
+                nullable=True,
+            ),
+        ]
+    )
+
+
+def test_delta_spark_nested_rename_is_readable_and_appendable_by_sail(
+    delta_jvm_spark: SparkSession,
+    spark: SparkSession,
+    tmp_path: Path,
+) -> None:
+    table_path = tmp_path / "delta_spark_nested_mapping"
+    table_identifier = f"delta.`{escape_sql_identifier(str(table_path))}`"
+    delta_jvm_spark.sql(
+        f"""
+        CREATE TABLE {table_identifier} (
+            id INT,
+            details STRUCT<amount: INT, active: BOOLEAN>
+        )
+        USING DELTA
+        TBLPROPERTIES ('delta.columnMapping.mode' = 'name')
+        """
+    )
+    delta_jvm_spark.sql(
+        f"""
+        INSERT INTO {table_identifier}
+        VALUES
+            (1, named_struct('amount', 10, 'active', true)),
+            (2, named_struct('amount', 20, 'active', false))
+        """
+    )
+    data_files_before_rename = sorted(table_path.rglob("*.parquet"))
+
+    delta_jvm_spark.sql(f"ALTER TABLE {table_identifier} RENAME COLUMN details.amount TO total")
+    assert sorted(table_path.rglob("*.parquet")) == data_files_before_rename
+
+    delta_jvm_spark.sql(
+        f"""
+        INSERT INTO {table_identifier}
+        VALUES (3, named_struct('total', 30, 'active', true))
+        """
+    )
+
+    frame = spark.read.format("delta").load(str(table_path))
+    rows = frame.selectExpr("id", "details.total AS total", "details.active AS active").orderBy("id").collect()
+    assert [(row.id, row.total, row.active) for row in rows] == [
+        (1, 10, True),
+        (2, 20, False),
+        (3, 30, True),
+    ]
+    assert [row.id for row in frame.where("details.total >= 20").select("id").orderBy("id").collect()] == [2, 3]
+
+    append = spark.createDataFrame(
+        [Row(id=4, details=Row(total=40, active=False))],
+        schema=_nested_schema("total"),
+    )
+    append.write.format("delta").mode("append").save(str(table_path))
+
+    delta_jvm_spark.catalog.refreshByPath(str(table_path))
+    rows = delta_jvm_spark.sql(
+        f"""
+        SELECT id, details.total AS total, details.active AS active
+        FROM {table_identifier}
+        ORDER BY id
+        """
+    ).collect()
+    assert [(row.id, row.total, row.active) for row in rows] == [
+        (1, 10, True),
+        (2, 20, False),
+        (3, 30, True),
+        (4, 40, False),
+    ]
+
+
+def test_sail_nested_mapping_is_readable_and_appendable_by_delta_spark(
+    delta_jvm_spark: SparkSession,
+    spark: SparkSession,
+    tmp_path: Path,
+) -> None:
+    table_path = tmp_path / "sail_nested_mapping"
+    table_identifier = f"delta.`{escape_sql_identifier(str(table_path))}`"
+    source = spark.createDataFrame(
+        [
+            Row(id=1, details=Row(amount=10, active=True)),
+            Row(id=2, details=Row(amount=20, active=False)),
+        ],
+        schema=_nested_schema("amount"),
+    )
+    (source.write.format("delta").mode("overwrite").option("delta.columnMapping.mode", "name").save(str(table_path)))
+
+    rows = delta_jvm_spark.sql(
+        f"""
+        SELECT id, details.amount AS amount, details.active AS active
+        FROM {table_identifier}
+        ORDER BY id
+        """
+    ).collect()
+    assert [(row.id, row.amount, row.active) for row in rows] == [
+        (1, 10, True),
+        (2, 20, False),
+    ]
+    filtered = delta_jvm_spark.sql(
+        f"""
+        SELECT id
+        FROM {table_identifier}
+        WHERE details.amount >= 20
+        ORDER BY id
+        """
+    ).collect()
+    assert [row.id for row in filtered] == [2]
+
+    delta_jvm_spark.sql(
+        f"""
+        INSERT INTO {table_identifier}
+        VALUES (3, named_struct('amount', 30, 'active', true))
+        """
+    )
+
+    frame = spark.read.format("delta").load(str(table_path))
+    rows = frame.selectExpr("id", "details.amount AS amount", "details.active AS active").orderBy("id").collect()
+    assert [(row.id, row.amount, row.active) for row in rows] == [
+        (1, 10, True),
+        (2, 20, False),
+        (3, 30, True),
+    ]


### PR DESCRIPTION
When writing to Delta tables with column mapping enabled (delta.columnMapping.mode = name/id), nested struct fields were matched only by logical name. This breaks when the physical parquet field names differ from the logical schema names — nested fields could be misaligned, dropped, or have stale parquet field-ID metadata leak into the committed table schema. This PR makes nested field resolution column-mapping-aware across the read (schema evolution) and write paths.