### PR TITLE
perf: hoist per-row NullArray downcast out of array() construction

### DIFF
--- a/crates/sail-function/src/scalar/array/spark_array.rs
+++ b/crates/sail-function/src/scalar/array/spark_array.rs
@@ -274,10 +274,16 @@ fn array_array<O: OffsetSizeTrait>(
     let data_ref = data.iter().collect::<Vec<_>>();
     let mut mutable = MutableArrayData::with_capacities(data_ref, true, capacity);
 
+    // `NullArray`-ness is a per-column property; hoist it out of the row loop.
+    let is_null_array = args
+        .iter()
+        .map(|arg| arg.as_any().is::<NullArray>())
+        .collect::<Vec<_>>();
+
     let num_rows = args[0].len();
     for row_idx in 0..num_rows {
         for (arr_idx, arg) in args.iter().enumerate() {
-            if !arg.as_any().is::<NullArray>() && !arg.is_null(row_idx) && arg.is_valid(row_idx) {
+            if !is_null_array[arr_idx] && arg.is_valid(row_idx) {
                 mutable.extend(arr_idx, row_idx, row_idx + 1);
             } else {
                 mutable.extend_nulls(1);


### PR DESCRIPTION
## Benchmark

Self-contained harness (public `arrow` only, pinned): davidlghellin/sail-benchmarks →
[`sail-2281-array-null-hoist`](https://github.com/davidlghellin/sail-benchmarks/tree/master/sail-2281-array-null-hoist).
`old`/`new` copied verbatim from `spark_array.rs`, differing only in hoisting the
`arg.as_any().is::<NullArray>()` downcast out of the `row × arg` loop (`num_args` downcasts instead
of `num_rows × num_args`) and dropping the redundant `!is_null && is_valid`.

**Time (criterion, 1M rows)**

| `array` of N args | old | new | speedup |
|---|---|---|---|
| 2 args | 25.9 ms | 21.5 ms | ~1.20× |
| 4 args | 47.5 ms | 37.0 ms | ~1.29× |
| 8 args | 101.3 ms | 84.9 ms | ~1.19× |

**Memory (divan, 8 args): identical** — both 68.15 MB; `new` does exactly **one** extra small alloc
(the `Vec<bool>` of per-arg flags), traded for `num_rows × num_args` vtable downcasts removed from the
hot loop. So the win is pure CPU.

**Correctness:** `cargo test -p sail-2281-array-null-hoist` — `old`/`new` produce byte-identical
`ArrayData`.

_Numbers on Apple M-series; treat as illustrative._
