### PR TITLE
perf: build arrays_zip result with a single take instead of per-row concat

### DIFF
--- a/crates/sail-function/src/scalar/array/arrays_zip.rs
+++ b/crates/sail-function/src/scalar/array/arrays_zip.rs
@@ -346,6 +346,10 @@ fn arrays_zip_generic<O: OffsetSizeTrait>(
     offsets.push(zero_offset);
     let mut last_offset = zero_offset;
 
+    // Reused across rows to avoid a per-row allocation of the two scratch vectors.
+    let mut arrays_one_row: Vec<ArrayRef> = Vec::with_capacity(lists.len());
+    let mut lens_one_row: Vec<O> = Vec::with_capacity(lists.len());
+
     for row_idx in 0..num_rows {
         if validity_mask_opt
             .as_ref()
@@ -355,8 +359,8 @@ fn arrays_zip_generic<O: OffsetSizeTrait>(
             continue;
         }
 
-        let mut arrays_one_row: Vec<ArrayRef> = Vec::with_capacity(lists.len());
-        let mut lens_one_row: Vec<O> = Vec::with_capacity(lists.len());
+        arrays_one_row.clear();
+        lens_one_row.clear();
         let mut max_len_one_row = zero_offset;
         let mut all_uniform = true;
         for arg in &lists {
@@ -372,10 +376,10 @@ fn arrays_zip_generic<O: OffsetSizeTrait>(
             lens_one_row.push(len);
         }
 
-        let arrays_padded = if all_uniform {
-            arrays_one_row
+        let struct_array = if all_uniform {
+            to_struct_array(arrays_one_row.as_slice(), field_names.as_slice(), &arg_fields)?
         } else {
-            arrays_one_row
+            let arrays_padded = arrays_one_row
                 .iter()
                 .zip(lens_one_row.iter())
                 .map(|(arr, len)| {
@@ -387,14 +391,9 @@ fn arrays_zip_generic<O: OffsetSizeTrait>(
                         ])?),
                     })
                 })
-                .collect::<Result<Vec<_>>>()?
+                .collect::<Result<Vec<_>>>()?;
+            to_struct_array(arrays_padded.as_slice(), field_names.as_slice(), &arg_fields)?
         };
-
-        let struct_array = to_struct_array(
-            arrays_padded.as_slice(),
-            field_names.as_slice(),
-            &arg_fields,
-        )?;
         let offset = O::from_usize(struct_array.len()).ok_or_else(|| {
             DataFusionError::Execution("`arrays_zip` offset overflow error".to_string())
         })?;

--- a/crates/sail-function/src/scalar/array/arrays_zip.rs
+++ b/crates/sail-function/src/scalar/array/arrays_zip.rs
@@ -2,12 +2,12 @@ use std::ops::BitAnd;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{
-    Array, ArrayRef, AsArray, FixedSizeListArray, GenericListArray, NullArray, OffsetSizeTrait,
-    StructArray, new_empty_array, new_null_array,
+    Array, ArrayRef, AsArray, FixedSizeListArray, GenericListArray, OffsetSizeTrait, StructArray,
+    UInt64Array, new_null_array,
 };
 use datafusion::arrow::buffer::{NullBuffer, OffsetBuffer};
-use datafusion::arrow::compute::{cast, concat};
-use datafusion::arrow::datatypes::{DataType, Field, Fields};
+use datafusion::arrow::compute::{cast, take};
+use datafusion::arrow::datatypes::{DataType, Field};
 use datafusion_common::{DataFusionError, Result, arrow_err, exec_err, plan_err};
 use datafusion_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
@@ -341,14 +341,15 @@ fn arrays_zip_generic<O: OffsetSizeTrait>(
         DataFusionError::Execution("`arrays_zip`: zero offset should always exist".to_string())
     })?;
 
-    let mut struct_arrays = Vec::with_capacity(num_rows);
+    // Flatten build: compute the output offsets once and gather each struct column with a single
+    // `take`, null-padding ragged rows via null indices. Avoids building a `StructArray` per row
+    // and a final `concat` of all of them.
+    let n_args = lists.len();
     let mut offsets = Vec::with_capacity(num_rows + 1);
     offsets.push(zero_offset);
     let mut last_offset = zero_offset;
