### PR TITLE
feat: add Python Kafka batch data source

### DIFF
--- a/docs/guide/sources/index.md
+++ b/docs/guide/sources/index.md
@@ -26,6 +26,7 @@ There are also features that are planned in our roadmap (:construction:).
 | Files (Avro)           | :white_check_mark: | :white_check_mark: |
 | [Python](./python/)    | :white_check_mark: | :white_check_mark: |
 | [JDBC](./jdbc/)        | :white_check_mark: | :construction:     |
+| [Kafka](./kafka/)      | :white_check_mark: | :construction:     |
 | [Vortex](./vortex/)    | :white_check_mark: | :construction:     |
 | Hudi                   | :construction:     | :construction:     |
 | Files (ORC)            | :construction:     | :construction:     |

--- a/docs/guide/sources/kafka/index.md
+++ b/docs/guide/sources/kafka/index.md
@@ -79,28 +79,28 @@ the [PySpark Kafka documentation](https://spark.apache.org/docs/latest/structure
 
 Option names are case-insensitive, as in Spark.
 
-| Name                                 | Required   | Default    | Description                                                                                                                   |
-| ------------------------------------ | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `kafka.bootstrap.servers`            | Yes        |            | Comma-separated broker list.                                                                                                  |
-| `assign`                             | One of the |            | JSON of `{"topic": [partition, ...]}`.                                                                                        |
-| `subscribe`                          | three      |            | Comma-separated topic names.                                                                                                  |
-| `subscribePattern`                   |            |            | Regular expression matched against whole topic names.                                                                         |
-| `startingOffsets`                    | No         | `earliest` | `earliest`, or per-partition JSON (see below).                                                                                |
-| `endingOffsets`                      | No         | `latest`   | `latest`, or per-partition JSON (see below).                                                                                  |
-| `startingTimestamp`                  | No         |            | Global start time as milliseconds since epoch. Applied to every partition.                                                    |
-| `endingTimestamp`                    | No         |            | Global end time as milliseconds since epoch. Applied to every partition.                                                      |
-| `startingOffsetsByTimestamp`         | No         |            | Per-partition JSON of start timestamps in ms since epoch.                                                                     |
-| `endingOffsetsByTimestamp`           | No         |            | Per-partition JSON of end timestamps in ms since epoch.                                                                       |
-| `startingOffsetsByTimestampStrategy` | No         | `error`    | `error` or `latest`: what to do when no offset matches a starting timestamp.                                                  |
-| `failOnDataLoss`                     | No         | `true`     | Whether to fail when records that were planned for reading are no longer in the log.                                          |
-| `includeHeaders`                     | No         | `false`    | Whether to project the `headers` column.                                                                                      |
-| `minPartitions`                      | No         |            | Lower bound on the number of input partitions; offset ranges are split to reach it.                                           |
-| `maxRecordsPerPartition`             | No         |            | Upper bound on records per input partition; larger ranges are split.                                                          |
-| `kafkaConsumer.pollTimeoutMs`        | No         | `120000`   | Per-call `consumer.poll()` timeout in milliseconds. Also accepted as `pollTimeoutMs`; the Spark-standard name wins if both are given. |
-| `maxBatchRows`                       | No         | `10000`    | Maximum rows per Arrow `RecordBatch` returned to the executor. Sail-specific.                                                 |
-| `stallTimeoutMs`                     | No         | `300000`   | Wall-clock time a read may go without receiving a record before failing (guards against an unreachable broker or dead partition leader). Sail-specific. |
+| Name                                 | Required   | Default    | Description                                                                                                                                                             |
+| ------------------------------------ | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kafka.bootstrap.servers`            | Yes        |            | Comma-separated broker list.                                                                                                                                            |
+| `assign`                             | One of the |            | JSON of `{"topic": [partition, ...]}`.                                                                                                                                  |
+| `subscribe`                          | three      |            | Comma-separated topic names.                                                                                                                                            |
+| `subscribePattern`                   |            |            | Regular expression matched against whole topic names.                                                                                                                   |
+| `startingOffsets`                    | No         | `earliest` | `earliest`, or per-partition JSON (see below).                                                                                                                          |
+| `endingOffsets`                      | No         | `latest`   | `latest`, or per-partition JSON (see below).                                                                                                                            |
+| `startingTimestamp`                  | No         |            | Global start time as milliseconds since epoch. Applied to every partition.                                                                                              |
+| `endingTimestamp`                    | No         |            | Global end time as milliseconds since epoch. Applied to every partition.                                                                                                |
+| `startingOffsetsByTimestamp`         | No         |            | Per-partition JSON of start timestamps in ms since epoch.                                                                                                               |
+| `endingOffsetsByTimestamp`           | No         |            | Per-partition JSON of end timestamps in ms since epoch.                                                                                                                 |
+| `startingOffsetsByTimestampStrategy` | No         | `error`    | `error` or `latest`: what to do when no offset matches a starting timestamp.                                                                                            |
+| `failOnDataLoss`                     | No         | `true`     | Whether to fail when records that were planned for reading are no longer in the log.                                                                                    |
+| `includeHeaders`                     | No         | `false`    | Whether to project the `headers` column.                                                                                                                                |
+| `minPartitions`                      | No         |            | Lower bound on the number of input partitions; offset ranges are split to reach it.                                                                                     |
+| `maxRecordsPerPartition`             | No         |            | Upper bound on records per input partition; larger ranges are split.                                                                                                    |
+| `kafkaConsumer.pollTimeoutMs`        | No         | `120000`   | Per-call `consumer.poll()` timeout in milliseconds. Also accepted as `pollTimeoutMs`; the Spark-standard name wins if both are given.                                   |
+| `maxBatchRows`                       | No         | `10000`    | Maximum rows per Arrow `RecordBatch` returned to the executor. Sail-specific.                                                                                           |
+| `stallTimeoutMs`                     | No         | `300000`   | Wall-clock time a read may go without receiving a record before failing (guards against an unreachable broker or dead partition leader). Sail-specific.                 |
 | `adminTimeoutMs`                     | No         | `10000`    | Timeout in milliseconds for the broker metadata, `describe_topics`, and `list_offsets` calls made while planning. Bump this for slow or remote clusters. Sail-specific. |
-| `kafka.*`                            | No         |            | Any additional `librdkafka` client property, passed through with the `kafka.` prefix stripped.                                |
+| `kafka.*`                            | No         |            | Any additional `librdkafka` client property, passed through with the `kafka.` prefix stripped.                                                                          |
 
 ::: info
 Exactly one of `assign`, `subscribe`, and `subscribePattern` must be specified.
@@ -284,7 +284,7 @@ compacted-away records are skipped, as Spark skips them.
 
 ### Transactional Topics
 
-`isolation.level` defaults to `read_uncommitted`, matching Spark. Note that this is *not* the
+`isolation.level` defaults to `read_uncommitted`, matching Spark. Note that this is _not_ the
 `librdkafka` default (`read_committed`), so it is set explicitly — otherwise a topic written by a
 transactional producer would return a different row set here than under Spark, dropping aborted records
 and anything past the last stable offset. Pass `kafka.isolation.level=read_committed` to opt in to

--- a/docs/guide/sources/kafka/index.md
+++ b/docs/guide/sources/kafka/index.md
@@ -1,0 +1,185 @@
+---
+title: Kafka
+rank: 6
+---
+
+# Kafka Data Source
+
+Sail provides a Kafka batch connector exposed under the `kafka` format name for API parity with vanilla
+PySpark. The implementation is based on the Python `confluent-kafka` library, which wraps `librdkafka`.
+No JVM or Kafka client JAR is involved.
+
+Every read resolves to a bounded `[start, end)` offset range per partition at planning time. The fixed
+Kafka schema (`key`, `value`, `topic`, `partition`, `offset`, `timestamp`, `timestampType`) matches Spark,
+so downstream code that already works against `spark.read.format("kafka")` runs unchanged.
+
+<!--@include: ../../_common/spark-session.md-->
+
+## Installation
+
+You need to install the `pysail` package with the `kafka` extra to use the Kafka data source.
+
+```bash
+pip install pysail[kafka]
+```
+
+## Quick Start
+
+Register the datasource once per Spark session.
+
+```python
+from pysail.spark.datasource.kafka import KafkaDataSource
+
+spark.dataSource.register(KafkaDataSource)
+```
+
+Then read from a Kafka topic using the standard PySpark API.
+
+```python
+df = (
+    spark.read.format("kafka")
+    .option("kafka.bootstrap.servers", "localhost:9092")
+    .option("subscribe", "orders")
+    .option("startingOffsets", "earliest")
+    .option("endingOffsets", "latest")
+    .load()
+)
+```
+
+## Schema
+
+Every read returns the fixed Spark-compatible Kafka schema:
+
+| Column          | Type                       | Description                                         |
+| --------------- | -------------------------- | --------------------------------------------------- |
+| `key`           | `binary`                   | Message key, or `null` if absent.                   |
+| `value`         | `binary`                   | Message value.                                      |
+| `topic`         | `string`                   | Source topic.                                       |
+| `partition`     | `int`                      | Source partition.                                   |
+| `offset`        | `bigint`                   | Message offset within the partition.                |
+| `timestamp`     | `timestamp` (microsecond)  | Message timestamp (see `timestampType`).            |
+| `timestampType` | `int`                      | `-1` = none, `0` = CreateTime, `1` = LogAppendTime. |
+| `headers`       | `array<struct<key,value>>` | Present only when `includeHeaders=true`.            |
+
+Cast `key` and `value` to `string` (or decode via `from_json`, `from_avro`, etc.) at the query level.
+
+::: info
+When the broker reports no timestamp type for a message, `timestampType` is `-1` (Spark's
+`NO_TIMESTAMP_TYPE`) and `timestamp` is `null` — Spark emits an epoch value there instead. This only arises
+against very old brokers; modern ones always set `CreateTime` or `LogAppendTime`, so `timestampType` is `0`
+or `1` in practice.
+:::
+
+## Options
+
+The data source options are consistent with
+the [PySpark Kafka documentation](https://spark.apache.org/docs/latest/structured-streaming-kafka-integration.html).
+
+| Name                         | Required | Default    | Description                                                                                                                   |
+| ---------------------------- | -------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `kafka.bootstrap.servers`    | Yes      |            | Comma-separated broker list.                                                                                                  |
+| `subscribe`                  | Yes      |            | Comma-separated topic names.                                                                                                  |
+| `startingOffsets`            | No       | `earliest` | `earliest`, or per-partition JSON (see below).                                                                                |
+| `endingOffsets`              | No       | `latest`   | `latest`, or per-partition JSON (see below).                                                                                  |
+| `startingTimestamp`          | No       |            | Global start time as milliseconds since epoch. Applied to every partition.                                                    |
+| `endingTimestamp`            | No       |            | Global end time as milliseconds since epoch. Applied to every partition.                                                      |
+| `startingOffsetsByTimestamp` | No       |            | Per-partition JSON of start timestamps in ms since epoch.                                                                     |
+| `endingOffsetsByTimestamp`   | No       |            | Per-partition JSON of end timestamps in ms since epoch.                                                                       |
+| `includeHeaders`             | No       | `false`    | Whether to project the `headers` column.                                                                                      |
+| `maxBatchRows`               | No       | `10000`    | Maximum rows per Arrow `RecordBatch` returned to the executor.                                                                |
+| `pollTimeoutMs`              | No       | `1000`     | Per-call `consumer.poll()` timeout in milliseconds.                                                                           |
+| `maxEmptyPolls`              | No       | `30`       | Consecutive empty polls tolerated before failing (guards against an unreachable broker or dead partition leader).             |
+| `adminTimeoutMs`             | No       | `10000`    | Timeout in milliseconds for broker metadata, watermark, and `offsets_for_times` calls. Bump this for slow or remote clusters. |
+| `kafka.*`                    | No       |            | Any additional `librdkafka` client property, passed through with the `kafka.` prefix stripped.                                |
+
+::: info
+Only one starting spec may be set at a time: `startingOffsets`, `startingOffsetsByTimestamp`, or
+`startingTimestamp`. The same rule applies to the three ending options.
+:::
+
+## Examples
+
+### Per-Partition Offset Ranges
+
+Use JSON to specify explicit start and end offsets per partition. The end offset is exclusive.
+
+```python
+import json
+
+df = (
+    spark.read.format("kafka")
+    .option("kafka.bootstrap.servers", "localhost:9092")
+    .option("subscribe", "orders")
+    .option("startingOffsets", json.dumps({"orders": {"0": 100, "1": 200}}))
+    .option("endingOffsets", json.dumps({"orders": {"0": 500, "1": 600}}))
+    .load()
+)
+```
+
+The sentinel values `-2` (earliest) and `-1` (latest) are also accepted in the JSON form for parity with Spark.
+As in Spark's batch source, each sentinel is only valid at its own endpoint: `-2` in `startingOffsets` and `-1` in
+`endingOffsets`. The reverse (`-1` in `startingOffsets`, `-2` in `endingOffsets`) would always produce an empty
+range, so it is rejected rather than silently returning no rows. The same rule applies to the string forms:
+`startingOffsets` does not accept `latest`, and `endingOffsets` does not accept `earliest`.
+
+### Including Headers
+
+Kafka message headers are excluded by default. Opt in with `includeHeaders=true` to project an
+`array<struct<key: string, value: binary>>` column.
+
+```python
+df = (
+    spark.read.format("kafka")
+    .option("kafka.bootstrap.servers", "localhost:9092")
+    .option("subscribe", "orders")
+    .option("includeHeaders", "true")
+    .load()
+)
+```
+
+### Timestamp-Based Reads
+
+`startingTimestamp` and `endingTimestamp` resolve to concrete offsets via Kafka's `offsets_for_times` API.
+Useful for time-window reads. A partition with no message satisfying `ts >= T` resolves to the current
+high watermark, so the read bounds cleanly at whatever's in the log at planning time.
+
+```python
+df = (
+    spark.read.format("kafka")
+    .option("kafka.bootstrap.servers", "localhost:9092")
+    .option("subscribe", "orders")
+    .option("startingTimestamp", "1700000000000")
+    .load()
+)
+```
+
+::: info
+`offsets_for_times` searches the topic's stored timestamps. If the topic is configured with
+`message.timestamp.type=CreateTime` (the default) the search runs against producer clocks, so results
+depend on producer time skew. Configure the topic with `message.timestamp.type=LogAppendTime` to search
+against broker ingest time instead.
+:::
+
+### Passing librdkafka Options
+
+Any option prefixed with `kafka.` is forwarded to the underlying `librdkafka` consumer with the prefix
+stripped. This is the standard mechanism for authentication, TLS, and tuning.
+
+```python
+df = (
+    spark.read.format("kafka")
+    .option("kafka.bootstrap.servers", "broker.example.com:9093")
+    .option("kafka.security.protocol", "SASL_SSL")
+    .option("kafka.sasl.mechanisms", "PLAIN")
+    .option("kafka.sasl.username", "alice")
+    .option("kafka.sasl.password", "secret")
+    .option("subscribe", "orders")
+    .load()
+)
+```
+
+## Limitations
+
+- **No `subscribePattern` or `assign`.** Only explicit `subscribe` with a comma-separated topic list is supported.
+- **No writes.** Producing messages via `df.write.format("kafka")` is not yet supported.
+- **No `failOnDataLoss` toggle.** The connector always fails fast on data loss, equivalent to Spark's `failOnDataLoss=true` with no `false` mode: if a partition's resolved start offset has already aged out of the log (retention or truncation) by the time the read runs, the query errors rather than silently skipping the gap. An unreachable _end_ offset is not treated as data loss — reads stop cleanly at the end of the log (for example on compacted topics or past aborted-transaction markers) and return the rows that are present.

--- a/docs/guide/sources/kafka/index.md
+++ b/docs/guide/sources/kafka/index.md
@@ -1,0 +1,298 @@
+---
+title: Kafka
+rank: 6
+---
+
+# Kafka Data Source
+
+Sail provides a Kafka batch connector exposed under the `kafka` format name for API parity with vanilla
+PySpark. The implementation is based on the Python `confluent-kafka` library, which wraps `librdkafka`.
+No JVM or Kafka client JAR is involved.
+
+Every read resolves to a bounded `[start, end)` offset range per partition. The fixed Kafka schema
+(`key`, `value`, `topic`, `partition`, `offset`, `timestamp`, `timestampType`) matches Spark, so
+downstream code that already works against `spark.read.format("kafka")` runs unchanged.
+
+<!--@include: ../../_common/spark-session.md-->
+
+## Installation
+
+You need to install the `pysail` package with the `kafka` extra to use the Kafka data source.
+
+```bash
+pip install pysail[kafka]
+```
+
+## Quick Start
+
+Register the datasource once per Spark session.
+
+```python
+from pysail.spark.datasource.kafka import KafkaDataSource
+
+spark.dataSource.register(KafkaDataSource)
+```
+
+Then read from a Kafka topic using the standard PySpark API.
+
+```python
+df = (
+    spark.read.format("kafka")
+    .option("kafka.bootstrap.servers", "localhost:9092")
+    .option("subscribe", "orders")
+    .option("startingOffsets", "earliest")
+    .option("endingOffsets", "latest")
+    .load()
+)
+```
+
+## Schema
+
+Every read returns the fixed Spark-compatible Kafka schema:
+
+| Column          | Type                       | Description                                         |
+| --------------- | -------------------------- | --------------------------------------------------- |
+| `key`           | `binary`                   | Message key, or `null` if absent.                   |
+| `value`         | `binary`                   | Message value.                                      |
+| `topic`         | `string`                   | Source topic.                                       |
+| `partition`     | `int`                      | Source partition.                                   |
+| `offset`        | `bigint`                   | Message offset within the partition.                |
+| `timestamp`     | `timestamp` (microsecond)  | Message timestamp (see `timestampType`).            |
+| `timestampType` | `int`                      | `-1` = none, `0` = CreateTime, `1` = LogAppendTime. |
+| `headers`       | `array<struct<key,value>>` | Present only when `includeHeaders=true`.            |
+
+Cast `key` and `value` to `string` (or decode via `from_json`, `from_avro`, etc.) at the query level.
+
+Every column is nullable, matching Spark's declared schema.
+
+::: info
+When the broker reports no timestamp type for a message, `timestampType` is `-1` (Spark's
+`NO_TIMESTAMP_TYPE`) and `timestamp` is the `-1` millisecond Kafka reports, i.e.
+`1969-12-31 23:59:59.999` — the same value Spark surfaces. This only arises against very old brokers;
+modern ones always set `CreateTime` or `LogAppendTime`, so `timestampType` is `0` or `1` in practice.
+:::
+
+## Options
+
+The data source options are consistent with
+the [PySpark Kafka documentation](https://spark.apache.org/docs/latest/structured-streaming-kafka-integration.html).
+
+Option names are case-insensitive, as in Spark.
+
+| Name                                 | Required   | Default    | Description                                                                                                                   |
+| ------------------------------------ | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `kafka.bootstrap.servers`            | Yes        |            | Comma-separated broker list.                                                                                                  |
+| `assign`                             | One of the |            | JSON of `{"topic": [partition, ...]}`.                                                                                        |
+| `subscribe`                          | three      |            | Comma-separated topic names.                                                                                                  |
+| `subscribePattern`                   |            |            | Regular expression matched against whole topic names.                                                                         |
+| `startingOffsets`                    | No         | `earliest` | `earliest`, or per-partition JSON (see below).                                                                                |
+| `endingOffsets`                      | No         | `latest`   | `latest`, or per-partition JSON (see below).                                                                                  |
+| `startingTimestamp`                  | No         |            | Global start time as milliseconds since epoch. Applied to every partition.                                                    |
+| `endingTimestamp`                    | No         |            | Global end time as milliseconds since epoch. Applied to every partition.                                                      |
+| `startingOffsetsByTimestamp`         | No         |            | Per-partition JSON of start timestamps in ms since epoch.                                                                     |
+| `endingOffsetsByTimestamp`           | No         |            | Per-partition JSON of end timestamps in ms since epoch.                                                                       |
+| `startingOffsetsByTimestampStrategy` | No         | `error`    | `error` or `latest`: what to do when no offset matches a starting timestamp.                                                  |
+| `failOnDataLoss`                     | No         | `true`     | Whether to fail when records that were planned for reading are no longer in the log.                                          |
+| `includeHeaders`                     | No         | `false`    | Whether to project the `headers` column.                                                                                      |
+| `minPartitions`                      | No         |            | Lower bound on the number of input partitions; offset ranges are split to reach it.                                           |
+| `maxRecordsPerPartition`             | No         |            | Upper bound on records per input partition; larger ranges are split.                                                          |
+| `kafkaConsumer.pollTimeoutMs`        | No         | `120000`   | Per-call `consumer.poll()` timeout in milliseconds. Also accepted as `pollTimeoutMs`; the Spark-standard name wins if both are given. |
+| `maxBatchRows`                       | No         | `10000`    | Maximum rows per Arrow `RecordBatch` returned to the executor. Sail-specific.                                                 |
+| `stallTimeoutMs`                     | No         | `300000`   | Wall-clock time a read may go without receiving a record before failing (guards against an unreachable broker or dead partition leader). Sail-specific. |
+| `adminTimeoutMs`                     | No         | `10000`    | Timeout in milliseconds for the broker metadata, `describe_topics`, and `list_offsets` calls made while planning. Bump this for slow or remote clusters. Sail-specific. |
+| `kafka.*`                            | No         |            | Any additional `librdkafka` client property, passed through with the `kafka.` prefix stripped.                                |
+
+::: info
+Exactly one of `assign`, `subscribe`, and `subscribePattern` must be specified.
+
+When several range options are given for the same endpoint, Spark's precedence applies rather than an
+error: the global timestamp wins, then the per-partition timestamp map, then the offsets. Lower-priority
+values are not parsed.
+:::
+
+::: warning
+The consumer properties this source owns are rejected rather than silently overridden, as in Spark:
+`kafka.auto.offset.reset` (use `startingOffsets`/`endingOffsets`), `kafka.enable.auto.commit`, and
+`kafka.enable.partition.eof`.
+:::
+
+::: info
+**Consumer group id.** Spark mints a fresh group id per query because its consumers call `subscribe()`
+and so join a real consumer group, where a shared id makes concurrent queries steal partitions from one
+another. This source always uses `assign()` — librdkafka's simple-consumer path, with no group
+membership — and never commits offsets, so it uses a stable `sail-kafka-*` id instead. Nothing is written
+to `__consumer_offsets`, and concurrent queries do not interfere. Override with `kafka.group.id` if your
+broker ACLs require a specific one.
+:::
+
+## Examples
+
+### Per-Partition Offset Ranges
+
+Use JSON to specify explicit start and end offsets per partition. The end offset is exclusive.
+
+```python
+import json
+
+df = (
+    spark.read.format("kafka")
+    .option("kafka.bootstrap.servers", "localhost:9092")
+    .option("subscribe", "orders")
+    .option("startingOffsets", json.dumps({"orders": {"0": 100, "1": 200}}))
+    .option("endingOffsets", json.dumps({"orders": {"0": 500, "1": 600}}))
+    .load()
+)
+```
+
+The sentinel values `-2` (earliest) and `-1` (latest) are also accepted in the JSON form for parity with Spark.
+As in Spark's batch source, each sentinel is only valid at its own endpoint: `-2` in `startingOffsets` and `-1` in
+`endingOffsets`. The reverse (`-1` in `startingOffsets`, `-2` in `endingOffsets`) would always produce an empty
+range, so it is rejected rather than silently returning no rows. The same rule applies to the string forms:
+`startingOffsets` does not accept `latest`, and `endingOffsets` does not accept `earliest`.
+
+### Including Headers
+
+Kafka message headers are excluded by default. Opt in with `includeHeaders=true` to project an
+`array<struct<key: string, value: binary>>` column.
+
+```python
+df = (
+    spark.read.format("kafka")
+    .option("kafka.bootstrap.servers", "localhost:9092")
+    .option("subscribe", "orders")
+    .option("includeHeaders", "true")
+    .load()
+)
+```
+
+### Timestamp-Based Reads
+
+`startingTimestamp` and `endingTimestamp` resolve to concrete offsets via a timestamp `list_offsets` lookup.
+Useful for time-window reads.
+
+When a partition holds no message satisfying `ts >= T`, the endpoint decides what happens, as in Spark. An
+_ending_ timestamp falls back to the current high watermark. A _starting_ timestamp follows
+`startingOffsetsByTimestampStrategy`, which defaults to `error` — so a future or mistaken start time fails
+rather than silently returning nothing. Set it to `latest` to bound the read at the end of the log instead.
+
+```python
+df = (
+    spark.read.format("kafka")
+    .option("kafka.bootstrap.servers", "localhost:9092")
+    .option("subscribe", "orders")
+    .option("startingTimestamp", "1700000000000")
+    .load()
+)
+```
+
+::: info
+The timestamp lookup searches the topic's stored timestamps. If the topic is configured with
+`message.timestamp.type=CreateTime` (the default) the search runs against producer clocks, so results
+depend on producer time skew. Configure the topic with `message.timestamp.type=LogAppendTime` to search
+against broker ingest time instead.
+:::
+
+### Passing librdkafka Options
+
+Any option prefixed with `kafka.` is forwarded to the underlying `librdkafka` consumer with the prefix
+stripped. This is the standard mechanism for authentication, TLS, and tuning.
+
+```python
+df = (
+    spark.read.format("kafka")
+    .option("kafka.bootstrap.servers", "broker.example.com:9093")
+    .option("kafka.security.protocol", "SASL_SSL")
+    .option("kafka.sasl.mechanisms", "PLAIN")
+    .option("kafka.sasl.username", "alice")
+    .option("kafka.sasl.password", "secret")
+    .option("subscribe", "orders")
+    .load()
+)
+```
+
+### Selecting Topics
+
+`subscribe` takes a comma-separated topic list, `subscribePattern` a regular expression matched against
+whole topic names, and `assign` a JSON map of explicit partitions.
+
+Topics the broker flags as internal — `__consumer_offsets` and `__transaction_state` — are excluded from
+all three strategies, matching Spark's `isInternal` filter. The flag is what counts, not the name: a topic
+of your own called `__audit` is read normally.
+
+```python
+df = (
+    spark.read.format("kafka")
+    .option("kafka.bootstrap.servers", "localhost:9092")
+    .option("assign", json.dumps({"orders": [0, 2]}))
+    .load()
+)
+```
+
+### Controlling Parallelism
+
+By default each Kafka partition becomes one input partition. `minPartitions` splits offset ranges — in
+proportion to their size — until there are at least that many, and `maxRecordsPerPartition` caps how many
+records any single input partition covers. Both leave the rows and their offsets unchanged, and both
+reproduce Spark's `KafkaOffsetRangeCalculator` exactly, down to the split boundaries: ranges too small to
+be worth splitting are set aside before the `minPartitions` budget is divided among the rest, and within a
+range the remainder lands in the last chunk.
+
+```python
+df = (
+    spark.read.format("kafka")
+    .option("kafka.bootstrap.servers", "localhost:9092")
+    .option("subscribe", "orders")
+    .option("minPartitions", "16")
+    .load()
+)
+```
+
+### When Offsets Are Resolved
+
+`earliest` and `latest` — including their JSON `-2`/`-1` forms — are resolved when each task starts
+reading, not when the query is planned. This matches Spark, whose `fetchPartitionOffsets` carries the
+sentinels through to `KafkaSourceRDD.resolveRange`, and it matters twice:
+
+- `latest` means the end of the log when the task runs, so a read started while a producer is active
+  picks up the tail rather than stopping at a watermark captured earlier.
+- An `earliest` start stays valid if the log ages on between planning and execution. Freezing it would
+  turn ordinary retention into a `failOnDataLoss` error.
+
+Explicit numeric offsets and all timestamp options are resolved during planning, as they are in Spark.
+Setting `minPartitions` or `maxRecordsPerPartition` forces the sentinels to be resolved early so the
+ranges can be divided — but the outer boundaries are then put back, so the overall start and end stay
+late-bound and only the interior split points are fixed.
+
+::: warning
+A consequence inherited from Spark: because `latest` binds per task, a retried task can observe a longer
+log than its first attempt. Use explicit `endingOffsets` if you need a byte-for-byte reproducible read.
+:::
+
+### Data Loss
+
+`failOnDataLoss` defaults to `true`, as in Spark. Data loss is reported when records that existed at
+planning time are gone by the time the read runs:
+
+- A start offset that has aged out of the log (retention or truncation) fails the query. With
+  `failOnDataLoss=false` the read skips ahead to the earliest offset still available.
+- Reaching the end of the log below the planned end offset fails the query when the high watermark no
+  longer covers that end — because the log was truncated, or because `endingOffsets` points past it. With
+  `failOnDataLoss=false` the records that remain are returned.
+
+Offsets that are simply unreadable within the available range are not data loss and never fail the read:
+compacted-away records are skipped, as Spark skips them.
+
+### Transactional Topics
+
+`isolation.level` defaults to `read_uncommitted`, matching Spark. Note that this is *not* the
+`librdkafka` default (`read_committed`), so it is set explicitly — otherwise a topic written by a
+transactional producer would return a different row set here than under Spark, dropping aborted records
+and anything past the last stable offset. Pass `kafka.isolation.level=read_committed` to opt in to
+committed-only reads.
+
+## Limitations
+
+- **No writes.** Producing messages via `df.write.format("kafka")` is not yet supported.
+- **Batch only.** There is no streaming or continuous mode; every read resolves to a bounded offset range.
+- **No filter pushdown.** Predicates are applied above the scan; every offset in the planned range is
+  fetched. Restrict the range with `startingOffsets`/`endingOffsets` or the timestamp options instead.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ test = [
     "moto[glue]>=5,<6",
     "testcontainers>=4,<5",
     "connectorx>=0.3,<1",
+    "confluent-kafka>=2,<3",
     "vortex-data>=0.64,<1; platform_system != 'Windows'",
     "pyarrow>=24.0,<25",
     "adbc-driver-flightsql>=1.0,<2",
@@ -58,6 +59,10 @@ mcp = [
 ]
 jdbc = [
     "connectorx>=0.3",
+    "pyarrow>=10.0",
+]
+kafka = [
+    "confluent-kafka>=2,<3",
     "pyarrow>=10.0",
 ]
 vortex = [
@@ -115,6 +120,7 @@ dependencies = [
     "moto[glue]>=5,<6",
     "testcontainers>=4,<5",
     "connectorx>=0.3,<1",
+    "confluent-kafka>=2,<3",
     "vortex-data>=0.64,<1; platform_system != 'Windows'",
 ]
 path = ".venvs/default"
@@ -169,6 +175,7 @@ dependencies = [
     "moto[glue]>=5,<6",
     "testcontainers>=4,<5",
     "connectorx>=0.3,<1",
+    "confluent-kafka>=2,<3",
     "vortex-data>=0.64,<1; platform_system != 'Windows'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ test = [
     "moto[glue]>=5,<6",
     "testcontainers>=4,<5",
     "connectorx>=0.3,<1",
+    "confluent-kafka>=2.5,<3",
     "vortex-data>=0.64,<1; platform_system != 'Windows'",
     "pyarrow>=24.0,<25",
     "adbc-driver-flightsql>=1.0,<2",
@@ -58,6 +59,10 @@ mcp = [
 ]
 jdbc = [
     "connectorx>=0.3",
+    "pyarrow>=10.0",
+]
+kafka = [
+    "confluent-kafka>=2.5,<3",
     "pyarrow>=10.0",
 ]
 vortex = [
@@ -115,6 +120,7 @@ dependencies = [
     "moto[glue]>=5,<6",
     "testcontainers>=4,<5",
     "connectorx>=0.3,<1",
+    "confluent-kafka>=2.5,<3",
     "vortex-data>=0.64,<1; platform_system != 'Windows'",
 ]
 path = ".venvs/default"
@@ -169,6 +175,7 @@ dependencies = [
     "moto[glue]>=5,<6",
     "testcontainers>=4,<5",
     "connectorx>=0.3,<1",
+    "confluent-kafka>=2.5,<3",
     "vortex-data>=0.64,<1; platform_system != 'Windows'",
 ]
 

--- a/python/pysail/spark/datasource/kafka.py
+++ b/python/pysail/spark/datasource/kafka.py
@@ -1,0 +1,887 @@
+"""Kafka batch data source for Sail, backed by confluent-kafka (librdkafka).
+
+Exposes ``spark.read.format("kafka")`` with a Spark-compatible schema and
+option surface. Every read resolves to a bounded ``[start_offset, end_offset)``
+range per partition at planning time.
+
+Install the optional dependency before use::
+
+    pip install pysail[kafka]
+"""
+
+from __future__ import annotations
+
+import json
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+import pyarrow as pa
+
+try:
+    from confluent_kafka import Consumer, KafkaError, KafkaException, TopicPartition
+except ImportError as e:
+    msg = "confluent-kafka is required for the kafka data source. Install it with: pip install pysail[kafka]"
+    raise ImportError(msg) from e
+
+try:
+    from pyspark.sql.datasource import DataSource, DataSourceReader, InputPartition
+except ImportError as e:
+    msg = "PySpark with the DataSource API is required (PySpark >= 4.0)"
+    raise ImportError(msg) from e
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+# ============================================================================
+# Fixed Spark-compatible schema
+# ============================================================================
+
+# Matches the column names, order, and types of
+# ``org.apache.spark.sql.kafka010.KafkaSource``'s output schema.
+# ``headers`` is only appended when the ``includeHeaders`` option is true.
+#
+# One deliberate difference: Spark declares every field nullable (its
+# ``StructField``s take the default ``nullable=True``), while the fields Kafka
+# always populates are marked non-nullable here. The values are identical; the
+# tighter declaration just lets downstream planning skip null checks.
+
+_BASE_FIELDS: list[pa.Field] = [
+    pa.field("key", pa.binary(), nullable=True),
+    pa.field("value", pa.binary(), nullable=True),
+    pa.field("topic", pa.string(), nullable=False),
+    pa.field("partition", pa.int32(), nullable=False),
+    pa.field("offset", pa.int64(), nullable=False),
+    pa.field("timestamp", pa.timestamp("us", tz="UTC"), nullable=True),
+    pa.field("timestampType", pa.int32(), nullable=False),
+]
+
+_HEADER_STRUCT = pa.struct(
+    [pa.field("key", pa.string(), nullable=False), pa.field("value", pa.binary(), nullable=True)]
+)
+
+# Spark's ``org.apache.kafka.common.record.TimestampType`` uses -1/0/1,
+# but librdkafka emits 0/1/2. Translate on the way out so downstream code
+# that keys off Spark's enum values (e.g. ``timestampType == 0`` for
+# CreateTime) behaves the same as against the JVM Kafka source.
+_LIBRDKAFKA_TO_SPARK_TS_TYPE = {
+    0: -1,  # NOT_AVAILABLE     -> NO_TIMESTAMP_TYPE
+    1: 0,  # CREATE_TIME       -> CREATE_TIME
+    2: 1,  # LOG_APPEND_TIME   -> LOG_APPEND_TIME
+}
+
+
+def _build_schema(*, include_headers: bool) -> pa.Schema:
+    fields = list(_BASE_FIELDS)
+    if include_headers:
+        fields.append(pa.field("headers", pa.list_(_HEADER_STRUCT), nullable=True))
+    return pa.schema(fields)
+
+
+# ============================================================================
+# Option parsing
+# ============================================================================
+
+
+_SENTINEL_EARLIEST = "earliest"
+_SENTINEL_LATEST = "latest"
+
+# Spark's magic per-partition offset sentinels.
+_SPARK_OFFSET_LATEST = -1
+_SPARK_OFFSET_EARLIEST = -2
+
+
+def _validate_tp_mapping(parsed: dict, *, label: str) -> dict[str, dict[str, int]]:
+    """Validate a parsed ``{topic: {partition: int}}`` JSON mapping.
+
+    The caller has already confirmed the top-level value is a ``dict``. Here we
+    check each topic maps to an object of ``{partition: int}`` so malformed
+    shapes (e.g. ``{"t": 5}`` or ``{"t": {"0": "x"}}``) fail loudly at parse
+    time with a clear message, rather than crashing later during offset
+    resolution with an opaque ``AttributeError``/``ValueError``.
+    """
+    for topic, partitions in parsed.items():
+        if not isinstance(partitions, dict):
+            msg = f"{label} entry for topic {topic!r} must be an object of {{partition: value}}, got: {type(partitions).__name__}"
+            raise ValueError(msg)  # noqa: TRY004
+        for partition, value in partitions.items():
+            # bool is an int subclass; reject it so JSON true/false isn't
+            # silently coerced to 1/0.
+            if not isinstance(value, int) or isinstance(value, bool):
+                msg = f"{label} value for topic {topic!r} partition {partition!r} must be an integer, got: {type(value).__name__}"
+                raise ValueError(msg)  # noqa: TRY004
+    return parsed
+
+
+def _parse_offset_spec(raw: str | None, *, default: str | None) -> str | dict[str, dict[str, int]] | None:
+    """Parse ``startingOffsets`` / ``endingOffsets``.
+
+    Returns either the string ``"earliest"``/``"latest"``, a mapping
+    ``{topic: {partition: offset}}``, or ``None`` if unset (caller supplies
+    the default). In Spark, JSON keys are strings (partition ids as strings).
+    """
+    if raw is None or not raw.strip():
+        return default
+    stripped = raw.strip()
+    if stripped in (_SENTINEL_EARLIEST, _SENTINEL_LATEST):
+        return stripped
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError as e:
+        msg = f"Invalid offset spec: {raw!r}. Expected 'earliest', 'latest', or JSON."
+        raise ValueError(msg) from e
+    if not isinstance(parsed, dict):
+        msg = f"Offset spec JSON must be an object, got: {type(parsed).__name__}"
+        raise ValueError(msg)  # noqa: TRY004
+    return _validate_tp_mapping(parsed, label="Offset spec")
+
+
+def _parse_timestamp_spec(
+    global_raw: str | None,
+    per_tp_raw: str | None,
+    *,
+    endpoint: str,
+) -> int | dict[str, dict[str, int]] | None:
+    """Parse ``{starting,ending}Timestamp`` (global ms) and
+    ``{starting,ending}OffsetsByTimestamp`` (per-tp JSON).
+
+    Returns an ``int`` (global ms), a mapping ``{topic: {partition: ts_ms}}``,
+    or ``None`` if unset. Global and per-tp are mutually exclusive.
+    """
+    global_set = global_raw is not None and global_raw.strip() != ""
+    per_tp_set = per_tp_raw is not None and per_tp_raw.strip() != ""
+    if global_set and per_tp_set:
+        msg = f"'{endpoint}Timestamp' and '{endpoint}OffsetsByTimestamp' are mutually exclusive"
+        raise ValueError(msg)
+    if global_set:
+        try:
+            return int(global_raw.strip())
+        except ValueError as e:
+            msg = f"'{endpoint}Timestamp' must be an integer (ms since epoch), got {global_raw!r}"
+            raise ValueError(msg) from e
+    if per_tp_set:
+        try:
+            parsed = json.loads(per_tp_raw.strip())
+        except json.JSONDecodeError as e:
+            msg = f"Invalid '{endpoint}OffsetsByTimestamp' JSON: {per_tp_raw!r}"
+            raise ValueError(msg) from e
+        if not isinstance(parsed, dict):
+            msg = f"'{endpoint}OffsetsByTimestamp' JSON must be an object"
+            raise ValueError(msg)
+        return _validate_tp_mapping(parsed, label=f"'{endpoint}OffsetsByTimestamp'")
+    return None
+
+
+def _validate_offset_spec(
+    spec: str | dict[str, dict[str, int]] | None,
+    *,
+    endpoint: str,
+    option_name: str,
+) -> None:
+    """Enforce Spark's batch-mode rules on an already-parsed offset spec.
+
+    Spark's batch Kafka source rejects ``latest`` for ``startingOffsets`` and
+    ``earliest`` for ``endingOffsets``, in both the string form and the
+    per-partition JSON form (``-1``/``-2``). Without this check the offending
+    endpoint silently resolves to a watermark that empties the range, so the
+    query returns zero rows instead of failing.
+
+    We also reject any offset below ``-2``. Only ``-1``/``-2`` are Spark
+    sentinels; everything below is a librdkafka sentinel that would be honoured
+    rather than rejected — notably ``-1000`` (``OFFSET_STORED``), which would
+    silently read from committed consumer-group offsets, and ``-1001``
+    (``OFFSET_INVALID``).
+
+    This is deliberately separate from ``_validate_tp_mapping``, which is shared
+    with ``_parse_timestamp_spec`` where negative values are legitimate
+    (pre-1970) instants.
+    """
+    if spec is None:
+        return
+
+    forbidden_sentinel = _SENTINEL_LATEST if endpoint == "starting" else _SENTINEL_EARLIEST
+    forbidden_offset = _SPARK_OFFSET_LATEST if endpoint == "starting" else _SPARK_OFFSET_EARLIEST
+    allowed_sentinel = _SENTINEL_EARLIEST if endpoint == "starting" else _SENTINEL_LATEST
+
+    if isinstance(spec, str):
+        if spec == forbidden_sentinel:
+            msg = (
+                f"'{option_name}' does not support {forbidden_sentinel!r} for batch reads; "
+                f"use {allowed_sentinel!r} or per-partition JSON"
+            )
+            raise ValueError(msg)
+        return
+
+    for topic, partitions in spec.items():
+        for partition, value in partitions.items():
+            where = f"topic {topic!r} partition {partition!r}"
+            if value == forbidden_offset:
+                msg = (
+                    f"'{option_name}' does not support offset {forbidden_offset} "
+                    f"({forbidden_sentinel}) for batch reads, at {where}"
+                )
+                raise ValueError(msg)
+            if value < _SPARK_OFFSET_EARLIEST:
+                msg = (
+                    f"'{option_name}' offset for {where} must be >= 0, "
+                    f"{_SPARK_OFFSET_LATEST} (latest), or {_SPARK_OFFSET_EARLIEST} (earliest), got: {value}"
+                )
+                raise ValueError(msg)
+
+
+def _validate_spec_topics(
+    spec: str | int | dict[str, dict[str, int]] | None,
+    topics: list[str],
+    *,
+    option_name: str,
+) -> None:
+    """Reject a per-topic spec naming a topic that is not subscribed.
+
+    Offset resolution looks specs up by subscribed topic, so an unmatched key
+    is otherwise dropped without a trace: a typo (``ordres`` for ``orders``)
+    leaves the real partition on its default watermark and the read quietly
+    starts somewhere other than where the user asked. String and global-int
+    specs have no topic keys, so they pass through untouched.
+    """
+    if not isinstance(spec, dict):
+        return
+    unknown = sorted(set(spec) - set(topics))
+    if unknown:
+        msg = f"'{option_name}' names topics that are not in 'subscribe': {unknown}. Subscribed topics: {topics}"
+        raise ValueError(msg)
+
+
+def _parse_positive_int(opts: dict[str, str], name: str, default: str) -> int:
+    """Parse a positive integer option, naming the option in any failure."""
+    raw = opts.get(name, default)
+    try:
+        value = int(raw)
+    except ValueError as e:
+        msg = f"'{name}' must be an integer, got {raw!r}"
+        raise ValueError(msg) from e
+    if value <= 0:
+        msg = f"'{name}' must be positive, got {value}"
+        raise ValueError(msg)
+    return value
+
+
+def _parse_positive_ms(opts: dict[str, str], name: str, default: str) -> float:
+    """Parse a positive millisecond option, returning it as seconds."""
+    raw = opts.get(name, default)
+    try:
+        value_ms = float(raw)
+    except ValueError as e:
+        msg = f"'{name}' must be a number of milliseconds, got {raw!r}"
+        raise ValueError(msg) from e
+    if value_ms <= 0:
+        msg = f"'{name}' must be positive, got {value_ms}"
+        raise ValueError(msg)
+    return value_ms / 1000.0
+
+
+def _extract_kafka_config(opts: dict[str, str]) -> dict[str, str]:
+    """Pass through any option prefixed with ``kafka.`` to librdkafka config.
+
+    Matches Spark's convention: ``kafka.bootstrap.servers`` →
+    ``bootstrap.servers``, ``kafka.security.protocol`` → ``security.protocol``,
+    etc.
+    """
+    return {k[len("kafka.") :]: v for k, v in opts.items() if k.startswith("kafka.")}
+
+
+# Static group id prefix. All reads use ``consumer.assign()`` (not
+# ``subscribe()``), so the consumer never actually joins a group — the id is
+# just required by librdkafka. A stable prefix keeps broker logs clean and
+# avoids polluting ``__consumer_offsets`` with a fresh id per query. Users
+# can still override by passing ``kafka.group.id``.
+_DEFAULT_GROUP_ID = "sail-kafka"
+
+
+def _build_consumer_config(client_config: dict[str, str], *, role: str) -> dict[str, str | bool]:
+    """Return the effective librdkafka config for a batch-read consumer.
+
+    User-supplied ``kafka.*`` options win. We fill in defaults for:
+
+    * ``group.id`` — required by librdkafka; unused because we
+      ``assign()`` explicitly rather than ``subscribe()``.
+    * ``enable.auto.commit`` — off; reads never commit.
+    * ``auto.offset.reset`` — ``error``; the planner resolved the range,
+      so a missing start offset means the log was truncated and we should
+      fail loudly rather than silently drift.
+    * ``enable.partition.eof`` — on; lets the read loop exit cleanly when
+      the log ends before the planned high watermark. This happens on
+      compacted topics (the watermark is past compacted-away tombstones)
+      and with ``read_committed`` isolation (aborted transaction markers
+      leave visible offsets unreachable). Without EOF events those cases
+      would stall until ``maxEmptyPolls``.
+    """
+    return {
+        "group.id": f"{_DEFAULT_GROUP_ID}-{role}",
+        "enable.auto.commit": False,
+        "auto.offset.reset": "error",
+        "enable.partition.eof": True,
+        **client_config,  # user overrides win
+    }
+
+
+# ============================================================================
+# InputPartition — one per (topic, partition, offset-range)
+# ============================================================================
+
+
+class KafkaInputPartition(InputPartition):
+    def __init__(
+        self,
+        partition_id: int,
+        *,
+        topic: str,
+        kafka_partition: int,
+        start_offset: int,
+        end_offset: int,
+        client_config: dict[str, str],
+        include_headers: bool,
+        poll_timeout_s: float,
+        max_batch_rows: int,
+        max_empty_polls: int,
+    ) -> None:
+        super().__init__(partition_id)
+        self.topic = topic
+        self.kafka_partition = kafka_partition
+        self.start_offset = start_offset
+        self.end_offset = end_offset  # exclusive
+        self.client_config = client_config
+        self.include_headers = include_headers
+        self.poll_timeout_s = poll_timeout_s
+        self.max_batch_rows = max_batch_rows
+        self.max_empty_polls = max_empty_polls
+
+
+# ============================================================================
+# DataSourceReader
+# ============================================================================
+
+
+class KafkaDataSourceReader(DataSourceReader):
+    def __init__(
+        self,
+        *,
+        topics: list[str],
+        starting_offsets: str | dict[str, dict[str, int]] | None,
+        ending_offsets: str | dict[str, dict[str, int]] | None,
+        starting_timestamps: int | dict[str, dict[str, int]] | None,
+        ending_timestamps: int | dict[str, dict[str, int]] | None,
+        client_config: dict[str, str],
+        include_headers: bool,
+        poll_timeout_s: float,
+        max_batch_rows: int,
+        max_empty_polls: int,
+        admin_timeout_s: float,
+    ) -> None:
+        self.topics = topics
+        self.starting_offsets = starting_offsets
+        self.ending_offsets = ending_offsets
+        self.starting_timestamps = starting_timestamps
+        self.ending_timestamps = ending_timestamps
+        self.client_config = client_config
+        self.include_headers = include_headers
+        self.poll_timeout_s = poll_timeout_s
+        self.max_batch_rows = max_batch_rows
+        self.max_empty_polls = max_empty_polls
+        self.admin_timeout_s = admin_timeout_s
+
+    # ------------------------------------------------------------------
+    # Partition planning — talks to the broker once on the driver
+    # ------------------------------------------------------------------
+
+    def partitions(self) -> list[InputPartition]:
+        # A short-lived admin consumer is used to enumerate partitions and
+        # resolve earliest/latest watermarks. Executors get their own consumer.
+        consumer = Consumer(_build_consumer_config(self.client_config, role="planner"))
+        admin_timeout_s = self.admin_timeout_s
+        try:
+            tps = _list_topic_partitions(consumer, self.topics, timeout_s=admin_timeout_s)
+            if self.starting_timestamps is not None:
+                starts = _resolve_by_timestamp(
+                    consumer,
+                    tps,
+                    self.starting_timestamps,
+                    endpoint="starting",
+                    timeout_s=admin_timeout_s,
+                )
+            else:
+                starts = _resolve_offsets(
+                    consumer,
+                    tps,
+                    self.starting_offsets or _SENTINEL_EARLIEST,
+                    endpoint="starting",
+                    timeout_s=admin_timeout_s,
+                )
+            if self.ending_timestamps is not None:
+                ends = _resolve_by_timestamp(
+                    consumer,
+                    tps,
+                    self.ending_timestamps,
+                    endpoint="ending",
+                    timeout_s=admin_timeout_s,
+                )
+            else:
+                ends = _resolve_offsets(
+                    consumer,
+                    tps,
+                    self.ending_offsets or _SENTINEL_LATEST,
+                    endpoint="ending",
+                    timeout_s=admin_timeout_s,
+                )
+        finally:
+            consumer.close()
+
+        parts: list[InputPartition] = []
+        pid = 0
+        for tp in tps:
+            key = (tp.topic, tp.partition)
+            start = starts[key]
+            end = ends[key]
+            if end < start:
+                # Spark's batch source treats an inverted range as data loss and
+                # fails. Skipping it silently would return a partial result that
+                # looks like a successful read, which is the worst outcome here.
+                msg = (
+                    f"Inverted offset range for {tp.topic}[{tp.partition}]: start {start} is past end {end}. "
+                    f"Check 'startingOffsets'/'endingOffsets'; the log may also have been truncated "
+                    f"while the range was being resolved."
+                )
+                raise ValueError(msg)
+            if end == start:
+                continue  # empty range; nothing to read
+            parts.append(
+                KafkaInputPartition(
+                    pid,
+                    topic=tp.topic,
+                    kafka_partition=tp.partition,
+                    start_offset=start,
+                    end_offset=end,
+                    client_config=self.client_config,
+                    include_headers=self.include_headers,
+                    poll_timeout_s=self.poll_timeout_s,
+                    max_batch_rows=self.max_batch_rows,
+                    max_empty_polls=self.max_empty_polls,
+                )
+            )
+            pid += 1
+        return parts
+
+    # ------------------------------------------------------------------
+    # Per-partition read — runs on executors
+    # ------------------------------------------------------------------
+
+    def read(self, partition: InputPartition) -> Iterator[pa.RecordBatch]:
+        if not isinstance(partition, KafkaInputPartition):
+            msg = f"Expected KafkaInputPartition, got {type(partition)}"
+            raise TypeError(msg)
+
+        schema = _build_schema(include_headers=partition.include_headers)
+
+        consumer = Consumer(_build_consumer_config(partition.client_config, role="reader"))
+        try:
+            consumer.assign([TopicPartition(partition.topic, partition.kafka_partition, partition.start_offset)])
+
+            buf = _RowBuffer(include_headers=partition.include_headers)
+            next_offset = partition.start_offset
+            end = partition.end_offset
+            empty_polls = 0
+            max_empty_polls = partition.max_empty_polls
+
+            while next_offset < end:
+                record = consumer.poll(partition.poll_timeout_s)
+                if record is None:
+                    # No message within poll timeout. Normally transient — the
+                    # broker is slow, or a fetch is in flight. But if this
+                    # keeps happening we're wedged (unreachable broker, dead
+                    # partition leader) and would hang forever without a cap.
+                    empty_polls += 1
+                    if empty_polls > max_empty_polls:
+                        stalled_ms = int(max_empty_polls * partition.poll_timeout_s * 1000)
+                        msg = (
+                            f"Kafka read stalled: no messages for {stalled_ms}ms on "
+                            f"{partition.topic}[{partition.kafka_partition}] at offset "
+                            f"{next_offset}, expected up to {end}. Broker may be "
+                            f"unreachable or the partition leader unavailable."
+                        )
+                        raise TimeoutError(msg)
+                    continue
+                if record.error():
+                    # EOF is not an error — the log ended before the planned
+                    # high watermark. Compacted topics and aborted transaction
+                    # markers can leave a gap between the last visible message
+                    # and the watermark; treat it as a clean stop.
+                    if record.error().code() == KafkaError._PARTITION_EOF:  # noqa: SLF001
+                        break
+                    raise KafkaException(record.error())
+
+                if record.offset() >= end:
+                    break
+
+                empty_polls = 0
+                buf.append(record)
+                next_offset = record.offset() + 1
+
+                if len(buf) >= partition.max_batch_rows:
+                    yield buf.to_batch(schema)
+                    buf = _RowBuffer(include_headers=partition.include_headers)
+
+            if len(buf) > 0:
+                yield buf.to_batch(schema)
+        finally:
+            consumer.close()
+
+
+# ============================================================================
+# Row buffer — accumulates messages, flushes to a RecordBatch
+# ============================================================================
+
+
+class _RowBuffer:
+    """Column-major accumulator sized to ``max_batch_rows``."""
+
+    def __init__(self, *, include_headers: bool) -> None:
+        self.include_headers = include_headers
+        self.key: list[bytes | None] = []
+        self.value: list[bytes | None] = []
+        self.topic: list[str] = []
+        self.partition: list[int] = []
+        self.offset: list[int] = []
+        self.timestamp_us: list[int | None] = []
+        self.timestamp_type: list[int] = []
+        self.headers: list[list[dict] | None] = []
+
+    def __len__(self) -> int:
+        return len(self.offset)
+
+    def append(self, record) -> None:
+        ts_type, ts_ms = record.timestamp()  # librdkafka: 0=NotAvailable, 1=Create, 2=LogAppend
+        self.key.append(record.key())
+        self.value.append(record.value())
+        self.topic.append(record.topic())
+        self.partition.append(record.partition())
+        self.offset.append(record.offset())
+        self.timestamp_us.append(ts_ms * 1000 if ts_type != 0 else None)
+        self.timestamp_type.append(_LIBRDKAFKA_TO_SPARK_TS_TYPE.get(ts_type, -1))
+        if self.include_headers:
+            hdrs = record.headers()
+            self.headers.append([{"key": k, "value": v} for k, v in hdrs] if hdrs else None)
+
+    def to_batch(self, schema: pa.Schema) -> pa.RecordBatch:
+        arrays = [
+            pa.array(self.key, type=pa.binary()),
+            pa.array(self.value, type=pa.binary()),
+            pa.array(self.topic, type=pa.string()),
+            pa.array(self.partition, type=pa.int32()),
+            pa.array(self.offset, type=pa.int64()),
+            pa.array(self.timestamp_us, type=pa.timestamp("us", tz="UTC")),
+            pa.array(self.timestamp_type, type=pa.int32()),
+        ]
+        if self.include_headers:
+            arrays.append(pa.array(self.headers, type=pa.list_(_HEADER_STRUCT)))
+        return pa.record_batch(arrays, schema=schema)
+
+
+# ============================================================================
+# Broker helpers — enumerate partitions, resolve watermarks
+# ============================================================================
+
+
+def _list_topic_partitions(consumer: Consumer, topics: list[str], *, timeout_s: float) -> list[TopicPartition]:
+    metadata = consumer.list_topics(timeout=timeout_s)
+    out: list[TopicPartition] = []
+    for topic in topics:
+        tmeta = metadata.topics.get(topic)
+        if tmeta is None:
+            msg = f"Topic {topic!r} not found on broker"
+            raise ValueError(msg)
+        if tmeta.error is not None:
+            # A per-topic error is not necessarily a missing topic: it also
+            # covers authorization failures (``TOPIC_AUTHORIZATION_FAILED``)
+            # and leader-election churn. Reporting all of those as "not found"
+            # sends users looking for the wrong misconfiguration, so relay what
+            # the broker actually said.
+            if tmeta.error.code() == KafkaError.UNKNOWN_TOPIC_OR_PART:
+                msg = f"Topic {topic!r} not found on broker"
+            else:
+                msg = f"Topic {topic!r} is not available: {tmeta.error}"
+            raise ValueError(msg)
+        out.extend(TopicPartition(topic, p) for p in sorted(tmeta.partitions.keys()))
+    return out
+
+
+def _watermark(consumer: Consumer, tp: TopicPartition, *, endpoint: str, timeout_s: float) -> int:
+    """Read the low (starting) or high (ending) watermark for a partition."""
+    low, high = consumer.get_watermark_offsets(tp, timeout=timeout_s, cached=False)
+    return low if endpoint == "starting" else high
+
+
+def _resolve_offsets(
+    consumer: Consumer,
+    tps: list[TopicPartition],
+    spec: str | dict[str, dict[str, int]],
+    *,
+    endpoint: str,
+    timeout_s: float,
+) -> dict[tuple[str, int], int]:
+    """Resolve a starting/ending-offset spec into concrete offsets per (topic, partition)."""
+    if spec in (_SENTINEL_EARLIEST, _SENTINEL_LATEST):
+        sentinel_endpoint = "starting" if spec == _SENTINEL_EARLIEST else "ending"
+        return {
+            (tp.topic, tp.partition): _watermark(consumer, tp, endpoint=sentinel_endpoint, timeout_s=timeout_s)
+            for tp in tps
+        }
+
+    # Explicit per-topic-partition JSON. Missing entries fall back to the
+    # sensible default per endpoint (earliest for starting, latest for ending)
+    # to match Spark's behavior on newly discovered partitions.
+    out: dict[tuple[str, int], int] = {}
+    for tp in tps:
+        raw = spec.get(tp.topic, {}).get(str(tp.partition))
+        if raw is None:
+            out[(tp.topic, tp.partition)] = _watermark(consumer, tp, endpoint=endpoint, timeout_s=timeout_s)
+        elif raw == _SPARK_OFFSET_LATEST:
+            out[(tp.topic, tp.partition)] = _watermark(consumer, tp, endpoint="ending", timeout_s=timeout_s)
+        elif raw == _SPARK_OFFSET_EARLIEST:
+            out[(tp.topic, tp.partition)] = _watermark(consumer, tp, endpoint="starting", timeout_s=timeout_s)
+        else:
+            out[(tp.topic, tp.partition)] = int(raw)
+    return out
+
+
+def _resolve_by_timestamp(
+    consumer: Consumer,
+    tps: list[TopicPartition],
+    spec: int | dict[str, dict[str, int]],
+    *,
+    endpoint: str,
+    timeout_s: float,
+) -> dict[tuple[str, int], int]:
+    """Resolve a timestamp spec to concrete offsets via ``offsets_for_times``.
+
+    ``spec`` is either a global ``int`` (ms since epoch, applied to every
+    partition) or a mapping ``{topic: {partition_str: ts_ms}}``. Partitions
+    with no message satisfying ``ts >= T`` resolve to the high watermark,
+    which bounds the read to whatever's currently in the log.
+
+    Partitions that exist on the broker but are absent from a per-partition
+    ``spec`` fall back to the same defaults as ``_resolve_offsets``: earliest
+    for a starting endpoint, latest for an ending endpoint. This matches
+    Spark's behaviour on newly discovered partitions and avoids silently
+    skipping data if the user omits a partition from the JSON.
+
+    Note: ``offsets_for_times`` searches the topic's actual stored
+    timestamps. If the topic is configured with
+    ``message.timestamp.type=LogAppendTime`` the search is against broker
+    ingest time; otherwise it's against producer clocks (``CreateTime``).
+    """
+    # Build the lookup list without any sentinel values — a user-supplied
+    # timestamp of -1 is a valid (if odd) instant, so we track which
+    # partitions have an explicit spec by set membership instead.
+    to_lookup: list[TopicPartition] = []
+    if isinstance(spec, int):
+        to_lookup = [TopicPartition(tp.topic, tp.partition, spec) for tp in tps]
+        specified: set[tuple[str, int]] = {(tp.topic, tp.partition) for tp in tps}
+    else:
+        specified = set()
+        for tp in tps:
+            raw = spec.get(tp.topic, {}).get(str(tp.partition))
+            if raw is None:
+                continue
+            specified.add((tp.topic, tp.partition))
+            to_lookup.append(TopicPartition(tp.topic, tp.partition, int(raw)))
+
+    resolved_list = consumer.offsets_for_times(to_lookup, timeout=timeout_s) if to_lookup else []
+    resolved_map = {(r.topic, r.partition): r.offset for r in resolved_list}
+
+    out: dict[tuple[str, int], int] = {}
+    for tp in tps:
+        key = (tp.topic, tp.partition)
+        if key not in specified:
+            out[key] = _watermark(consumer, tp, endpoint=endpoint, timeout_s=timeout_s)
+            continue
+        offset = resolved_map.get(key, -1)
+        if offset < 0:
+            # No message with ts >= T in the log. Bound to the current high
+            # watermark so the read covers everything up to "now" without
+            # failing.
+            out[key] = _watermark(consumer, tp, endpoint="ending", timeout_s=timeout_s)
+        else:
+            out[key] = offset
+    return out
+
+
+# ============================================================================
+# DataSource
+# ============================================================================
+
+
+class KafkaDataSource(DataSource):
+    """Kafka batch data source backed by confluent-kafka.
+
+    Every ``.load()`` resolves to a bounded ``[start, end)`` range per
+    partition on the driver, then reads that range on executors. There is
+    no streaming / continuous mode.
+
+    Register and use::
+
+        from pysail.spark.datasource.kafka import KafkaDataSource
+
+        spark.dataSource.register(KafkaDataSource)
+
+        df = (
+            spark.read.format("kafka")
+            .option("kafka.bootstrap.servers", "localhost:9092")
+            .option("subscribe", "orders")
+            .option("startingOffsets", "earliest")
+            .option("endingOffsets", "latest")
+            .load()
+        )
+
+    Supported options (subset of Spark's Kafka source):
+
+    +--------------------------------+----------+----------+------------------------------------------+
+    | Option                         | Required | Default  | Description                              |
+    +================================+==========+==========+==========================================+
+    | kafka.bootstrap.servers        | Yes      |          | Broker list                              |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | subscribe                      | Yes      |          | Comma-separated topic names              |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | startingOffsets                | No       | earliest | "earliest" / per-tp JSON                 |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | endingOffsets                  | No       | latest   | "latest" / per-tp JSON                   |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | startingTimestamp              | No       |          | Global ms since epoch                    |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | endingTimestamp                | No       |          | Global ms since epoch                    |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | startingOffsetsByTimestamp     | No       |          | Per-tp timestamp JSON (ms since epoch)   |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | endingOffsetsByTimestamp       | No       |          | Per-tp timestamp JSON (ms since epoch)   |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | includeHeaders                 | No       | false    | Include the ``headers`` column           |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | maxBatchRows                   | No       | 10000    | Max rows per Arrow RecordBatch           |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | pollTimeoutMs                  | No       | 1000     | ``consumer.poll()`` timeout              |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | maxEmptyPolls                  | No       | 30       | Consecutive empty polls before failing   |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | adminTimeoutMs                 | No       | 10000    | Broker metadata / offset-lookup timeout  |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | kafka.*                        | No       |          | Any extra librdkafka client config       |
+    +--------------------------------+----------+----------+------------------------------------------+
+
+    Only one starting spec may be set at a time (``startingOffsets`` vs
+    ``startingOffsetsByTimestamp`` vs ``startingTimestamp``); same for
+    ending. As in Spark's batch source, ``latest`` (and its JSON form ``-1``)
+    is rejected for ``startingOffsets``, and ``earliest`` (``-2``) is rejected
+    for ``endingOffsets``. Timestamp-based reads rely on Kafka's ``offsets_for_times``,
+    which searches the topic's stored timestamps — configure the topic
+    with ``message.timestamp.type=LogAppendTime`` if you want the search
+    against broker ingest time rather than producer clocks.
+
+    Not supported: ``subscribePattern`` / ``assign``, ``failOnDataLoss``,
+    writes.
+
+    Planning cost: watermarks are resolved with one blocking
+    ``get_watermark_offsets`` call per partition, because librdkafka exposes no
+    batched equivalent of Spark's ``beginningOffsets``/``endOffsets``. Reads
+    against very wide topics may need ``adminTimeoutMs`` raised. Timestamp
+    lookups are batched into a single ``offsets_for_times`` call.
+    """
+
+    @classmethod
+    def name(cls) -> str:
+        return "kafka"
+
+    @cached_property
+    def _resolved(self) -> dict:
+        opts = dict(self.options)
+
+        client_config = _extract_kafka_config(opts)
+        if "bootstrap.servers" not in client_config:
+            msg = "Option 'kafka.bootstrap.servers' is required for the kafka data source"
+            raise ValueError(msg)
+
+        subscribe = opts.get("subscribe")
+        if not subscribe:
+            msg = "Option 'subscribe' is required (comma-separated topics)"
+            raise ValueError(msg)
+        # Dedupe: a repeated topic would otherwise be enumerated once per
+        # occurrence in `_list_topic_partitions`, producing duplicate input
+        # partitions over the same offset range and emitting every row twice.
+        # `dict.fromkeys` preserves first-seen order so planning stays stable.
+        topics = list(dict.fromkeys(t.strip() for t in subscribe.split(",") if t.strip()))
+        if not topics:
+            msg = "Option 'subscribe' must list at least one topic"
+            raise ValueError(msg)
+
+        starting_offsets_raw = opts.get("startingOffsets")
+        ending_offsets_raw = opts.get("endingOffsets")
+
+        starting_ts = _parse_timestamp_spec(
+            opts.get("startingTimestamp"),
+            opts.get("startingOffsetsByTimestamp"),
+            endpoint="starting",
+        )
+        ending_ts = _parse_timestamp_spec(
+            opts.get("endingTimestamp"),
+            opts.get("endingOffsetsByTimestamp"),
+            endpoint="ending",
+        )
+
+        # Parse offsets first so a blank value ("" or whitespace) collapses to
+        # None, matching Spark's "blank means unset" semantics. Checking the
+        # raw option for None alone would treat "" as set and spuriously reject
+        # an otherwise-valid timestamp-based read.
+        starting_offsets = _parse_offset_spec(starting_offsets_raw, default=None)
+        ending_offsets = _parse_offset_spec(ending_offsets_raw, default=None)
+
+        _validate_offset_spec(starting_offsets, endpoint="starting", option_name="startingOffsets")
+        _validate_offset_spec(ending_offsets, endpoint="ending", option_name="endingOffsets")
+
+        if starting_ts is not None and starting_offsets is not None:
+            msg = "'startingOffsets' cannot be combined with a starting-timestamp option"
+            raise ValueError(msg)
+        if ending_ts is not None and ending_offsets is not None:
+            msg = "'endingOffsets' cannot be combined with an ending-timestamp option"
+            raise ValueError(msg)
+
+        _validate_spec_topics(starting_offsets, topics, option_name="startingOffsets")
+        _validate_spec_topics(ending_offsets, topics, option_name="endingOffsets")
+        _validate_spec_topics(starting_ts, topics, option_name="startingOffsetsByTimestamp")
+        _validate_spec_topics(ending_ts, topics, option_name="endingOffsetsByTimestamp")
+
+        include_headers = opts.get("includeHeaders", "false").lower() == "true"
+        max_batch_rows = _parse_positive_int(opts, "maxBatchRows", "10000")
+        max_empty_polls = _parse_positive_int(opts, "maxEmptyPolls", "30")
+        # A negative poll timeout makes ``consumer.poll()`` block indefinitely,
+        # which defeats the ``maxEmptyPolls`` stall guard entirely — that guard
+        # can only count polls that return. Zero spins the read loop instead.
+        # Neither is a usable configuration, so both are rejected.
+        poll_timeout_s = _parse_positive_ms(opts, "pollTimeoutMs", "1000")
+        admin_timeout_s = _parse_positive_ms(opts, "adminTimeoutMs", "10000")
+
+        return {
+            "topics": topics,
+            "starting_offsets": starting_offsets,
+            "ending_offsets": ending_offsets,
+            "starting_timestamps": starting_ts,
+            "ending_timestamps": ending_ts,
+            "client_config": client_config,
+            "include_headers": include_headers,
+            "poll_timeout_s": poll_timeout_s,
+            "max_batch_rows": max_batch_rows,
+            "max_empty_polls": max_empty_polls,
+            "admin_timeout_s": admin_timeout_s,
+        }
+
+    def schema(self) -> pa.Schema:
+        return _build_schema(include_headers=self._resolved["include_headers"])
+
+    def reader(self, schema: pa.Schema) -> KafkaDataSourceReader:  # noqa: ARG002
+        return KafkaDataSourceReader(**self._resolved)

--- a/python/pysail/spark/datasource/kafka.py
+++ b/python/pysail/spark/datasource/kafka.py
@@ -1,0 +1,1519 @@
+"""Kafka batch data source for Sail, backed by confluent-kafka (librdkafka).
+
+Exposes ``spark.read.format("kafka")`` with a Spark-compatible schema and
+option surface. Every read resolves to a bounded ``[start_offset, end_offset)``
+range per partition, with ``earliest``/``latest`` bound per task rather than on
+the driver, as Spark's batch Kafka source does.
+
+Install the optional dependency before use::
+
+    pip install pysail[kafka]
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import time
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+import pyarrow as pa
+
+try:
+    from confluent_kafka import Consumer, IsolationLevel, KafkaError, KafkaException, TopicCollection, TopicPartition
+    from confluent_kafka.admin import AdminClient, OffsetSpec
+except ImportError as e:
+    msg = "confluent-kafka >= 2.5 is required for the kafka data source. Install it with: pip install pysail[kafka]"
+    raise ImportError(msg) from e
+
+try:
+    from pyspark.sql.datasource import CaseInsensitiveDict, DataSource, DataSourceReader, InputPartition
+except ImportError as e:
+    msg = "PySpark with the DataSource API is required (PySpark >= 4.0)."
+    raise ImportError(msg) from e
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
+
+
+# ============================================================================
+# Fixed Spark-compatible schema
+# ============================================================================
+
+# Matches the column names, order, types, and nullability of
+# ``org.apache.spark.sql.kafka010.KafkaRecordToRowConverter``'s output schema.
+# ``headers`` is only appended when the ``includeHeaders`` option is true.
+#
+# Every field is nullable because Spark builds these with plain ``StructField``s,
+# whose ``nullable`` defaults to true. Declaring the always-populated columns
+# non-nullable would be a user-visible schema difference: nullability shows up in
+# ``printSchema`` output and in the compatibility checks Spark runs when a
+# DataFrame is written into an existing table.
+
+_BASE_FIELDS: list[pa.Field] = [
+    pa.field("key", pa.binary(), nullable=True),
+    pa.field("value", pa.binary(), nullable=True),
+    pa.field("topic", pa.string(), nullable=True),
+    pa.field("partition", pa.int32(), nullable=True),
+    pa.field("offset", pa.int64(), nullable=True),
+    pa.field("timestamp", pa.timestamp("us", tz="UTC"), nullable=True),
+    pa.field("timestampType", pa.int32(), nullable=True),
+]
+
+_HEADER_STRUCT = pa.struct([pa.field("key", pa.string(), nullable=True), pa.field("value", pa.binary(), nullable=True)])
+
+# librdkafka's timestamp types. Spark reports
+# ``org.apache.kafka.common.record.TimestampType``'s -1/0/1, so translate on the
+# way out: downstream code keying off Spark's enum (e.g. ``timestampType == 0``
+# for CreateTime) then behaves the same as against the JVM Kafka source.
+_LIBRDKAFKA_TS_NOT_AVAILABLE = 0
+_LIBRDKAFKA_TO_SPARK_TS_TYPE = {
+    _LIBRDKAFKA_TS_NOT_AVAILABLE: -1,  # NOT_AVAILABLE    -> NO_TIMESTAMP_TYPE
+    1: 0,  # CREATE_TIME      -> CREATE_TIME
+    2: 1,  # LOG_APPEND_TIME  -> LOG_APPEND_TIME
+}
+
+# Kafka reports no timestamp as -1 ms, and Spark passes that straight through
+# ``millisToMicros``, surfacing 1969-12-31 23:59:59.999 rather than null. Only
+# ``timestampType`` marks the record as untimed.
+_NO_TIMESTAMP_MS = -1
+
+
+def _build_schema(*, include_headers: bool) -> pa.Schema:
+    fields = list(_BASE_FIELDS)
+    if include_headers:
+        fields.append(pa.field("headers", pa.list_(_HEADER_STRUCT), nullable=True))
+    return pa.schema(fields)
+
+
+# ============================================================================
+# Option parsing
+# ============================================================================
+
+
+_SENTINEL_EARLIEST = "earliest"
+_SENTINEL_LATEST = "latest"
+
+# Spark's magic per-partition offset sentinels.
+_SPARK_OFFSET_LATEST = -1
+_SPARK_OFFSET_EARLIEST = -2
+
+# ``startingOffsetsByTimestampStrategy`` values.
+_TS_STRATEGY_ERROR = "error"
+_TS_STRATEGY_LATEST = "latest"
+
+_SUBSCRIPTION_KEYS = ("assign", "subscribe", "subscribePattern")
+
+
+def _validate_tp_mapping(parsed: dict, *, label: str) -> dict[str, dict[str, int]]:
+    """Validate a parsed ``{topic: {partition: int}}`` JSON mapping.
+
+    The caller has already confirmed the top-level value is a ``dict``. Here we
+    check each topic maps to an object of ``{partition: int}`` so malformed
+    shapes (e.g. ``{"t": 5}`` or ``{"t": {"0": "x"}}``) fail loudly at parse
+    time with a clear message, rather than crashing later during offset
+    resolution with an opaque ``AttributeError``/``ValueError``.
+    """
+    for topic, partitions in parsed.items():
+        if not isinstance(partitions, dict):
+            msg = f"{label} entry for topic {topic!r} must be an object of {{partition: value}}, got: {type(partitions).__name__}"
+            raise ValueError(msg)  # noqa: TRY004
+        for partition, value in partitions.items():
+            # Partition ids are JSON object keys, so they arrive as strings.
+            # They are compared against the broker's integer partition ids, and
+            # a non-numeric key would otherwise fail there with a bare
+            # ``invalid literal for int()``.
+            try:
+                int(partition)
+            except ValueError as e:
+                msg = f"{label} partition id for topic {topic!r} must be an integer, got: {partition!r}"
+                raise ValueError(msg) from e
+            # bool is an int subclass; reject it so JSON true/false isn't
+            # silently coerced to 1/0.
+            if not isinstance(value, int) or isinstance(value, bool):
+                msg = f"{label} value for topic {topic!r} partition {partition!r} must be an integer, got: {type(value).__name__}"
+                raise ValueError(msg)  # noqa: TRY004
+    return parsed
+
+
+def _parse_offset_spec(raw: str, *, option_name: str) -> str | dict[str, dict[str, int]]:
+    """Parse a present ``startingOffsets`` / ``endingOffsets`` value.
+
+    Returns either the string ``"earliest"``/``"latest"`` or a mapping
+    ``{topic: {partition: offset}}``. In Spark, JSON keys are strings (partition
+    ids as strings).
+
+    Spark matches the sentinels case-insensitively and parses whatever else is
+    present as JSON, so a blank value is a parse error rather than "unset" —
+    only an *absent* option falls back to the endpoint default. Callers reach
+    this function only once the option is known to be present.
+    """
+    stripped = raw.strip()
+    lowered = stripped.lower()
+    if lowered in (_SENTINEL_EARLIEST, _SENTINEL_LATEST):
+        return lowered
+    try:
+        parsed = json.loads(stripped)
+    except json.JSONDecodeError as e:
+        msg = f"Invalid '{option_name}' value: {raw!r}. Expected 'earliest', 'latest', or JSON."
+        raise ValueError(msg) from e
+    if not isinstance(parsed, dict):
+        msg = f"'{option_name}' JSON must be an object, got: {type(parsed).__name__}"
+        raise ValueError(msg)  # noqa: TRY004
+    return _validate_tp_mapping(parsed, label=f"'{option_name}'")
+
+
+def _parse_global_timestamp(raw: str, *, option_name: str) -> int:
+    """Parse a global ``{starting,ending}Timestamp`` (ms since epoch)."""
+    try:
+        return int(raw.strip())
+    except ValueError as e:
+        msg = f"'{option_name}' must be an integer (ms since epoch), got {raw!r}"
+        raise ValueError(msg) from e
+
+
+def _parse_timestamp_json(raw: str, *, option_name: str) -> dict[str, dict[str, int]]:
+    """Parse ``{starting,ending}OffsetsByTimestamp`` (per-tp JSON, ms since epoch)."""
+    try:
+        parsed = json.loads(raw.strip())
+    except json.JSONDecodeError as e:
+        msg = f"Invalid '{option_name}' JSON: {raw!r}"
+        raise ValueError(msg) from e
+    if not isinstance(parsed, dict):
+        msg = f"'{option_name}' JSON must be an object"
+        raise ValueError(msg)  # noqa: TRY004
+    return _validate_tp_mapping(parsed, label=f"'{option_name}'")
+
+
+def _resolve_range_option(
+    opts: Mapping[str, str], *, endpoint: str
+) -> tuple[str | dict[str, dict[str, int]] | None, int | dict[str, dict[str, int]] | None]:
+    """Select one range option per endpoint, using Spark's precedence.
+
+    ``KafkaSourceProvider.getKafkaOffsetRangeLimit`` picks the global timestamp
+    first, then the per-partition timestamp map, then the offsets — and never
+    looks at the lower-priority options, so it neither rejects combinations nor
+    parses the values it skipped. Rejecting combinations here instead would fail
+    queries that Spark runs happily, and parsing a skipped option would reject
+    values Spark never reads (a blank ``startingOffsets`` alongside a
+    ``startingTimestamp``, say).
+
+    Returns ``(offsets_spec, timestamp_spec)`` with at most one set; both are
+    ``None`` when the endpoint is unspecified and the caller applies the default
+    (earliest for starting, latest for ending).
+    """
+    global_ts_key = f"{endpoint}Timestamp"
+    per_tp_ts_key = f"{endpoint}OffsetsByTimestamp"
+    offsets_key = f"{endpoint}Offsets"
+
+    if global_ts_key in opts:
+        return None, _parse_global_timestamp(opts[global_ts_key], option_name=global_ts_key)
+    if per_tp_ts_key in opts:
+        return None, _parse_timestamp_json(opts[per_tp_ts_key], option_name=per_tp_ts_key)
+    if offsets_key in opts:
+        return _parse_offset_spec(opts[offsets_key], option_name=offsets_key), None
+    return None, None
+
+
+def _validate_offset_spec(
+    spec: str | dict[str, dict[str, int]] | None,
+    *,
+    endpoint: str,
+    option_name: str,
+) -> None:
+    """Enforce Spark's batch-mode rules on an already-parsed offset spec.
+
+    Spark's batch Kafka source rejects ``latest`` for ``startingOffsets`` and
+    ``earliest`` for ``endingOffsets``, in both the string form and the
+    per-partition JSON form (``-1``/``-2``). Without this check the offending
+    endpoint silently resolves to a watermark that empties the range, so the
+    query returns zero rows instead of failing.
+
+    We also reject any offset below ``-2``. Only ``-1``/``-2`` are Spark
+    sentinels; everything below is a librdkafka sentinel that would be honoured
+    rather than rejected — notably ``-1000`` (``OFFSET_STORED``), which would
+    silently read from committed consumer-group offsets, and ``-1001``
+    (``OFFSET_INVALID``).
+
+    This is deliberately separate from ``_validate_tp_mapping``, which is shared
+    with the timestamp parsers where negative values are legitimate (pre-1970)
+    instants.
+    """
+    if spec is None:
+        return
+
+    forbidden_sentinel = _SENTINEL_LATEST if endpoint == "starting" else _SENTINEL_EARLIEST
+    forbidden_offset = _SPARK_OFFSET_LATEST if endpoint == "starting" else _SPARK_OFFSET_EARLIEST
+    allowed_sentinel = _SENTINEL_EARLIEST if endpoint == "starting" else _SENTINEL_LATEST
+
+    if isinstance(spec, str):
+        if spec == forbidden_sentinel:
+            msg = (
+                f"'{option_name}' does not support {forbidden_sentinel!r} for batch reads; "
+                f"use {allowed_sentinel!r} or per-partition JSON"
+            )
+            raise ValueError(msg)
+        return
+
+    for topic, partitions in spec.items():
+        for partition, value in partitions.items():
+            where = f"topic {topic!r} partition {partition!r}"
+            if value == forbidden_offset:
+                msg = (
+                    f"'{option_name}' does not support offset {forbidden_offset} "
+                    f"({forbidden_sentinel}) for batch reads, at {where}"
+                )
+                raise ValueError(msg)
+            if value < _SPARK_OFFSET_EARLIEST:
+                msg = (
+                    f"'{option_name}' offset for {where} must be >= 0, "
+                    f"{_SPARK_OFFSET_LATEST} (latest), or {_SPARK_OFFSET_EARLIEST} (earliest), got: {value}"
+                )
+                raise ValueError(msg)
+
+
+def _parse_ts_strategy(opts: Mapping[str, str]) -> str:
+    """Parse ``startingOffsetsByTimestampStrategy`` (Spark default: ``error``)."""
+    option_name = "startingOffsetsByTimestampStrategy"
+    raw = opts.get(option_name, _TS_STRATEGY_ERROR)
+    value = raw.strip().lower()
+    if value not in (_TS_STRATEGY_ERROR, _TS_STRATEGY_LATEST):
+        msg = f"'{option_name}' must be {_TS_STRATEGY_ERROR!r} or {_TS_STRATEGY_LATEST!r}, got {raw!r}"
+        raise ValueError(msg)
+    return value
+
+
+def _parse_bool(opts: Mapping[str, str], name: str, *, default: bool) -> bool:
+    """Parse a boolean option the way Scala's ``toBoolean`` does.
+
+    Spark calls ``.toBoolean`` on these, which accepts ``true``/``false`` in any
+    case and throws on anything else. Treating every non-``true`` value as false
+    would silently swallow ``includeHeaders=yes`` and ``failOnDataLoss=0``.
+    """
+    if name not in opts:
+        return default
+    value = opts[name].strip().lower()
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    msg = f"'{name}' must be 'true' or 'false', got {opts[name]!r}"
+    raise ValueError(msg)
+
+
+def _parse_positive_int(opts: Mapping[str, str], name: str, default: str) -> int:
+    """Parse a positive integer option, naming the option in any failure."""
+    raw = opts.get(name, default)
+    try:
+        value = int(raw)
+    except ValueError as e:
+        msg = f"'{name}' must be an integer, got {raw!r}"
+        raise ValueError(msg) from e
+    if value <= 0:
+        msg = f"'{name}' must be positive, got {value}"
+        raise ValueError(msg)
+    return value
+
+
+def _parse_optional_positive_int(opts: Mapping[str, str], name: str) -> int | None:
+    """Parse an optional positive integer option, returning ``None`` when absent."""
+    if name not in opts:
+        return None
+    return _parse_positive_int(opts, name, default="")
+
+
+def _parse_positive_ms(opts: Mapping[str, str], names: tuple[str, ...], default: str) -> float:
+    """Parse a positive, finite millisecond option, returning it as seconds.
+
+    ``names`` are checked in order so a Spark-standard option name can take
+    precedence over an alias.
+
+    ``float`` accepts ``nan`` and ``inf``, and neither is caught by a ``<= 0``
+    check: ``inf`` makes ``Consumer.poll()`` block forever, which defeats the
+    stall guard entirely, and ``nan`` makes every comparison false.
+    """
+    name = next((n for n in names if n in opts), names[0])
+    raw = opts.get(name, default)
+    try:
+        value_ms = float(raw)
+    except ValueError as e:
+        msg = f"'{name}' must be a number of milliseconds, got {raw!r}"
+        raise ValueError(msg) from e
+    if not math.isfinite(value_ms):
+        msg = f"'{name}' must be a finite number of milliseconds, got {raw!r}"
+        raise ValueError(msg)
+    if value_ms <= 0:
+        msg = f"'{name}' must be positive, got {value_ms}"
+        raise ValueError(msg)
+    return value_ms / 1000.0
+
+
+def _extract_kafka_config(opts: Mapping[str, str]) -> dict[str, str]:
+    """Pass through any option prefixed with ``kafka.`` to librdkafka config.
+
+    Matches Spark's convention: ``kafka.bootstrap.servers`` →
+    ``bootstrap.servers``, ``kafka.security.protocol`` → ``security.protocol``,
+    etc.
+
+    ``opts`` is a ``CaseInsensitiveDict``, so iteration yields lowercased keys and
+    ``KAFKA.Bootstrap.Servers`` is matched here just as Spark matches it. Every
+    librdkafka property name is lowercase already, so lowercasing the part after
+    the prefix does not change which property is set.
+    """
+    return {k[len("kafka.") :]: v for k, v in opts.items() if k.startswith("kafka.")}
+
+
+# Consumer properties this source owns. Spark rejects the same set in
+# ``KafkaSourceProvider.validateGeneralOptions`` because each one silently
+# rewrites the read that was planned:
+#
+# * ``auto.offset.reset`` — the planner already resolved a concrete start, so a
+#   reset policy can only move it. ``earliest``/``latest`` would turn a start
+#   that aged out of the log into a silent jump instead of the data-loss error
+#   ``failOnDataLoss`` promises.
+# * ``enable.auto.commit`` — a batch read must not commit offsets; with a
+#   user-supplied ``kafka.group.id`` this would corrupt that group's position.
+# * ``enable.partition.eof`` — the read loop's termination path. Disabling it
+#   turns a clean end-of-log stop into a stall until ``stallTimeoutMs``.
+#
+# The deserializer and interceptor properties Spark also protects have no
+# librdkafka equivalent (messages arrive as raw bytes), so they are not listed.
+_PROTECTED_KAFKA_CONFIGS = {
+    "auto.offset.reset": "startingOffsets/endingOffsets",
+    "enable.auto.commit": None,
+    "enable.partition.eof": None,
+}
+
+
+def _validate_kafka_config(client_config: Mapping[str, str]) -> None:
+    """Reject ``kafka.*`` options that would override this source's own settings."""
+    for name, alternative in _PROTECTED_KAFKA_CONFIGS.items():
+        if name in client_config:
+            msg = f"Kafka option 'kafka.{name}' is not supported"
+            if alternative:
+                msg += f"; use the source option(s) '{alternative}' instead"
+            raise ValueError(msg)
+
+
+# Static group id. Spark mints a unique id per query
+# (``KafkaSourceProvider.batchUniqueGroupId``) because its consumers call
+# ``subscribe()`` and so join a real consumer group, where a shared id makes
+# concurrent queries steal partitions from each other. Every read here uses
+# ``consumer.assign()`` instead, which is librdkafka's simple-consumer path: no
+# JoinGroup, no partition assignment from a coordinator, and with
+# ``enable.auto.commit`` off, nothing written to ``__consumer_offsets``. The id
+# is required by librdkafka but never used for coordination, so a stable one is
+# safe here and keeps broker logs readable. Users can still override it with
+# ``kafka.group.id``, as Spark allows.
+_DEFAULT_GROUP_ID = "sail-kafka-reader"
+
+# Consumer-only properties, stripped before building an ``AdminClient``.
+# librdkafka builds the admin handle on a producer, and logs a CONFWARN for
+# every consumer property it finds there. The user's ``kafka.*`` config is
+# shared between both clients, so a user-supplied ``kafka.group.id`` would
+# otherwise produce a warning on every planning call.
+_CONSUMER_ONLY_CONFIGS = ("group.id", "enable.auto.commit", "auto.offset.reset", "enable.partition.eof")
+
+
+def _build_admin_config(client_config: dict[str, str]) -> dict[str, str]:
+    """Return the librdkafka config for the planning-time ``AdminClient``.
+
+    Mirrors Spark's ``kafkaParamsForDriver``: the user's ``kafka.*`` options
+    carry the connection and security settings, and the source contributes
+    nothing the admin protocol does not need.
+    """
+    return {k: v for k, v in client_config.items() if k not in _CONSUMER_ONLY_CONFIGS}
+
+
+def _build_consumer_config(client_config: dict[str, str], *, fail_on_data_loss: bool = True) -> dict[str, str | bool]:
+    """Return the effective librdkafka config for a batch-read consumer.
+
+    Only executors build consumers; planning goes through an ``AdminClient``
+    configured by :func:`_build_admin_config`.
+
+    Source-owned settings are applied *after* the user's ``kafka.*`` options, so
+    they stay authoritative exactly as Spark's ``ConfigUpdater`` keeps its own
+    values authoritative. ``_validate_kafka_config`` has already rejected the
+    ones a user could meaningfully try to set, so this ordering only matters as
+    a second line of defence.
+
+    ``auto.offset.reset`` encodes ``failOnDataLoss``: ``error`` surfaces a start
+    offset that has aged out of the log, while ``earliest`` reproduces Spark's
+    ``failOnDataLoss=false`` behaviour of skipping ahead to what is still there.
+
+    ``isolation.level`` is pinned to the Java client's default because the two
+    clients disagree: librdkafka defaults to ``read_committed``, while Spark
+    never sets the property and so inherits ``read_uncommitted``. Left alone, a
+    topic written by a transactional producer would silently return a different
+    row set here than under Spark — aborted records dropped, and nothing past
+    the last stable offset — with planning still using the high watermark, so
+    the short read would look like a clean one. It is placed before the user's
+    config so ``kafka.isolation.level`` can still opt into ``read_committed``.
+    """
+    return {
+        "group.id": _DEFAULT_GROUP_ID,
+        "isolation.level": "read_uncommitted",
+        **client_config,  # user config first...
+        # ...source-owned settings last, so they win.
+        "enable.auto.commit": False,
+        "auto.offset.reset": "error" if fail_on_data_loss else _SENTINEL_EARLIEST,
+        "enable.partition.eof": True,
+    }
+
+
+# ============================================================================
+# Subscription strategy — assign / subscribe / subscribePattern
+# ============================================================================
+
+
+def _parse_subscription(opts: Mapping[str, str]) -> tuple[str, object]:
+    """Parse Spark's three topic-selection strategies.
+
+    Spark requires exactly one of ``assign``, ``subscribe``, and
+    ``subscribePattern``, rejecting both zero and more than one. Returns the
+    strategy name and its parsed value: a topic list for ``subscribe``, a
+    compiled regex for ``subscribePattern``, and a ``{topic: [partition, ...]}``
+    mapping for ``assign``.
+    """
+    present = [key for key in _SUBSCRIPTION_KEYS if key in opts]
+    if len(present) > 1:
+        msg = f"Only one of the following options may be specified: {', '.join(_SUBSCRIPTION_KEYS)}. Got: {', '.join(present)}"
+        raise ValueError(msg)
+    if not present:
+        msg = (
+            f"One of the following options must be specified for the kafka data source: {', '.join(_SUBSCRIPTION_KEYS)}"
+        )
+        raise ValueError(msg)
+
+    strategy = present[0]
+    raw = opts[strategy]
+
+    if strategy == "subscribe":
+        # Dedupe: a repeated topic would otherwise be enumerated once per
+        # occurrence, producing duplicate input partitions over the same offset
+        # range and emitting every row twice. `dict.fromkeys` preserves
+        # first-seen order so planning stays stable.
+        topics = list(dict.fromkeys(t.strip() for t in raw.split(",") if t.strip()))
+        if not topics:
+            msg = "Option 'subscribe' must list at least one topic"
+            raise ValueError(msg)
+        return strategy, topics
+
+    if strategy == "subscribePattern":
+        pattern = raw.strip()
+        if not pattern:
+            msg = "Option 'subscribePattern' must be a non-empty regular expression"
+            raise ValueError(msg)
+        try:
+            return strategy, re.compile(pattern)
+        except re.error as e:
+            msg = f"Option 'subscribePattern' is not a valid regular expression: {pattern!r} ({e})"
+            raise ValueError(msg) from e
+
+    try:
+        parsed = json.loads(raw.strip())
+    except json.JSONDecodeError as e:
+        msg = f"Invalid 'assign' JSON: {raw!r}. Expected {{\"topic\": [partition, ...]}}."
+        raise ValueError(msg) from e
+    if not isinstance(parsed, dict) or not parsed:
+        msg = f"'assign' JSON must be a non-empty object of {{topic: [partition, ...]}}, got: {raw!r}"
+        raise ValueError(msg)
+    for topic, partitions in parsed.items():
+        if not isinstance(partitions, list) or not partitions:
+            msg = f"'assign' entry for topic {topic!r} must be a non-empty array of partition ids"
+            raise ValueError(msg)
+        for partition in partitions:
+            if not isinstance(partition, int) or isinstance(partition, bool) or partition < 0:
+                msg = f"'assign' partition id for topic {topic!r} must be a non-negative integer, got: {partition!r}"
+                raise ValueError(msg)
+    return strategy, parsed
+
+
+# ============================================================================
+# InputPartition — one per (topic, partition, offset-range)
+# ============================================================================
+
+
+class KafkaInputPartition(InputPartition):
+    def __init__(
+        self,
+        partition_id: int,
+        *,
+        topic: str,
+        kafka_partition: int,
+        start_offset: int,
+        end_offset: int,
+        client_config: dict[str, str],
+        include_headers: bool,
+        poll_timeout_s: float,
+        max_batch_rows: int,
+        stall_timeout_s: float,
+        admin_timeout_s: float,
+        fail_on_data_loss: bool,
+    ) -> None:
+        super().__init__(partition_id)
+        self.topic = topic
+        self.kafka_partition = kafka_partition
+        self.start_offset = start_offset
+        self.end_offset = end_offset  # exclusive
+        self.client_config = client_config
+        self.include_headers = include_headers
+        self.poll_timeout_s = poll_timeout_s
+        self.max_batch_rows = max_batch_rows
+        self.stall_timeout_s = stall_timeout_s
+        self.admin_timeout_s = admin_timeout_s
+        self.fail_on_data_loss = fail_on_data_loss
+
+
+# ============================================================================
+# Offset range splitting — minPartitions / maxRecordsPerPartition
+# ============================================================================
+
+
+def _divide_range(start: int, end: int, parts: int) -> list[tuple[int, int]]:
+    """Split ``[start, end)`` into ``parts`` contiguous chunks.
+
+    Mirrors ``KafkaOffsetRangeCalculator.getDividedPartition``, which takes
+    ``remaining / (parts - i)`` records for chunk ``i``. Chunks differ by at most
+    one record, and because each chunk is sized against what is left, the
+    remainder lands in the *last* chunks — dividing ten records three ways gives
+    3/3/4, not 4/3/3. Distributing it the other way would put every split
+    boundary in a different place than Spark.
+
+    Empty chunks are dropped, as Spark drops them with ``filter(_.size > 0)``.
+    """
+    remaining = end - start
+    parts = max(parts, 1)  # callers guarantee this; never silently drop a range
+    out: list[tuple[int, int]] = []
+    offset = start
+    for i in range(parts):
+        length = remaining // (parts - i)
+        remaining -= length
+        chunk_end = min(offset + length, end)
+        if chunk_end > offset:
+            out.append((offset, chunk_end))
+        offset = chunk_end
+    return out
+
+
+def _check_range(rng: tuple[str, int, int, int]) -> tuple[str, int, int, int] | None:
+    """Reject an inverted range and drop an empty one.
+
+    Only reachable once both endpoints are concrete. Spark applies the same two
+    rules — ``KafkaSourceRDD.compute`` asserts ``fromOffset <= untilOffset`` and
+    returns an empty iterator when they are equal — but does so per task, since
+    a late-bound range has no size until it is read.
+    """
+    topic, partition, start, end = rng
+    if end < start:
+        msg = (
+            f"Inverted offset range for {topic}[{partition}]: start {start} is past end {end}. "
+            f"Check 'startingOffsets'/'endingOffsets'; the log may also have been truncated "
+            f"while the range was being resolved."
+        )
+        raise ValueError(msg)
+    return None if end == start else rng
+
+
+def _resolve_sentinels(
+    admin: AdminClient, ranges: list[tuple[str, int, int, int]], *, timeout_s: float
+) -> list[tuple[str, int, int, int]]:
+    """Bind any ``earliest``/``latest`` sentinel still present in ``ranges``.
+
+    ``_list_offsets`` is keyed by partition, so a partition needing both
+    watermarks cannot ask for them in one request; the two endpoints are batched
+    into one call each instead.
+    """
+    need_low = {(topic, part) for topic, part, start, _ in ranges if start == _SPARK_OFFSET_EARLIEST}
+    need_high = {(topic, part) for topic, part, _, end in ranges if end == _SPARK_OFFSET_LATEST}
+    if not need_low and not need_high:
+        return ranges
+
+    lows = _list_offsets(admin, {k: OffsetSpec.earliest() for k in need_low}, timeout_s=timeout_s)
+    highs = _list_offsets(admin, {k: OffsetSpec.latest() for k in need_high}, timeout_s=timeout_s)
+    out = []
+    for topic, partition, start, end in ranges:
+        key = (topic, partition)
+        bound_start = lows[key] if start == _SPARK_OFFSET_EARLIEST else start
+        bound_end = highs[key] if end == _SPARK_OFFSET_LATEST else end
+        out.append((topic, partition, bound_start, bound_end))
+    return out
+
+
+def _restore_outer_bounds(
+    ranges: list[tuple[str, int, int, int]], outer: dict[tuple[str, int], tuple[int, int]]
+) -> list[tuple[str, int, int, int]]:
+    """Put each partition's original endpoints back on its first and last chunk.
+
+    Mirrors ``getOffsetRangesFromUnresolvedOffsets``, which after dividing a
+    range copies the pre-resolution ``fromOffset`` onto the head chunk and
+    ``untilOffset`` onto the last one. Splitting therefore fixes only the
+    *interior* boundaries; a late-bound start or end stays late-bound.
+    """
+    first: dict[tuple[str, int], int] = {}
+    last: dict[tuple[str, int], int] = {}
+    for i, (topic, partition, _, _) in enumerate(ranges):
+        first.setdefault((topic, partition), i)
+        last[(topic, partition)] = i
+
+    out = list(ranges)
+    for key, i in first.items():
+        topic, partition, _, end = out[i]
+        out[i] = (topic, partition, outer[key][0], end)
+    for key, i in last.items():
+        topic, partition, start, _ = out[i]
+        out[i] = (topic, partition, start, outer[key][1])
+    return out
+
+
+def _part_count(size: int, total_size: int, min_parts: int) -> int:
+    """How many chunks a range of ``size`` gets, per Spark's ``getPartCount``.
+
+    Scala's ``math.round`` is floor(x + 0.5); Python's ``round`` is banker's
+    rounding, which would place split boundaries differently.
+    """
+    return max(math.floor(size / total_size * min_parts + 0.5), 1)
+
+
+def _split_offset_ranges(
+    ranges: list[tuple[str, int, int, int]],
+    *,
+    min_partitions: int | None,
+    max_records_per_partition: int | None,
+) -> list[tuple[str, int, int, int]]:
+    """Apply Spark's ``minPartitions``/``maxRecordsPerPartition`` splitting.
+
+    ``KafkaOffsetRangeCalculator.getRanges`` first caps each range at
+    ``maxRecordsPerPartition``, then — if the result still has fewer partitions
+    than ``minPartitions`` — splits ranges further in proportion to their size.
+    Ignoring these options would silently change both parallelism and the
+    observable partition count relative to Spark.
+    """
+    if max_records_per_partition is not None:
+        divided: list[tuple[str, int, int, int]] = []
+        for topic, partition, start, end in ranges:
+            parts = math.ceil((end - start) / max_records_per_partition)
+            divided.extend(
+                (topic, partition, chunk_start, chunk_end)
+                for chunk_start, chunk_end in _divide_range(start, end, parts)
+            )
+        ranges = divided
+
+    if min_partitions is None or min_partitions <= len(ranges):
+        return ranges
+
+    total_size = sum(end - start for _, _, start, end in ranges)
+    if total_size == 0:
+        return ranges
+
+    # Spark splits in two passes. Ranges whose proportional share rounds down to
+    # a single chunk are set aside first, and the remaining `minPartitions`
+    # budget is then divided among the rest against *their* combined size only.
+    # A single proportional pass would let one large range claim the whole
+    # budget while the small ranges still contribute a partition each, so the
+    # result overshoots: sizes [100, 1, 1] with minPartitions=4 would yield 6
+    # ranges instead of Spark's 4.
+    #
+    # `unsplit` is keyed by (topic, partition) rather than by range, matching
+    # Spark's `unsplitRangeTopicPartitions`: when `maxRecordsPerPartition` has
+    # already divided one Kafka partition, one small piece pins every piece of
+    # that partition to a single chunk.
+    unsplit = [r for r in ranges if _part_count(r[3] - r[2], total_size, min_partitions) == 1]
+    unsplit_tps = {(topic, partition) for topic, partition, _, _ in unsplit}
+    split_total_size = total_size - sum(end - start for _, _, start, end in unsplit)
+    split_min_partitions = max(min_partitions - len(unsplit), 1)
+
+    out: list[tuple[str, int, int, int]] = []
+    for topic, partition, start, end in ranges:
+        # `split_total_size` is only zero when every range is unsplit, and then
+        # this branch is never taken, so it cannot divide by zero.
+        parts = (
+            1 if (topic, partition) in unsplit_tps else _part_count(end - start, split_total_size, split_min_partitions)
+        )
+        out.extend(
+            (topic, partition, chunk_start, chunk_end) for chunk_start, chunk_end in _divide_range(start, end, parts)
+        )
+    return out
+
+
+# ============================================================================
+# DataSourceReader
+# ============================================================================
+
+
+class KafkaDataSourceReader(DataSourceReader):
+    def __init__(
+        self,
+        *,
+        subscription: tuple[str, object],
+        starting_offsets: str | dict[str, dict[str, int]] | None,
+        ending_offsets: str | dict[str, dict[str, int]] | None,
+        starting_timestamps: int | dict[str, dict[str, int]] | None,
+        ending_timestamps: int | dict[str, dict[str, int]] | None,
+        starting_ts_strategy: str,
+        client_config: dict[str, str],
+        include_headers: bool,
+        poll_timeout_s: float,
+        max_batch_rows: int,
+        stall_timeout_s: float,
+        admin_timeout_s: float,
+        fail_on_data_loss: bool,
+        min_partitions: int | None,
+        max_records_per_partition: int | None,
+    ) -> None:
+        self.subscription = subscription
+        self.starting_offsets = starting_offsets
+        self.ending_offsets = ending_offsets
+        self.starting_timestamps = starting_timestamps
+        self.ending_timestamps = ending_timestamps
+        self.starting_ts_strategy = starting_ts_strategy
+        self.client_config = client_config
+        self.include_headers = include_headers
+        self.poll_timeout_s = poll_timeout_s
+        self.max_batch_rows = max_batch_rows
+        self.stall_timeout_s = stall_timeout_s
+        self.admin_timeout_s = admin_timeout_s
+        self.fail_on_data_loss = fail_on_data_loss
+        self.min_partitions = min_partitions
+        self.max_records_per_partition = max_records_per_partition
+
+    # ------------------------------------------------------------------
+    # Partition planning — talks to the broker once on the driver
+    # ------------------------------------------------------------------
+
+    def partitions(self) -> list[InputPartition]:
+        # A short-lived AdminClient enumerates partitions and resolves offsets,
+        # as Spark's `KafkaOffsetReaderAdmin` does. Executors get their own
+        # consumer; nothing here is reused across the driver/executor boundary.
+        # AdminClient exposes no `close()` — the handle is released when it goes
+        # out of scope, so there is nothing to unwind in a `finally`.
+        #
+        # `earliest`/`latest` are deliberately *not* resolved here. Spark's
+        # `fetchPartitionOffsets` returns the -2/-1 sentinels for those limits
+        # ("Obtain TopicPartition offsets with late binding support") and binds
+        # them per task in `KafkaSourceRDD.resolveRange`. Freezing them on the
+        # driver would drop records produced between planning and task start,
+        # and — worse — an `earliest` start frozen at planning can age out of
+        # the log before the task runs, failing a query Spark completes by
+        # simply re-resolving. Explicit offsets and timestamps are resolved
+        # here, as they are in Spark.
+        admin = AdminClient(_build_admin_config(self.client_config))
+        admin_timeout_s = self.admin_timeout_s
+
+        tps = _list_topic_partitions(admin, self.subscription, timeout_s=admin_timeout_s)
+        for spec, option_name in (
+            (self.starting_offsets, "startingOffsets"),
+            (self.ending_offsets, "endingOffsets"),
+            (self.starting_timestamps, "startingOffsetsByTimestamp"),
+            (self.ending_timestamps, "endingOffsetsByTimestamp"),
+        ):
+            _validate_spec_partitions(spec, tps, option_name=option_name)
+
+        if self.starting_timestamps is not None:
+            starts = _resolve_by_timestamp(
+                admin,
+                tps,
+                self.starting_timestamps,
+                endpoint="starting",
+                timeout_s=admin_timeout_s,
+                strategy=self.starting_ts_strategy,
+            )
+        else:
+            starts = _map_offset_spec(tps, self.starting_offsets or _SENTINEL_EARLIEST)
+        if self.ending_timestamps is not None:
+            ends = _resolve_by_timestamp(
+                admin,
+                tps,
+                self.ending_timestamps,
+                endpoint="ending",
+                timeout_s=admin_timeout_s,
+                strategy=_TS_STRATEGY_LATEST,
+            )
+        else:
+            ends = _map_offset_spec(tps, self.ending_offsets or _SENTINEL_LATEST)
+
+        ranges = [
+            (tp.topic, tp.partition, starts[(tp.topic, tp.partition)], ends[(tp.topic, tp.partition)]) for tp in tps
+        ]
+
+        # Splitting needs concrete sizes, so it forces the sentinels to be
+        # resolved. Spark does the same in `getOffsetRangesFromUnresolvedOffsets`
+        # and then puts the unresolved endpoints back on the outer chunks, so
+        # the overall range stays late-bound even when it has been divided.
+        needs_split = self.max_records_per_partition is not None or (
+            self.min_partitions is not None and self.min_partitions > len(ranges)
+        )
+        if needs_split:
+            outer = {(topic, part): (start, end) for topic, part, start, end in ranges}
+            ranges = _resolve_sentinels(admin, ranges, timeout_s=admin_timeout_s)
+            ranges = [r for r in (_check_range(r) for r in ranges) if r is not None]
+            ranges = _split_offset_ranges(
+                ranges,
+                min_partitions=self.min_partitions,
+                max_records_per_partition=self.max_records_per_partition,
+            )
+            ranges = _restore_outer_bounds(ranges, outer)
+
+        return [
+            KafkaInputPartition(
+                pid,
+                topic=topic,
+                kafka_partition=partition,
+                start_offset=start,
+                end_offset=end,
+                client_config=self.client_config,
+                include_headers=self.include_headers,
+                poll_timeout_s=self.poll_timeout_s,
+                max_batch_rows=self.max_batch_rows,
+                stall_timeout_s=self.stall_timeout_s,
+                admin_timeout_s=self.admin_timeout_s,
+                fail_on_data_loss=self.fail_on_data_loss,
+            )
+            for pid, (topic, partition, start, end) in enumerate(ranges)
+        ]
+
+    # ------------------------------------------------------------------
+    # Per-partition read — runs on executors
+    # ------------------------------------------------------------------
+
+    def read(self, partition: InputPartition) -> Iterator[pa.RecordBatch]:
+        if not isinstance(partition, KafkaInputPartition):
+            msg = f"Expected KafkaInputPartition, got {type(partition)}"
+            raise TypeError(msg)
+
+        schema = _build_schema(include_headers=partition.include_headers)
+
+        consumer = Consumer(
+            _build_consumer_config(partition.client_config, fail_on_data_loss=partition.fail_on_data_loss)
+        )
+        try:
+            start, end = _bind_partition_range(consumer, partition)
+            if _check_range((partition.topic, partition.kafka_partition, start, end)) is None:
+                return  # empty range; nothing to read
+
+            tp = TopicPartition(partition.topic, partition.kafka_partition, start)
+            consumer.assign([tp])
+
+            buf = _RowBuffer(include_headers=partition.include_headers)
+            next_offset = start
+            # Wall-clock, not a poll count: the stall bound must not scale with
+            # `pollTimeoutMs`. Spark's 120s default for that option would turn a
+            # 30-poll budget into an hour of silence before the read gave up.
+            last_progress = time.monotonic()
+
+            while next_offset < end:
+                record = consumer.poll(partition.poll_timeout_s)
+                if record is None:
+                    # No message within poll timeout. Normally transient — the
+                    # broker is slow, or a fetch is in flight. But if this
+                    # keeps happening we're wedged (unreachable broker, dead
+                    # partition leader) and would hang forever without a cap.
+                    idle_s = time.monotonic() - last_progress
+                    if idle_s > partition.stall_timeout_s:
+                        msg = (
+                            f"Kafka read stalled: no messages for {idle_s:.0f}s on "
+                            f"{partition.topic}[{partition.kafka_partition}] at offset "
+                            f"{next_offset}, expected up to {end}. Broker may be "
+                            f"unreachable or the partition leader unavailable. "
+                            f"Raise 'stallTimeoutMs' if the topic is simply idle."
+                        )
+                        raise TimeoutError(msg)
+                    continue
+                if record.error():
+                    if record.error().code() == KafkaError._PARTITION_EOF:  # noqa: SLF001
+                        _check_eof_data_loss(consumer, tp, partition, next_offset=next_offset, end_offset=end)
+                        break
+                    raise KafkaException(record.error())
+
+                last_progress = time.monotonic()
+
+                if record.offset() >= end:
+                    break
+                if record.offset() < start:
+                    # librdkafka applies `auto.offset.reset` to an out-of-range
+                    # start in *both* directions. Under `failOnDataLoss=false`
+                    # the policy is `earliest`, so a start past the end of the
+                    # log does not read nothing — it rewinds to the beginning of
+                    # the log and delivers records the planner never asked for.
+                    # Spark returns no rows there instead
+                    # (`getEarliestAvailableOffsetBetween` gives up once
+                    # `offset >= latest`), so drop anything below the planned
+                    # start rather than emitting the whole partition.
+                    continue
+
+                buf.append(record)
+                next_offset = record.offset() + 1
+
+                if len(buf) >= partition.max_batch_rows:
+                    yield buf.to_batch(schema)
+                    buf = _RowBuffer(include_headers=partition.include_headers)
+
+            if len(buf) > 0:
+                yield buf.to_batch(schema)
+        finally:
+            consumer.close()
+
+
+def _bind_partition_range(consumer: Consumer, partition: KafkaInputPartition) -> tuple[int, int]:
+    """Bind this partition's ``earliest``/``latest`` sentinels at task start.
+
+    Mirrors ``KafkaSourceRDD.resolveRange``, which late-binds any negative
+    endpoint against the watermarks the consumer sees when the task actually
+    runs. Doing it here rather than on the driver is what lets the read pick up
+    records produced since planning, and what keeps an ``earliest`` start valid
+    when the log has aged on in the meantime.
+
+    Fully concrete ranges skip the broker round-trip entirely.
+    """
+    start, end = partition.start_offset, partition.end_offset
+    if start >= 0 and end >= 0:
+        return start, end
+    low, high = consumer.get_watermark_offsets(
+        TopicPartition(partition.topic, partition.kafka_partition),
+        timeout=partition.admin_timeout_s,
+        cached=False,
+    )
+    if start == _SPARK_OFFSET_EARLIEST:
+        start = low
+    if end == _SPARK_OFFSET_LATEST:
+        end = high
+    return start, end
+
+
+def _check_eof_data_loss(
+    consumer: Consumer,
+    tp: TopicPartition,
+    partition: KafkaInputPartition,
+    *,
+    next_offset: int,
+    end_offset: int,
+) -> None:
+    """Decide whether an end-of-partition event before the planned end is data loss.
+
+    EOF means the consumer reached the end of the log. Reaching it below the
+    planned exclusive end has two very different causes, and Spark distinguishes
+    them:
+
+    * The high watermark still covers the planned end. The offsets we did not
+      see were within the available range and are simply not readable — compacted
+      away, transaction control markers, or aborted records if the user opted
+      into ``read_committed``. Spark skips those and keeps going, so stopping
+      cleanly here matches it.
+    * The high watermark has fallen below the planned end. Records that existed
+      at planning time are gone (retention or truncation), or an explicit
+      ``endingOffsets`` points past the log. Spark reports data loss, which under
+      the default ``failOnDataLoss=true`` fails the query.
+
+    ``end_offset`` is the bound end for this task, which for a late-bound
+    ``latest`` is the high watermark as of task start rather than planning time.
+    """
+    if next_offset >= end_offset:
+        return
+    _, high = consumer.get_watermark_offsets(tp, timeout=partition.admin_timeout_s, cached=False)
+    if high >= end_offset:
+        return
+    if not partition.fail_on_data_loss:
+        return
+    msg = (
+        f"Data loss on {partition.topic}[{partition.kafka_partition}]: reached end of log at offset "
+        f"{next_offset}, but the read was planned up to {end_offset} and the high watermark "
+        f"is now {high}. Records were removed after planning (retention or truncation), or "
+        f"'endingOffsets' points past the end of the log. "
+        f"Set 'failOnDataLoss' to false to return the records that remain."
+    )
+    raise ValueError(msg)
+
+
+# ============================================================================
+# Row buffer — accumulates messages, flushes to a RecordBatch
+# ============================================================================
+
+
+class _RowBuffer:
+    """Column-major accumulator sized to ``max_batch_rows``."""
+
+    def __init__(self, *, include_headers: bool) -> None:
+        self.include_headers = include_headers
+        self.key: list[bytes | None] = []
+        self.value: list[bytes | None] = []
+        self.topic: list[str] = []
+        self.partition: list[int] = []
+        self.offset: list[int] = []
+        self.timestamp_us: list[int] = []
+        self.timestamp_type: list[int] = []
+        self.headers: list[list[dict] | None] = []
+
+    def __len__(self) -> int:
+        return len(self.offset)
+
+    def append(self, record) -> None:
+        ts_type, ts_ms = record.timestamp()  # librdkafka: 0=NotAvailable, 1=Create, 2=LogAppend
+        self.key.append(record.key())
+        self.value.append(record.value())
+        self.topic.append(record.topic())
+        self.partition.append(record.partition())
+        self.offset.append(record.offset())
+        # Spark emits the -1ms Kafka reports for an untimed record rather than
+        # null, surfacing 1969-12-31 23:59:59.999; only `timestampType` is -1.
+        # Normalising here keeps that exact value whatever librdkafka reports
+        # alongside NOT_AVAILABLE.
+        if ts_type == _LIBRDKAFKA_TS_NOT_AVAILABLE:
+            ts_ms = _NO_TIMESTAMP_MS
+        self.timestamp_us.append(ts_ms * 1000)
+        self.timestamp_type.append(_LIBRDKAFKA_TO_SPARK_TS_TYPE.get(ts_type, -1))
+        if self.include_headers:
+            hdrs = record.headers()
+            self.headers.append([{"key": k, "value": v} for k, v in hdrs] if hdrs else None)
+
+    def to_batch(self, schema: pa.Schema) -> pa.RecordBatch:
+        arrays = [
+            pa.array(self.key, type=pa.binary()),
+            pa.array(self.value, type=pa.binary()),
+            pa.array(self.topic, type=pa.string()),
+            pa.array(self.partition, type=pa.int32()),
+            pa.array(self.offset, type=pa.int64()),
+            pa.array(self.timestamp_us, type=pa.timestamp("us", tz="UTC")),
+            pa.array(self.timestamp_type, type=pa.int32()),
+        ]
+        if self.include_headers:
+            arrays.append(pa.array(self.headers, type=pa.list_(_HEADER_STRUCT)))
+        return pa.record_batch(arrays, schema=schema)
+
+
+# ============================================================================
+# Broker helpers — enumerate partitions, resolve watermarks
+# ============================================================================
+
+
+# Extra wall-clock budget allowed on top of a request's own timeout before we
+# give up waiting for its future. librdkafka bounds the request with
+# ``request_timeout`` and completes the future with an error, so under normal
+# failure this margin is never reached and the broker's own message wins. It
+# exists only so that a future which never resolves at all cannot wedge planning
+# forever, which a bare ``Future.result()`` would.
+_FUTURE_TIMEOUT_MARGIN_S = 5.0
+
+
+def _await(future, *, timeout_s: float, what: str):
+    """Resolve an admin-call future, refusing to wait indefinitely."""
+    try:
+        return future.result(timeout=timeout_s + _FUTURE_TIMEOUT_MARGIN_S)
+    except FuturesTimeoutError as e:
+        msg = (
+            f"Timed out after {timeout_s:g}s waiting for the broker to {what}. "
+            f"The broker may be unreachable or a partition leader unavailable; "
+            f"raise 'adminTimeoutMs' if the cluster is simply slow."
+        )
+        raise TimeoutError(msg) from e
+
+
+def _describe_topics(admin: AdminClient, topics: list[str], *, timeout_s: float) -> dict[str, list[int]]:
+    """Describe ``topics``, returning ``{topic: [partition, ...]}`` for the non-internal ones.
+
+    Mirrors Spark's ``ConsumerStrategy.retrieveAllPartitions``, which calls
+    ``admin.describeTopics(...)`` and drops whatever the broker flags with
+    ``isInternal``. That flag is the authority: only ``__consumer_offsets`` and
+    ``__transaction_state`` carry it, so a *user* topic that happens to start
+    with ``__`` stays visible, exactly as it does under Spark. Matching on the
+    name prefix instead would silently hide it.
+
+    One request covers every topic, as Spark's does.
+    """
+    futures = admin.describe_topics(TopicCollection(topics), request_timeout=timeout_s)
+    out: dict[str, list[int]] = {}
+    for topic, future in futures.items():
+        try:
+            description = _await(future, timeout_s=timeout_s, what=f"describe topic {topic!r}")
+        except KafkaException as e:
+            # A per-topic failure is not necessarily a missing topic: it also
+            # covers authorization failures (``TOPIC_AUTHORIZATION_FAILED``) and
+            # leader-election churn. Reporting all of those as "not found" sends
+            # users looking for the wrong misconfiguration, so relay what the
+            # broker actually said.
+            error = e.args[0]
+            if error.code() == KafkaError.UNKNOWN_TOPIC_OR_PART:
+                msg = f"Topic {topic!r} not found on broker"
+            else:
+                msg = f"Topic {topic!r} is not available: {error}"
+            raise ValueError(msg) from e
+        if description.is_internal:
+            continue
+        out[topic] = sorted(p.id for p in description.partitions)
+    return out
+
+
+def _list_topic_partitions(
+    admin: AdminClient, subscription: tuple[str, object], *, timeout_s: float
+) -> list[TopicPartition]:
+    """Enumerate the (topic, partition) pairs selected by the subscription."""
+    strategy, value = subscription
+
+    if strategy == "subscribePattern":
+        # Only the pattern strategy needs the full topic list; the other two
+        # name their topics up front and can go straight to `describe_topics`.
+        metadata = admin.list_topics(timeout=timeout_s)
+        names = sorted(topic for topic in metadata.topics if value.fullmatch(topic))
+        if not names:
+            return []
+        described = _describe_topics(admin, names, timeout_s=timeout_s)
+        return [TopicPartition(topic, p) for topic in sorted(described) for p in described[topic]]
+
+    topics = list(value) if strategy == "subscribe" else list(value.keys())
+    described = _describe_topics(admin, topics, timeout_s=timeout_s)
+
+    out: list[TopicPartition] = []
+    for topic in topics:
+        if topic not in described:
+            # The topic exists but the broker flags it internal. Spark's
+            # `retrieveAllPartitions` filters it out of every strategy, leaving
+            # a read with no partitions rather than an error.
+            continue
+        available = described[topic]
+        if strategy == "subscribe":
+            out.extend(TopicPartition(topic, p) for p in available)
+            continue
+        missing = sorted(set(value[topic]) - set(available))
+        if missing:
+            msg = (
+                f"'assign' names partitions that do not exist for topic {topic!r}: {missing}. "
+                f"Available partitions: {available}"
+            )
+            raise ValueError(msg)
+        out.extend(TopicPartition(topic, p) for p in sorted(set(value[topic])))
+    return out
+
+
+def _validate_spec_partitions(
+    spec: str | int | dict[str, dict[str, int]] | None,
+    tps: list[TopicPartition],
+    *,
+    option_name: str,
+) -> None:
+    """Require a per-partition spec to name exactly the assigned partitions.
+
+    Spark asserts ``partitions == partitionOffsets.keySet`` once the broker's
+    partitions are known ("If startingOffsets contains specific offsets, you
+    must specify all TopicPartitions"). Without that check an omitted partition
+    silently falls back to a watermark and an extra or misspelled one is
+    dropped, so a typo turns into a successful read of the wrong data. String
+    sentinels and global timestamps have no partition keys and pass through.
+    """
+    if not isinstance(spec, dict):
+        return
+    specified = {(topic, int(partition)) for topic, partitions in spec.items() for partition in partitions}
+    assigned = {(tp.topic, tp.partition) for tp in tps}
+    if specified == assigned:
+        return
+    missing = sorted(assigned - specified)
+    extra = sorted(specified - assigned)
+    details = []
+    if missing:
+        details.append(f"missing: {missing}")
+    if extra:
+        details.append(f"not assigned: {extra}")
+    msg = (
+        f"'{option_name}' must specify all assigned TopicPartitions ({', '.join(details)}). "
+        f"Use -1 for latest and -2 for earliest. "
+        f"Specified: {sorted(specified)} Assigned: {sorted(assigned)}"
+    )
+    raise ValueError(msg)
+
+
+def _list_offsets(
+    admin: AdminClient, specs: dict[tuple[str, int], object], *, timeout_s: float
+) -> dict[tuple[str, int], int]:
+    """Resolve ``{(topic, partition): OffsetSpec}`` to concrete offsets in one request.
+
+    Spark's ``KafkaOffsetReaderAdmin`` resolves every partition with a single
+    ``admin.listOffsets`` call. Asking per partition instead would turn planning
+    a wide topic into one blocking round-trip per partition.
+
+    ``isolation_level`` is pinned to ``READ_UNCOMMITTED``, matching both the
+    Java admin client's default (which is what Spark gets) and the reader's own
+    ``isolation.level``. Under ``READ_COMMITTED`` the broker answers a "latest"
+    query with the last stable offset instead of the high watermark, so an open
+    transaction would silently shrink the planned range.
+    """
+    if not specs:
+        return {}
+    futures = admin.list_offsets(
+        {TopicPartition(topic, partition): spec for (topic, partition), spec in specs.items()},
+        isolation_level=IsolationLevel.READ_UNCOMMITTED,
+        request_timeout=timeout_s,
+    )
+    out: dict[tuple[str, int], int] = {}
+    for tp, future in futures.items():
+        try:
+            result = _await(future, timeout_s=timeout_s, what=f"list offsets for {tp.topic}[{tp.partition}]")
+            out[(tp.topic, tp.partition)] = result.offset
+        except KafkaException as e:
+            msg = f"Failed to look up offsets for {tp.topic}[{tp.partition}]: {e.args[0]}"
+            raise ValueError(msg) from e
+    return out
+
+
+def _map_offset_spec(tps: list[TopicPartition], spec: str | dict[str, dict[str, int]]) -> dict[tuple[str, int], int]:
+    """Map a starting/ending-offset spec to a per-partition offset.
+
+    ``earliest``/``latest`` — in either the string form or the JSON ``-2``/``-1``
+    form — are returned as those sentinels rather than resolved, and are bound
+    per task in :func:`_bind_partition_range`. Spark's ``fetchPartitionOffsets``
+    does the same, which is what lets a batch read pick up records produced
+    after planning and keeps an ``earliest`` start valid if the log ages on.
+
+    No broker call is made here; explicit numeric offsets are used as given.
+    """
+    if spec == _SENTINEL_EARLIEST:
+        return {(tp.topic, tp.partition): _SPARK_OFFSET_EARLIEST for tp in tps}
+    if spec == _SENTINEL_LATEST:
+        return {(tp.topic, tp.partition): _SPARK_OFFSET_LATEST for tp in tps}
+
+    # Explicit per-topic-partition JSON. `_validate_spec_partitions` has already
+    # required an entry for every assigned partition, so a lookup miss is not
+    # reachable here. `-1`/`-2` are already the sentinel values, so they pass
+    # through unchanged.
+    return {(tp.topic, tp.partition): int(spec[tp.topic][str(tp.partition)]) for tp in tps}
+
+
+def _resolve_by_timestamp(
+    admin: AdminClient,
+    tps: list[TopicPartition],
+    spec: int | dict[str, dict[str, int]],
+    *,
+    endpoint: str,
+    timeout_s: float,
+    strategy: str,
+) -> dict[tuple[str, int], int]:
+    """Resolve a timestamp spec to concrete offsets via a timestamp ``list_offsets``.
+
+    ``spec`` is either a global ``int`` (ms since epoch, applied to every
+    partition) or a mapping ``{topic: {partition_str: ts_ms}}``.
+
+    When a partition holds no message with ``ts >= T``, Spark's behaviour
+    depends on the endpoint: an ending timestamp falls back to the latest
+    offset, while a starting timestamp follows
+    ``startingOffsetsByTimestampStrategy`` — ``error`` (the default) fails the
+    query, and ``latest`` bounds the read to what is currently in the log.
+    Always falling back would silently return an empty result for a mistaken or
+    future starting timestamp.
+
+    Note: the lookup searches the topic's actual stored timestamps. If the topic
+    is configured with ``message.timestamp.type=LogAppendTime`` the search is
+    against broker ingest time; otherwise it's against producer clocks
+    (``CreateTime``).
+    """
+    if isinstance(spec, int):
+        wanted = {(tp.topic, tp.partition): OffsetSpec.for_timestamp(spec) for tp in tps}
+    else:
+        # `_validate_spec_partitions` has already required an entry per assigned
+        # partition, so every lookup below is present.
+        wanted = {
+            (tp.topic, tp.partition): OffsetSpec.for_timestamp(int(spec[tp.topic][str(tp.partition)])) for tp in tps
+        }
+
+    # A broker-side failure surfaces as a raised `KafkaException` inside
+    # `_list_offsets`, which reports it rather than letting it read as "no
+    # timestamp match" — that would turn a lookup failure into a silently empty
+    # (starting) or widened (ending) read.
+    resolved = _list_offsets(admin, wanted, timeout_s=timeout_s)
+
+    # Partitions with no message at or after the timestamp come back as -1.
+    unmatched = [tp for tp in tps if resolved.get((tp.topic, tp.partition), -1) < 0]
+    if unmatched and endpoint == "starting" and strategy == _TS_STRATEGY_ERROR:
+        tp = unmatched[0]
+        msg = (
+            f"No offset matches the requested timestamp for {tp.topic}[{tp.partition}]. "
+            f"Set 'startingOffsetsByTimestampStrategy' to 'latest' to read from the end of "
+            f"the log instead of failing."
+        )
+        raise ValueError(msg)
+    if unmatched:
+        fallback = _list_offsets(
+            admin,
+            {(tp.topic, tp.partition): OffsetSpec.latest() for tp in unmatched},
+            timeout_s=timeout_s,
+        )
+        resolved.update(fallback)
+    return resolved
+
+
+# ============================================================================
+# DataSource
+# ============================================================================
+
+
+class KafkaDataSource(DataSource):
+    """Kafka batch data source backed by confluent-kafka.
+
+    Every ``.load()`` resolves to a bounded ``[start, end)`` range per
+    partition on the driver, then reads that range on executors. There is
+    no streaming / continuous mode.
+
+    Register and use::
+
+        from pysail.spark.datasource.kafka import KafkaDataSource
+
+        spark.dataSource.register(KafkaDataSource)
+
+        df = (
+            spark.read.format("kafka")
+            .option("kafka.bootstrap.servers", "localhost:9092")
+            .option("subscribe", "orders")
+            .option("startingOffsets", "earliest")
+            .option("endingOffsets", "latest")
+            .load()
+        )
+
+    Options (as in Spark's Kafka source; option names are case-insensitive):
+
+    +--------------------------------+----------+----------+------------------------------------------+
+    | Option                         | Required | Default  | Description                              |
+    +================================+==========+==========+==========================================+
+    | kafka.bootstrap.servers        | Yes      |          | Broker list                              |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | assign                         | One of   |          | ``{"topic": [partition, ...]}`` JSON     |
+    +--------------------------------+ the      +----------+------------------------------------------+
+    | subscribe                      | three    |          | Comma-separated topic names              |
+    +--------------------------------+          +----------+------------------------------------------+
+    | subscribePattern               |          |          | Topic-name regular expression            |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | startingOffsets                | No       | earliest | "earliest" / per-tp JSON                 |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | endingOffsets                  | No       | latest   | "latest" / per-tp JSON                   |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | startingTimestamp              | No       |          | Global ms since epoch                    |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | endingTimestamp                | No       |          | Global ms since epoch                    |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | startingOffsetsByTimestamp     | No       |          | Per-tp timestamp JSON (ms since epoch)   |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | endingOffsetsByTimestamp       | No       |          | Per-tp timestamp JSON (ms since epoch)   |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | startingOffsetsByTimestampStrategy | No   | error    | ``error`` / ``latest`` on no match       |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | failOnDataLoss                 | No       | true     | Fail when planned records are gone       |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | includeHeaders                 | No       | false    | Include the ``headers`` column           |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | minPartitions                  | No       |          | Lower bound on input partitions          |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | maxRecordsPerPartition         | No       |          | Upper bound on records per partition     |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | kafkaConsumer.pollTimeoutMs    | No       | 120000   | ``consumer.poll()`` timeout; also        |
+    |                                |          |          | accepted as ``pollTimeoutMs``            |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | maxBatchRows                   | No       | 10000    | Max rows per Arrow RecordBatch (Sail)    |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | stallTimeoutMs                 | No       | 300000   | Idle time before failing a read (Sail)   |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | adminTimeoutMs                 | No       | 10000    | Metadata / offset-lookup timeout (Sail)  |
+    +--------------------------------+----------+----------+------------------------------------------+
+    | kafka.*                        | No       |          | Any extra librdkafka client config       |
+    +--------------------------------+----------+----------+------------------------------------------+
+
+    Where both an offsets option and a timestamp option are given for the same
+    endpoint, Spark's precedence applies: the global timestamp wins, then the
+    per-partition timestamp map, then the offsets. As in Spark's batch source,
+    ``latest`` (and its JSON form ``-1``) is rejected for ``startingOffsets``,
+    and ``earliest`` (``-2``) for ``endingOffsets``; per-partition JSON must
+    name every assigned partition. Timestamp-based reads resolve through a
+    timestamp ``list_offsets`` lookup, which searches the topic's stored
+    timestamps — configure the topic with ``message.timestamp.type=LogAppendTime``
+    if you want the search against broker ingest time rather than producer clocks.
+
+    Not supported: writes, streaming reads, and filter pushdown.
+
+    Planning cost: partitions are enumerated with one ``describe_topics`` call.
+    ``earliest``/``latest`` need no call at all, being bound per task; timestamps
+    and any endpoint that ``minPartitions``/``maxRecordsPerPartition`` forces to
+    resolve early take one batched ``list_offsets`` call per endpoint, however
+    many partitions are involved — the same shape as Spark's
+    ``KafkaOffsetReaderAdmin``. ``adminTimeoutMs`` bounds each of them.
+    """
+
+    @classmethod
+    def name(cls) -> str:
+        return "kafka"
+
+    @cached_property
+    def _resolved(self) -> dict:
+        # Spark data source options are case-insensitive. Sail and PySpark both
+        # construct this class with a ``CaseInsensitiveDict``; re-wrapping keeps
+        # that behavior when the class is constructed directly (as the parsing
+        # tests do) and — unlike ``dict(self.options)`` — does not flatten the
+        # mapping back into a case-sensitive one, which would strand every
+        # camelCase lookup below against lowercased keys.
+        opts = CaseInsensitiveDict(self.options)
+
+        client_config = _extract_kafka_config(opts)
+        if "bootstrap.servers" not in client_config:
+            msg = "Option 'kafka.bootstrap.servers' is required for the kafka data source"
+            raise ValueError(msg)
+        _validate_kafka_config(client_config)
+
+        subscription = _parse_subscription(opts)
+
+        starting_offsets, starting_ts = _resolve_range_option(opts, endpoint="starting")
+        ending_offsets, ending_ts = _resolve_range_option(opts, endpoint="ending")
+
+        _validate_offset_spec(starting_offsets, endpoint="starting", option_name="startingOffsets")
+        _validate_offset_spec(ending_offsets, endpoint="ending", option_name="endingOffsets")
+
+        include_headers = _parse_bool(opts, "includeHeaders", default=False)
+        fail_on_data_loss = _parse_bool(opts, "failOnDataLoss", default=True)
+        max_batch_rows = _parse_positive_int(opts, "maxBatchRows", "10000")
+        stall_timeout_s = _parse_positive_ms(opts, ("stallTimeoutMs",), "300000")
+        min_partitions = _parse_optional_positive_int(opts, "minPartitions")
+        max_records_per_partition = _parse_optional_positive_int(opts, "maxRecordsPerPartition")
+        # A negative poll timeout makes ``consumer.poll()`` block indefinitely,
+        # which defeats the ``stallTimeoutMs`` stall guard entirely — that guard
+        # can only count polls that return. Zero spins the read loop instead.
+        # Neither is a usable configuration, so both are rejected.
+        #
+        # The default matches Spark's batch source, which falls back to
+        # ``spark.network.timeout`` (120s) for ``kafkaConsumer.pollTimeoutMs``.
+        poll_timeout_s = _parse_positive_ms(opts, ("kafkaConsumer.pollTimeoutMs", "pollTimeoutMs"), "120000")
+        admin_timeout_s = _parse_positive_ms(opts, ("adminTimeoutMs",), "10000")
+
+        return {
+            "subscription": subscription,
+            "starting_offsets": starting_offsets,
+            "ending_offsets": ending_offsets,
+            "starting_timestamps": starting_ts,
+            "ending_timestamps": ending_ts,
+            "starting_ts_strategy": _parse_ts_strategy(opts),
+            "client_config": client_config,
+            "include_headers": include_headers,
+            "poll_timeout_s": poll_timeout_s,
+            "max_batch_rows": max_batch_rows,
+            "stall_timeout_s": stall_timeout_s,
+            "admin_timeout_s": admin_timeout_s,
+            "fail_on_data_loss": fail_on_data_loss,
+            "min_partitions": min_partitions,
+            "max_records_per_partition": max_records_per_partition,
+        }
+
+    def schema(self) -> pa.Schema:
+        return _build_schema(include_headers=self._resolved["include_headers"])
+
+    def reader(self, schema: pa.Schema) -> KafkaDataSourceReader:
+        # Spark's Kafka source has a fixed schema and rejects a user-specified
+        # one outright. Sail hands whatever schema the caller supplied straight
+        # through to this method, so without a check here planning would
+        # advertise the user's columns while `read()` kept emitting Kafka's.
+        #
+        # Column names and types are compared, but not nullability: the schema
+        # Sail passes back has made a round trip through Arrow's C data
+        # interface, and a stricter comparison risks rejecting our own schema
+        # over a detail that cannot change what `read()` produces.
+        expected = _build_schema(include_headers=self._resolved["include_headers"])
+        if schema is not None and (schema.names != expected.names or schema.types != expected.types):
+            msg = (
+                f"The kafka data source has a fixed schema and does not accept a user-specified one.\n"
+                f"Expected: {expected}\nGot: {schema}"
+            )
+            raise ValueError(msg)
+        return KafkaDataSourceReader(**self._resolved)

--- a/python/pysail/tests/spark/datasource/test_kafka.py
+++ b/python/pysail/tests/spark/datasource/test_kafka.py
@@ -1,0 +1,734 @@
+"""Integration tests for the Kafka data source using testcontainers.
+
+A single-node Kafka container is started once per module and torn down at
+the end. Messages are seeded via a synchronous producer, then read back
+through Sail's Spark Connect server via ``spark.read.format("kafka")``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from pysail.testing.spark.utils.common import pyspark_version
+
+pytestmark = pytest.mark.integration
+
+if pyspark_version() < (4, 1):
+    pytest.skip("Python data source requires Spark 4.1+", allow_module_level=True)
+
+confluent_kafka = pytest.importorskip("confluent_kafka")
+testcontainers_kafka = pytest.importorskip("testcontainers.kafka")
+
+Producer = confluent_kafka.Producer
+KafkaContainer = testcontainers_kafka.KafkaContainer
+
+
+_TOPIC = "sail-test-topic"
+_TOPIC_ALT = "sail-test-topic-alt"
+_TOPIC_MSG_COUNT = 10
+_TOPIC_ALT_MSG_COUNT = 5
+
+
+@pytest.fixture(scope="module")
+def kafka_container():
+    with KafkaContainer() as container:
+        yield container
+
+
+@pytest.fixture(scope="module")
+def bootstrap_servers(kafka_container):
+    return kafka_container.get_bootstrap_server()
+
+
+def _flush(producer) -> None:
+    """Flush and assert the queue drained.
+
+    ``flush()`` returns the number of messages still queued when it gives up.
+    Ignoring that lets the suite seed fewer messages than expected and fail
+    later in an unrelated assertion, which is a confusing way to learn the
+    broker was slow.
+    """
+    remaining = producer.flush(timeout=15)
+    assert remaining == 0, f"producer failed to drain within 15s; {remaining} message(s) still queued"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _seed_messages(bootstrap_servers):
+    """Produce a fixed set of messages to two topics, single partition each."""
+    producer = Producer({"bootstrap.servers": bootstrap_servers})
+    for i in range(_TOPIC_MSG_COUNT):
+        producer.produce(
+            _TOPIC,
+            key=f"key-{i}".encode(),
+            value=f"value-{i}".encode(),
+            partition=0,
+            headers=[("h1", b"v1"), ("h2", b"v2")],
+        )
+        _flush(producer)
+        time.sleep(0.01)
+    for i in range(_TOPIC_ALT_MSG_COUNT):
+        producer.produce(
+            _TOPIC_ALT,
+            key=f"alt-{i}".encode(),
+            value=f"alt-value-{i}".encode(),
+            partition=0,
+        )
+    _flush(producer)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def register_kafka(spark):
+    from pysail.spark.datasource.kafka import KafkaDataSource
+
+    spark.dataSource.register(KafkaDataSource)
+
+
+@pytest.fixture
+def kafka_opts(bootstrap_servers):
+    return {"kafka.bootstrap.servers": bootstrap_servers}
+
+
+# ---------------------------------------------------------------------------
+# Basic read
+# ---------------------------------------------------------------------------
+
+
+def test_basic_read(spark, kafka_opts):
+    df = spark.read.format("kafka").option("subscribe", _TOPIC).options(**kafka_opts).load()
+    rows = df.collect()
+    assert len(rows) == _TOPIC_MSG_COUNT
+    assert all(r.topic == _TOPIC for r in rows)
+    values = sorted(bytes(r.value).decode() for r in rows)
+    assert values == [f"value-{i}" for i in range(_TOPIC_MSG_COUNT)]
+    # timestampType must use Spark's enum values (0=CreateTime, 1=LogAppendTime),
+    # not librdkafka's (1=CreateTime, 2=LogAppendTime). Default topic config is
+    # CreateTime, so every row should report 0.
+    assert all(r.timestampType == 0 for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# Fixed Spark-compatible schema
+# ---------------------------------------------------------------------------
+
+
+def test_schema(spark, kafka_opts):
+    df = spark.read.format("kafka").option("subscribe", _TOPIC).options(**kafka_opts).load()
+    schema_map = {f.name: f.dataType.simpleString() for f in df.schema.fields}
+    assert schema_map["key"] == "binary"
+    assert schema_map["value"] == "binary"
+    assert schema_map["topic"] == "string"
+    assert schema_map["partition"] == "int"
+    assert schema_map["offset"] == "bigint"
+    assert schema_map["timestampType"] == "int"
+    assert "headers" not in schema_map
+
+
+# ---------------------------------------------------------------------------
+# includeHeaders exposes the headers column
+# ---------------------------------------------------------------------------
+
+
+def test_include_headers(spark, kafka_opts):
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("includeHeaders", "true")
+        .options(**kafka_opts)
+        .load()
+    )
+    field_names = {f.name for f in df.schema.fields}
+    assert "headers" in field_names
+    row = df.collect()[0]
+    hdr_keys = {h.key for h in row.headers}
+    assert hdr_keys == {"h1", "h2"}
+
+
+# ---------------------------------------------------------------------------
+# JSON-scoped startingOffsets and endingOffsets
+# ---------------------------------------------------------------------------
+
+
+def test_json_offsets(spark, kafka_opts):
+    starting = json.dumps({_TOPIC: {"0": 2}})
+    ending = json.dumps({_TOPIC: {"0": 7}})
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("startingOffsets", starting)
+        .option("endingOffsets", ending)
+        .options(**kafka_opts)
+        .load()
+    )
+    offsets = sorted(r.offset for r in df.collect())
+    assert offsets == [2, 3, 4, 5, 6]  # end exclusive
+
+
+# ---------------------------------------------------------------------------
+# Spark-style sentinel offsets (-1 latest, -2 earliest)
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_offsets(spark, kafka_opts):
+    starting = json.dumps({_TOPIC: {"0": -2}})
+    ending = json.dumps({_TOPIC: {"0": -1}})
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("startingOffsets", starting)
+        .option("endingOffsets", ending)
+        .options(**kafka_opts)
+        .load()
+    )
+    assert df.count() == _TOPIC_MSG_COUNT
+
+
+# ---------------------------------------------------------------------------
+# Empty range returns zero rows without hanging
+# ---------------------------------------------------------------------------
+
+
+def test_empty_range(spark, kafka_opts):
+    starting = json.dumps({_TOPIC: {"0": 3}})
+    ending = json.dumps({_TOPIC: {"0": 3}})
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("startingOffsets", starting)
+        .option("endingOffsets", ending)
+        .options(**kafka_opts)
+        .load()
+    )
+    assert df.count() == 0
+
+
+def test_inverted_range_raises(spark, kafka_opts):
+    """An explicit start-past-end range must fail rather than silently
+    returning a partial (here empty) result, matching Spark's treatment of an
+    inverted range as data loss."""
+    starting = json.dumps({_TOPIC: {"0": 7}})
+    ending = json.dumps({_TOPIC: {"0": 3}})
+    with pytest.raises(Exception, match=r"Inverted offset range"):
+        (
+            spark.read.format("kafka")
+            .option("subscribe", _TOPIC)
+            .option("startingOffsets", starting)
+            .option("endingOffsets", ending)
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )
+
+
+def test_offsets_for_unsubscribed_topic_raises(spark, kafka_opts):
+    """A typo'd topic in the offsets JSON must not be silently ignored."""
+    with pytest.raises(Exception, match=r"must specify all assigned TopicPartitions"):
+        (
+            spark.read.format("kafka")
+            .option("subscribe", _TOPIC)
+            .option("startingOffsets", json.dumps({"not-subscribed": {"0": 2}}))
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )
+
+
+def test_offsets_missing_a_partition_raises(spark, kafka_opts):
+    """Spark asserts the specific-offsets map covers every assigned partition.
+
+    An omitted partition would otherwise fall back to a watermark, so the read
+    silently starts somewhere the user did not ask for.
+    """
+    with pytest.raises(Exception, match=r"must specify all assigned TopicPartitions"):
+        (
+            spark.read.format("kafka")
+            .option("subscribe", f"{_TOPIC},{_TOPIC_ALT}")
+            .option("startingOffsets", json.dumps({_TOPIC: {"0": 2}}))
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-topic subscribe unions both topics
+# ---------------------------------------------------------------------------
+
+
+def test_multi_topic(spark, kafka_opts):
+    df = spark.read.format("kafka").option("subscribe", f"{_TOPIC},{_TOPIC_ALT}").options(**kafka_opts).load()
+    topics = {r.topic for r in df.collect()}
+    assert topics == {_TOPIC, _TOPIC_ALT}
+    assert df.count() == _TOPIC_MSG_COUNT + _TOPIC_ALT_MSG_COUNT
+
+
+def test_duplicate_topic_not_double_counted(spark, kafka_opts):
+    """A repeated topic in `subscribe` must be deduped.
+
+    Without dedup each occurrence is enumerated separately, producing duplicate
+    input partitions over the same offset range and emitting every row twice.
+    """
+    df = spark.read.format("kafka").option("subscribe", f"{_TOPIC},{_TOPIC}").options(**kafka_opts).load()
+    assert df.count() == _TOPIC_MSG_COUNT
+    offsets = sorted(r.offset for r in df.collect())
+    assert offsets == list(range(_TOPIC_MSG_COUNT))
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_missing_bootstrap_raises(spark):
+    with pytest.raises(Exception, match=r"bootstrap\.servers"):
+        spark.read.format("kafka").option("subscribe", _TOPIC).load().collect()
+
+
+def test_missing_subscribe_raises(spark, kafka_opts):
+    with pytest.raises(Exception, match=r"subscribe"):
+        spark.read.format("kafka").options(**kafka_opts).load().collect()
+
+
+def test_unknown_topic_raises(spark, kafka_opts):
+    with pytest.raises(Exception, match=r"not found"):
+        spark.read.format("kafka").option("subscribe", "does-not-exist").options(**kafka_opts).load().collect()
+
+
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [
+        ("startingOffsets", "latest"),
+        ("endingOffsets", "earliest"),
+        ("startingOffsets", json.dumps({_TOPIC: {"0": -1}})),
+        ("endingOffsets", json.dumps({_TOPIC: {"0": -2}})),
+    ],
+)
+def test_wrong_endpoint_sentinel_raises(spark, kafka_opts, option, value):
+    """Spark's batch source rejects latest-at-start and earliest-at-end.
+
+    Both always resolve to an empty range, so they must fail loudly rather than
+    silently returning no rows.
+    """
+    with pytest.raises(Exception, match=r"does not support"):
+        (
+            spark.read.format("kafka")
+            .option("subscribe", _TOPIC)
+            .option(option, value)
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )
+
+
+def test_out_of_range_offset_sentinel_raises(spark, kafka_opts):
+    """-1000 is librdkafka's OFFSET_STORED; passed through it would silently
+    read from committed consumer-group offsets."""
+    with pytest.raises(Exception, match=r"must be >= 0"):
+        (
+            spark.read.format("kafka")
+            .option("subscribe", _TOPIC)
+            .option("startingOffsets", json.dumps({_TOPIC: {"0": -1000}}))
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Timestamp-based reads (list_offsets by timestamp)
+# ---------------------------------------------------------------------------
+
+
+def test_starting_timestamp(spark, kafka_opts):
+    """Global startingTimestamp resolves via a timestamp list_offsets lookup."""
+    # Grab the timestamp of message at offset 5, then start from there.
+    baseline = (
+        spark.read.format("kafka").option("subscribe", _TOPIC).options(**kafka_opts).load().orderBy("offset").collect()
+    )
+    pivot_ts_ms = int(baseline[5].timestamp.timestamp() * 1000)
+
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("startingTimestamp", str(pivot_ts_ms))
+        .options(**kafka_opts)
+        .load()
+    )
+    rows = sorted(df.collect(), key=lambda r: r.offset)
+    assert rows, "startingTimestamp should return at least the pivot message"
+    assert all(int(r.timestamp.timestamp() * 1000) >= pivot_ts_ms for r in rows)
+    assert rows[-1].offset == _TOPIC_MSG_COUNT - 1
+
+
+def test_offsets_by_timestamp_json(spark, kafka_opts):
+    """Per-partition startingOffsetsByTimestamp with a far-past timestamp
+    behaves like earliest."""
+    starting = json.dumps({_TOPIC: {"0": 0}})  # epoch = before any message
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("startingOffsetsByTimestamp", starting)
+        .options(**kafka_opts)
+        .load()
+    )
+    assert df.count() == _TOPIC_MSG_COUNT
+
+
+def test_starting_timestamp_future_raises_by_default(spark, kafka_opts):
+    """Spark defaults startingOffsetsByTimestampStrategy to `error`.
+
+    A future or mistaken starting timestamp must fail rather than silently
+    return an empty result.
+    """
+    far_future_ms = 4102444800000  # year 2100
+    with pytest.raises(Exception, match=r"No offset matches the requested timestamp"):
+        (
+            spark.read.format("kafka")
+            .option("subscribe", _TOPIC)
+            .option("startingTimestamp", str(far_future_ms))
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )
+
+
+def test_starting_timestamp_future_with_latest_strategy_reads_nothing(spark, kafka_opts):
+    """Only an explicit `latest` strategy falls back to the high watermark."""
+    far_future_ms = 4102444800000  # year 2100
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("startingTimestamp", str(far_future_ms))
+        .option("startingOffsetsByTimestampStrategy", "latest")
+        .options(**kafka_opts)
+        .load()
+    )
+    assert df.count() == 0
+
+
+def test_starting_timestamp_takes_precedence_over_offsets(spark, kafka_opts):
+    """Spark applies precedence rather than rejecting the combination.
+
+    The global timestamp wins and the offsets value is never parsed, so a job
+    supplying a fallback keeps working.
+    """
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("startingOffsets", "earliest")
+        .option("startingTimestamp", "0")  # epoch: before every message
+        .options(**kafka_opts)
+        .load()
+    )
+    assert df.count() == _TOPIC_MSG_COUNT
+
+
+def test_ending_timestamp(spark, kafka_opts):
+    """endingTimestamp resolves via a timestamp lookup and bounds the read."""
+    baseline = (
+        spark.read.format("kafka").option("subscribe", _TOPIC).options(**kafka_opts).load().orderBy("offset").collect()
+    )
+    pivot_ts_ms = int(baseline[5].timestamp.timestamp() * 1000)
+
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("endingTimestamp", str(pivot_ts_ms))
+        .options(**kafka_opts)
+        .load()
+    )
+    rows = sorted(df.collect(), key=lambda r: r.offset)
+    assert rows, "endingTimestamp should return at least the earliest messages"
+    # Every returned row has timestamp strictly less than the pivot — the
+    # ending offset is the first offset with ts >= pivot, and the read range
+    # is end-exclusive.
+    assert all(int(r.timestamp.timestamp() * 1000) < pivot_ts_ms for r in rows)
+
+
+def test_ending_offsets_by_timestamp_json(spark, kafka_opts):
+    """Per-partition endingOffsetsByTimestamp with a far-future timestamp
+    reads everything currently in the log."""
+    far_future_ms = 4102444800000  # year 2100
+    ending = json.dumps({_TOPIC: {"0": far_future_ms}})
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("endingOffsetsByTimestamp", ending)
+        .options(**kafka_opts)
+        .load()
+    )
+    assert df.count() == _TOPIC_MSG_COUNT
+
+
+def test_ending_timestamp_takes_precedence_over_offsets(spark, kafka_opts):
+    far_future_ms = 4102444800000  # year 2100
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("endingOffsets", "latest")
+        .option("endingTimestamp", str(far_future_ms))
+        .options(**kafka_opts)
+        .load()
+    )
+    assert df.count() == _TOPIC_MSG_COUNT
+
+
+# ---------------------------------------------------------------------------
+# Subscription strategies — assign / subscribePattern
+# ---------------------------------------------------------------------------
+
+
+def test_assign(spark, kafka_opts):
+    df = spark.read.format("kafka").option("assign", json.dumps({_TOPIC: [0]})).options(**kafka_opts).load()
+    assert df.count() == _TOPIC_MSG_COUNT
+    assert {r.topic for r in df.collect()} == {_TOPIC}
+
+
+def test_assign_unknown_partition_raises(spark, kafka_opts):
+    with pytest.raises(Exception, match=r"partitions that do not exist"):
+        (spark.read.format("kafka").option("assign", json.dumps({_TOPIC: [7]})).options(**kafka_opts).load().collect())
+
+
+def test_subscribe_pattern(spark, kafka_opts):
+    """The pattern is matched against whole topic names, as Spark does."""
+    df = spark.read.format("kafka").option("subscribePattern", "sail-test-topic(-alt)?").options(**kafka_opts).load()
+    assert {r.topic for r in df.collect()} == {_TOPIC, _TOPIC_ALT}
+    assert df.count() == _TOPIC_MSG_COUNT + _TOPIC_ALT_MSG_COUNT
+
+
+def test_subscribe_pattern_narrow(spark, kafka_opts):
+    df = spark.read.format("kafka").option("subscribePattern", ".*-alt").options(**kafka_opts).load()
+    assert {r.topic for r in df.collect()} == {_TOPIC_ALT}
+
+
+def test_multiple_subscription_strategies_raise(spark, kafka_opts):
+    with pytest.raises(Exception, match=r"Only one of the following options"):
+        (
+            spark.read.format("kafka")
+            .option("subscribe", _TOPIC)
+            .option("assign", json.dumps({_TOPIC: [0]}))
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )
+
+
+# ---------------------------------------------------------------------------
+# minPartitions / maxRecordsPerPartition
+#
+# Spark splits Kafka offset ranges into additional input partitions for these.
+# The observable guarantee through the DataFrame API is that splitting changes
+# neither the rows nor their offsets.
+# ---------------------------------------------------------------------------
+
+
+def test_min_partitions_preserves_rows(spark, kafka_opts):
+    df = (
+        spark.read.format("kafka").option("subscribe", _TOPIC).option("minPartitions", "4").options(**kafka_opts).load()
+    )
+    offsets = sorted(r.offset for r in df.collect())
+    assert offsets == list(range(_TOPIC_MSG_COUNT))
+
+
+def test_max_records_per_partition_preserves_rows(spark, kafka_opts):
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("maxRecordsPerPartition", "3")
+        .options(**kafka_opts)
+        .load()
+    )
+    offsets = sorted(r.offset for r in df.collect())
+    assert offsets == list(range(_TOPIC_MSG_COUNT))
+
+
+# ---------------------------------------------------------------------------
+# failOnDataLoss
+# ---------------------------------------------------------------------------
+
+
+def test_ending_offset_past_end_of_log_raises(spark, kafka_opts):
+    """An end offset the log cannot reach is data loss under the default.
+
+    The read stops at end-of-log below the planned end, and with
+    failOnDataLoss=true (Spark's default) that must fail rather than return a
+    partial result that looks like a successful read.
+    """
+    ending = json.dumps({_TOPIC: {"0": _TOPIC_MSG_COUNT + 1000}})
+    with pytest.raises(Exception, match=r"Data loss"):
+        (
+            spark.read.format("kafka")
+            .option("subscribe", _TOPIC)
+            .option("endingOffsets", ending)
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )
+
+
+def test_fail_on_data_loss_false_returns_partial(spark, kafka_opts):
+    ending = json.dumps({_TOPIC: {"0": _TOPIC_MSG_COUNT + 1000}})
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("endingOffsets", ending)
+        .option("failOnDataLoss", "false")
+        .options(**kafka_opts)
+        .load()
+    )
+    assert df.count() == _TOPIC_MSG_COUNT
+
+
+def test_invalid_fail_on_data_loss_raises(spark, kafka_opts):
+    with pytest.raises(Exception, match=r"must be 'true' or 'false'"):
+        (
+            spark.read.format("kafka")
+            .option("subscribe", _TOPIC)
+            .option("failOnDataLoss", "maybe")
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Option validation that mirrors Spark's
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_include_headers_raises(spark, kafka_opts):
+    """Spark rejects a non-boolean; silently treating it as false would drop
+    the headers column the user asked for."""
+    with pytest.raises(Exception, match=r"must be 'true' or 'false'"):
+        (
+            spark.read.format("kafka")
+            .option("subscribe", _TOPIC)
+            .option("includeHeaders", "yes")
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )
+
+
+def test_protected_consumer_option_raises(spark, kafka_opts):
+    """`auto.offset.reset` is owned by the source: the planner already resolved
+    a concrete start, so a reset policy could only move it silently."""
+    with pytest.raises(Exception, match=r"is not supported"):
+        (
+            spark.read.format("kafka")
+            .option("subscribe", _TOPIC)
+            .option("kafka.auto.offset.reset", "earliest")
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )
+
+
+def test_user_specified_schema_rejected(spark, kafka_opts):
+    """Spark's Kafka source has a fixed schema and rejects a custom one."""
+    with pytest.raises(Exception, match=r"fixed schema"):
+        (
+            spark.read.format("kafka")
+            .schema("value STRING")
+            .option("subscribe", _TOPIC)
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Late binding of earliest/latest
+#
+# These drive the data source API directly rather than going through a
+# DataFrame. Spark Connect plans lazily at `collect()`, so the DataFrame API
+# gives no seam between planning and reading — and the seam is exactly what
+# these assert. Everything below still runs against the real broker: real
+# AdminClient, real consumer, real watermarks. A dedicated topic per test keeps
+# them from perturbing the row counts the rest of the module asserts.
+# ---------------------------------------------------------------------------
+
+
+def _plan_and_read(bootstrap_servers, topic, before_read, **options):
+    """Plan a read, run ``before_read`` against the broker, then read.
+
+    Returns the offsets the read produced. The callback runs after
+    ``partitions()`` and before ``read()``, which is the window in which a
+    late-bound endpoint is supposed to notice the broker has moved on.
+    """
+    from pysail.spark.datasource.kafka import KafkaDataSource
+
+    reader = KafkaDataSource(
+        options={"kafka.bootstrap.servers": bootstrap_servers, "subscribe": topic, **options}
+    ).reader(None)
+    partitions = reader.partitions()
+    before_read()
+    offsets = []
+    for partition in partitions:
+        for batch in reader.read(partition):
+            offsets.extend(batch.to_pylist()[i]["offset"] for i in range(batch.num_rows))
+    return sorted(offsets)
+
+
+def test_late_binding_picks_up_records_produced_after_planning(bootstrap_servers):
+    """`latest` means the end of the log when the task runs, as in Spark.
+
+    Spark carries the -1 sentinel to the executor and binds it in
+    `KafkaSourceRDD.resolveRange`. Resolving on the driver instead would stop at
+    the watermark captured during planning and silently drop this tail.
+    """
+    topic = "sail-test-late-bind-tail"
+    producer = Producer({"bootstrap.servers": bootstrap_servers})
+    for i in range(4):
+        producer.produce(topic, value=f"before-{i}".encode(), partition=0)
+    _flush(producer)
+
+    def produce_more():
+        for i in range(3):
+            producer.produce(topic, value=f"after-{i}".encode(), partition=0)
+        _flush(producer)
+
+    # Planned while the log held 4 records; 3 more land before the read runs.
+    assert _plan_and_read(bootstrap_servers, topic, produce_more) == [0, 1, 2, 3, 4, 5, 6]
+
+
+def test_late_binding_survives_retention_after_planning(bootstrap_servers):
+    """An `earliest` start stays valid when the log ages on mid-query.
+
+    A start frozen at planning would now sit below the low watermark, and with
+    the default `failOnDataLoss=true` that fails a query Spark completes by
+    simply re-resolving `earliest` at task start.
+    """
+    from confluent_kafka import TopicPartition
+    from confluent_kafka.admin import AdminClient
+
+    topic = "sail-test-late-bind-retention"
+    producer = Producer({"bootstrap.servers": bootstrap_servers})
+    for i in range(10):
+        producer.produce(topic, value=f"value-{i}".encode(), partition=0)
+    _flush(producer)
+
+    def truncate():
+        admin = AdminClient({"bootstrap.servers": bootstrap_servers})
+        futures = admin.delete_records([TopicPartition(topic, 0, 6)])
+        for future in futures.values():
+            future.result(timeout=30)
+
+    # Offsets 0-5 are deleted between planning and reading. The read must bind
+    # `earliest` to the new low watermark rather than fail on the stale one.
+    assert _plan_and_read(bootstrap_servers, topic, truncate) == [6, 7, 8, 9]
+
+
+def test_schema_fields_are_nullable(spark, kafka_opts):
+    """Spark declares every Kafka column nullable; nullability is user-visible
+    in printSchema and in write-compatibility checks."""
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("includeHeaders", "true")
+        .options(**kafka_opts)
+        .load()
+    )
+    assert all(f.nullable for f in df.schema.fields)

--- a/python/pysail/tests/spark/datasource/test_kafka.py
+++ b/python/pysail/tests/spark/datasource/test_kafka.py
@@ -1,0 +1,438 @@
+"""Integration tests for the Kafka data source using testcontainers.
+
+A single-node Kafka container is started once per module and torn down at
+the end. Messages are seeded via a synchronous producer, then read back
+through Sail's Spark Connect server via ``spark.read.format("kafka")``.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from pysail.testing.spark.utils.common import pyspark_version
+
+pytestmark = pytest.mark.integration
+
+if pyspark_version() < (4, 1):
+    pytest.skip("Python data source requires Spark 4.1+", allow_module_level=True)
+
+confluent_kafka = pytest.importorskip("confluent_kafka")
+testcontainers_kafka = pytest.importorskip("testcontainers.kafka")
+
+Producer = confluent_kafka.Producer
+KafkaContainer = testcontainers_kafka.KafkaContainer
+
+
+_TOPIC = "sail-test-topic"
+_TOPIC_ALT = "sail-test-topic-alt"
+_TOPIC_MSG_COUNT = 10
+_TOPIC_ALT_MSG_COUNT = 5
+
+
+@pytest.fixture(scope="module")
+def kafka_container():
+    with KafkaContainer() as container:
+        yield container
+
+
+@pytest.fixture(scope="module")
+def bootstrap_servers(kafka_container):
+    return kafka_container.get_bootstrap_server()
+
+
+def _flush(producer) -> None:
+    """Flush and assert the queue drained.
+
+    ``flush()`` returns the number of messages still queued when it gives up.
+    Ignoring that lets the suite seed fewer messages than expected and fail
+    later in an unrelated assertion, which is a confusing way to learn the
+    broker was slow.
+    """
+    remaining = producer.flush(timeout=15)
+    assert remaining == 0, f"producer failed to drain within 15s; {remaining} message(s) still queued"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _seed_messages(bootstrap_servers):
+    """Produce a fixed set of messages to two topics, single partition each."""
+    producer = Producer({"bootstrap.servers": bootstrap_servers})
+    for i in range(_TOPIC_MSG_COUNT):
+        producer.produce(
+            _TOPIC,
+            key=f"key-{i}".encode(),
+            value=f"value-{i}".encode(),
+            partition=0,
+            headers=[("h1", b"v1"), ("h2", b"v2")],
+        )
+        _flush(producer)
+        time.sleep(0.01)
+    for i in range(_TOPIC_ALT_MSG_COUNT):
+        producer.produce(
+            _TOPIC_ALT,
+            key=f"alt-{i}".encode(),
+            value=f"alt-value-{i}".encode(),
+            partition=0,
+        )
+    _flush(producer)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def register_kafka(spark):
+    from pysail.spark.datasource.kafka import KafkaDataSource
+
+    spark.dataSource.register(KafkaDataSource)
+
+
+@pytest.fixture
+def kafka_opts(bootstrap_servers):
+    return {"kafka.bootstrap.servers": bootstrap_servers}
+
+
+# ---------------------------------------------------------------------------
+# Basic read
+# ---------------------------------------------------------------------------
+
+
+def test_basic_read(spark, kafka_opts):
+    df = spark.read.format("kafka").option("subscribe", _TOPIC).options(**kafka_opts).load()
+    rows = df.collect()
+    assert len(rows) == _TOPIC_MSG_COUNT
+    assert all(r.topic == _TOPIC for r in rows)
+    values = sorted(bytes(r.value).decode() for r in rows)
+    assert values == [f"value-{i}" for i in range(_TOPIC_MSG_COUNT)]
+    # timestampType must use Spark's enum values (0=CreateTime, 1=LogAppendTime),
+    # not librdkafka's (1=CreateTime, 2=LogAppendTime). Default topic config is
+    # CreateTime, so every row should report 0.
+    assert all(r.timestampType == 0 for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# Fixed Spark-compatible schema
+# ---------------------------------------------------------------------------
+
+
+def test_schema(spark, kafka_opts):
+    df = spark.read.format("kafka").option("subscribe", _TOPIC).options(**kafka_opts).load()
+    schema_map = {f.name: f.dataType.simpleString() for f in df.schema.fields}
+    assert schema_map["key"] == "binary"
+    assert schema_map["value"] == "binary"
+    assert schema_map["topic"] == "string"
+    assert schema_map["partition"] == "int"
+    assert schema_map["offset"] == "bigint"
+    assert schema_map["timestampType"] == "int"
+    assert "headers" not in schema_map
+
+
+# ---------------------------------------------------------------------------
+# includeHeaders exposes the headers column
+# ---------------------------------------------------------------------------
+
+
+def test_include_headers(spark, kafka_opts):
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("includeHeaders", "true")
+        .options(**kafka_opts)
+        .load()
+    )
+    field_names = {f.name for f in df.schema.fields}
+    assert "headers" in field_names
+    row = df.collect()[0]
+    hdr_keys = {h.key for h in row.headers}
+    assert hdr_keys == {"h1", "h2"}
+
+
+# ---------------------------------------------------------------------------
+# JSON-scoped startingOffsets and endingOffsets
+# ---------------------------------------------------------------------------
+
+
+def test_json_offsets(spark, kafka_opts):
+    starting = json.dumps({_TOPIC: {"0": 2}})
+    ending = json.dumps({_TOPIC: {"0": 7}})
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("startingOffsets", starting)
+        .option("endingOffsets", ending)
+        .options(**kafka_opts)
+        .load()
+    )
+    offsets = sorted(r.offset for r in df.collect())
+    assert offsets == [2, 3, 4, 5, 6]  # end exclusive
+
+
+# ---------------------------------------------------------------------------
+# Spark-style sentinel offsets (-1 latest, -2 earliest)
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_offsets(spark, kafka_opts):
+    starting = json.dumps({_TOPIC: {"0": -2}})
+    ending = json.dumps({_TOPIC: {"0": -1}})
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("startingOffsets", starting)
+        .option("endingOffsets", ending)
+        .options(**kafka_opts)
+        .load()
+    )
+    assert df.count() == _TOPIC_MSG_COUNT
+
+
+# ---------------------------------------------------------------------------
+# Empty range returns zero rows without hanging
+# ---------------------------------------------------------------------------
+
+
+def test_empty_range(spark, kafka_opts):
+    starting = json.dumps({_TOPIC: {"0": 3}})
+    ending = json.dumps({_TOPIC: {"0": 3}})
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("startingOffsets", starting)
+        .option("endingOffsets", ending)
+        .options(**kafka_opts)
+        .load()
+    )
+    assert df.count() == 0
+
+
+def test_inverted_range_raises(spark, kafka_opts):
+    """An explicit start-past-end range must fail rather than silently
+    returning a partial (here empty) result, matching Spark's treatment of an
+    inverted range as data loss."""
+    starting = json.dumps({_TOPIC: {"0": 7}})
+    ending = json.dumps({_TOPIC: {"0": 3}})
+    with pytest.raises(Exception, match=r"Inverted offset range"):
+        (
+            spark.read.format("kafka")
+            .option("subscribe", _TOPIC)
+            .option("startingOffsets", starting)
+            .option("endingOffsets", ending)
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )
+
+
+def test_offsets_for_unsubscribed_topic_raises(spark, kafka_opts):
+    """A typo'd topic in the offsets JSON must not be silently ignored."""
+    with pytest.raises(Exception, match=r"not in 'subscribe'"):
+        (
+            spark.read.format("kafka")
+            .option("subscribe", _TOPIC)
+            .option("startingOffsets", json.dumps({"not-subscribed": {"0": 2}}))
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-topic subscribe unions both topics
+# ---------------------------------------------------------------------------
+
+
+def test_multi_topic(spark, kafka_opts):
+    df = spark.read.format("kafka").option("subscribe", f"{_TOPIC},{_TOPIC_ALT}").options(**kafka_opts).load()
+    topics = {r.topic for r in df.collect()}
+    assert topics == {_TOPIC, _TOPIC_ALT}
+    assert df.count() == _TOPIC_MSG_COUNT + _TOPIC_ALT_MSG_COUNT
+
+
+def test_duplicate_topic_not_double_counted(spark, kafka_opts):
+    """A repeated topic in `subscribe` must be deduped.
+
+    Without dedup each occurrence is enumerated separately, producing duplicate
+    input partitions over the same offset range and emitting every row twice.
+    """
+    df = spark.read.format("kafka").option("subscribe", f"{_TOPIC},{_TOPIC}").options(**kafka_opts).load()
+    assert df.count() == _TOPIC_MSG_COUNT
+    offsets = sorted(r.offset for r in df.collect())
+    assert offsets == list(range(_TOPIC_MSG_COUNT))
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_missing_bootstrap_raises(spark):
+    with pytest.raises(Exception, match=r"bootstrap\.servers"):
+        spark.read.format("kafka").option("subscribe", _TOPIC).load().collect()
+
+
+def test_missing_subscribe_raises(spark, kafka_opts):
+    with pytest.raises(Exception, match=r"subscribe"):
+        spark.read.format("kafka").options(**kafka_opts).load().collect()
+
+
+def test_unknown_topic_raises(spark, kafka_opts):
+    with pytest.raises(Exception, match=r"not found"):
+        spark.read.format("kafka").option("subscribe", "does-not-exist").options(**kafka_opts).load().collect()
+
+
+@pytest.mark.parametrize(
+    ("option", "value"),
+    [
+        ("startingOffsets", "latest"),
+        ("endingOffsets", "earliest"),
+        ("startingOffsets", json.dumps({_TOPIC: {"0": -1}})),
+        ("endingOffsets", json.dumps({_TOPIC: {"0": -2}})),
+    ],
+)
+def test_wrong_endpoint_sentinel_raises(spark, kafka_opts, option, value):
+    """Spark's batch source rejects latest-at-start and earliest-at-end.
+
+    Both always resolve to an empty range, so they must fail loudly rather than
+    silently returning no rows.
+    """
+    with pytest.raises(Exception, match=r"does not support"):
+        (
+            spark.read.format("kafka")
+            .option("subscribe", _TOPIC)
+            .option(option, value)
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )
+
+
+def test_out_of_range_offset_sentinel_raises(spark, kafka_opts):
+    """-1000 is librdkafka's OFFSET_STORED; passed through it would silently
+    read from committed consumer-group offsets."""
+    with pytest.raises(Exception, match=r"must be >= 0"):
+        (
+            spark.read.format("kafka")
+            .option("subscribe", _TOPIC)
+            .option("startingOffsets", json.dumps({_TOPIC: {"0": -1000}}))
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )
+
+
+# ---------------------------------------------------------------------------
+# Timestamp-based reads (offsets_for_times)
+# ---------------------------------------------------------------------------
+
+
+def test_starting_timestamp(spark, kafka_opts):
+    """Global startingTimestamp resolves via offsets_for_times."""
+    # Grab the timestamp of message at offset 5, then start from there.
+    baseline = (
+        spark.read.format("kafka").option("subscribe", _TOPIC).options(**kafka_opts).load().orderBy("offset").collect()
+    )
+    pivot_ts_ms = int(baseline[5].timestamp.timestamp() * 1000)
+
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("startingTimestamp", str(pivot_ts_ms))
+        .options(**kafka_opts)
+        .load()
+    )
+    rows = sorted(df.collect(), key=lambda r: r.offset)
+    assert rows, "startingTimestamp should return at least the pivot message"
+    assert all(int(r.timestamp.timestamp() * 1000) >= pivot_ts_ms for r in rows)
+    assert rows[-1].offset == _TOPIC_MSG_COUNT - 1
+
+
+def test_offsets_by_timestamp_json(spark, kafka_opts):
+    """Per-partition startingOffsetsByTimestamp with a far-past timestamp
+    behaves like earliest."""
+    starting = json.dumps({_TOPIC: {"0": 0}})  # epoch = before any message
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("startingOffsetsByTimestamp", starting)
+        .options(**kafka_opts)
+        .load()
+    )
+    assert df.count() == _TOPIC_MSG_COUNT
+
+
+def test_starting_timestamp_future_reads_nothing(spark, kafka_opts):
+    """A startingTimestamp far in the future resolves to the high watermark,
+    so no rows are returned — but the query does not fail. This is the
+    'never miss a message' semantic: rerun later and any new messages will
+    be picked up."""
+    far_future_ms = 4102444800000  # year 2100
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("startingTimestamp", str(far_future_ms))
+        .options(**kafka_opts)
+        .load()
+    )
+    assert df.count() == 0
+
+
+def test_conflicting_starting_options_raise(spark, kafka_opts):
+    with pytest.raises(Exception, match=r"cannot be combined|mutually exclusive"):
+        (
+            spark.read.format("kafka")
+            .option("subscribe", _TOPIC)
+            .option("startingOffsets", "earliest")
+            .option("startingTimestamp", "1000")
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )
+
+
+def test_ending_timestamp(spark, kafka_opts):
+    """endingTimestamp resolves via offsets_for_times and bounds the read."""
+    baseline = (
+        spark.read.format("kafka").option("subscribe", _TOPIC).options(**kafka_opts).load().orderBy("offset").collect()
+    )
+    pivot_ts_ms = int(baseline[5].timestamp.timestamp() * 1000)
+
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("endingTimestamp", str(pivot_ts_ms))
+        .options(**kafka_opts)
+        .load()
+    )
+    rows = sorted(df.collect(), key=lambda r: r.offset)
+    assert rows, "endingTimestamp should return at least the earliest messages"
+    # Every returned row has timestamp strictly less than the pivot — the
+    # ending offset is the first offset with ts >= pivot, and the read range
+    # is end-exclusive.
+    assert all(int(r.timestamp.timestamp() * 1000) < pivot_ts_ms for r in rows)
+
+
+def test_ending_offsets_by_timestamp_json(spark, kafka_opts):
+    """Per-partition endingOffsetsByTimestamp with a far-future timestamp
+    reads everything currently in the log."""
+    far_future_ms = 4102444800000  # year 2100
+    ending = json.dumps({_TOPIC: {"0": far_future_ms}})
+    df = (
+        spark.read.format("kafka")
+        .option("subscribe", _TOPIC)
+        .option("endingOffsetsByTimestamp", ending)
+        .options(**kafka_opts)
+        .load()
+    )
+    assert df.count() == _TOPIC_MSG_COUNT
+
+
+def test_conflicting_ending_options_raise(spark, kafka_opts):
+    with pytest.raises(Exception, match=r"cannot be combined|mutually exclusive"):
+        (
+            spark.read.format("kafka")
+            .option("subscribe", _TOPIC)
+            .option("endingOffsets", "latest")
+            .option("endingTimestamp", "1000")
+            .options(**kafka_opts)
+            .load()
+            .collect()
+        )

--- a/python/pysail/tests/spark/datasource/test_kafka_parsing.py
+++ b/python/pysail/tests/spark/datasource/test_kafka_parsing.py
@@ -1,0 +1,395 @@
+"""Unit tests for pure option-parsing helpers in the Kafka data source.
+
+These don't touch Kafka or Docker — they cover the parsing/validation surface
+that would otherwise only be exercised through the integration tests.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pysail.testing.spark.utils.common import pyspark_version
+
+if pyspark_version() < (4, 1):
+    pytest.skip("Python data source requires Spark 4.1+", allow_module_level=True)
+
+pytest.importorskip("confluent_kafka")
+
+from pysail.spark.datasource.kafka import (
+    KafkaDataSource,
+    _build_consumer_config,
+    _extract_kafka_config,
+    _parse_offset_spec,
+    _parse_timestamp_spec,
+    _validate_offset_spec,
+)
+
+_TS_MS = 1700000000000
+_POLL_TIMEOUT_MS = 250
+
+# ---------------------------------------------------------------------------
+# _parse_offset_spec
+# ---------------------------------------------------------------------------
+
+
+class TestParseOffsetSpec:
+    def test_none_returns_default(self):
+        assert _parse_offset_spec(None, default="earliest") == "earliest"
+        assert _parse_offset_spec(None, default=None) is None
+
+    def test_blank_returns_default(self):
+        assert _parse_offset_spec("", default="latest") == "latest"
+        assert _parse_offset_spec("   ", default="latest") == "latest"
+
+    def test_earliest_sentinel(self):
+        assert _parse_offset_spec("earliest", default=None) == "earliest"
+
+    def test_latest_sentinel(self):
+        assert _parse_offset_spec("latest", default=None) == "latest"
+
+    def test_stripped_sentinel(self):
+        assert _parse_offset_spec("  earliest  ", default=None) == "earliest"
+
+    def test_json_object(self):
+        result = _parse_offset_spec('{"t": {"0": 5}}', default=None)
+        assert result == {"t": {"0": 5}}
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(ValueError, match="Invalid offset spec"):
+            _parse_offset_spec("not-json", default=None)
+
+    def test_non_object_json_raises(self):
+        with pytest.raises(ValueError, match="must be an object"):
+            _parse_offset_spec("[1, 2, 3]", default=None)
+
+    def test_non_object_topic_value_raises(self):
+        with pytest.raises(ValueError, match="topic 't' must be an object"):
+            _parse_offset_spec('{"t": 5}', default=None)
+
+    def test_non_int_partition_value_raises(self):
+        with pytest.raises(ValueError, match="partition '0' must be an integer"):
+            _parse_offset_spec('{"t": {"0": "x"}}', default=None)
+
+    def test_bool_partition_value_raises(self):
+        with pytest.raises(ValueError, match="must be an integer"):
+            _parse_offset_spec('{"t": {"0": true}}', default=None)
+
+
+# ---------------------------------------------------------------------------
+# _parse_timestamp_spec
+# ---------------------------------------------------------------------------
+
+
+class TestParseTimestampSpec:
+    def test_both_unset_returns_none(self):
+        assert _parse_timestamp_spec(None, None, endpoint="starting") is None
+        assert _parse_timestamp_spec("", "", endpoint="starting") is None
+
+    def test_global_int(self):
+        assert _parse_timestamp_spec("1700000000000", None, endpoint="starting") == _TS_MS
+
+    def test_global_int_stripped(self):
+        assert _parse_timestamp_spec("  1700000000000  ", None, endpoint="ending") == _TS_MS
+
+    def test_per_tp_json(self):
+        result = _parse_timestamp_spec(None, '{"t": {"0": 1700000000000}}', endpoint="starting")
+        assert result == {"t": {"0": _TS_MS}}
+
+    def test_both_set_raises(self):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            _parse_timestamp_spec("1000", '{"t": {}}', endpoint="starting")
+
+    def test_endpoint_appears_in_error(self):
+        with pytest.raises(ValueError, match=r"'ending"):
+            _parse_timestamp_spec("1000", '{"t": {}}', endpoint="ending")
+
+    def test_invalid_global_raises(self):
+        with pytest.raises(ValueError, match="must be an integer"):
+            _parse_timestamp_spec("not-a-number", None, endpoint="starting")
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(ValueError, match="Invalid 'starting"):
+            _parse_timestamp_spec(None, "not-json", endpoint="starting")
+
+    def test_non_object_json_raises(self):
+        with pytest.raises(ValueError, match="must be an object"):
+            _parse_timestamp_spec(None, "[1, 2, 3]", endpoint="starting")
+
+    def test_non_object_topic_value_raises(self):
+        with pytest.raises(ValueError, match="topic 't' must be an object"):
+            _parse_timestamp_spec(None, '{"t": 5}', endpoint="starting")
+
+    def test_non_int_partition_value_raises(self):
+        with pytest.raises(ValueError, match="partition '0' must be an integer"):
+            _parse_timestamp_spec(None, '{"t": {"0": "x"}}', endpoint="ending")
+
+
+# ---------------------------------------------------------------------------
+# _extract_kafka_config
+# ---------------------------------------------------------------------------
+
+
+class TestExtractKafkaConfig:
+    def test_strips_kafka_prefix(self):
+        opts = {
+            "kafka.bootstrap.servers": "localhost:9092",
+            "kafka.security.protocol": "SASL_SSL",
+            "subscribe": "orders",
+            "includeHeaders": "true",
+        }
+        assert _extract_kafka_config(opts) == {
+            "bootstrap.servers": "localhost:9092",
+            "security.protocol": "SASL_SSL",
+        }
+
+    def test_no_kafka_options(self):
+        assert _extract_kafka_config({"subscribe": "t"}) == {}
+
+    def test_empty_dict(self):
+        assert _extract_kafka_config({}) == {}
+
+
+# ---------------------------------------------------------------------------
+# _build_consumer_config
+# ---------------------------------------------------------------------------
+
+
+class TestBuildConsumerConfig:
+    def test_defaults_applied(self):
+        config = _build_consumer_config({"bootstrap.servers": "localhost:9092"}, role="reader")
+        assert config["bootstrap.servers"] == "localhost:9092"
+        assert config["group.id"] == "sail-kafka-reader"
+        assert config["enable.auto.commit"] is False
+        assert config["auto.offset.reset"] == "error"
+
+    def test_role_reflected_in_default_group_id(self):
+        planner = _build_consumer_config({}, role="planner")
+        reader = _build_consumer_config({}, role="reader")
+        assert planner["group.id"] == "sail-kafka-planner"
+        assert reader["group.id"] == "sail-kafka-reader"
+
+    def test_user_group_id_overrides_default(self):
+        config = _build_consumer_config(
+            {"bootstrap.servers": "localhost:9092", "group.id": "my-group"},
+            role="reader",
+        )
+        assert config["group.id"] == "my-group"
+
+    def test_user_enable_auto_commit_overrides_default(self):
+        # Users can override safety defaults if they really want to — we log
+        # nothing about it. Round-trip verifies the merge order.
+        config = _build_consumer_config(
+            {"bootstrap.servers": "localhost:9092", "enable.auto.commit": "true"},
+            role="reader",
+        )
+        assert config["enable.auto.commit"] == "true"
+
+
+# ---------------------------------------------------------------------------
+# KafkaDataSource._resolved — offset/timestamp mutual exclusion.
+# `_resolved` only parses options (no broker I/O), so it is unit-testable.
+# ---------------------------------------------------------------------------
+
+
+def _resolved(**extra):
+    opts = {"kafka.bootstrap.servers": "localhost:9092", "subscribe": "t", **extra}
+    return KafkaDataSource(options=opts)._resolved  # noqa: SLF001
+
+
+class TestResolvedMutualExclusion:
+    def test_blank_starting_offsets_with_timestamp_ok(self):
+        # Spark treats a blank offsets value as unset, so it must not conflict
+        # with a timestamp-based start.
+        resolved = _resolved(startingOffsets="", startingTimestamp="1700000000000")
+        assert resolved["starting_offsets"] is None
+        assert resolved["starting_timestamps"] == _TS_MS
+
+    def test_whitespace_ending_offsets_with_timestamp_ok(self):
+        resolved = _resolved(endingOffsets="   ", endingTimestamp="1700000000000")
+        assert resolved["ending_offsets"] is None
+        assert resolved["ending_timestamps"] == _TS_MS
+
+    def test_real_starting_offsets_with_timestamp_raises(self):
+        with pytest.raises(ValueError, match="cannot be combined"):
+            _resolved(startingOffsets="earliest", startingTimestamp="1700000000000")
+
+    def test_real_ending_offsets_with_timestamp_raises(self):
+        with pytest.raises(ValueError, match="cannot be combined"):
+            _resolved(endingOffsets="latest", endingTimestamp="1700000000000")
+
+
+# ---------------------------------------------------------------------------
+# Topic list handling
+# ---------------------------------------------------------------------------
+
+
+class TestResolvedTopics:
+    def test_duplicate_topics_deduped(self):
+        # A repeated topic would otherwise be enumerated once per occurrence,
+        # producing duplicate input partitions over the same offset range and
+        # emitting every row twice.
+        assert _resolved(subscribe="t,t, t")["topics"] == ["t"]
+
+    def test_dedup_preserves_first_seen_order(self):
+        assert _resolved(subscribe="b,a,b,c")["topics"] == ["b", "a", "c"]
+
+    def test_distinct_topics_unchanged(self):
+        assert _resolved(subscribe="a, b ,c")["topics"] == ["a", "b", "c"]
+
+
+# ---------------------------------------------------------------------------
+# _validate_offset_spec — Spark batch-mode sentinel rules
+# ---------------------------------------------------------------------------
+
+
+class TestValidateOffsetSpec:
+    def test_none_is_noop(self):
+        _validate_offset_spec(None, endpoint="starting", option_name="startingOffsets")
+        _validate_offset_spec(None, endpoint="ending", option_name="endingOffsets")
+
+    def test_allowed_string_sentinels(self):
+        _validate_offset_spec("earliest", endpoint="starting", option_name="startingOffsets")
+        _validate_offset_spec("latest", endpoint="ending", option_name="endingOffsets")
+
+    def test_latest_rejected_for_starting(self):
+        with pytest.raises(ValueError, match="does not support 'latest'"):
+            _validate_offset_spec("latest", endpoint="starting", option_name="startingOffsets")
+
+    def test_earliest_rejected_for_ending(self):
+        with pytest.raises(ValueError, match="does not support 'earliest'"):
+            _validate_offset_spec("earliest", endpoint="ending", option_name="endingOffsets")
+
+    def test_allowed_json_sentinels(self):
+        _validate_offset_spec({"t": {"0": -2}}, endpoint="starting", option_name="startingOffsets")
+        _validate_offset_spec({"t": {"0": -1}}, endpoint="ending", option_name="endingOffsets")
+
+    def test_json_latest_rejected_for_starting(self):
+        with pytest.raises(ValueError, match="does not support offset -1"):
+            _validate_offset_spec({"t": {"0": -1}}, endpoint="starting", option_name="startingOffsets")
+
+    def test_json_earliest_rejected_for_ending(self):
+        with pytest.raises(ValueError, match="does not support offset -2"):
+            _validate_offset_spec({"t": {"0": -2}}, endpoint="ending", option_name="endingOffsets")
+
+    def test_concrete_offsets_allowed(self):
+        _validate_offset_spec({"t": {"0": 0, "1": 12345}}, endpoint="starting", option_name="startingOffsets")
+        _validate_offset_spec({"t": {"0": 0, "1": 12345}}, endpoint="ending", option_name="endingOffsets")
+
+    @pytest.mark.parametrize("endpoint", ["starting", "ending"])
+    def test_offset_below_negative_two_rejected(self, endpoint):
+        with pytest.raises(ValueError, match="must be >= 0"):
+            _validate_offset_spec({"t": {"0": -3}}, endpoint=endpoint, option_name="opt")
+
+    @pytest.mark.parametrize("offset", [-1000, -1001])
+    def test_librdkafka_sentinels_rejected(self, offset):
+        # -1000 is OFFSET_STORED and -1001 is OFFSET_INVALID. Passed through,
+        # OFFSET_STORED would silently read from committed group offsets.
+        with pytest.raises(ValueError, match="must be >= 0"):
+            _validate_offset_spec({"t": {"0": offset}}, endpoint="starting", option_name="startingOffsets")
+
+    def test_error_names_the_offending_partition(self):
+        with pytest.raises(ValueError, match=r"topic 't' partition '3'"):
+            _validate_offset_spec({"t": {"0": 5, "3": -7}}, endpoint="starting", option_name="startingOffsets")
+
+
+class TestResolvedOffsetValidation:
+    """The validator must be wired into both call sites in `_resolved`."""
+
+    def test_starting_latest_rejected(self):
+        with pytest.raises(ValueError, match="does not support 'latest'"):
+            _resolved(startingOffsets="latest")
+
+    def test_ending_earliest_rejected(self):
+        with pytest.raises(ValueError, match="does not support 'earliest'"):
+            _resolved(endingOffsets="earliest")
+
+    def test_starting_json_latest_rejected(self):
+        with pytest.raises(ValueError, match="does not support offset -1"):
+            _resolved(startingOffsets='{"t": {"0": -1}}')
+
+    def test_ending_json_earliest_rejected(self):
+        with pytest.raises(ValueError, match="does not support offset -2"):
+            _resolved(endingOffsets='{"t": {"0": -2}}')
+
+    def test_legal_sentinel_combination_accepted(self):
+        # The combination used by the integration suite.
+        resolved = _resolved(startingOffsets='{"t": {"0": -2}}', endingOffsets='{"t": {"0": -1}}')
+        assert resolved["starting_offsets"] == {"t": {"0": -2}}
+        assert resolved["ending_offsets"] == {"t": {"0": -1}}
+
+    def test_defaults_unaffected(self):
+        resolved = _resolved()
+        assert resolved["starting_offsets"] is None
+        assert resolved["ending_offsets"] is None
+
+
+# ---------------------------------------------------------------------------
+# Numeric option validation
+# ---------------------------------------------------------------------------
+
+
+class TestSpecTopicValidation:
+    """A per-topic spec naming an unsubscribed topic must fail loudly.
+
+    Resolution looks specs up by subscribed topic, so an unmatched key is
+    otherwise dropped silently and the partition quietly keeps its default
+    watermark.
+    """
+
+    @pytest.mark.parametrize(
+        "option",
+        ["startingOffsets", "endingOffsets", "startingOffsetsByTimestamp", "endingOffsetsByTimestamp"],
+    )
+    def test_unknown_topic_rejected(self, option):
+        with pytest.raises(ValueError, match="not in 'subscribe'"):
+            _resolved(subscribe="orders", **{option: '{"ordres": {"0": 5}}'})
+
+    def test_error_lists_the_unknown_topics(self):
+        with pytest.raises(ValueError, match=r"\['a', 'b'\]"):
+            _resolved(subscribe="orders", startingOffsets='{"a": {"0": 1}, "b": {"0": 2}}')
+
+    def test_subscribed_topic_accepted(self):
+        assert _resolved(subscribe="orders", startingOffsets='{"orders": {"0": 5}}')["starting_offsets"] == {
+            "orders": {"0": 5}
+        }
+
+    def test_string_spec_unaffected(self):
+        assert _resolved(subscribe="orders", startingOffsets="earliest")["starting_offsets"] == "earliest"
+
+    def test_global_timestamp_spec_unaffected(self):
+        assert _resolved(subscribe="orders", startingTimestamp=str(_TS_MS))["starting_timestamps"] == _TS_MS
+
+
+class TestNumericOptionValidation:
+    @pytest.mark.parametrize("option", ["maxBatchRows", "maxEmptyPolls", "pollTimeoutMs", "adminTimeoutMs"])
+    def test_non_numeric_value_names_the_option(self, option):
+        # A bare int()/float() failure reports only the offending literal, giving
+        # the user no way to tell which option was rejected.
+        with pytest.raises(ValueError, match=rf"'{option}' must be"):
+            _resolved(**{option: "abc"})
+
+    @pytest.mark.parametrize("option", ["maxBatchRows", "maxEmptyPolls", "adminTimeoutMs"])
+    def test_non_positive_rejected(self, option):
+        with pytest.raises(ValueError, match=rf"'{option}' must be positive"):
+            _resolved(**{option: "0"})
+
+    def test_defaults_applied(self):
+        resolved = _resolved()
+        assert resolved["max_batch_rows"] == 10000  # noqa: PLR2004
+        assert resolved["max_empty_polls"] == 30  # noqa: PLR2004
+        assert resolved["admin_timeout_s"] == 10.0  # noqa: PLR2004
+
+
+class TestPollTimeoutValidation:
+    @pytest.mark.parametrize("value", ["0", "-1", "-1000", "-0.5"])
+    def test_non_positive_rejected(self, value):
+        # A negative timeout makes `consumer.poll()` block indefinitely, which
+        # defeats the `maxEmptyPolls` stall guard; zero spins the read loop.
+        with pytest.raises(ValueError, match="'pollTimeoutMs' must be positive"):
+            _resolved(pollTimeoutMs=value)
+
+    def test_positive_accepted(self):
+        assert _resolved(pollTimeoutMs=str(_POLL_TIMEOUT_MS))["poll_timeout_s"] == _POLL_TIMEOUT_MS / 1000
+
+    def test_default_applied(self):
+        assert _resolved()["poll_timeout_s"] == 1.0

--- a/python/pysail/tests/spark/datasource/test_kafka_parsing.py
+++ b/python/pysail/tests/spark/datasource/test_kafka_parsing.py
@@ -1,0 +1,773 @@
+"""Unit tests for pure option-parsing helpers in the Kafka data source.
+
+These don't touch Kafka or Docker — they cover the parsing/validation surface
+that would otherwise only be exercised through the integration tests.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from pysail.testing.spark.utils.common import pyspark_version
+
+if pyspark_version() < (4, 1):
+    pytest.skip("Python data source requires Spark 4.1+", allow_module_level=True)
+
+pytest.importorskip("confluent_kafka")
+
+from pyspark.sql.datasource import CaseInsensitiveDict
+
+from pysail.spark.datasource.kafka import (
+    KafkaDataSource,
+    _build_admin_config,
+    _build_consumer_config,
+    _build_schema,
+    _divide_range,
+    _extract_kafka_config,
+    _parse_bool,
+    _parse_global_timestamp,
+    _parse_offset_spec,
+    _parse_subscription,
+    _parse_timestamp_json,
+    _resolve_range_option,
+    _split_offset_ranges,
+    _validate_kafka_config,
+    _validate_offset_spec,
+    _validate_spec_partitions,
+)
+
+_TS_MS = 1700000000000
+_POLL_TIMEOUT_MS = 250
+
+
+class _TP:
+    """Stand-in for confluent_kafka.TopicPartition (constructor needs a client)."""
+
+    def __init__(self, topic, partition):
+        self.topic = topic
+        self.partition = partition
+
+
+# ---------------------------------------------------------------------------
+# _parse_offset_spec
+# ---------------------------------------------------------------------------
+
+
+class TestParseOffsetSpec:
+    def test_earliest_sentinel(self):
+        assert _parse_offset_spec("earliest", option_name="startingOffsets") == "earliest"
+
+    def test_latest_sentinel(self):
+        assert _parse_offset_spec("latest", option_name="endingOffsets") == "latest"
+
+    def test_stripped_sentinel(self):
+        assert _parse_offset_spec("  earliest  ", option_name="startingOffsets") == "earliest"
+
+    @pytest.mark.parametrize("raw", ["EARLIEST", "Earliest", "eArLiEsT"])
+    def test_sentinel_is_case_insensitive(self, raw):
+        # Spark lowercases before matching, so `EARLIEST` is a valid value.
+        assert _parse_offset_spec(raw, option_name="startingOffsets") == "earliest"
+
+    def test_blank_is_a_parse_error(self):
+        # Spark distinguishes absent from present-but-blank: a present blank
+        # value is parsed as JSON and fails. Only absence means "use default".
+        with pytest.raises(ValueError, match="Invalid 'startingOffsets' value"):
+            _parse_offset_spec("", option_name="startingOffsets")
+
+    def test_json_object(self):
+        assert _parse_offset_spec('{"t": {"0": 5}}', option_name="startingOffsets") == {"t": {"0": 5}}
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(ValueError, match="Invalid 'startingOffsets' value"):
+            _parse_offset_spec("not-json", option_name="startingOffsets")
+
+    def test_non_object_json_raises(self):
+        with pytest.raises(ValueError, match="must be an object"):
+            _parse_offset_spec("[1, 2, 3]", option_name="startingOffsets")
+
+    def test_non_object_topic_value_raises(self):
+        with pytest.raises(ValueError, match="topic 't' must be an object"):
+            _parse_offset_spec('{"t": 5}', option_name="startingOffsets")
+
+    def test_non_int_partition_value_raises(self):
+        with pytest.raises(ValueError, match="partition '0' must be an integer"):
+            _parse_offset_spec('{"t": {"0": "x"}}', option_name="startingOffsets")
+
+    def test_bool_partition_value_raises(self):
+        with pytest.raises(ValueError, match="must be an integer"):
+            _parse_offset_spec('{"t": {"0": true}}', option_name="startingOffsets")
+
+    def test_non_numeric_partition_key_raises(self):
+        with pytest.raises(ValueError, match="partition id for topic 't' must be an integer"):
+            _parse_offset_spec('{"t": {"zero": 1}}', option_name="startingOffsets")
+
+
+# ---------------------------------------------------------------------------
+# Timestamp option parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseTimestamps:
+    def test_global_int(self):
+        assert _parse_global_timestamp("1700000000000", option_name="startingTimestamp") == _TS_MS
+
+    def test_global_int_stripped(self):
+        assert _parse_global_timestamp("  1700000000000  ", option_name="endingTimestamp") == _TS_MS
+
+    def test_invalid_global_raises(self):
+        with pytest.raises(ValueError, match="must be an integer"):
+            _parse_global_timestamp("not-a-number", option_name="startingTimestamp")
+
+    def test_per_tp_json(self):
+        result = _parse_timestamp_json('{"t": {"0": 1700000000000}}', option_name="startingOffsetsByTimestamp")
+        assert result == {"t": {"0": _TS_MS}}
+
+    def test_invalid_json_raises(self):
+        with pytest.raises(ValueError, match="Invalid 'startingOffsetsByTimestamp' JSON"):
+            _parse_timestamp_json("not-json", option_name="startingOffsetsByTimestamp")
+
+    def test_non_object_json_raises(self):
+        with pytest.raises(ValueError, match="must be an object"):
+            _parse_timestamp_json("[1, 2, 3]", option_name="startingOffsetsByTimestamp")
+
+    def test_non_object_topic_value_raises(self):
+        with pytest.raises(ValueError, match="topic 't' must be an object"):
+            _parse_timestamp_json('{"t": 5}', option_name="startingOffsetsByTimestamp")
+
+    def test_non_int_partition_value_raises(self):
+        with pytest.raises(ValueError, match="partition '0' must be an integer"):
+            _parse_timestamp_json('{"t": {"0": "x"}}', option_name="endingOffsetsByTimestamp")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_range_option — Spark's precedence between the range options
+# ---------------------------------------------------------------------------
+
+
+class TestRangeOptionPrecedence:
+    def test_absent_returns_none(self):
+        assert _resolve_range_option(CaseInsensitiveDict({}), endpoint="starting") == (None, None)
+
+    def test_offsets_only(self):
+        offsets, timestamps = _resolve_range_option(
+            CaseInsensitiveDict({"startingOffsets": "earliest"}), endpoint="starting"
+        )
+        assert offsets == "earliest"
+        assert timestamps is None
+
+    def test_global_timestamp_beats_everything(self):
+        # Spark checks the global timestamp first and never looks at the rest,
+        # so the lower-priority values are not even parsed.
+        offsets, timestamps = _resolve_range_option(
+            CaseInsensitiveDict(
+                {
+                    "startingTimestamp": "1700000000000",
+                    "startingOffsetsByTimestamp": "not-even-json",
+                    "startingOffsets": "not-even-json",
+                }
+            ),
+            endpoint="starting",
+        )
+        assert offsets is None
+        assert timestamps == _TS_MS
+
+    def test_per_partition_timestamp_beats_offsets(self):
+        offsets, timestamps = _resolve_range_option(
+            CaseInsensitiveDict(
+                {
+                    "endingOffsetsByTimestamp": '{"t": {"0": 1700000000000}}',
+                    "endingOffsets": "not-even-json",
+                }
+            ),
+            endpoint="ending",
+        )
+        assert offsets is None
+        assert timestamps == {"t": {"0": _TS_MS}}
+
+    def test_combination_is_not_rejected(self):
+        # Spark applies precedence rather than failing, so a job that supplies
+        # a fallback keeps working.
+        resolved = _resolved(startingOffsets="earliest", startingTimestamp="1700000000000")
+        assert resolved["starting_offsets"] is None
+        assert resolved["starting_timestamps"] == _TS_MS
+
+    def test_blank_lower_priority_option_is_ignored(self):
+        resolved = _resolved(endingOffsets="", endingTimestamp="1700000000000")
+        assert resolved["ending_offsets"] is None
+        assert resolved["ending_timestamps"] == _TS_MS
+
+    def test_blank_winning_option_raises(self):
+        with pytest.raises(ValueError, match="Invalid 'startingOffsets' value"):
+            _resolved(startingOffsets="")
+
+
+# ---------------------------------------------------------------------------
+# startingOffsetsByTimestampStrategy
+# ---------------------------------------------------------------------------
+
+
+class TestTimestampStrategy:
+    def test_default_is_error(self):
+        assert _resolved()["starting_ts_strategy"] == "error"
+
+    @pytest.mark.parametrize("raw", ["latest", "LATEST", " Latest "])
+    def test_latest_accepted(self, raw):
+        assert _resolved(startingOffsetsByTimestampStrategy=raw)["starting_ts_strategy"] == "latest"
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError, match="startingOffsetsByTimestampStrategy"):
+            _resolved(startingOffsetsByTimestampStrategy="earliest")
+
+
+# ---------------------------------------------------------------------------
+# _parse_bool
+# ---------------------------------------------------------------------------
+
+
+class TestParseBool:
+    def test_absent_uses_default(self):
+        assert _parse_bool(CaseInsensitiveDict({}), "includeHeaders", default=False) is False
+        assert _parse_bool(CaseInsensitiveDict({}), "failOnDataLoss", default=True) is True
+
+    @pytest.mark.parametrize(("raw", "want"), [("true", True), ("TRUE", True), ("false", False), (" False ", False)])
+    def test_case_insensitive(self, raw, want):
+        assert _parse_bool(CaseInsensitiveDict({"includeHeaders": raw}), "includeHeaders", default=False) is want
+
+    @pytest.mark.parametrize("raw", ["yes", "1", "0", "", "no"])
+    def test_invalid_raises(self, raw):
+        # Spark calls Scala's `toBoolean`, which throws on anything else;
+        # treating them as false would silently drop the headers column.
+        with pytest.raises(ValueError, match="must be 'true' or 'false'"):
+            _parse_bool(CaseInsensitiveDict({"includeHeaders": raw}), "includeHeaders", default=False)
+
+
+# ---------------------------------------------------------------------------
+# _extract_kafka_config / protected consumer properties
+# ---------------------------------------------------------------------------
+
+
+class TestExtractKafkaConfig:
+    def test_strips_kafka_prefix(self):
+        opts = {
+            "kafka.bootstrap.servers": "localhost:9092",
+            "kafka.security.protocol": "SASL_SSL",
+            "subscribe": "orders",
+            "includeHeaders": "true",
+        }
+        assert _extract_kafka_config(opts) == {
+            "bootstrap.servers": "localhost:9092",
+            "security.protocol": "SASL_SSL",
+        }
+
+    def test_no_kafka_options(self):
+        assert _extract_kafka_config({"subscribe": "t"}) == {}
+
+    def test_empty_dict(self):
+        assert _extract_kafka_config({}) == {}
+
+
+class TestProtectedKafkaConfigs:
+    @pytest.mark.parametrize("name", ["auto.offset.reset", "enable.auto.commit", "enable.partition.eof"])
+    def test_rejected(self, name):
+        with pytest.raises(ValueError, match=f"kafka.{name}' is not supported".replace(".", r"\.")):
+            _validate_kafka_config({"bootstrap.servers": "localhost:9092", name: "whatever"})
+
+    def test_auto_offset_reset_names_the_alternative(self):
+        with pytest.raises(ValueError, match="startingOffsets"):
+            _validate_kafka_config({"auto.offset.reset": "earliest"})
+
+    def test_group_id_still_allowed(self):
+        _validate_kafka_config({"bootstrap.servers": "localhost:9092", "group.id": "mine"})
+
+    def test_rejected_through_resolved(self):
+        with pytest.raises(ValueError, match="is not supported"):
+            _resolved(**{"kafka.enable.auto.commit": "true"})
+
+
+# ---------------------------------------------------------------------------
+# _build_consumer_config
+# ---------------------------------------------------------------------------
+
+
+class TestBuildConsumerConfig:
+    def test_defaults_applied(self):
+        config = _build_consumer_config({"bootstrap.servers": "localhost:9092"})
+        assert config["bootstrap.servers"] == "localhost:9092"
+        assert config["group.id"] == "sail-kafka-reader"
+        assert config["enable.auto.commit"] is False
+        assert config["auto.offset.reset"] == "error"
+        assert config["enable.partition.eof"] is True
+
+    def test_user_group_id_overrides_default(self):
+        config = _build_consumer_config({"bootstrap.servers": "localhost:9092", "group.id": "my-group"})
+        assert config["group.id"] == "my-group"
+
+    def test_source_owned_settings_win(self):
+        # `_validate_kafka_config` rejects these before we get here; the merge
+        # order is the second line of defence, and Spark likewise keeps its own
+        # consumer settings authoritative.
+        config = _build_consumer_config(
+            {"enable.auto.commit": "true", "auto.offset.reset": "earliest", "enable.partition.eof": "false"}
+        )
+        assert config["enable.auto.commit"] is False
+        assert config["auto.offset.reset"] == "error"
+        assert config["enable.partition.eof"] is True
+
+    def test_fail_on_data_loss_false_skips_ahead(self):
+        # Spark's failOnDataLoss=false skips to what is still in the log rather
+        # than failing on an aged-out start offset.
+        config = _build_consumer_config({}, fail_on_data_loss=False)
+        assert config["auto.offset.reset"] == "earliest"
+
+    def test_isolation_level_matches_the_java_client_default(self):
+        # librdkafka defaults to `read_committed`; Spark never sets the property
+        # and so inherits the Java client's `read_uncommitted`. Left to the
+        # librdkafka default, a transactional topic would silently return a
+        # different row set here than under Spark.
+        config = _build_consumer_config({})
+        assert config["isolation.level"] == "read_uncommitted"
+
+    def test_user_isolation_level_overrides_default(self):
+        config = _build_consumer_config({"isolation.level": "read_committed"})
+        assert config["isolation.level"] == "read_committed"
+
+
+class TestBuildAdminConfig:
+    def test_connection_settings_pass_through(self):
+        config = _build_admin_config({"bootstrap.servers": "localhost:9092", "security.protocol": "SASL_SSL"})
+        assert config == {"bootstrap.servers": "localhost:9092", "security.protocol": "SASL_SSL"}
+
+    def test_consumer_only_properties_are_stripped(self):
+        # librdkafka builds the admin handle on a producer and logs a CONFWARN
+        # for every consumer property it finds there, so a user-supplied
+        # `kafka.group.id` would warn on every planning call.
+        config = _build_admin_config({"bootstrap.servers": "localhost:9092", "group.id": "my-group"})
+        assert config == {"bootstrap.servers": "localhost:9092"}
+
+
+# ---------------------------------------------------------------------------
+# KafkaDataSource._resolved — `_resolved` only parses options (no broker I/O),
+# so it is unit-testable.
+# ---------------------------------------------------------------------------
+
+
+def _resolved(**extra):
+    opts = {"kafka.bootstrap.servers": "localhost:9092", "subscribe": "t", **extra}
+    return KafkaDataSource(options=opts)._resolved  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Subscription strategies — assign / subscribe / subscribePattern
+# ---------------------------------------------------------------------------
+
+
+class TestSubscription:
+    def test_subscribe_topic_list(self):
+        assert _parse_subscription(CaseInsensitiveDict({"subscribe": "a, b ,c"})) == ("subscribe", ["a", "b", "c"])
+
+    def test_subscribe_dedupes(self):
+        # A repeated topic would otherwise be enumerated once per occurrence,
+        # producing duplicate input partitions and emitting every row twice.
+        assert _parse_subscription(CaseInsensitiveDict({"subscribe": "t,t, t"})) == ("subscribe", ["t"])
+
+    def test_subscribe_preserves_first_seen_order(self):
+        assert _parse_subscription(CaseInsensitiveDict({"subscribe": "b,a,b,c"})) == ("subscribe", ["b", "a", "c"])
+
+    def test_subscribe_empty_raises(self):
+        with pytest.raises(ValueError, match="at least one topic"):
+            _parse_subscription(CaseInsensitiveDict({"subscribe": " , "}))
+
+    def test_subscribe_pattern(self):
+        strategy, pattern = _parse_subscription(CaseInsensitiveDict({"subscribePattern": "orders-.*"}))
+        assert strategy == "subscribePattern"
+        assert pattern.fullmatch("orders-eu")
+        assert not pattern.fullmatch("shipments")
+
+    def test_subscribe_pattern_invalid_regex_raises(self):
+        with pytest.raises(ValueError, match="not a valid regular expression"):
+            _parse_subscription(CaseInsensitiveDict({"subscribePattern": "orders-["}))
+
+    def test_assign(self):
+        strategy, value = _parse_subscription(CaseInsensitiveDict({"assign": '{"t": [0, 2]}'}))
+        assert strategy == "assign"
+        assert value == {"t": [0, 2]}
+
+    def test_assign_invalid_json_raises(self):
+        with pytest.raises(ValueError, match="Invalid 'assign' JSON"):
+            _parse_subscription(CaseInsensitiveDict({"assign": "not-json"}))
+
+    def test_assign_empty_partition_list_raises(self):
+        with pytest.raises(ValueError, match="non-empty array"):
+            _parse_subscription(CaseInsensitiveDict({"assign": '{"t": []}'}))
+
+    def test_assign_negative_partition_raises(self):
+        with pytest.raises(ValueError, match="non-negative integer"):
+            _parse_subscription(CaseInsensitiveDict({"assign": '{"t": [-1]}'}))
+
+    def test_none_specified_raises(self):
+        with pytest.raises(ValueError, match="must be specified"):
+            _parse_subscription(CaseInsensitiveDict({"kafka.bootstrap.servers": "localhost:9092"}))
+
+    def test_more_than_one_raises(self):
+        with pytest.raises(ValueError, match="Only one of the following options"):
+            _parse_subscription(CaseInsensitiveDict({"subscribe": "t", "assign": '{"t": [0]}'}))
+
+
+# ---------------------------------------------------------------------------
+# Option key case-insensitivity
+#
+# Spark data source options are case-insensitive, and both PySpark and Sail
+# construct the data source with a `CaseInsensitiveDict`. These tests pin that
+# the same options work regardless of case, and — via the explicit
+# `CaseInsensitiveDict` case — that `_resolved` does not flatten the mapping
+# back into a case-sensitive dict, which would strand every camelCase lookup
+# against the wrapper's lowercased keys.
+# ---------------------------------------------------------------------------
+
+
+class TestOptionCaseInsensitivity:
+    def test_upper_case_option_keys(self):
+        source = KafkaDataSource(
+            options={
+                "KAFKA.BOOTSTRAP.SERVERS": "localhost:9092",
+                "SUBSCRIBE": "t",
+                "STARTINGOFFSETS": "earliest",
+                "INCLUDEHEADERS": "true",
+            }
+        )
+        resolved = source._resolved  # noqa: SLF001
+        assert resolved["client_config"]["bootstrap.servers"] == "localhost:9092"
+        assert resolved["subscription"] == ("subscribe", ["t"])
+        assert resolved["starting_offsets"] == "earliest"
+        assert resolved["include_headers"] is True
+
+    def test_lower_case_option_keys(self):
+        resolved = _resolved(startingoffsets="earliest", maxbatchrows="99")
+        assert resolved["starting_offsets"] == "earliest"
+        assert resolved["max_batch_rows"] == 99  # noqa: PLR2004
+
+    def test_case_insensitive_dict_input_is_not_flattened(self):
+        # This is what PySpark and Sail actually pass to the constructor.
+        source = KafkaDataSource(
+            options=CaseInsensitiveDict(
+                {
+                    "kafka.bootstrap.servers": "localhost:9092",
+                    "subscribe": "t",
+                    "startingOffsets": "earliest",
+                    "maxBatchRows": "77",
+                }
+            )
+        )
+        resolved = source._resolved  # noqa: SLF001
+        assert resolved["starting_offsets"] == "earliest"
+        assert resolved["max_batch_rows"] == 77  # noqa: PLR2004
+
+
+# ---------------------------------------------------------------------------
+# Numeric options
+# ---------------------------------------------------------------------------
+
+
+class TestNumericOptions:
+    def test_poll_timeout_default_matches_spark(self):
+        # Spark's batch default for kafkaConsumer.pollTimeoutMs is
+        # spark.network.timeout, i.e. 120s.
+        assert _resolved()["poll_timeout_s"] == 120.0  # noqa: PLR2004
+
+    def test_spark_poll_timeout_option_name(self):
+        assert _resolved(**{"kafkaConsumer.pollTimeoutMs": str(_POLL_TIMEOUT_MS)})["poll_timeout_s"] == 0.25  # noqa: PLR2004
+
+    def test_short_poll_timeout_alias(self):
+        assert _resolved(pollTimeoutMs=str(_POLL_TIMEOUT_MS))["poll_timeout_s"] == 0.25  # noqa: PLR2004
+
+    def test_spark_name_wins_over_alias(self):
+        resolved = _resolved(**{"kafkaConsumer.pollTimeoutMs": "500", "pollTimeoutMs": "250"})
+        assert resolved["poll_timeout_s"] == 0.5  # noqa: PLR2004
+
+    @pytest.mark.parametrize("raw", ["Infinity", "inf", "-inf", "nan", "NaN"])
+    def test_non_finite_poll_timeout_rejected(self, raw):
+        # `float()` accepts these and a `<= 0` check does not catch them:
+        # `poll(inf)` blocks forever, defeating the stallTimeoutMs guard.
+        with pytest.raises(ValueError, match=r"finite|must be positive"):
+            _resolved(pollTimeoutMs=raw)
+
+    @pytest.mark.parametrize("raw", ["0", "-1"])
+    def test_non_positive_poll_timeout_rejected(self, raw):
+        with pytest.raises(ValueError, match="must be positive"):
+            _resolved(pollTimeoutMs=raw)
+
+    def test_min_partitions_absent(self):
+        assert _resolved()["min_partitions"] is None
+        assert _resolved()["max_records_per_partition"] is None
+
+    def test_min_partitions_parsed(self):
+        assert _resolved(minPartitions="4")["min_partitions"] == 4  # noqa: PLR2004
+        assert _resolved(maxRecordsPerPartition="100")["max_records_per_partition"] == 100  # noqa: PLR2004
+
+    def test_min_partitions_must_be_positive(self):
+        with pytest.raises(ValueError, match="must be positive"):
+            _resolved(minPartitions="0")
+
+
+# ---------------------------------------------------------------------------
+# failOnDataLoss
+# ---------------------------------------------------------------------------
+
+
+class TestFailOnDataLoss:
+    def test_default_true(self):
+        assert _resolved()["fail_on_data_loss"] is True
+
+    def test_explicit_false(self):
+        assert _resolved(failOnDataLoss="false")["fail_on_data_loss"] is False
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError, match="must be 'true' or 'false'"):
+            _resolved(failOnDataLoss="maybe")
+
+
+# ---------------------------------------------------------------------------
+# _validate_offset_spec — Spark batch-mode sentinel rules
+# ---------------------------------------------------------------------------
+
+
+class TestValidateOffsetSpec:
+    def test_none_is_noop(self):
+        _validate_offset_spec(None, endpoint="starting", option_name="startingOffsets")
+        _validate_offset_spec(None, endpoint="ending", option_name="endingOffsets")
+
+    def test_allowed_string_sentinels(self):
+        _validate_offset_spec("earliest", endpoint="starting", option_name="startingOffsets")
+        _validate_offset_spec("latest", endpoint="ending", option_name="endingOffsets")
+
+    def test_latest_rejected_for_starting(self):
+        with pytest.raises(ValueError, match="does not support 'latest'"):
+            _validate_offset_spec("latest", endpoint="starting", option_name="startingOffsets")
+
+    def test_earliest_rejected_for_ending(self):
+        with pytest.raises(ValueError, match="does not support 'earliest'"):
+            _validate_offset_spec("earliest", endpoint="ending", option_name="endingOffsets")
+
+    def test_allowed_json_sentinels(self):
+        _validate_offset_spec({"t": {"0": -2}}, endpoint="starting", option_name="startingOffsets")
+        _validate_offset_spec({"t": {"0": -1}}, endpoint="ending", option_name="endingOffsets")
+
+    def test_json_latest_rejected_for_starting(self):
+        with pytest.raises(ValueError, match="does not support offset -1"):
+            _validate_offset_spec({"t": {"0": -1}}, endpoint="starting", option_name="startingOffsets")
+
+    def test_json_earliest_rejected_for_ending(self):
+        with pytest.raises(ValueError, match="does not support offset -2"):
+            _validate_offset_spec({"t": {"0": -2}}, endpoint="ending", option_name="endingOffsets")
+
+    def test_concrete_offsets_allowed(self):
+        _validate_offset_spec({"t": {"0": 0, "1": 12345}}, endpoint="starting", option_name="startingOffsets")
+        _validate_offset_spec({"t": {"0": 0, "1": 12345}}, endpoint="ending", option_name="endingOffsets")
+
+    @pytest.mark.parametrize("endpoint", ["starting", "ending"])
+    def test_offset_below_negative_two_rejected(self, endpoint):
+        with pytest.raises(ValueError, match="must be >= 0"):
+            _validate_offset_spec({"t": {"0": -3}}, endpoint=endpoint, option_name="opt")
+
+    @pytest.mark.parametrize("offset", [-1000, -1001])
+    def test_librdkafka_sentinels_rejected(self, offset):
+        # -1000 is OFFSET_STORED and -1001 is OFFSET_INVALID. Passed through,
+        # OFFSET_STORED would silently read from committed group offsets.
+        with pytest.raises(ValueError, match="must be >= 0"):
+            _validate_offset_spec({"t": {"0": offset}}, endpoint="starting", option_name="startingOffsets")
+
+    def test_error_names_the_offending_partition(self):
+        with pytest.raises(ValueError, match=r"topic 't' partition '3'"):
+            _validate_offset_spec({"t": {"0": 5, "3": -7}}, endpoint="starting", option_name="startingOffsets")
+
+
+class TestResolvedOffsetValidation:
+    """The validator must be wired into both call sites in `_resolved`."""
+
+    def test_starting_latest_rejected(self):
+        with pytest.raises(ValueError, match="does not support 'latest'"):
+            _resolved(startingOffsets="latest")
+
+    def test_ending_earliest_rejected(self):
+        with pytest.raises(ValueError, match="does not support 'earliest'"):
+            _resolved(endingOffsets="earliest")
+
+    def test_starting_json_latest_rejected(self):
+        with pytest.raises(ValueError, match="does not support offset -1"):
+            _resolved(startingOffsets='{"t": {"0": -1}}')
+
+
+# ---------------------------------------------------------------------------
+# _validate_spec_partitions — Spark's exact (topic, partition) set check
+# ---------------------------------------------------------------------------
+
+
+_TPS = [_TP("t", 0), _TP("t", 1)]
+
+
+class TestValidateSpecPartitions:
+    def test_string_spec_is_noop(self):
+        _validate_spec_partitions("earliest", _TPS, option_name="startingOffsets")
+
+    def test_global_timestamp_is_noop(self):
+        _validate_spec_partitions(_TS_MS, _TPS, option_name="startingTimestamp")
+
+    def test_exact_match_ok(self):
+        _validate_spec_partitions({"t": {"0": 1, "1": 2}}, _TPS, option_name="startingOffsets")
+
+    def test_missing_partition_raises(self):
+        # Spark requires every assigned partition; without this an omitted
+        # partition silently falls back to a watermark.
+        with pytest.raises(ValueError, match=r"missing: \[\('t', 1\)\]"):
+            _validate_spec_partitions({"t": {"0": 1}}, _TPS, option_name="startingOffsets")
+
+    def test_extra_partition_raises(self):
+        with pytest.raises(ValueError, match=r"not assigned: \[\('t', 7\)\]"):
+            _validate_spec_partitions({"t": {"0": 1, "1": 2, "7": 3}}, _TPS, option_name="startingOffsets")
+
+    def test_unknown_topic_raises(self):
+        with pytest.raises(ValueError, match="not assigned"):
+            _validate_spec_partitions({"other": {"0": 1}}, _TPS, option_name="startingOffsets")
+
+
+# ---------------------------------------------------------------------------
+# minPartitions / maxRecordsPerPartition splitting
+# ---------------------------------------------------------------------------
+
+
+class TestDivideRange:
+    def test_single_part(self):
+        assert _divide_range(0, 10, 1) == [(0, 10)]
+
+    def test_even_split(self):
+        assert _divide_range(0, 10, 2) == [(0, 5), (5, 10)]
+
+    def test_remainder_goes_to_latest_chunks(self):
+        # Spark sizes each chunk against what is left (`remaining / (parts - i)`),
+        # so ten records over three chunks are 3/3/4 rather than 4/3/3.
+        assert _divide_range(0, 10, 3) == [(0, 3), (3, 6), (6, 10)]
+        assert _divide_range(0, 10, 4) == [(0, 2), (2, 4), (4, 7), (7, 10)]
+
+    def test_more_parts_than_records(self):
+        assert _divide_range(0, 2, 5) == [(0, 1), (1, 2)]
+
+    def test_chunks_are_contiguous_and_complete(self):
+        chunks = _divide_range(100, 137, 4)
+        assert chunks[0][0] == 100  # noqa: PLR2004
+        assert chunks[-1][1] == 137  # noqa: PLR2004
+        assert all(a[1] == b[0] for a, b in itertools.pairwise(chunks))
+
+
+class TestSplitOffsetRanges:
+    def test_no_options_is_identity(self):
+        ranges = [("t", 0, 0, 100)]
+        assert _split_offset_ranges(ranges, min_partitions=None, max_records_per_partition=None) == ranges
+
+    def test_max_records_caps_each_range(self):
+        out = _split_offset_ranges([("t", 0, 0, 10)], min_partitions=None, max_records_per_partition=4)
+        assert out == [("t", 0, 0, 3), ("t", 0, 3, 6), ("t", 0, 6, 10)]
+        assert all(end - start <= 4 for _, _, start, end in out)  # noqa: PLR2004
+
+    def test_min_partitions_below_count_is_identity(self):
+        ranges = [("t", 0, 0, 10), ("t", 1, 0, 10)]
+        assert _split_offset_ranges(ranges, min_partitions=2, max_records_per_partition=None) == ranges
+
+    def test_min_partitions_splits_proportionally(self):
+        # One partition, 100 records, minPartitions=4 -> four equal chunks.
+        out = _split_offset_ranges([("t", 0, 0, 100)], min_partitions=4, max_records_per_partition=None)
+        assert out == [("t", 0, 0, 25), ("t", 0, 25, 50), ("t", 0, 50, 75), ("t", 0, 75, 100)]
+
+    def test_min_partitions_weights_by_size(self):
+        # 90 vs 10 records with minPartitions=10 -> 9 chunks and 1 chunk.
+        out = _split_offset_ranges(
+            [("t", 0, 0, 90), ("t", 1, 0, 10)], min_partitions=10, max_records_per_partition=None
+        )
+        assert len([r for r in out if r[1] == 0]) == 9  # noqa: PLR2004
+        assert len([r for r in out if r[1] == 1]) == 1
+
+    def test_both_options_apply_in_order(self):
+        out = _split_offset_ranges([("t", 0, 0, 100)], min_partitions=8, max_records_per_partition=50)
+        # maxRecords gives 2 ranges, then minPartitions splits those up to 8.
+        assert len(out) == 8  # noqa: PLR2004
+        assert out[0][2] == 0
+        assert out[-1][3] == 100  # noqa: PLR2004
+
+    def test_records_are_never_lost(self):
+        out = _split_offset_ranges([("t", 0, 5, 47)], min_partitions=7, max_records_per_partition=9)
+        assert sum(end - start for _, _, start, end in out) == 42  # noqa: PLR2004
+        assert out[0][2] == 5  # noqa: PLR2004
+        assert out[-1][3] == 47  # noqa: PLR2004
+
+    def test_small_ranges_do_not_inflate_the_partition_count(self):
+        # Spark sets aside ranges too small to split before dividing the
+        # `minPartitions` budget, so the big range takes only the budget the
+        # small ones left behind. A single proportional pass would give the big
+        # range 4 chunks and still add one per small range, overshooting to 6.
+        out = _split_offset_ranges(
+            [("t", 0, 0, 100), ("t", 1, 0, 1), ("t", 2, 0, 1)],
+            min_partitions=4,
+            max_records_per_partition=None,
+        )
+        assert out == [("t", 0, 0, 50), ("t", 0, 50, 100), ("t", 1, 0, 1), ("t", 2, 0, 1)]
+
+    def test_skewed_split_matches_spark_budget(self):
+        out = _split_offset_ranges(
+            [("t", 0, 0, 1000), ("t", 1, 0, 5)], min_partitions=8, max_records_per_partition=None
+        )
+        assert len(out) == 8  # noqa: PLR2004
+        assert [r for r in out if r[1] == 1] == [("t", 1, 0, 5)]
+        assert out[0][2] == 0
+        assert out[-2][3] == 1000  # noqa: PLR2004
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+class TestSchema:
+    def test_all_fields_nullable(self):
+        # Spark builds these with plain StructFields, which default to
+        # nullable=True. Nullability is user-visible in printSchema and in
+        # write-compatibility checks.
+        schema = _build_schema(include_headers=True)
+        assert all(field.nullable for field in schema)
+
+    def test_header_struct_fields_nullable(self):
+        headers = _build_schema(include_headers=True).field("headers")
+        assert all(field.nullable for field in headers.type.value_type)
+
+    def test_headers_omitted_by_default(self):
+        assert "headers" not in _build_schema(include_headers=False).names
+
+    def test_reader_rejects_user_specified_schema(self):
+        import pyarrow as pa
+
+        source = KafkaDataSource(options={"kafka.bootstrap.servers": "localhost:9092", "subscribe": "t"})
+        custom = pa.schema([pa.field("value", pa.string(), nullable=True)])
+        with pytest.raises(ValueError, match="fixed schema"):
+            source.reader(custom)
+
+    def test_reader_rejects_a_wrong_column_type(self):
+        import pyarrow as pa
+
+        source = KafkaDataSource(options={"kafka.bootstrap.servers": "localhost:9092", "subscribe": "t"})
+        wrong = pa.schema([pa.field(f.name, pa.string() if f.name == "value" else f.type) for f in source.schema()])
+        with pytest.raises(ValueError, match="fixed schema"):
+            source.reader(wrong)
+
+    def test_reader_accepts_the_fixed_schema(self):
+        source = KafkaDataSource(options={"kafka.bootstrap.servers": "localhost:9092", "subscribe": "t"})
+        assert source.reader(source.schema()) is not None
+
+    def test_reader_tolerates_a_nullability_only_difference(self):
+        # The schema Sail passes back has round-tripped through Arrow's C data
+        # interface; nullability cannot change what `read()` produces, so it
+        # must not be grounds for rejecting our own schema.
+        import pyarrow as pa
+
+        source = KafkaDataSource(options={"kafka.bootstrap.servers": "localhost:9092", "subscribe": "t"})
+        tightened = pa.schema([pa.field(f.name, f.type, nullable=False) for f in source.schema()])
+        assert source.reader(tightened) is not None

--- a/python/pysail/tests/spark/datasource/test_kafka_planning.py
+++ b/python/pysail/tests/spark/datasource/test_kafka_planning.py
@@ -1,0 +1,748 @@
+"""Unit tests for Kafka planning and read logic, against fake broker clients.
+
+The integration tests in ``test_kafka.py`` need Docker and a broker, so they
+only run in the integration job. These cover the same Spark-parity rules —
+offset resolution, the exact partition-set check, timestamp strategies, and
+data-loss detection — with a stand-in consumer, so a regression surfaces in the
+ordinary test run.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pysail.testing.spark.utils.common import pyspark_version
+
+if pyspark_version() < (4, 1):
+    pytest.skip("Python data source requires Spark 4.1+", allow_module_level=True)
+
+pytest.importorskip("confluent_kafka")
+
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+
+from confluent_kafka import KafkaError, KafkaException
+from confluent_kafka.admin._listoffsets import EarliestSpec, TimestampSpec
+
+from pysail.spark.datasource import kafka as kafka_module
+from pysail.spark.datasource.kafka import KafkaDataSource
+
+_TOPIC = "orders"
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeError:
+    def __init__(self, code, message="fake error"):
+        self._code = code
+        self._message = message
+
+    def code(self):
+        return self._code
+
+    def __str__(self):
+        return self._message
+
+
+class _FakeFuture:
+    """Stand-in for the ``concurrent.futures.Future`` the admin calls return.
+
+    ``never_resolves`` models a broker that leaves the future pending, which is
+    what a bare ``Future.result()`` would wait on indefinitely.
+    """
+
+    def __init__(self, result=None, exception=None, *, never_resolves=False):
+        self._result = result
+        self._exception = exception
+        self._never_resolves = never_resolves
+
+    def result(self, timeout=None):  # noqa: ARG002
+        if self._never_resolves:
+            raise FuturesTimeoutError
+        if self._exception is not None:
+            raise self._exception
+        return self._result
+
+
+class _FakePartitionInfo:
+    def __init__(self, partition_id):
+        self.id = partition_id
+
+
+class _FakeTopicDescription:
+    """Stand-in for ``TopicDescription``, the result of ``describe_topics``."""
+
+    def __init__(self, partitions, *, is_internal=False):
+        self.partitions = [_FakePartitionInfo(p) for p in partitions]
+        self.is_internal = is_internal
+
+
+class _FakeListOffsetsResult:
+    def __init__(self, offset):
+        self.offset = offset
+
+
+class _FakeTopicMeta:
+    def __init__(self, partitions, error=None, *, is_internal=False):
+        self.partitions = dict.fromkeys(partitions)
+        self.error = error
+        self.is_internal = is_internal
+
+
+class _FakeMetadata:
+    def __init__(self, topics):
+        self.topics = topics
+
+
+class _FakeMessage:
+    """Stand-in for confluent_kafka.Message."""
+
+    def __init__(self, offset, *, topic=_TOPIC, partition=0, ts=(1, 1700000000000), error=None):
+        self._offset = offset
+        self._topic = topic
+        self._partition = partition
+        self._ts = ts
+        self._error = error
+
+    def error(self):
+        return self._error
+
+    def offset(self):
+        return self._offset
+
+    def topic(self):
+        return self._topic
+
+    def partition(self):
+        return self._partition
+
+    def key(self):
+        return f"k{self._offset}".encode()
+
+    def value(self):
+        return f"v{self._offset}".encode()
+
+    def timestamp(self):
+        return self._ts
+
+    def headers(self):
+        return None
+
+
+def _eof_message():
+    return _FakeMessage(-1, error=_FakeError(KafkaError._PARTITION_EOF))  # noqa: SLF001
+
+
+class _FakeConsumer:
+    """Broker state, plus the slice of the Consumer API that ``read()`` uses.
+
+    Planning goes through :class:`_FakeAdminClient`, which reads the same state,
+    so a single instance describes one broker to both clients.
+    """
+
+    def __init__(
+        self,
+        *,
+        topics=None,
+        watermarks=None,
+        times=None,
+        messages=None,
+        watermarks_after_assign=None,
+    ):
+        # `is None` rather than a falsy check: an empty topic map is a valid
+        # broker state (it is how the unknown-topic case is set up).
+        self.topics = {_TOPIC: _FakeTopicMeta([0])} if topics is None else topics
+        self.watermarks = {(_TOPIC, 0): (0, 10)} if watermarks is None else watermarks
+        self.times = {} if times is None else times
+        self.messages = list(messages or [])
+        # Watermarks observed once reading has started, for truncation cases.
+        self.watermarks_after_assign = watermarks_after_assign
+        self.assigned = None
+        self.closed = False
+
+    # -- reading -------------------------------------------------------
+    def get_watermark_offsets(self, tp, timeout=None, *, cached=False):  # noqa: ARG002
+        source = (
+            self.watermarks_after_assign
+            if self.assigned is not None and self.watermarks_after_assign is not None
+            else self.watermarks
+        )
+        return source[(tp.topic, tp.partition)]
+
+    def assign(self, partitions):
+        self.assigned = partitions
+
+    def poll(self, timeout=None):  # noqa: ARG002
+        return self.messages.pop(0) if self.messages else None
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeAdminClient:
+    """Implements the slice of the AdminClient API that planning uses.
+
+    Mirrors the real contract closely: results arrive as futures, per-topic
+    failures surface when the future is resolved, and `list_offsets` answers
+    every partition in a single call.
+    """
+
+    def __init__(self, state):
+        self.state = state
+        self.list_offsets_calls = 0
+        self.hang = False
+
+    def list_topics(self, timeout=None):  # noqa: ARG002
+        return _FakeMetadata(self.state.topics)
+
+    def describe_topics(self, topic_collection, request_timeout=None):  # noqa: ARG002
+        out = {}
+        for name in topic_collection.topic_names:
+            if self.hang:
+                out[name] = _FakeFuture(never_resolves=True)
+                continue
+            meta = self.state.topics.get(name)
+            if meta is None:
+                error = _FakeError(KafkaError.UNKNOWN_TOPIC_OR_PART, "unknown topic")
+                out[name] = _FakeFuture(exception=KafkaException(error))
+            elif meta.error is not None:
+                out[name] = _FakeFuture(exception=KafkaException(meta.error))
+            else:
+                out[name] = _FakeFuture(_FakeTopicDescription(sorted(meta.partitions), is_internal=meta.is_internal))
+        return out
+
+    def list_offsets(self, specs, isolation_level=None, request_timeout=None):  # noqa: ARG002
+        self.list_offsets_calls += 1
+        out = {}
+        for tp, spec in specs.items():
+            low, high = self.state.watermarks[(tp.topic, tp.partition)]
+            if isinstance(spec, TimestampSpec):
+                offset, error = self.state.times.get((tp.topic, tp.partition, spec.timestamp), (-1, None))
+                if error is not None:
+                    out[tp] = _FakeFuture(exception=KafkaException(error))
+                    continue
+            elif isinstance(spec, EarliestSpec):
+                offset = low
+            else:
+                offset = high
+            out[tp] = _FakeFuture(_FakeListOffsetsResult(offset))
+        return out
+
+
+@pytest.fixture
+def consumer_factory(monkeypatch):
+    """Install a fake Consumer and AdminClient backed by one broker state."""
+    holder = {}
+
+    def _install(consumer):
+        holder["consumer"] = consumer
+        holder["admin"] = _FakeAdminClient(consumer)
+        monkeypatch.setattr(kafka_module, "Consumer", lambda _config: holder["consumer"])
+        monkeypatch.setattr(kafka_module, "AdminClient", lambda _config: holder["admin"])
+        consumer.admin = holder["admin"]
+        return consumer
+
+    return _install
+
+
+def _reader(consumer_factory, consumer, **options):
+    consumer_factory(consumer)
+    opts = {"kafka.bootstrap.servers": "localhost:9092", "subscribe": _TOPIC, **options}
+    return KafkaDataSource(options=opts).reader(None)
+
+
+def _ranges(partitions):
+    """Ranges as planned, which may still carry the -2/-1 late-binding sentinels."""
+    return [(p.topic, p.kafka_partition, p.start_offset, p.end_offset) for p in partitions]
+
+
+def _bound_ranges(consumer, partitions):
+    """Ranges as each task will see them, after binding sentinels at task start."""
+    bind = kafka_module._bind_partition_range  # noqa: SLF001
+    return [(p.topic, p.kafka_partition, *bind(consumer, p)) for p in partitions]
+
+
+# Spark's late-binding sentinels, carried from planning into the task.
+_EARLIEST = kafka_module._SPARK_OFFSET_EARLIEST  # noqa: SLF001
+_LATEST = kafka_module._SPARK_OFFSET_LATEST  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Partition planning
+# ---------------------------------------------------------------------------
+
+
+class TestPlanning:
+    def test_default_range_is_carried_as_sentinels(self, consumer_factory):
+        # Spark's `fetchPartitionOffsets` returns -2/-1 for earliest/latest and
+        # binds them per task, so planning must not freeze them here.
+        consumer = _FakeConsumer()
+        reader = _reader(consumer_factory, consumer)
+        partitions = reader.partitions()
+        assert _ranges(partitions) == [(_TOPIC, 0, _EARLIEST, _LATEST)]
+        assert _bound_ranges(consumer, partitions) == [(_TOPIC, 0, 0, 10)]
+
+    def test_late_binding_picks_up_records_produced_after_planning(self, consumer_factory):
+        # The whole point of late binding: `latest` means the end of the log when
+        # the task runs, not when the query was planned. Freezing it on the
+        # driver would silently drop this tail.
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (0, 3)})
+        reader = _reader(consumer_factory, consumer)
+        partitions = reader.partitions()
+        consumer.watermarks = {(_TOPIC, 0): (0, 7)}  # four more records arrive
+        assert _bound_ranges(consumer, partitions) == [(_TOPIC, 0, 0, 7)]
+
+    def test_late_binding_survives_retention_after_planning(self, consumer_factory):
+        # An `earliest` start frozen at planning can age out before the task
+        # runs, failing a query Spark completes by simply re-resolving.
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (0, 10)})
+        reader = _reader(consumer_factory, consumer)
+        partitions = reader.partitions()
+        consumer.watermarks = {(_TOPIC, 0): (6, 10)}  # offsets 0-5 aged out
+        assert _bound_ranges(consumer, partitions) == [(_TOPIC, 0, 6, 10)]
+
+    def test_empty_range_yields_no_rows(self, consumer_factory):
+        # A late-bound range has no size until it is read, so the empty case is
+        # detected per task, as `KafkaSourceRDD.compute` does.
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (4, 4)})
+        reader = _reader(consumer_factory, consumer)
+        partition = reader.partitions()[0]
+        assert _bound_ranges(consumer, [partition]) == [(_TOPIC, 0, 4, 4)]
+        assert _read_all(reader, partition) == []
+
+    def test_inverted_range_raises_at_task_time(self, consumer_factory):
+        # Both endpoints are concrete, but with no splitting to force an early
+        # resolve the check lands in the task, where Spark's
+        # `KafkaSourceRDD.compute` asserts `fromOffset <= untilOffset`.
+        consumer = _FakeConsumer()
+        reader = _reader(
+            consumer_factory,
+            consumer,
+            startingOffsets='{"orders": {"0": 8}}',
+            endingOffsets='{"orders": {"0": 3}}',
+        )
+        partition = reader.partitions()[0]
+        with pytest.raises(ValueError, match="Inverted offset range"):
+            _read_all(reader, partition)
+
+    def test_inverted_range_raises_during_planning_when_splitting(self, consumer_factory):
+        # `minPartitions` forces an early resolve, so the same range is caught
+        # on the driver instead.
+        reader = _reader(
+            consumer_factory,
+            _FakeConsumer(),
+            startingOffsets='{"orders": {"0": 8}}',
+            endingOffsets='{"orders": {"0": 3}}',
+            minPartitions="4",
+        )
+        with pytest.raises(ValueError, match="Inverted offset range"):
+            reader.partitions()
+
+    def test_unknown_topic_raises(self, consumer_factory):
+        consumer = _FakeConsumer(topics={})
+        reader = _reader(consumer_factory, consumer)
+        with pytest.raises(ValueError, match="not found on broker"):
+            reader.partitions()
+
+    def test_topic_error_is_relayed(self, consumer_factory):
+        consumer = _FakeConsumer(topics={_TOPIC: _FakeTopicMeta([0], error=_FakeError(29, "authorization failed"))})
+        reader = _reader(consumer_factory, consumer)
+        with pytest.raises(ValueError, match="is not available: authorization failed"):
+            reader.partitions()
+
+    def test_json_sentinels_are_late_bound_too(self, consumer_factory):
+        # The JSON -2/-1 form is the same limit as the string form, so it gets
+        # the same late binding.
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (2, 9)})
+        reader = _reader(
+            consumer_factory,
+            consumer,
+            startingOffsets='{"orders": {"0": -2}}',
+            endingOffsets='{"orders": {"0": -1}}',
+        )
+        partitions = reader.partitions()
+        assert _ranges(partitions) == [(_TOPIC, 0, _EARLIEST, _LATEST)]
+        assert _bound_ranges(consumer, partitions) == [(_TOPIC, 0, 2, 9)]
+
+    def test_explicit_offsets_are_not_late_bound(self, consumer_factory):
+        # Concrete offsets are used as given and need no broker round-trip,
+        # either on the driver or in the task.
+        consumer = _FakeConsumer()
+        reader = _reader(
+            consumer_factory,
+            consumer,
+            startingOffsets='{"orders": {"0": 2}}',
+            endingOffsets='{"orders": {"0": 7}}',
+        )
+        partitions = reader.partitions()
+        assert _ranges(partitions) == [(_TOPIC, 0, 2, 7)]
+        assert consumer.admin.list_offsets_calls == 0
+
+    def test_unresolved_admin_future_does_not_hang_planning(self, consumer_factory):
+        # `Future.result()` with no timeout blocks forever. librdkafka normally
+        # completes the future itself via `request_timeout`, but if it does not,
+        # planning must still give up rather than wedge the query.
+        consumer = _FakeConsumer()
+        reader = _reader(consumer_factory, consumer, adminTimeoutMs="1")
+        consumer.admin.hang = True
+        with pytest.raises(TimeoutError, match=r"Timed out .* waiting for the broker to describe topic"):
+            reader.partitions()
+
+    def test_planning_does_not_open_a_consumer(self, consumer_factory):
+        # Planning runs entirely on the AdminClient, as Spark's
+        # KafkaOffsetReaderAdmin does; only executors open consumers.
+        consumer = _FakeConsumer()
+        reader = _reader(consumer_factory, consumer)
+        reader.partitions()
+        assert consumer.assigned is None
+
+    def _wide_consumer(self):
+        return _FakeConsumer(
+            topics={_TOPIC: _FakeTopicMeta([0, 1, 2, 3])},
+            watermarks={(_TOPIC, p): (0, 10) for p in range(4)},
+        )
+
+    def test_late_bound_planning_makes_no_offset_request(self, consumer_factory):
+        # Nothing to resolve on the driver when both endpoints are sentinels.
+        consumer = self._wide_consumer()
+        reader = _reader(consumer_factory, consumer)
+        assert len(reader.partitions()) == 4  # noqa: PLR2004
+        assert consumer.admin.list_offsets_calls == 0
+
+    def test_forced_resolution_is_one_request_per_endpoint(self, consumer_factory):
+        # `minPartitions` forces the sentinels to be resolved. That resolution
+        # is batched — one call per endpoint, not one per partition, which is
+        # what would turn planning a wide topic into a round-trip each.
+        consumer = self._wide_consumer()
+        reader = _reader(consumer_factory, consumer, minPartitions="8")
+        assert len(reader.partitions()) == 8  # noqa: PLR2004
+        assert consumer.admin.list_offsets_calls == 2  # noqa: PLR2004
+
+
+# ---------------------------------------------------------------------------
+# Subscription strategies
+# ---------------------------------------------------------------------------
+
+
+_MULTI_TOPICS = {
+    "orders": _FakeTopicMeta([0, 1]),
+    "orders-eu": _FakeTopicMeta([0]),
+    "shipments": _FakeTopicMeta([0]),
+    # Flagged internal by the broker, as `__consumer_offsets` really is.
+    "__consumer_offsets": _FakeTopicMeta([0], is_internal=True),
+    # A *user* topic that merely looks internal. The broker does not flag it,
+    # so Spark reads it and so must we — a `__` name-prefix rule would not.
+    "__audit": _FakeTopicMeta([0]),
+}
+_MULTI_WATERMARKS = {
+    ("orders", 0): (0, 5),
+    ("orders", 1): (0, 5),
+    ("orders-eu", 0): (0, 5),
+    ("shipments", 0): (0, 5),
+    ("__consumer_offsets", 0): (0, 5),
+    ("__audit", 0): (0, 5),
+}
+
+
+class TestSubscriptionStrategies:
+    def _consumer(self):
+        return _FakeConsumer(topics=_MULTI_TOPICS, watermarks=_MULTI_WATERMARKS)
+
+    def test_subscribe_enumerates_all_partitions(self, consumer_factory):
+        reader = _reader(consumer_factory, self._consumer(), subscribe="orders")
+        assert _ranges(reader.partitions()) == [("orders", 0, _EARLIEST, _LATEST), ("orders", 1, _EARLIEST, _LATEST)]
+
+    def test_assign_selects_named_partitions_only(self, consumer_factory):
+        consumer_factory(self._consumer())
+        reader = KafkaDataSource(
+            options={"kafka.bootstrap.servers": "localhost:9092", "assign": '{"orders": [1]}'}
+        ).reader(None)
+        assert _ranges(reader.partitions()) == [("orders", 1, _EARLIEST, _LATEST)]
+
+    def test_assign_unknown_partition_raises(self, consumer_factory):
+        consumer_factory(self._consumer())
+        reader = KafkaDataSource(
+            options={"kafka.bootstrap.servers": "localhost:9092", "assign": '{"orders": [4]}'}
+        ).reader(None)
+        with pytest.raises(ValueError, match="partitions that do not exist"):
+            reader.partitions()
+
+    def test_subscribe_pattern_matches_whole_name(self, consumer_factory):
+        consumer_factory(self._consumer())
+        reader = KafkaDataSource(
+            options={"kafka.bootstrap.servers": "localhost:9092", "subscribePattern": "orders"}
+        ).reader(None)
+        # `orders-eu` must not match: Spark anchors the pattern to the whole name.
+        assert _ranges(reader.partitions()) == [("orders", 0, _EARLIEST, _LATEST), ("orders", 1, _EARLIEST, _LATEST)]
+
+    def test_subscribe_pattern_wildcard(self, consumer_factory):
+        consumer_factory(self._consumer())
+        reader = KafkaDataSource(
+            options={"kafka.bootstrap.servers": "localhost:9092", "subscribePattern": "orders.*"}
+        ).reader(None)
+        assert {topic for topic, _, _, _ in _ranges(reader.partitions())} == {"orders", "orders-eu"}
+
+    def test_subscribe_pattern_excludes_broker_internal_topics(self, consumer_factory):
+        consumer_factory(self._consumer())
+        reader = KafkaDataSource(
+            options={"kafka.bootstrap.servers": "localhost:9092", "subscribePattern": ".*"}
+        ).reader(None)
+        topics = {topic for topic, _, _, _ in _ranges(reader.partitions())}
+        assert "__consumer_offsets" not in topics
+        # `__audit` is a user topic the broker does not flag internal. Spark's
+        # `retrieveAllPartitions` filters on `isInternal`, not on the name, so
+        # excluding it by its `__` prefix would hide data Spark returns.
+        assert topics == {"orders", "orders-eu", "shipments", "__audit"}
+
+    def test_internal_topics_are_excluded_from_subscribe_too(self, consumer_factory):
+        # Spark applies the isInternal filter in `retrieveAllPartitions`, which
+        # every strategy goes through — not just the pattern one.
+        consumer_factory(self._consumer())
+        reader = KafkaDataSource(
+            options={"kafka.bootstrap.servers": "localhost:9092", "subscribe": "__consumer_offsets"}
+        ).reader(None)
+        assert reader.partitions() == []
+
+
+# ---------------------------------------------------------------------------
+# Specific offsets must name every assigned partition (Spark's assertion)
+# ---------------------------------------------------------------------------
+
+
+class TestSpecificOffsetValidation:
+    def _consumer(self):
+        return _FakeConsumer(
+            topics={_TOPIC: _FakeTopicMeta([0, 1])},
+            watermarks={(_TOPIC, 0): (0, 10), (_TOPIC, 1): (0, 10)},
+        )
+
+    def test_all_partitions_named_ok(self, consumer_factory):
+        reader = _reader(consumer_factory, self._consumer(), startingOffsets='{"orders": {"0": 1, "1": 2}}')
+        assert _ranges(reader.partitions()) == [(_TOPIC, 0, 1, _LATEST), (_TOPIC, 1, 2, _LATEST)]
+
+    def test_missing_partition_raises(self, consumer_factory):
+        reader = _reader(consumer_factory, self._consumer(), startingOffsets='{"orders": {"0": 1}}')
+        with pytest.raises(ValueError, match="must specify all assigned TopicPartitions"):
+            reader.partitions()
+
+    def test_extra_partition_raises(self, consumer_factory):
+        reader = _reader(consumer_factory, self._consumer(), endingOffsets='{"orders": {"0": 1, "1": 2, "9": 3}}')
+        with pytest.raises(ValueError, match="not assigned"):
+            reader.partitions()
+
+    def test_timestamp_map_is_validated_too(self, consumer_factory):
+        reader = _reader(consumer_factory, self._consumer(), startingOffsetsByTimestamp='{"orders": {"0": 100}}')
+        with pytest.raises(ValueError, match="must specify all assigned TopicPartitions"):
+            reader.partitions()
+
+
+# ---------------------------------------------------------------------------
+# Timestamp resolution
+# ---------------------------------------------------------------------------
+
+
+class TestTimestampResolution:
+    def test_match_resolves_to_offset(self, consumer_factory):
+        consumer = _FakeConsumer(times={(_TOPIC, 0, 500): (4, None)})
+        reader = _reader(consumer_factory, consumer, startingTimestamp="500")
+        assert _ranges(reader.partitions()) == [(_TOPIC, 0, 4, _LATEST)]
+
+    def test_no_match_on_start_raises_by_default(self, consumer_factory):
+        # Spark's startingOffsetsByTimestampStrategy defaults to `error`.
+        consumer = _FakeConsumer(times={})
+        reader = _reader(consumer_factory, consumer, startingTimestamp="99999")
+        with pytest.raises(ValueError, match="No offset matches the requested timestamp"):
+            reader.partitions()
+
+    def test_no_match_on_start_with_latest_strategy(self, consumer_factory):
+        consumer = _FakeConsumer(times={})
+        reader = _reader(
+            consumer_factory,
+            consumer,
+            startingTimestamp="99999",
+            startingOffsetsByTimestampStrategy="latest",
+        )
+        # Start collapses onto the high watermark. The end is still late-bound,
+        # so the range only turns out to be empty once the task binds it.
+        partitions = reader.partitions()
+        assert _ranges(partitions) == [(_TOPIC, 0, 10, _LATEST)]
+        assert _bound_ranges(consumer, partitions) == [(_TOPIC, 0, 10, 10)]
+        assert _read_all(reader, partitions[0]) == []
+
+    def test_no_match_on_end_falls_back_to_latest(self, consumer_factory):
+        # Ending timestamps always fall back, no strategy option involved.
+        consumer = _FakeConsumer(times={})
+        reader = _reader(consumer_factory, consumer, endingTimestamp="99999")
+        assert _ranges(reader.partitions()) == [(_TOPIC, 0, _EARLIEST, 10)]
+
+    def test_lookup_error_is_surfaced(self, consumer_factory):
+        # A per-partition error carries an invalid offset; treating it as "no
+        # match" would turn a broker failure into a silently empty read.
+        consumer = _FakeConsumer(times={(_TOPIC, 0, 500): (-1001, _FakeError(7, "leader not available"))})
+        reader = _reader(consumer_factory, consumer, startingTimestamp="500")
+        with pytest.raises(ValueError, match="Failed to look up offsets for"):
+            reader.partitions()
+
+
+# ---------------------------------------------------------------------------
+# minPartitions / maxRecordsPerPartition through planning
+# ---------------------------------------------------------------------------
+
+
+class TestPlanningSplits:
+    def test_min_partitions_splits(self, consumer_factory):
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (0, 100)})
+        reader = _reader(consumer_factory, consumer, minPartitions="4")
+        assert _ranges(reader.partitions()) == [
+            (_TOPIC, 0, _EARLIEST, 25),
+            (_TOPIC, 0, 25, 50),
+            (_TOPIC, 0, 50, 75),
+            (_TOPIC, 0, 75, _LATEST),
+        ]
+
+    def test_max_records_splits(self, consumer_factory):
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (0, 10)})
+        reader = _reader(consumer_factory, consumer, maxRecordsPerPartition="4")
+        # Spark's chunking puts the remainder in the last chunk: 3/3/4, not 4/3/3.
+        assert _ranges(reader.partitions()) == [(_TOPIC, 0, _EARLIEST, 3), (_TOPIC, 0, 3, 6), (_TOPIC, 0, 6, _LATEST)]
+
+    def test_partition_ids_stay_sequential(self, consumer_factory):
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (0, 100)})
+        reader = _reader(consumer_factory, consumer, minPartitions="4")
+        assert [p.value for p in reader.partitions()] == [0, 1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# read() — data loss and row conversion
+# ---------------------------------------------------------------------------
+
+
+def _read_all(reader, partition):
+    rows = []
+    for batch in reader.read(partition):
+        rows.extend(batch.to_pylist())
+    return rows
+
+
+class TestRead:
+    def _partition(self, reader, consumer, messages, *, watermarks_after=None):
+        consumer.messages = messages
+        consumer.watermarks_after_assign = watermarks_after
+        return reader.partitions()[0]
+
+    def test_reads_the_planned_range(self, consumer_factory):
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (0, 3)})
+        reader = _reader(consumer_factory, consumer)
+        partition = self._partition(reader, consumer, [_FakeMessage(i) for i in range(3)])
+        rows = _read_all(reader, partition)
+        assert [r["offset"] for r in rows] == [0, 1, 2]
+        assert [r["value"] for r in rows] == [b"v0", b"v1", b"v2"]
+
+    def test_eof_within_available_range_stops_cleanly(self, consumer_factory):
+        # Compacted or aborted-transaction offsets are unreadable but not lost:
+        # the high watermark still covers the planned end, so Spark skips them.
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (0, 3)})
+        reader = _reader(consumer_factory, consumer)
+        partition = self._partition(reader, consumer, [_FakeMessage(0), _eof_message()])
+        rows = _read_all(reader, partition)
+        assert [r["offset"] for r in rows] == [0]
+
+    def test_eof_below_shrunken_watermark_is_data_loss(self, consumer_factory):
+        # The log no longer reaches the planned end: records that existed at
+        # planning time are gone, which Spark reports as data loss.
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (0, 5)})
+        reader = _reader(consumer_factory, consumer)
+        partition = self._partition(
+            reader,
+            consumer,
+            [_FakeMessage(0), _eof_message()],
+            watermarks_after={(_TOPIC, 0): (0, 1)},
+        )
+        with pytest.raises(ValueError, match="Data loss"):
+            _read_all(reader, partition)
+
+    def test_fail_on_data_loss_false_returns_partial(self, consumer_factory):
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (0, 5)})
+        reader = _reader(consumer_factory, consumer, failOnDataLoss="false")
+        partition = self._partition(
+            reader,
+            consumer,
+            [_FakeMessage(0), _eof_message()],
+            watermarks_after={(_TOPIC, 0): (0, 1)},
+        )
+        assert [r["offset"] for r in _read_all(reader, partition)] == [0]
+
+    def test_records_below_the_planned_start_are_dropped(self, consumer_factory):
+        # Under failOnDataLoss=false the consumer runs with
+        # `auto.offset.reset=earliest`, which librdkafka applies to an
+        # out-of-range start in both directions: a start past the end of the log
+        # rewinds to the beginning and delivers the whole partition. Spark reads
+        # nothing there, so anything below the planned start must be dropped
+        # rather than emitted.
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (0, 3)})
+        reader = _reader(
+            consumer_factory,
+            consumer,
+            failOnDataLoss="false",
+            startingOffsets=f'{{"{_TOPIC}": {{"0": 100}}}}',
+            endingOffsets=f'{{"{_TOPIC}": {{"0": 110}}}}',
+        )
+        partition = self._partition(
+            reader,
+            consumer,
+            [_FakeMessage(0), _FakeMessage(1), _FakeMessage(2), _eof_message()],
+        )
+        assert _read_all(reader, partition) == []
+
+    def test_stops_at_the_exclusive_end(self, consumer_factory):
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (0, 2)})
+        reader = _reader(consumer_factory, consumer)
+        partition = self._partition(reader, consumer, [_FakeMessage(i) for i in range(4)])
+        assert [r["offset"] for r in _read_all(reader, partition)] == [0, 1]
+
+    def test_batches_are_capped_at_max_batch_rows(self, consumer_factory):
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (0, 5)})
+        reader = _reader(consumer_factory, consumer, maxBatchRows="2")
+        partition = self._partition(reader, consumer, [_FakeMessage(i) for i in range(5)])
+        assert [batch.num_rows for batch in reader.read(partition)] == [2, 2, 1]
+
+    def test_stall_guard_fires(self, consumer_factory):
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (0, 3)})
+        reader = _reader(consumer_factory, consumer, stallTimeoutMs="1", pollTimeoutMs="1")
+        partition = self._partition(reader, consumer, [])  # poll() always returns None
+        with pytest.raises(TimeoutError, match="Kafka read stalled"):
+            _read_all(reader, partition)
+
+    def test_timestamp_type_is_translated_to_spark_values(self, consumer_factory):
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (0, 2)})
+        reader = _reader(consumer_factory, consumer)
+        partition = self._partition(
+            reader,
+            consumer,
+            [
+                _FakeMessage(0, ts=(1, 1700000000000)),  # librdkafka CREATE_TIME
+                _FakeMessage(1, ts=(2, 1700000000000)),  # librdkafka LOG_APPEND_TIME
+            ],
+        )
+        assert [r["timestampType"] for r in _read_all(reader, partition)] == [0, 1]
+
+    def test_missing_timestamp_keeps_sparks_minus_one_ms(self, consumer_factory):
+        # Spark passes Kafka's -1ms through millisToMicros rather than emitting
+        # null, surfacing 1969-12-31 23:59:59.999.
+        import datetime
+
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (0, 1)})
+        reader = _reader(consumer_factory, consumer)
+        partition = self._partition(reader, consumer, [_FakeMessage(0, ts=(0, -1))])
+        row = _read_all(reader, partition)[0]
+        assert row["timestampType"] == -1
+        assert row["timestamp"] == datetime.datetime(1969, 12, 31, 23, 59, 59, 999000, tzinfo=datetime.timezone.utc)
+
+    def test_reader_consumer_is_closed(self, consumer_factory):
+        consumer = _FakeConsumer(watermarks={(_TOPIC, 0): (0, 1)})
+        reader = _reader(consumer_factory, consumer)
+        partition = self._partition(reader, consumer, [_FakeMessage(0)])
+        _read_all(reader, partition)
+        assert consumer.closed


### PR DESCRIPTION
Adds a Kafka batch connector under the `kafka` format name, backed by `confluent-kafka` (librdkafka). No JVM or Kafka client JAR is involved. Available via `pip install pysail[kafka]`.

```python
from pysail.spark.datasource.kafka import KafkaDataSource

spark.dataSource.register(KafkaDataSource)

df = (
    spark.read.format("kafka")
    .option("kafka.bootstrap.servers", "localhost:9092")
    .option("subscribe", "orders")
    .load()
)
```

## Spark parity

The schema, option surface, and semantics track Spark's batch Kafka source. Each of these was checked against the Scala rather than the docs:

- **Schema** matches `KafkaRecordToRowConverter` exactly — column order, types, nullability, the `timestampType` enum values (librdkafka's 0/1/2 remapped to Spark's -1/0/1), and the -1ms timestamp Spark surfaces for an untimed record rather than a null.
- **Subscription**: `assign` / `subscribe` / `subscribePattern` with Spark's exactly-one rule. Internal topics are filtered on the broker's `isInternal` flag, as `ConsumerStrategy.retrieveAllPartitions` does — so a user topic named `__audit` is read, while `__consumer_offsets` is not.
- **Offsets**: the -2/-1 sentinels, `validateBatchOptions`' rejection of latest-at-start and earliest-at-end, and the assertion that a per-partition map names every assigned partition.
- **Late binding**: `earliest`/`latest` are bound per task, as `fetchPartitionOffsets` and `KafkaSourceRDD.resolveRange` do. A read therefore picks up records produced after planning, and an `earliest` start survives retention mid-query rather than failing.
- **Timestamps**: precedence (global → per-partition → offsets) matching `getKafkaOffsetRangeLimit`, and `startingOffsetsByTimestampStrategy` defaulting to `error` for starting endpoints while ending endpoints always fall back to latest.
- **Splitting**: `minPartitions` / `maxRecordsPerPartition` reproduce `KafkaOffsetRangeCalculator` down to the split boundaries, including the two-pass exclusion of ranges too small to split. Verified against a transcription of the Scala over 6000 randomized inputs — byte-identical, with no records lost.
- **`failOnDataLoss`**: distinguishes offsets that are unreadable within the available range (compacted, control markers — skipped, as Spark skips them) from records that are genuinely gone (retention or truncation — raised).

One deliberate divergence from librdkafka defaults: `isolation.level` is pinned to `read_uncommitted`. librdkafka defaults to `read_committed`, Spark never sets the property and so inherits the Java client's `read_uncommitted`. Left alone, a transactional topic would silently return a different row set here than under Spark. Overridable with `kafka.isolation.level`.

## Planning

Runs on an `AdminClient`, like Spark's `KafkaOffsetReaderAdmin`: one `describe_topics` call, and one batched `list_offsets` per endpoint when resolution is needed at all. A plain `earliest`→`latest` read makes no offset request during planning, since both endpoints are late-bound.

## Testing

215 tests: 174 unit against fake broker clients, 41 integration against a real broker via testcontainers.

The late-binding tests drive the data source API directly rather than through a DataFrame — Spark Connect plans lazily at `collect()`, so the DataFrame API offers no seam between planning and reading, and that seam is exactly what they assert. They still run against the real broker, and both were verified to fail against driver-side resolution. The retention case reproduces the production symptom precisely: `_AUTO_OFFSET_RESET`, *"requested offset not available on the broker: Offset out of range"*.

Integration tests are deselected by default and only run in the repo-wide integration job, so the head commit carries `[catalog tests]` to trigger it.

## Not supported

Writes, streaming reads, and filter pushdown.

---

The `pushFilters` compatibility fix originally in this branch has been split out to #2437, as it affects all Python data sources and is independent of this work.