### PR TITLE
fix: honor spark.sql.ansi.enabled in array() element coercion

### DIFF
--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -184,6 +184,7 @@ message ExtendedScalarUdf {
     SparkFromXmlUdf spark_from_xml = 32;
     SparkCeilUdf spark_ceil = 33;
     SparkFloorUdf spark_floor = 34;
+    SparkArrayUdf spark_array = 35;
   }
 }
 
@@ -323,6 +324,10 @@ message SparkPmodUdf {
 }
 
 message SparkNegativeUdf {
+  bool ansi_mode = 1;
+}
+
+message SparkArrayUdf {
   bool ansi_mode = 1;
 }
 

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -2426,6 +2426,9 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             UdfKind::SparkNegative(r#gen::SparkNegativeUdf { ansi_mode }) => {
                 return Ok(Arc::new(ScalarUDF::from(SparkNegative::new(ansi_mode))));
             }
+            UdfKind::SparkArray(r#gen::SparkArrayUdf { ansi_mode }) => {
+                return Ok(Arc::new(ScalarUDF::from(SparkArray::new(ansi_mode))));
+            }
             UdfKind::SparkMakeTimestampNtz(r#gen::SparkMakeTimestampNtzUdf { is_try }) => {
                 return Ok(Arc::new(ScalarUDF::from(SparkMakeTimestampNtz::new(
                     is_try,
@@ -2488,9 +2491,6 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             "st_asbinary" => Ok(Arc::new(ScalarUDF::from(StAsBinary::new()))),
             "st_geomfromwkb" => Ok(Arc::new(ScalarUDF::from(StGeomFromWKB::new()))),
             "st_geogfromwkb" => Ok(Arc::new(ScalarUDF::from(StGeogFromWKB::new()))),
-            "spark_array" | "spark_make_array" | "array" => {
-                Ok(Arc::new(ScalarUDF::from(SparkArray::new())))
-            }
             "spark_concat" | "concat" | "array_concat" => {
                 Ok(Arc::new(ScalarUDF::from(SparkConcat::new())))
             }
@@ -2666,7 +2666,6 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node_inner.is::<RewriteLikePatternFunc>()
             || node_inner.is::<SparkAESDecrypt>()
             || node_inner.is::<SparkAESEncrypt>()
-            || node_inner.is::<SparkArray>()
             || node_inner.is::<SparkBase64>()
             || node_inner.is::<SparkBitCount>()
             || node_inner.is::<SparkBitGet>()
@@ -2894,6 +2893,9 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
         } else if let Some(func) = node.inner().downcast_ref::<SparkFloor>() {
             let ansi_mode = func.ansi_mode();
             UdfKind::SparkFloor(r#gen::SparkFloorUdf { ansi_mode })
+        } else if let Some(func) = node.inner().downcast_ref::<SparkArray>() {
+            let ansi_mode = func.ansi_mode();
+            UdfKind::SparkArray(r#gen::SparkArrayUdf { ansi_mode })
         } else if let Some(func) = node.inner().downcast_ref::<SparkMakeTimestampNtz>() {
             let is_try = func.is_try();
             UdfKind::SparkMakeTimestampNtz(r#gen::SparkMakeTimestampNtzUdf { is_try })

--- a/crates/sail-function/src/scalar/array/spark_array.rs
+++ b/crates/sail-function/src/scalar/array/spark_array.rs
@@ -3,13 +3,13 @@
 use std::sync::Arc;
 
 use datafusion::arrow::array::{
-    Array, ArrayData, ArrayRef, Capacities, GenericListArray, MutableArrayData, NullArray,
-    OffsetSizeTrait, make_array, new_empty_array, new_null_array,
+    make_array, new_empty_array, new_null_array, Array, ArrayData, ArrayRef, Capacities,
+    GenericListArray, MutableArrayData, NullArray, OffsetSizeTrait,
 };
 use datafusion::arrow::buffer::OffsetBuffer;
 use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion_common::utils::SingleRowListArrayBuilder;
-use datafusion_common::{Result, plan_datafusion_err, plan_err};
+use datafusion_common::{plan_datafusion_err, plan_err, Result};
 use datafusion_expr::type_coercion::binary::comparison_coercion;
 use datafusion_expr::{
     ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature,
@@ -22,23 +22,29 @@ use crate::functions_nested_utils::make_scalar_function;
 pub struct SparkArray {
     signature: Signature,
     aliases: Vec<String>,
+    ansi_mode: bool,
 }
 
 impl Default for SparkArray {
     fn default() -> Self {
-        Self::new()
+        Self::new(false)
     }
 }
 
 impl SparkArray {
-    pub fn new() -> Self {
+    pub fn new(ansi_mode: bool) -> Self {
         Self {
             signature: Signature::one_of(
                 vec![TypeSignature::UserDefined, TypeSignature::Nullary],
                 Volatility::Immutable,
             ),
             aliases: vec![String::from("spark_make_array")],
+            ansi_mode,
         }
+    }
+
+    pub fn ansi_mode(&self) -> bool {
+        self.ansi_mode
     }
 }
 
@@ -107,29 +113,47 @@ impl ScalarUDFImpl for SparkArray {
         let first_type = arg_types.first().ok_or_else(|| {
             plan_datafusion_err!("Spark array function requires at least one argument")
         })?;
-        // Spark non-ANSI semantics: when mixing strings with other (non-null) types,
-        // coerce everything to string. DataFusion's `comparison_coercion` prefers
-        // numeric types, which would break Spark's string-wins behavior and cause
-        // runtime cast failures for values like `array('a', 1)`.
         let is_string_like = |dt: &DataType| {
             matches!(
                 dt,
                 DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
             )
         };
-        let has_string = arg_types.iter().any(is_string_like);
-        let has_non_string_non_null = arg_types
-            .iter()
-            .any(|dt| !is_string_like(dt) && !dt.is_null());
-        if has_string && has_non_string_non_null {
-            let string_type = if arg_types.iter().any(|dt| matches!(dt, DataType::LargeUtf8)) {
-                DataType::LargeUtf8
-            } else if arg_types.iter().any(|dt| matches!(dt, DataType::Utf8View)) {
-                DataType::Utf8View
-            } else {
-                DataType::Utf8
-            };
-            return Ok(vec![string_type; arg_types.len()]);
+        // Spark's legacy "string promotion" applies ONLY when ANSI is disabled, and only
+        // to a mix of STRING with atomic numeric/date/timestamp values — never BOOLEAN,
+        // BINARY, or nested types (those are rejected with DATATYPE_MISMATCH in both
+        // modes). Under ANSI, string promotion is off: Spark resolves a numeric common
+        // type and fails the cast at runtime for values like `array('a', 1)`. DataFusion's
+        // `comparison_coercion` prefers numeric types, matching the ANSI path.
+        let is_string_promotable = |dt: &DataType| {
+            dt.is_numeric()
+                || matches!(
+                    dt,
+                    DataType::Decimal128(_, _)
+                        | DataType::Decimal256(_, _)
+                        | DataType::Date32
+                        | DataType::Date64
+                        | DataType::Timestamp(_, _)
+                )
+        };
+        if !self.ansi_mode {
+            let has_string = arg_types.iter().any(is_string_like);
+            let has_non_string_non_null = arg_types
+                .iter()
+                .any(|dt| !is_string_like(dt) && !dt.is_null());
+            let others_all_promotable = arg_types
+                .iter()
+                .all(|dt| is_string_like(dt) || dt.is_null() || is_string_promotable(dt));
+            if has_string && has_non_string_non_null && others_all_promotable {
+                let string_type = if arg_types.iter().any(|dt| matches!(dt, DataType::LargeUtf8)) {
+                    DataType::LargeUtf8
+                } else if arg_types.iter().any(|dt| matches!(dt, DataType::Utf8View)) {
+                    DataType::Utf8View
+                } else {
+                    DataType::Utf8
+                };
+                return Ok(vec![string_type; arg_types.len()]);
+            }
         }
         let new_type = arg_types
             .iter()

--- a/crates/sail-function/src/scalar/array/spark_array.rs
+++ b/crates/sail-function/src/scalar/array/spark_array.rs
@@ -3,13 +3,13 @@
 use std::sync::Arc;
 
 use datafusion::arrow::array::{
-    make_array, new_empty_array, new_null_array, Array, ArrayData, ArrayRef, Capacities,
-    GenericListArray, MutableArrayData, NullArray, OffsetSizeTrait,
+    Array, ArrayData, ArrayRef, Capacities, GenericListArray, MutableArrayData, NullArray,
+    OffsetSizeTrait, make_array, new_empty_array, new_null_array,
 };
 use datafusion::arrow::buffer::OffsetBuffer;
 use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion_common::utils::SingleRowListArrayBuilder;
-use datafusion_common::{plan_datafusion_err, plan_err, Result};
+use datafusion_common::{Result, plan_datafusion_err, plan_err};
 use datafusion_expr::type_coercion::binary::comparison_coercion;
 use datafusion_expr::{
     ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature,

--- a/crates/sail-plan/src/function/generator.rs
+++ b/crates/sail-plan/src/function/generator.rs
@@ -49,7 +49,7 @@ fn stack(input: ScalarFunctionInput) -> PlanResult<Expr> {
 
     let arrays = (0..num_cols)
         .map(|i| args.iter().skip(i).step_by(num_cols).cloned().collect())
-        .map(|col| ScalarUDF::from(SparkArray::new()).call(col))
+        .map(|col| ScalarUDF::from(SparkArray::new(false)).call(col))
         .collect::<Vec<_>>();
 
     let zipped = ScalarUDF::from(ArraysZip::new(field_names)).call(arrays);

--- a/crates/sail-plan/src/function/scalar/array.rs
+++ b/crates/sail-plan/src/function/scalar/array.rs
@@ -50,6 +50,17 @@ fn array_compact(array: expr::Expr) -> expr::Expr {
     ScalarUDF::from(SparkArrayCompact::new()).call(vec![array])
 }
 
+/// Dispatch for `array(...)`.
+///
+/// Reads `PlanConfig::ansi_mode` at planning time and bakes it into the UDF so
+/// element coercion follows Spark: under ANSI the array resolves a numeric
+/// common type (failing the cast at runtime for `array('a', 1)`), while non-ANSI
+/// applies legacy string promotion.
+fn array(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
+    let ansi_mode = input.function_context.plan_config.ansi_mode;
+    Ok(ScalarUDF::from(SparkArray::new(ansi_mode)).call(input.arguments))
+}
+
 fn arrays_zip(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     let field_names: Vec<String> = input
         .arguments
@@ -375,7 +386,7 @@ pub(super) fn list_built_in_array_functions() -> Vec<(&'static str, ScalarFuncti
     use crate::function::common::ScalarFunctionBuilder as F;
 
     vec![
-        ("array", F::udf(SparkArray::new())),
+        ("array", F::custom(array)),
         ("array_append", F::custom(array_append)),
         ("array_compact", F::unary(array_compact)),
         ("array_contains", F::binary(array_contains)),

--- a/crates/sail-plan/src/function/scalar/json.rs
+++ b/crates/sail-plan/src/function/scalar/json.rs
@@ -168,7 +168,7 @@ fn json_tuple(input: ScalarFunctionInput) -> PlanResult<Expr> {
     let json_tuple_expr = df_json_tuple(arguments);
 
     // Wrap in array and explode with Inline
-    let array_expr = ScalarUDF::from(SparkArray::new()).call(vec![json_tuple_expr]);
+    let array_expr = ScalarUDF::from(SparkArray::new(false)).call(vec![json_tuple_expr]);
     Ok(ScalarUDF::from(Explode::new(ExplodeKind::Inline)).call(vec![array_expr]))
 }
 

--- a/python/pysail/tests/spark/function/features/array_coercion.feature
+++ b/python/pysail/tests/spark/function/features/array_coercion.feature
@@ -1,8 +1,18 @@
+@array_coercion
 Feature: array() type coercion with mixed element types
 
-  Spark's non-ANSI semantics coerce mixed string/numeric arrays to string,
-  not to numeric. DataFusion 54 changed `comparison_coercion` to prefer
-  numeric, which would otherwise reject `array('a', 1)` at runtime.
+  Spark resolves a single element type for `array(...)` via its type-coercion
+  rules. The result depends on `spark.sql.ansi.enabled`:
+
+  - ANSI=false: legacy "string promotion" is ON, so a STRING mixed with a
+    numeric/date/timestamp coerces the whole array to STRING.
+  - ANSI=true (Spark 4.x default, and the value pinned by the test harness):
+    string promotion is OFF. `array('a', 1)` resolves to a numeric common type
+    and Spark raises CAST_INVALID_INPUT at runtime when the string is not a
+    valid number.
+
+  Type-incompatible combinations (string+boolean, string+binary, date+int) are
+  rejected by Spark in BOTH modes with DATATYPE_MISMATCH.
 
   Rule: Homogeneous arrays preserve their element type
 
@@ -44,9 +54,58 @@ Feature: array() type coercion with mixed element types
       | result     |
       | [1.0, 2.5] |
 
-  Rule: Mixed string and numeric types coerce to string (Spark non-ANSI)
+    Scenario: tinyint and bigint coerce to bigint
+      When query
+      """
+      SELECT array(CAST(1 AS TINYINT), CAST(2 AS BIGINT)) AS result
+      """
+      Then query result
+      | result |
+      | [1, 2] |
 
-    Scenario: string and integer coerce to string
+  Rule: NULL elements are preserved during numeric coercion
+
+    Scenario: integer and NULL
+      When query
+      """
+      SELECT array(1, NULL) AS result
+      """
+      Then query result
+      | result    |
+      | [1, NULL] |
+
+    Scenario: all-NULL array
+      When query
+      """
+      SELECT array(NULL, NULL) AS result
+      """
+      Then query result
+      | result       |
+      | [NULL, NULL] |
+
+    Scenario: leading NULL with numeric widening
+      When query
+      """
+      SELECT array(NULL, 1, 2.5) AS result
+      """
+      Then query result
+      | result           |
+      | [NULL, 1.0, 2.5] |
+
+  Rule: Mixed string and numeric — ANSI=true rejects, ANSI=false promotes to string
+
+    # String promotion is disabled under ANSI: Spark picks a numeric common type
+    # and fails casting the non-numeric string at runtime.
+    Scenario: string and integer under ANSI errors
+      Given config spark.sql.ansi.enabled = true
+      When query
+      """
+      SELECT array('a', 1) AS result
+      """
+      Then query error .*
+
+    Scenario: string and integer coerce to string (non-ANSI)
+      Given config spark.sql.ansi.enabled = false
       When query
       """
       SELECT array('a', 1) AS result
@@ -55,31 +114,164 @@ Feature: array() type coercion with mixed element types
       | result |
       | [a, 1] |
 
-    Scenario: string and double coerce to string
+    Scenario: string and double under ANSI errors
+      Given config spark.sql.ansi.enabled = true
+      When query
+      """
+      SELECT array('a', 1.5) AS result
+      """
+      Then query error .*
+
+    Scenario: string and double coerce to string (non-ANSI)
+      Given config spark.sql.ansi.enabled = false
       When query
       """
       SELECT array('a', 1.5) AS result
       """
       Then query result
-      | result    |
+      | result   |
       | [a, 1.5] |
 
-    Scenario: multiple strings and numerics coerce to string
+    Scenario: string and decimal under ANSI errors
+      Given config spark.sql.ansi.enabled = true
+      When query
+      """
+      SELECT array('a', CAST(1.5 AS DECIMAL(10,2))) AS result
+      """
+      Then query error .*
+
+    Scenario: string and decimal coerce to string preserving scale (non-ANSI)
+      Given config spark.sql.ansi.enabled = false
+      When query
+      """
+      SELECT array('a', CAST(1.5 AS DECIMAL(10,2))) AS result
+      """
+      Then query result
+      | result    |
+      | [a, 1.50] |
+
+    Scenario: multiple strings and numerics under ANSI errors
+      Given config spark.sql.ansi.enabled = true
+      When query
+      """
+      SELECT array('a', 1, 2.5, 'b') AS result
+      """
+      Then query error .*
+
+    Scenario: multiple strings and numerics coerce to string (non-ANSI)
+      Given config spark.sql.ansi.enabled = false
       When query
       """
       SELECT array('a', 1, 2.5, 'b') AS result
       """
       Then query result
-      | result          |
-      | [a, 1, 2.5, b]  |
+      | result         |
+      | [a, 1, 2.5, b] |
 
-  Rule: NULL elements are preserved during coercion
+    Scenario: string, numeric and NULL under ANSI errors
+      Given config spark.sql.ansi.enabled = true
+      When query
+      """
+      SELECT array('a', 1, NULL, 1.0) AS result
+      """
+      Then query error .*
 
-    Scenario: string, numeric and NULL coerce to string with NULL preserved
+    Scenario: string, numeric and NULL coerce to string with NULL preserved (non-ANSI)
+      Given config spark.sql.ansi.enabled = false
       When query
       """
       SELECT array('a', 1, NULL, 1.0) AS result
       """
       Then query result
-      | result              |
-      | [a, 1, NULL, 1.0]   |
+      | result            |
+      | [a, 1, NULL, 1.0] |
+
+  Rule: Numeric-parseable strings cast cleanly even under ANSI
+
+    # '1' is a valid number, so the numeric common type succeeds under ANSI;
+    # only non-numeric strings like 'a' trigger CAST_INVALID_INPUT.
+    Scenario: parseable string and integer under ANSI
+      Given config spark.sql.ansi.enabled = true
+      When query
+      """
+      SELECT array('1', 2) AS result
+      """
+      Then query result
+      | result |
+      | [1, 2] |
+
+    Scenario: parseable string and integer coerce to string (non-ANSI)
+      Given config spark.sql.ansi.enabled = false
+      When query
+      """
+      SELECT array('1', 2) AS result
+      """
+      Then query result
+      | result |
+      | [1, 2] |
+
+  Rule: String and date/timestamp — ANSI=true rejects, ANSI=false promotes to string
+
+    Scenario: string and date under ANSI errors
+      Given config spark.sql.ansi.enabled = true
+      When query
+      """
+      SELECT array('a', DATE '2024-01-15') AS result
+      """
+      Then query error .*
+
+    Scenario: string and date coerce to string (non-ANSI)
+      Given config spark.sql.ansi.enabled = false
+      When query
+      """
+      SELECT array('a', DATE '2024-01-15') AS result
+      """
+      Then query result
+      | result          |
+      | [a, 2024-01-15] |
+
+    # Independent bug: even when string promotion is correct (ANSI=false), Sail
+    # serializes TIMESTAMP via ISO-8601 ("2024-01-15T12:00:00Z") instead of
+    # Spark's "2024-01-15 12:00:00".
+    @sail-bug
+    Scenario: string and timestamp coerce to string with Spark formatting (non-ANSI)
+      Given config spark.sql.ansi.enabled = false
+      When query
+      """
+      SELECT array('a', TIMESTAMP '2024-01-15 12:00:00') AS result
+      """
+      Then query result
+      | result                   |
+      | [a, 2024-01-15 12:00:00] |
+
+  Rule: Type-incompatible elements are rejected by Spark in both ANSI modes
+
+    # Spark raises DATATYPE_MISMATCH (no string promotion for boolean/binary,
+    # no numeric->date coercion).
+    Scenario: string and boolean rejected
+      When query
+      """
+      SELECT array('a', true) AS result
+      """
+      Then query error .*
+
+    # Still divergent: DataFusion's `comparison_coercion` resolves STRING+BINARY to
+    # BINARY, so Sail casts the string to binary instead of rejecting like Spark.
+    @sail-bug
+    Scenario: string and binary rejected
+      Given config spark.sql.ansi.enabled = false
+      When query
+      """
+      SELECT array('a', X'4869') AS result
+      """
+      Then query error .*
+
+    # Still divergent: `comparison_coercion` resolves DATE+INT to DATE, so Sail
+    # coerces the integer to an epoch-day date instead of rejecting like Spark.
+    @sail-bug
+    Scenario: date and integer rejected
+      When query
+      """
+      SELECT array(DATE '2024-01-15', 1) AS result
+      """
+      Then query error .*


### PR DESCRIPTION
array() applied legacy "string promotion" unconditionally in SparkArray::coerce_types, ignoring ANSI mode. Under ANSI=true (Spark 4.x default), Spark disables string promotion: it resolves a numeric common type and fails the runtime cast for values like array('a', 1) with CAST_INVALID_INPUT. Sail instead coerced everything to STRING and returned [a, 1]. Promotion was also too broad — it covered BOOLEAN and BINARY, which Spark never string-promotes.

Bake ansi_mode into the UDF (matching SparkNextDay/SparkAbs/SparkPmod): a custom plan-time array() builder reads PlanConfig::ansi_mode and constructs SparkArray::new(ansi_mode). coerce_types now string-promotes only when ANSI is disabled and only for STRING mixed with numeric/date/timestamp; under ANSI it falls through to comparison_coercion so the runtime cast fails like Spark. Carry the flag across distributed execution via a new SparkArrayUdf proto message and fielded codec serialize/deserialize (removed from the name-based path).

Rewrite array_coercion.feature into ANSI on/off pairs validated against Spark JVM, plus 6 coerce_types unit tests. Remaining divergences (string+binary, date+int, timestamp->string formatting) stay tagged @sail-bug.