-
-    // Reused across rows to avoid a per-row allocation of the two scratch vectors.
-    let mut arrays_one_row: Vec<ArrayRef> = Vec::with_capacity(lists.len());
-    let mut lens_one_row: Vec<O> = Vec::with_capacity(lists.len());
+    let mut take_indices: Vec<Vec<Option<u64>>> = (0..n_args).map(|_| Vec::new()).collect();
+    let mut row_spans: Vec<(usize, usize)> = Vec::with_capacity(n_args);
 
     for row_idx in 0..num_rows {
         if validity_mask_opt
@@ -359,73 +360,34 @@ fn arrays_zip_generic<O: OffsetSizeTrait>(
             continue;
         }
 
-        arrays_one_row.clear();
-        lens_one_row.clear();
-        let mut max_len_one_row = zero_offset;
-        let mut all_uniform = true;
-        for arg in &lists {
-            let arr = arg.value(row_idx);
-            let len = arg.value_length(row_idx);
-            if !lens_one_row.is_empty() && len != lens_one_row[0] {
-                all_uniform = false;
-            }
-            if len > max_len_one_row {
-                max_len_one_row = len;
-            }
-            arrays_one_row.push(arr);
-            lens_one_row.push(len);
+        row_spans.clear();
+        let mut max_len = 0usize;
+        for list in &lists {
+            let start = list.value_offsets()[row_idx].as_usize();
+            let len = list.value_length(row_idx).as_usize();
+            row_spans.push((start, len));
+            max_len = max_len.max(len);
         }
-
-        let struct_array = if all_uniform {
-            to_struct_array(arrays_one_row.as_slice(), field_names.as_slice(), &arg_fields)?
-        } else {
-            let arrays_padded = arrays_one_row
-                .iter()
-                .zip(lens_one_row.iter())
-                .map(|(arr, len)| {
-                    Ok(match (max_len_one_row - *len).as_usize() {
-                        0 => arr.clone(),
-                        len_diff => Arc::new(concat(&[
-                            arr,
-                            &cast(&NullArray::new(len_diff), arr.data_type())?,
-                        ])?),
-                    })
-                })
-                .collect::<Result<Vec<_>>>()?;
-            to_struct_array(arrays_padded.as_slice(), field_names.as_slice(), &arg_fields)?
-        };
-        let offset = O::from_usize(struct_array.len()).ok_or_else(|| {
-            DataFusionError::Execution("`arrays_zip` offset overflow error".to_string())
-        })?;
-
-        last_offset += offset;
+        for k in 0..max_len {
+            for (j, &(start, len)) in row_spans.iter().enumerate() {
+                take_indices[j].push((k < len).then(|| (start + k) as u64));
+            }
+        }
+        last_offset += O::usize_as(max_len);
         offsets.push(last_offset);
-        struct_arrays.push(struct_array);
     }
 
-    let values: ArrayRef = if struct_arrays.is_empty() {
-        // When all rows are null, struct_arrays is empty. Create an empty struct array.
-        let fields: Fields = field_names
-            .iter()
-            .zip(inner_fields.iter())
-            .map(|(name, f)| {
-                Field::new(name, f.data_type().clone(), true).with_metadata(f.metadata().clone())
-            })
-            .collect();
-        let empty_arrays: Vec<ArrayRef> = inner_fields
-            .iter()
-            .map(|f| new_empty_array(f.data_type()))
-            .collect();
-        Arc::new(StructArray::try_new(fields, empty_arrays, None)?)
-    } else {
-        concat(
-            struct_arrays
-                .iter()
-                .map(|a| a.as_ref())
-                .collect::<Vec<_>>()
-                .as_slice(),
-        )?
-    };
+    // One `take` per struct column; a `None` index null-pads a ragged position.
+    let columns = lists
+        .iter()
+        .zip(take_indices)
+        .map(|(list, indices)| {
+            let indices = UInt64Array::from(indices);
+            take(list.values().as_ref(), &indices, None).map_or_else(|err| arrow_err!(err), Ok)
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let values = to_struct_array(columns.as_slice(), field_names.as_slice(), &arg_fields)?;
 
     Ok(Arc::new(GenericListArray::<O>::try_new(
         struct_result_field(&inner_fields, &field_names),

--- a/python/pysail/tests/spark/function/features/arrays_zip.feature
+++ b/python/pysail/tests/spark/function/features/arrays_zip.feature
@@ -1,3 +1,4 @@
+@arrays_zip
 Feature: arrays_zip comprehensive tests
 
   Rule: Basic usage
@@ -187,6 +188,38 @@ Feature: arrays_zip comprehensive tests
         | result |
         | NULL   |
 
+    # Columnar path: neither column is fully NULL, so the invoke short-circuits do
+    # not fire — the combined validity mask makes every row NULL and the result
+    # values struct ends up empty. This exercises the flatten build with empty
+    # `take` outputs (the path that replaced the removed all-null special case).
+    Scenario: arrays_zip all rows NULL via combined validity across columns
+      When query
+        """
+        SELECT arrays_zip(a, b) AS result
+        FROM VALUES
+          (array(1), CAST(NULL AS ARRAY<INT>)),
+          (CAST(NULL AS ARRAY<INT>), array(2))
+        AS t(a, b)
+        """
+      Then query result ordered
+        | result |
+        | NULL   |
+        | NULL   |
+
+    Scenario: arrays_zip mixed valid and NULL rows via a per-row NULL array
+      When query
+        """
+        SELECT arrays_zip(a, b) AS result
+        FROM VALUES
+          (array(1,2), array('x','y')),
+          (array(3), CAST(NULL AS ARRAY<STRING>))
+        AS t(a, b)
+        """
+      Then query result ordered
+        | result           |
+        | [{1, x}, {2, y}] |
+        | NULL             |
+
     Scenario: arrays_zip untyped empty array() pads first as NULL
       When query
         """
@@ -195,6 +228,46 @@ Feature: arrays_zip comprehensive tests
       Then query result
         | result                 |
         | [{NULL, 1}, {NULL, 2}] |
+
+  Rule: Columnar multi-row paths (flatten build)
+    # Multi-row FROM VALUES columns exercise the flatten kernel's per-row offset
+    # and null-pad logic that single-row literals never reach.
+
+    Scenario: arrays_zip empty rows in a column
+      When query
+        """
+        SELECT arrays_zip(a, b) AS result
+        FROM VALUES (array(), array()), (array(), array()) AS t(a, b)
+        """
+      Then query result ordered
+        | result |
+        | []     |
+        | []     |
+
+    Scenario: arrays_zip ragged lengths per row in a column
+      When query
+        """
+        SELECT arrays_zip(a, b) AS result
+        FROM VALUES
+          (array(1,2,3), array('a')),
+          (array(4), array('b','c','d'))
+        AS t(a, b)
+        """
+      Then query result ordered
+        | result                         |
+        | [{1, a}, {2, NULL}, {3, NULL}] |
+        | [{4, b}, {NULL, c}, {NULL, d}] |
+
+    Scenario: arrays_zip empty and non-empty rows in a column
+      When query
+        """
+        SELECT arrays_zip(a, b) AS result
+        FROM VALUES (array(), array(1)), (array(2), array()) AS t(a, b)
+        """
+      Then query result ordered
+        | result      |
+        | [{NULL, 1}] |
+        | [{2, NULL}] |
 
   Rule: Type variety
 


### PR DESCRIPTION
## Benchmark

Self-contained harness (public `arrow` only, pinned): davidlghellin/sail-benchmarks#2 →
[`sail-2272-arrays-zip`](https://github.com/davidlghellin/sail-benchmarks/tree/master/sail-2272-arrays-zip).
`old` = the previous per-row `StructArray` + `concat(N)` build; `new` = compute the output offsets once
and gather each struct column with a single `arrow::compute::take`.

**Time — criterion, 200k rows**

| case | old (per-row struct + concat) | new (flatten + take) | speedup |
|---|---|---|---|
| 2 args | 72.0 ms | 5.56 ms | **~13×** |
| 4 args | 130.0 ms | 11.76 ms | **~11×** |

**Memory — divan, 200k rows × 4 args**

| metric | old | new | improvement |
|---|---|---|---|
| time | 116.4 ms | 11.19 ms | ~10× |
| bytes allocated | 273.6 MB | 26.4 MB | **~10×** |
| **allocation count** | **3,000,046** | **56** | **~54,000×** |
| peak memory | 264 MB | 37.6 MB | ~7× |

The old path builds one `StructArray` per row (200k of them) and then `concat`s them — ~3M tiny
allocations. The new path computes offsets once and does a single `take` per struct column: 56
allocations total. So the win is both CPU and, above all, allocator pressure.

**Correctness:** `cargo test -p sail-2272-arrays-zip` — `old` and `new` produce byte-identical
`ArrayData` on uniform, ragged (null-padded), null-row, null-element and empty/mixed inputs (5 tests).

_Numbers on Apple M-series; exact values vary by CPU / Rust / arrow version — treat as illustrative._


benchmarks https://github.com/davidlghellin/sail-benchmarks/pull/2