### PR TITLE
perf: bit-pack the keep mask and hoist validity in `array_compact`

### DIFF
--- a/crates/sail-function/src/scalar/array/spark_array_compact.rs
+++ b/crates/sail-function/src/scalar/array/spark_array_compact.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use datafusion::arrow::array::{
-    Array, ArrayRef, BooleanArray, GenericListArray, OffsetSizeTrait, as_large_list_array,
-    as_list_array,
+    Array, ArrayRef, BooleanArray, BooleanBufferBuilder, GenericListArray, OffsetSizeTrait,
+    as_large_list_array, as_list_array,
 };
 use datafusion::arrow::buffer::OffsetBuffer;
 use datafusion::arrow::compute;
@@ -86,9 +86,14 @@ fn array_compact_generic<O: OffsetSizeTrait>(list: &GenericListArray<O>) -> Resu
     let values = list.values();
     let offsets = list.offsets();
 
-    // Build a boolean filter mask for the flattened values array.
-    // We keep a value if its parent row is not null AND the value itself is not null.
-    let mut keep: Vec<bool> = Vec::with_capacity(values.len());
+    // Validity of the flattened values, fetched once instead of a per-element vtable
+    // `is_valid` call.
+    let value_nulls = values.nulls();
+
+    // Build the keep mask directly as a bit-packed boolean buffer (no intermediate
+    // `Vec<bool>` that then gets repacked into bits). We keep a value if its parent row
+    // is not null AND the value itself is not null.
+    let mut keep = BooleanBufferBuilder::new(values.len());
     // New offsets after compaction: one entry per row, counting retained values.
     let mut new_offsets: Vec<O> = Vec::with_capacity(list.len() + 1);
     new_offsets.push(O::usize_as(0));
@@ -100,23 +105,22 @@ fn array_compact_generic<O: OffsetSizeTrait>(list: &GenericListArray<O>) -> Resu
 
         if list.is_null(i) {
             // Null row: mark all values in the range as not kept.
-            keep.extend(std::iter::repeat_n(false, end - start));
-            // Null row: offset stays the same (empty slice).
-            new_offsets.push(O::usize_as(total_kept));
+            keep.append_n(end - start, false);
         } else {
             // Non-null row: keep only non-null values.
             for j in start..end {
-                let keep_value = values.is_valid(j);
-                keep.push(keep_value);
+                let keep_value = value_nulls.is_none_or(|n| n.is_valid(j));
+                keep.append(keep_value);
                 if keep_value {
                     total_kept += 1;
                 }
             }
-            new_offsets.push(O::usize_as(total_kept));
         }
+        // Offset stays put for a null row (empty slice) and advances by the retained count otherwise.
+        new_offsets.push(O::usize_as(total_kept));
     }
 
-    let keep_mask = BooleanArray::from(keep);
+    let keep_mask = BooleanArray::new(keep.finish(), None);
     let new_values = compute::filter(values.as_ref(), &keep_mask)?;
 
     let field = match list.data_type() {


### PR DESCRIPTION
## Benchmark

Self-contained harness (public `arrow` only, pinned): davidlghellin/sail-benchmarks →
[`sail-2280-array-compact`](https://github.com/davidlghellin/sail-benchmarks/tree/master/sail-2280-array-compact).
`old`/`new` are copied verbatim from `spark_array_compact.rs`, differing only in the two changed
spots (hoisted `values.nulls()` + `BooleanBufferBuilder` instead of `Vec<bool>` + per-element
`is_valid`).

**The solid win is memory.** Over 1M rows × 8 elems (8M values), divan reports:

| | bytes allocated |
|---|---|
| old | 40.59 MB |
| **new** | **32.20 MB** |

**−8.4 MB** — exactly the intermediate `Vec<bool>` (8M values × 1 byte) the new path never builds; it
writes the keep mask straight into a bit-packed buffer. The saving is structural and scales with total
values.

**Time (criterion, 1M rows):** a smaller, noisier improvement.

| case | old | new |
|---|---|---|
| 3 elems/row | 13.0 ms | 10.5 ms (~1.24×) |
| 8 elems/row | 29.0 ms | 26.3 ms (~1.10×) |

**Correctness:** `cargo test -p sail-2280-array-compact` — `old` and `new` produce byte-identical
`ArrayData` (null rows, null elements, mixed).

_Numbers on Apple M-series; time varies run-to-run — the −8.4 MB memory delta is the robust result._
