### PR TITLE
feat: add EliminateRedundantRepartition physical optimizer rule

### DIFF
--- a/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
+++ b/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
@@ -41,7 +41,10 @@ impl PhysicalOptimizerRule for EliminateRedundantRepartition {
                 return Ok(Transformed::no(node));
             };
 
-            let child = node.children()[0];
+            let [child] = node.children()[..] else {
+                return Ok(Transformed::no(node));
+            };
+
             if child.downcast_ref::<ExplicitRepartitionExec>().is_some() {
                 Ok(Transformed::yes(child.clone()))
             } else {

--- a/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
+++ b/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
@@ -67,6 +67,7 @@ impl Debug for EliminateRedundantRepartition {
 }
 
 #[cfg(test)]
+#[expect(clippy::unwrap_used)]
 mod tests {
     use std::sync::Arc;
 

--- a/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
+++ b/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
@@ -1,12 +1,13 @@
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
-use datafusion::{common::tree_node::TreeNode, physical_optimizer::PhysicalOptimizerRule};
-use datafusion::physical_plan::ExecutionPlan;
-use sail_physical_plan::repartition::ExplicitRepartitionExec;
-use datafusion::physical_plan::repartition::RepartitionExec;
-use datafusion::error::Result;
-use datafusion::common::tree_node::Transformed;
+
+use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::config::ConfigOptions;
+use datafusion::error::Result;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use sail_physical_plan::repartition::ExplicitRepartitionExec;
 
 /// EliminateRedundantRepartition optimizer rule removes a RepartitionExec
 /// that is directly on top of an ExplicitRepartitionExec, since the input has
@@ -34,11 +35,10 @@ impl PhysicalOptimizerRule for EliminateRedundantRepartition {
         &self,
         plan: Arc<dyn ExecutionPlan>,
         _config: &ConfigOptions,
-    ) -> Result<Arc<dyn ExecutionPlan>>
-    {
-        let result = plan.transform_up(|node| {
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let result = plan.transform_up(|node: Arc<dyn ExecutionPlan>| {
             if node.downcast_ref::<RepartitionExec>().is_none() {
-                return Ok(Transformed::no(node))
+                return Ok(Transformed::no(node));
             };
 
             let child = node.children()[0];
@@ -66,3 +66,54 @@ impl Debug for EliminateRedundantRepartition {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::config::ConfigOptions;
+    use datafusion::physical_optimizer::PhysicalOptimizerRule;
+    use datafusion::physical_plan::empty::EmptyExec;
+    use datafusion::physical_plan::repartition::RepartitionExec;
+    use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
+    use datafusion_physical_expr::Partitioning;
+    use sail_physical_plan::repartition::ExplicitRepartitionExec;
+
+    use super::EliminateRedundantRepartition;
+
+    fn schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]))
+    }
+
+    #[test]
+    fn test_eliminate_redundant_repartition_above_explicit_repartition() {
+        let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema()));
+        let explicit: Arc<dyn ExecutionPlan> = Arc::new(ExplicitRepartitionExec::new(
+            input,
+            Partitioning::RoundRobinBatch(3),
+        ));
+        let redundant: Arc<dyn ExecutionPlan> = Arc::new(
+            RepartitionExec::try_new(explicit, Partitioning::RoundRobinBatch(10)).unwrap(),
+        );
+
+        let rule = EliminateRedundantRepartition::new();
+        let result = rule.optimize(redundant, &ConfigOptions::default()).unwrap();
+
+        assert!(result.downcast_ref::<ExplicitRepartitionExec>().is_some());
+        assert_eq!(result.output_partitioning().partition_count(), 3);
+    }
+
+    #[test]
+    fn test_no_change_when_child_is_not_explicit_repartition() {
+        let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema()));
+        let repartition: Arc<dyn ExecutionPlan> =
+            Arc::new(RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(3)).unwrap());
+
+        let rule = EliminateRedundantRepartition::new();
+        let result = rule
+            .optimize(repartition, &ConfigOptions::default())
+            .unwrap();
+
+        assert!(result.downcast_ref::<RepartitionExec>().is_some());
+    }
+}

--- a/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
+++ b/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
@@ -38,12 +38,15 @@ impl PhysicalOptimizerRule for EliminateRedundantRepartition {
         _config: &ConfigOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let result = plan.transform_up(|node: Arc<dyn ExecutionPlan>| {
-            let Some(repartition) = node.downcast_ref::<RepartitionExec>() else {
+            if node.downcast_ref::<RepartitionExec>().is_none() {
                 return Ok(Transformed::no(node));
             };
 
             // Do not eliminate hash partitioning, as it may voilate the parent node's distribution requirements.
-            if matches!(repartition.partitioning(), Partitioning::Hash(_, _)) {
+            if matches!(
+                node.properties().output_partitioning(),
+                Partitioning::Hash(_, _)
+            ) {
                 return Ok(Transformed::no(node));
             };
 

--- a/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
+++ b/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
@@ -8,6 +8,7 @@ use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::repartition::RepartitionExec;
 use sail_physical_plan::repartition::ExplicitRepartitionExec;
+use datafusion_physical_expr::Partitioning;
 
 /// EliminateRedundantRepartition optimizer rule removes a RepartitionExec
 /// that is directly on top of an ExplicitRepartitionExec, since the input has
@@ -37,8 +38,13 @@ impl PhysicalOptimizerRule for EliminateRedundantRepartition {
         _config: &ConfigOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let result = plan.transform_up(|node: Arc<dyn ExecutionPlan>| {
-            if node.downcast_ref::<RepartitionExec>().is_none() {
-                return Ok(Transformed::no(node));
+            let Some(repartition) = node.downcast_ref::<RepartitionExec>() else {
+                return Ok(Transformed::no(node))
+            };
+
+            // Do not eliminate hash partitioning, as it may voilate the parent node's distribution requirements.
+            if matches!(repartition.partitioning(), Partitioning::Hash(_, _)) {
+                return Ok(Transformed::no(node))
             };
 
             let [child] = node.children()[..] else {

--- a/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
+++ b/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
@@ -1,0 +1,68 @@
+use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
+use datafusion::{common::tree_node::TreeNode, physical_optimizer::PhysicalOptimizerRule};
+use datafusion::physical_plan::ExecutionPlan;
+use sail_physical_plan::repartition::ExplicitRepartitionExec;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion::error::Result;
+use datafusion::common::tree_node::Transformed;
+use datafusion::config::ConfigOptions;
+
+/// EliminateRedundantRepartition optimizer rule removes a RepartitionExec
+/// that is directly on top of an ExplicitRepartitionExec, since the input has
+/// already been explicitly repartitioned and the additional repartition is
+/// redundant.
+///
+/// This rule should be applied after the EnforceDistribution
+/// rule and before the RewriteExplicitRepartition rule.
+pub struct EliminateRedundantRepartition {}
+
+impl EliminateRedundantRepartition {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for EliminateRedundantRepartition {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PhysicalOptimizerRule for EliminateRedundantRepartition {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>>
+    {
+        let result = plan.transform_up(|node| {
+            if node.downcast_ref::<RepartitionExec>().is_none() {
+                return Ok(Transformed::no(node))
+            };
+
+            let child = node.children()[0];
+            if child.downcast_ref::<ExplicitRepartitionExec>().is_some() {
+                Ok(Transformed::yes(child.clone()))
+            } else {
+                Ok(Transformed::no(node))
+            }
+        })?;
+        Ok(result.data)
+    }
+
+    fn name(&self) -> &str {
+        "EliminateRedundantRepartition"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+impl Debug for EliminateRedundantRepartition {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+

--- a/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
+++ b/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
@@ -7,8 +7,8 @@ use datafusion::error::Result;
 use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::repartition::RepartitionExec;
-use sail_physical_plan::repartition::ExplicitRepartitionExec;
 use datafusion_physical_expr::Partitioning;
+use sail_physical_plan::repartition::ExplicitRepartitionExec;
 
 /// EliminateRedundantRepartition optimizer rule removes a RepartitionExec
 /// that is directly on top of an ExplicitRepartitionExec, since the input has
@@ -39,12 +39,12 @@ impl PhysicalOptimizerRule for EliminateRedundantRepartition {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let result = plan.transform_up(|node: Arc<dyn ExecutionPlan>| {
             let Some(repartition) = node.downcast_ref::<RepartitionExec>() else {
-                return Ok(Transformed::no(node))
+                return Ok(Transformed::no(node));
             };
 
             // Do not eliminate hash partitioning, as it may voilate the parent node's distribution requirements.
             if matches!(repartition.partitioning(), Partitioning::Hash(_, _)) {
-                return Ok(Transformed::no(node))
+                return Ok(Transformed::no(node));
             };
 
             let [child] = node.children()[..] else {

--- a/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
+++ b/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
@@ -10,15 +10,45 @@ use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion_physical_expr::Partitioning;
 use sail_physical_plan::repartition::ExplicitRepartitionExec;
 
-/// `EliminateRedundantRepartition` optimizer rule removes a `RepartitionExec`
-/// with `Partitioning::RoundRobinBatch` inserted by `EnforceDistribution` rule,
-/// that sits directly on top of an `ExplicitRepartitionExec`.
+/// `EliminateRedundantRepartition` rule removes redundant repartition nodes from the physical
+/// plan, thereby optimizing repartition performance across the plan.
 ///
-/// `RepartitionExec` with `Partitioning::Hash(..)` or `Partitioning::UnknownPartitioning`
-/// is left untouched, since eliminating it could violate the parent node's
-/// distribution requirement.
+/// The rule targets two redundant patterns:
 ///
-/// This rule should be applied right after the `EnforceDistribution` rule.
+/// Pattern 1: `RepartitionExec(RoundRobinBatch)` → `ExplicitRepartitionExec`
+///
+/// This rule removes a `RepartitionExec` with `Partitioning::RoundRobinBatch` inserted by the
+/// `EnforceDistribution` rule that sits directly on top of an `ExplicitRepartitionExec`.
+///
+/// `EnforceDistribution` inserts a `RepartitionExec` with `Partitioning::RoundRobinBatch` only
+/// when the parent node's required input distribution is `Distribution::UnspecifiedDistribution`,
+/// purely to increase parallelism up to `target_partitions`. Removing this round-robin
+/// repartition does not violate the parent node's distribution requirement, since it is
+/// unspecified. It only means the resulting number of partitions is bounded by
+/// `ExplicitRepartitionExec`'s own partitioning rather than being raised to
+/// `target_partitions`.
+///
+/// Note: `RepartitionExec` with `Partitioning::Hash(..)` or
+/// `Partitioning::UnknownPartitioning` is left untouched, since eliminating it could violate
+/// the parent node's distribution requirement.
+///
+/// To avoid eliminating any unintended `RepartitionExec`, this rule should be applied
+/// immediately after the `EnforceDistribution` rule.
+///
+/// Pattern 2: `ExplicitRepartitionExec` → `ExplicitRepartitionExec`
+///
+/// This rule collapses nested `ExplicitRepartitionExec` nodes into one, using the outer node's
+/// partitioning scheme, since the outer repartition redistributes the data regardless of how
+/// the inner one arranged it.
+///
+/// Exception: an outer `UnknownPartitioning` over an inner `RoundRobin`/`Hash` is preserved.
+/// When the outer partition count is less than the inner partition count,
+/// `UnknownPartitioning` gets rewritten to `CoalesceExec`/`CoalescePartitionsExec` by the
+/// `RewriteExplicitRepartition` rule. Coalesce never shuffles; it only merges partitions down
+/// to the outer count. Collapsing here would silently remove the shuffle and turn it into a
+/// no-shuffle operation.
+///
+
 pub struct EliminateRedundantRepartition {}
 
 impl EliminateRedundantRepartition {
@@ -40,21 +70,46 @@ impl PhysicalOptimizerRule for EliminateRedundantRepartition {
         _config: &ConfigOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let result = plan.transform_up(|node: Arc<dyn ExecutionPlan>| {
-            let Some(repartition) = node.downcast_ref::<RepartitionExec>() else {
+            // Pattern 1: RepartitionExec(RoundRobinBatch) → ExplicitRepartitionExec
+            if let Some(repartition) = node.downcast_ref::<RepartitionExec>() {
+                if matches!(
+                    repartition.properties().output_partitioning(),
+                    Partitioning::RoundRobinBatch(_)
+                ) && repartition
+                    .input()
+                    .downcast_ref::<ExplicitRepartitionExec>()
+                    .is_some()
+                {
+                    return Ok(Transformed::yes(repartition.input().clone()));
+                }
                 return Ok(Transformed::no(node));
-            };
-
-            let child = repartition.input();
-            let Some(_explicit) = child.downcast_ref::<ExplicitRepartitionExec>() else {
-                return Ok(Transformed::no(node));
-            };
-
-            // Eliminating a RepartitionExec with a RoundRobinBatch scheme that sits directly
-            // on top of an ExplicitRepartitionExec does not violate the parent node's
-            // distribution requirements.
-            if matches!(repartition.partitioning(), Partitioning::RoundRobinBatch(_)) {
-                return Ok(Transformed::yes(child.clone()));
             }
+
+            // Pattern 2: ExplicitRepartitionExec → ExplicitRepartitionExec
+            if let Some(outer) = node.downcast_ref::<ExplicitRepartitionExec>() {
+                if let Some(inner) = outer.input().downcast_ref::<ExplicitRepartitionExec>() {
+                    let outer_p = outer.properties().output_partitioning();
+                    let inner_p = inner.properties().output_partitioning();
+
+                    if !matches!(
+                        (outer_p, inner_p),
+                        (
+                            Partitioning::UnknownPartitioning(_),
+                            Partitioning::RoundRobinBatch(_),
+                        ) | (
+                            Partitioning::UnknownPartitioning(_),
+                            Partitioning::Hash(_, _)
+                        )
+                    ) {
+                        return Ok(Transformed::yes(Arc::new(ExplicitRepartitionExec::new(
+                            inner.input().clone(),
+                            outer_p.clone(),
+                        ))));
+                    }
+                }
+                return Ok(Transformed::no(node));
+            }
+
             Ok(Transformed::no(node))
         })?;
         Ok(result.data)

--- a/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
+++ b/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
@@ -11,15 +11,14 @@ use datafusion_physical_expr::Partitioning;
 use sail_physical_plan::repartition::ExplicitRepartitionExec;
 
 /// `EliminateRedundantRepartition` optimizer rule removes a `RepartitionExec`
-/// with `Partitioning::RoundRobinBatch` that sits directly on top of an
-/// `ExplicitRepartitionExec`.
+/// with `Partitioning::RoundRobinBatch` inserted by `EnforceDistribution` rule,
+/// that sits directly on top of an `ExplicitRepartitionExec`.
 ///
 /// `RepartitionExec` with `Partitioning::Hash(..)` or `Partitioning::UnknownPartitioning`
 /// is left untouched, since eliminating it could violate the parent node's
 /// distribution requirement.
 ///
-/// This rule should be applied after the `EnforceDistribution`
-/// rule and before the `RewriteExplicitRepartition` rule.
+/// This rule should be applied right after the `EnforceDistribution` rule.
 pub struct EliminateRedundantRepartition {}
 
 impl EliminateRedundantRepartition {
@@ -133,6 +132,7 @@ mod tests {
         let result = optimize(redundant);
 
         assert!(result.downcast_ref::<ExplicitRepartitionExec>().is_some());
+        assert_eq!(result.output_partitioning().partition_count(), 3);
     }
 
     #[test]
@@ -147,6 +147,7 @@ mod tests {
         let result = optimize(redundant);
 
         assert!(result.downcast_ref::<ExplicitRepartitionExec>().is_some());
+        assert_eq!(result.output_partitioning().partition_count(), 3);
     }
 
     #[test]

--- a/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
+++ b/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
@@ -10,13 +10,16 @@ use datafusion::physical_plan::repartition::RepartitionExec;
 use datafusion_physical_expr::Partitioning;
 use sail_physical_plan::repartition::ExplicitRepartitionExec;
 
-/// EliminateRedundantRepartition optimizer rule removes a RepartitionExec
-/// that is directly on top of an ExplicitRepartitionExec, since the input has
-/// already been explicitly repartitioned and the additional repartition is
-/// redundant.
+/// `EliminateRedundantRepartition` optimizer rule removes a `RepartitionExec`
+/// with `Partitioning::RoundRobinBatch` that sits directly on top of an
+/// `ExplicitRepartitionExec`.
 ///
-/// This rule should be applied after the EnforceDistribution
-/// rule and before the RewriteExplicitRepartition rule.
+/// `RepartitionExec` with `Partitioning::Hash(..)` or `Partitioning::UnknownPartitioning`
+/// is left untouched, since eliminating it could violate the parent node's
+/// distribution requirement.
+///
+/// This rule should be applied after the `EnforceDistribution`
+/// rule and before the `RewriteExplicitRepartition` rule.
 pub struct EliminateRedundantRepartition {}
 
 impl EliminateRedundantRepartition {
@@ -38,27 +41,22 @@ impl PhysicalOptimizerRule for EliminateRedundantRepartition {
         _config: &ConfigOptions,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let result = plan.transform_up(|node: Arc<dyn ExecutionPlan>| {
-            if node.downcast_ref::<RepartitionExec>().is_none() {
+            let Some(repartition) = node.downcast_ref::<RepartitionExec>() else {
                 return Ok(Transformed::no(node));
             };
 
-            // Do not eliminate hash partitioning, as it may voilate the parent node's distribution requirements.
-            if matches!(
-                node.properties().output_partitioning(),
-                Partitioning::Hash(_, _)
-            ) {
+            let child = repartition.input();
+            let Some(_explicit) = child.downcast_ref::<ExplicitRepartitionExec>() else {
                 return Ok(Transformed::no(node));
             };
 
-            let [child] = node.children()[..] else {
-                return Ok(Transformed::no(node));
-            };
-
-            if child.downcast_ref::<ExplicitRepartitionExec>().is_some() {
-                Ok(Transformed::yes(child.clone()))
-            } else {
-                Ok(Transformed::no(node))
+            // Eliminating a RepartitionExec with a RoundRobinBatch scheme that sits directly
+            // on top of an ExplicitRepartitionExec does not violate the parent node's
+            // distribution requirements.
+            if matches!(repartition.partitioning(), Partitioning::RoundRobinBatch(_)) {
+                return Ok(Transformed::yes(child.clone()));
             }
+            Ok(Transformed::no(node))
         })?;
         Ok(result.data)
     }
@@ -98,34 +96,92 @@ mod tests {
         Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]))
     }
 
+    fn empty_plan() -> Arc<dyn ExecutionPlan> {
+        Arc::new(EmptyExec::new(schema()))
+    }
+
+    fn optimize(plan: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+        EliminateRedundantRepartition::new()
+            .optimize(plan, &ConfigOptions::default())
+            .unwrap()
+    }
+
     #[test]
-    fn test_eliminate_redundant_repartition_above_explicit_repartition() {
-        let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema()));
+    fn test_eliminates_rr_repartition_above_rr_explicit() {
         let explicit: Arc<dyn ExecutionPlan> = Arc::new(ExplicitRepartitionExec::new(
-            input,
+            empty_plan(),
             Partitioning::RoundRobinBatch(3),
         ));
         let redundant: Arc<dyn ExecutionPlan> = Arc::new(
             RepartitionExec::try_new(explicit, Partitioning::RoundRobinBatch(10)).unwrap(),
         );
-
-        let rule = EliminateRedundantRepartition::new();
-        let result = rule.optimize(redundant, &ConfigOptions::default()).unwrap();
+        let result = optimize(redundant);
 
         assert!(result.downcast_ref::<ExplicitRepartitionExec>().is_some());
         assert_eq!(result.output_partitioning().partition_count(), 3);
     }
 
     #[test]
-    fn test_no_change_when_child_is_not_explicit_repartition() {
-        let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema()));
-        let repartition: Arc<dyn ExecutionPlan> =
-            Arc::new(RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(3)).unwrap());
+    fn test_eliminates_rr_repartition_above_hash_explicit() {
+        let explicit: Arc<dyn ExecutionPlan> = Arc::new(ExplicitRepartitionExec::new(
+            empty_plan(),
+            Partitioning::Hash(vec![], 3),
+        ));
+        let redundant: Arc<dyn ExecutionPlan> = Arc::new(
+            RepartitionExec::try_new(explicit, Partitioning::RoundRobinBatch(10)).unwrap(),
+        );
+        let result = optimize(redundant);
 
-        let rule = EliminateRedundantRepartition::new();
-        let result = rule
-            .optimize(repartition, &ConfigOptions::default())
-            .unwrap();
+        assert!(result.downcast_ref::<ExplicitRepartitionExec>().is_some());
+    }
+
+    #[test]
+    fn test_eliminates_rr_repartition_above_unknown_explicit() {
+        let explicit: Arc<dyn ExecutionPlan> = Arc::new(ExplicitRepartitionExec::new(
+            empty_plan(),
+            Partitioning::UnknownPartitioning(3),
+        ));
+        let redundant: Arc<dyn ExecutionPlan> = Arc::new(
+            RepartitionExec::try_new(explicit, Partitioning::RoundRobinBatch(10)).unwrap(),
+        );
+        let result = optimize(redundant);
+
+        assert!(result.downcast_ref::<ExplicitRepartitionExec>().is_some());
+    }
+
+    #[test]
+    fn test_no_change_when_repartition_is_hash() {
+        let explicit: Arc<dyn ExecutionPlan> = Arc::new(ExplicitRepartitionExec::new(
+            empty_plan(),
+            Partitioning::RoundRobinBatch(3),
+        ));
+        let plan: Arc<dyn ExecutionPlan> =
+            Arc::new(RepartitionExec::try_new(explicit, Partitioning::Hash(vec![], 10)).unwrap());
+        let result = optimize(plan);
+
+        assert!(result.downcast_ref::<RepartitionExec>().is_some());
+    }
+
+    #[test]
+    fn test_no_change_when_repartition_is_unknown() {
+        let explicit: Arc<dyn ExecutionPlan> = Arc::new(ExplicitRepartitionExec::new(
+            empty_plan(),
+            Partitioning::RoundRobinBatch(3),
+        ));
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(
+            RepartitionExec::try_new(explicit, Partitioning::UnknownPartitioning(10)).unwrap(),
+        );
+        let result = optimize(plan);
+
+        assert!(result.downcast_ref::<RepartitionExec>().is_some());
+    }
+
+    #[test]
+    fn test_no_change_when_child_is_not_explicit_repartition() {
+        let repartition: Arc<dyn ExecutionPlan> = Arc::new(
+            RepartitionExec::try_new(empty_plan(), Partitioning::RoundRobinBatch(3)).unwrap(),
+        );
+        let result = optimize(repartition);
 
         assert!(result.downcast_ref::<RepartitionExec>().is_some());
     }

--- a/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
+++ b/crates/sail-physical-optimizer/src/eliminate_redundant_repartition.rs
@@ -15,7 +15,7 @@ use sail_physical_plan::repartition::ExplicitRepartitionExec;
 ///
 /// The rule targets two redundant patterns:
 ///
-/// Pattern 1: `RepartitionExec(RoundRobinBatch)` → `ExplicitRepartitionExec`
+/// ## Pattern 1: `RepartitionExec(RoundRobinBatch)` → `ExplicitRepartitionExec`
 ///
 /// This rule removes a `RepartitionExec` with `Partitioning::RoundRobinBatch` inserted by the
 /// `EnforceDistribution` rule that sits directly on top of an `ExplicitRepartitionExec`.
@@ -35,7 +35,7 @@ use sail_physical_plan::repartition::ExplicitRepartitionExec;
 /// To avoid eliminating any unintended `RepartitionExec`, this rule should be applied
 /// immediately after the `EnforceDistribution` rule.
 ///
-/// Pattern 2: `ExplicitRepartitionExec` → `ExplicitRepartitionExec`
+/// ## Pattern 2: `ExplicitRepartitionExec` → `ExplicitRepartitionExec`
 ///
 /// This rule collapses nested `ExplicitRepartitionExec` nodes into one, using the outer node's
 /// partitioning scheme, since the outer repartition redistributes the data regardless of how
@@ -48,7 +48,6 @@ use sail_physical_plan::repartition::ExplicitRepartitionExec;
 /// to the outer count. Collapsing here would silently remove the shuffle and turn it into a
 /// no-shuffle operation.
 ///
-
 pub struct EliminateRedundantRepartition {}
 
 impl EliminateRedundantRepartition {
@@ -161,7 +160,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eliminates_rr_repartition_above_rr_explicit() {
+    fn test_p1_eliminates_rr_repartition_and_preserves_explicit_partition_count() {
         let explicit: Arc<dyn ExecutionPlan> = Arc::new(ExplicitRepartitionExec::new(
             empty_plan(),
             Partitioning::RoundRobinBatch(3),
@@ -169,6 +168,7 @@ mod tests {
         let redundant: Arc<dyn ExecutionPlan> = Arc::new(
             RepartitionExec::try_new(explicit, Partitioning::RoundRobinBatch(10)).unwrap(),
         );
+
         let result = optimize(redundant);
 
         assert!(result.downcast_ref::<ExplicitRepartitionExec>().is_some());
@@ -176,50 +176,7 @@ mod tests {
     }
 
     #[test]
-    fn test_eliminates_rr_repartition_above_hash_explicit() {
-        let explicit: Arc<dyn ExecutionPlan> = Arc::new(ExplicitRepartitionExec::new(
-            empty_plan(),
-            Partitioning::Hash(vec![], 3),
-        ));
-        let redundant: Arc<dyn ExecutionPlan> = Arc::new(
-            RepartitionExec::try_new(explicit, Partitioning::RoundRobinBatch(10)).unwrap(),
-        );
-        let result = optimize(redundant);
-
-        assert!(result.downcast_ref::<ExplicitRepartitionExec>().is_some());
-        assert_eq!(result.output_partitioning().partition_count(), 3);
-    }
-
-    #[test]
-    fn test_eliminates_rr_repartition_above_unknown_explicit() {
-        let explicit: Arc<dyn ExecutionPlan> = Arc::new(ExplicitRepartitionExec::new(
-            empty_plan(),
-            Partitioning::UnknownPartitioning(3),
-        ));
-        let redundant: Arc<dyn ExecutionPlan> = Arc::new(
-            RepartitionExec::try_new(explicit, Partitioning::RoundRobinBatch(10)).unwrap(),
-        );
-        let result = optimize(redundant);
-
-        assert!(result.downcast_ref::<ExplicitRepartitionExec>().is_some());
-        assert_eq!(result.output_partitioning().partition_count(), 3);
-    }
-
-    #[test]
-    fn test_no_change_when_repartition_is_hash() {
-        let explicit: Arc<dyn ExecutionPlan> = Arc::new(ExplicitRepartitionExec::new(
-            empty_plan(),
-            Partitioning::RoundRobinBatch(3),
-        ));
-        let plan: Arc<dyn ExecutionPlan> =
-            Arc::new(RepartitionExec::try_new(explicit, Partitioning::Hash(vec![], 10)).unwrap());
-        let result = optimize(plan);
-
-        assert!(result.downcast_ref::<RepartitionExec>().is_some());
-    }
-
-    #[test]
-    fn test_no_change_when_repartition_is_unknown() {
+    fn test_p1_keeps_unknown_repartition() {
         let explicit: Arc<dyn ExecutionPlan> = Arc::new(ExplicitRepartitionExec::new(
             empty_plan(),
             Partitioning::RoundRobinBatch(3),
@@ -227,18 +184,64 @@ mod tests {
         let plan: Arc<dyn ExecutionPlan> = Arc::new(
             RepartitionExec::try_new(explicit, Partitioning::UnknownPartitioning(10)).unwrap(),
         );
-        let result = optimize(plan);
+
+        let result: Arc<dyn ExecutionPlan> = optimize(plan);
 
         assert!(result.downcast_ref::<RepartitionExec>().is_some());
     }
 
     #[test]
-    fn test_no_change_when_child_is_not_explicit_repartition() {
-        let repartition: Arc<dyn ExecutionPlan> = Arc::new(
-            RepartitionExec::try_new(empty_plan(), Partitioning::RoundRobinBatch(3)).unwrap(),
-        );
-        let result = optimize(repartition);
+    fn test_p2_keeps_nested_structure_when_outer_unknown_over_inner_rr() {
+        let inner: Arc<dyn ExecutionPlan> = Arc::new(ExplicitRepartitionExec::new(
+            empty_plan(),
+            Partitioning::RoundRobinBatch(9),
+        ));
+        let outer: Arc<dyn ExecutionPlan> = Arc::new(ExplicitRepartitionExec::new(
+            inner,
+            Partitioning::UnknownPartitioning(5),
+        ));
 
-        assert!(result.downcast_ref::<RepartitionExec>().is_some());
+        let result = optimize(outer);
+
+        let outer = result.downcast_ref::<ExplicitRepartitionExec>().unwrap();
+        assert_eq!(
+            outer.properties().output_partitioning().partition_count(),
+            5
+        );
+        assert!(
+            outer
+                .input()
+                .downcast_ref::<ExplicitRepartitionExec>()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn test_p2_collapses_chain_of_three_to_single_explicit() {
+        let inner: Arc<dyn ExecutionPlan> = Arc::new(ExplicitRepartitionExec::new(
+            empty_plan(),
+            Partitioning::RoundRobinBatch(3),
+        ));
+        let middle: Arc<dyn ExecutionPlan> = Arc::new(ExplicitRepartitionExec::new(
+            inner,
+            Partitioning::RoundRobinBatch(9),
+        ));
+        let outer: Arc<dyn ExecutionPlan> = Arc::new(ExplicitRepartitionExec::new(
+            middle,
+            Partitioning::RoundRobinBatch(11),
+        ));
+
+        let result: Arc<dyn ExecutionPlan> = optimize(outer);
+
+        let node = result.downcast_ref::<ExplicitRepartitionExec>().unwrap();
+        assert_eq!(
+            node.properties().output_partitioning().partition_count(),
+            11
+        );
+        assert!(
+            node.input()
+                .downcast_ref::<ExplicitRepartitionExec>()
+                .is_none()
+        );
     }
 }

--- a/crates/sail-physical-optimizer/src/lib.rs
+++ b/crates/sail-physical-optimizer/src/lib.rs
@@ -23,12 +23,14 @@ use datafusion::physical_optimizer::window_topn::WindowTopN;
 
 use crate::barrier::EnforceBarrierPartitioning;
 use crate::collect_left::RewriteCollectLeftHashJoin;
+use crate::eliminate_redundant_repartition::EliminateRedundantRepartition;
 use crate::explicit_repartition::RewriteExplicitRepartition;
 use crate::join_reorder::JoinReorder;
 pub use crate::join_reorder::JoinReorderOptions;
 
 mod barrier;
 mod collect_left;
+mod eliminate_redundant_repartition;
 mod explicit_repartition;
 mod join_reorder;
 
@@ -67,6 +69,7 @@ pub fn get_physical_optimizers(
     rules.push(Arc::new(PushdownSort::new()));
     rules.push(Arc::new(EnsureCooperative::new()));
     rules.push(Arc::new(FilterPushdown::new_post_optimization()));
+    rules.push(Arc::new(EliminateRedundantRepartition::new()));
     rules.push(Arc::new(RewriteExplicitRepartition::new()));
     rules.push(Arc::new(RewriteCollectLeftHashJoin::new()));
     rules.push(Arc::new(EnforceBarrierPartitioning::new()));

--- a/crates/sail-physical-optimizer/src/lib.rs
+++ b/crates/sail-physical-optimizer/src/lib.rs
@@ -54,6 +54,7 @@ pub fn get_physical_optimizers(
     rules.push(Arc::new(LimitedDistinctAggregation::new()));
     rules.push(Arc::new(FilterPushdown::new()));
     rules.push(Arc::new(EnforceDistribution::new()));
+    rules.push(Arc::new(EliminateRedundantRepartition::new()));
     rules.push(Arc::new(CombinePartialFinalAggregate::new()));
     rules.push(Arc::new(EnforceSorting::new()));
     rules.push(Arc::new(OptimizeAggregateOrder::new()));
@@ -69,7 +70,6 @@ pub fn get_physical_optimizers(
     rules.push(Arc::new(PushdownSort::new()));
     rules.push(Arc::new(EnsureCooperative::new()));
     rules.push(Arc::new(FilterPushdown::new_post_optimization()));
-    rules.push(Arc::new(EliminateRedundantRepartition::new()));
     rules.push(Arc::new(RewriteExplicitRepartition::new()));
     rules.push(Arc::new(RewriteCollectLeftHashJoin::new()));
     rules.push(Arc::new(EnforceBarrierPartitioning::new()));

--- a/python/pysail/tests/spark/analyzer/__snapshots__/features/explain.yaml
+++ b/python/pysail/tests/spark/analyzer/__snapshots__/features/explain.yaml
@@ -329,6 +329,9 @@ data:
     physical_plan after FilterPushdown(Post):
     SAME TEXT AS ABOVE
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after RewriteExplicitRepartition:
     SAME TEXT AS ABOVE
   

--- a/python/pysail/tests/spark/analyzer/__snapshots__/features/explain.yaml
+++ b/python/pysail/tests/spark/analyzer/__snapshots__/features/explain.yaml
@@ -278,6 +278,9 @@ data:
                 DataSourceExec: partitions=1, partition_sizes=[1]
   
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     SAME TEXT AS ABOVE
   
@@ -327,9 +330,6 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after FilterPushdown(Post):
-    SAME TEXT AS ABOVE
-  
-    physical_plan after EliminateRedundantRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after RewriteExplicitRepartition:

--- a/python/pysail/tests/spark/dataframe/__snapshots__/test_repartition.plan.yaml
+++ b/python/pysail/tests/spark/dataframe/__snapshots__/test_repartition.plan.yaml
@@ -1,23 +1,23 @@
 # serializer version: 1
 ---
-name: "test_explicit_repartition_pushes_column_projection_down_plan"
+name: "test_eliminate_redundant_repartition_above_explicit_repartition_plan"
 data:
   |-
     == Physical Plan ==
-    ProjectionExec: expr=[#6@0 as id1, #7@1 as id2]
-      ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=4
-        ProjectionExec: expr=[#1@0 as #6, #3@1 as #7]
-          HashJoinExec: mode=Partitioned, join_type=Inner, on=[(#1@0, #5@0)], projection=[#1@0, #3@1]
-            HashJoinExec: mode=Partitioned, join_type=Inner, on=[(#1@0, #3@0)]
-              RepartitionExec: partitioning=Hash([#1@0], 4), input_partitions=1
-                ProjectionExec: expr=[id@0 as #1]
-                  RangeExec
-              RepartitionExec: partitioning=Hash([#3@0], 4), input_partitions=1
-                ProjectionExec: expr=[id@0 as #3]
-                  RangeExec
-            RepartitionExec: partitioning=Hash([#5@0], 4), input_partitions=1
-              ProjectionExec: expr=[id@0 as #5]
-                RangeExec
+    ProjectionExec: expr=[#0@0 as id]
+      ExplicitRepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=3
+        FilterExec: #0@0 % 2 = 0
+          ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+            RangeExec
+---
+name: "test_explicit_repartition_does_not_push_filter_down_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      FilterExec: #0@0 % 2 = 0
+        ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+          RangeExec
 ---
 name: "test_explicit_repartition_hash_partitioning_remaps_after_projection_pushdown_plan"
 data:
@@ -38,12 +38,21 @@ data:
               ProjectionExec: expr=[id@0 as #5]
                 RangeExec
 ---
-name: "test_explicit_repartition_does_not_push_filter_down_plan"
+name: "test_explicit_repartition_pushes_column_projection_down_plan"
 data:
   |-
     == Physical Plan ==
-    ProjectionExec: expr=[#0@0 as id]
-      FilterExec: #0@0 % 2 = 0
-        RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
-          ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-            RangeExec
+    ProjectionExec: expr=[#6@0 as id1, #7@1 as id2]
+      ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=4
+        ProjectionExec: expr=[#1@0 as #6, #3@1 as #7]
+          HashJoinExec: mode=Partitioned, join_type=Inner, on=[(#1@0, #5@0)], projection=[#1@0, #3@1]
+            HashJoinExec: mode=Partitioned, join_type=Inner, on=[(#1@0, #3@0)]
+              RepartitionExec: partitioning=Hash([#1@0], 4), input_partitions=1
+                ProjectionExec: expr=[id@0 as #1]
+                  RangeExec
+              RepartitionExec: partitioning=Hash([#3@0], 4), input_partitions=1
+                ProjectionExec: expr=[id@0 as #3]
+                  RangeExec
+            RepartitionExec: partitioning=Hash([#5@0], 4), input_partitions=1
+              ProjectionExec: expr=[id@0 as #5]
+                RangeExec

--- a/python/pysail/tests/spark/dataframe/__snapshots__/test_repartition.plan.yaml
+++ b/python/pysail/tests/spark/dataframe/__snapshots__/test_repartition.plan.yaml
@@ -1,6 +1,6 @@
 # serializer version: 1
 ---
-name: "test_eliminate_redundant_repartition_above_explicit_repartition_plan"
+name: "test_eliminate_rr_repartition_above_rr_explicit_repartition_plan"
 data:
   |-
     == Physical Plan ==

--- a/python/pysail/tests/spark/dataframe/__snapshots__/test_repartition.plan.yaml
+++ b/python/pysail/tests/spark/dataframe/__snapshots__/test_repartition.plan.yaml
@@ -1,15 +1,5 @@
 # serializer version: 1
 ---
-name: "test_eliminate_rr_repartition_above_rr_explicit_repartition_plan"
-data:
-  |-
-    == Physical Plan ==
-    ProjectionExec: expr=[#0@0 as id]
-      ExplicitRepartitionExec: partitioning=RoundRobinBatch(10), input_partitions=3
-        FilterExec: #0@0 % 2 = 0
-          ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-            RangeExec
----
 name: "test_explicit_repartition_does_not_push_filter_down_plan"
 data:
   |-

--- a/python/pysail/tests/spark/dataframe/test_repartition.py
+++ b/python/pysail/tests/spark/dataframe/test_repartition.py
@@ -154,6 +154,22 @@ def test_explicit_repartition_does_not_push_filter_down_plan(spark, snapshot):
     assert plan == snapshot
 
 
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_eliminate_redundant_repartition_above_explicit_repartition_plan(spark, snapshot):
+    df = spark.range(6).repartition(3).filter(F.col("id") % 2 == 0).repartition(10)
+    plan = normalized_plan(df)
+
+    assert plan == snapshot
+
+
+def test_eliminate_redundant_repartition_above_explicit_repartition_result(spark):
+    df = spark.range(6).repartition(3).filter(F.col("id") % 2 == 0).orderBy("id")
+    result = df.collect()
+
+    assert [row["id"] for row in result] == [0, 2, 4]
+
+
 def test_explicit_coalesce(spark):
     assert partition_count(spark.range(0, 10, 1, 2).coalesce(1)) == 1
     assert partition_count(spark.range(0, 10, 1, 2).coalesce(2)) == 2  # noqa: PLR2004

--- a/python/pysail/tests/spark/dataframe/test_repartition.py
+++ b/python/pysail/tests/spark/dataframe/test_repartition.py
@@ -156,14 +156,14 @@ def test_explicit_repartition_does_not_push_filter_down_plan(spark, snapshot):
 
 @pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
 @pytest.mark.yamlsnapshot(group="plan")
-def test_eliminate_redundant_repartition_above_explicit_repartition_plan(spark, snapshot):
+def test_eliminate_rr_repartition_above_rr_explicit_repartition_plan(spark, snapshot):
     df = spark.range(6).repartition(3).filter(F.col("id") % 2 == 0).repartition(10)
     plan = normalized_plan(df)
 
     assert plan == snapshot
 
 
-def test_eliminate_redundant_repartition_above_explicit_repartition_result(spark):
+def test_eliminate_rr_repartition_above_rr_explicit_repartition_result(spark):
     df = spark.range(6).repartition(3).filter(F.col("id") % 2 == 0).orderBy("id")
     result = df.collect()
 

--- a/python/pysail/tests/spark/dataframe/test_repartition.py
+++ b/python/pysail/tests/spark/dataframe/test_repartition.py
@@ -154,22 +154,6 @@ def test_explicit_repartition_does_not_push_filter_down_plan(spark, snapshot):
     assert plan == snapshot
 
 
-@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
-@pytest.mark.yamlsnapshot(group="plan")
-def test_eliminate_rr_repartition_above_rr_explicit_repartition_plan(spark, snapshot):
-    df = spark.range(6).repartition(3).filter(F.col("id") % 2 == 0).repartition(10)
-    plan = normalized_plan(df)
-
-    assert plan == snapshot
-
-
-def test_eliminate_rr_repartition_above_rr_explicit_repartition_result(spark):
-    df = spark.range(6).repartition(3).filter(F.col("id") % 2 == 0).orderBy("id")
-    result = df.collect()
-
-    assert [row["id"] for row in result] == [0, 2, 4]
-
-
 def test_explicit_coalesce(spark):
     assert partition_count(spark.range(0, 10, 1, 2).coalesce(1)) == 1
     assert partition_count(spark.range(0, 10, 1, 2).coalesce(2)) == 2  # noqa: PLR2004

--- a/python/pysail/tests/spark/delta/__snapshots__/features/delete.yaml
+++ b/python/pysail/tests/spark/delta/__snapshots__/features/delete.yaml
@@ -366,6 +366,9 @@ data:
     physical_plan after FilterPushdown(Post):
     SAME TEXT AS ABOVE
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after RewriteExplicitRepartition:
     SAME TEXT AS ABOVE
   

--- a/python/pysail/tests/spark/delta/__snapshots__/features/delete.yaml
+++ b/python/pysail/tests/spark/delta/__snapshots__/features/delete.yaml
@@ -268,6 +268,9 @@ data:
                                   DataSourceExec: file_groups={2 groups: [[<tmp>/delete_explain_codegen/_delta_log/00000000000000000000.json], [<tmp>/delete_explain_codegen/_delta_log/00000000000000000001.json]]}, projection=[add, remove, __sail_delta_log_version], file_type=json
   
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     SAME TEXT AS ABOVE
   
@@ -364,9 +367,6 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after FilterPushdown(Post):
-    SAME TEXT AS ABOVE
-  
-    physical_plan after EliminateRedundantRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after RewriteExplicitRepartition:

--- a/python/pysail/tests/spark/delta/__snapshots__/features/merge.yaml
+++ b/python/pysail/tests/spark/delta/__snapshots__/features/merge.yaml
@@ -2215,6 +2215,9 @@ data:
     physical_plan after FilterPushdown(Post):
     SAME TEXT AS ABOVE
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after RewriteExplicitRepartition:
     SAME TEXT AS ABOVE
   

--- a/python/pysail/tests/spark/delta/__snapshots__/features/merge.yaml
+++ b/python/pysail/tests/spark/delta/__snapshots__/features/merge.yaml
@@ -1753,6 +1753,9 @@ data:
                                   DataSourceExec: file_groups={2 groups: [[<tmp>/merge_explain_codegen/_delta_log/00000000000000000000.json], [<tmp>/merge_explain_codegen/_delta_log/00000000000000000001.json]]}, projection=[add, remove, __sail_delta_log_version], file_type=json
   
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     SAME TEXT AS ABOVE
   
@@ -2213,9 +2216,6 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after FilterPushdown(Post):
-    SAME TEXT AS ABOVE
-  
-    physical_plan after EliminateRedundantRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after RewriteExplicitRepartition:

--- a/python/pysail/tests/spark/execution/__snapshots__/features/explain.yaml
+++ b/python/pysail/tests/spark/execution/__snapshots__/features/explain.yaml
@@ -254,6 +254,9 @@ data:
                 DataSourceExec: partitions=1, partition_sizes=[1]
   
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     SAME TEXT AS ABOVE
   

--- a/python/pysail/tests/spark/execution/__snapshots__/features/lakehouse_commit.yaml
+++ b/python/pysail/tests/spark/execution/__snapshots__/features/lakehouse_commit.yaml
@@ -351,6 +351,9 @@ data:
                       RangeExec
   
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     SAME TEXT AS ABOVE
   
@@ -805,6 +808,9 @@ data:
             ProjectionExec: expr=[id@0 as id]
               RangeExec
   
+  
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
   
     physical_plan after CombinePartialFinalAggregate:
     SAME TEXT AS ABOVE

--- a/python/pysail/tests/spark/execution/__snapshots__/features/scalar_subquery.yaml
+++ b/python/pysail/tests/spark/execution/__snapshots__/features/scalar_subquery.yaml
@@ -472,6 +472,9 @@ data:
                         DataSourceExec: partitions=1, partition_sizes=[1]
   
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     SAME TEXT AS ABOVE
   
@@ -982,6 +985,9 @@ data:
                       ProjectionExec: expr=[column1@0 as #6, column2@1 as #7]
                         DataSourceExec: partitions=1, partition_sizes=[1]
   
+  
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
   
     physical_plan after CombinePartialFinalAggregate:
     SAME TEXT AS ABOVE
@@ -1509,6 +1515,9 @@ data:
                       ProjectionExec: expr=[column1@0 as #6, column2@1 as #7]
                         DataSourceExec: partitions=1, partition_sizes=[1]
   
+  
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
   
     physical_plan after CombinePartialFinalAggregate:
     SAME TEXT AS ABOVE
@@ -2257,6 +2266,9 @@ data:
                 DataSourceExec: partitions=1, partition_sizes=[1]
   
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       ScalarSubqueryExec: subqueries=1
@@ -2900,6 +2912,9 @@ data:
                 DataSourceExec: partitions=1, partition_sizes=[1]
   
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       ScalarSubqueryExec: subqueries=1
@@ -3435,6 +3450,9 @@ data:
                 DataSourceExec: partitions=1, partition_sizes=[1]
   
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     SAME TEXT AS ABOVE
   
@@ -3892,6 +3910,9 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after EnforceDistribution:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EliminateRedundantRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after CombinePartialFinalAggregate:
@@ -4393,6 +4414,9 @@ data:
     physical_plan after EnforceDistribution:
     SAME TEXT AS ABOVE
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       ScalarSubqueryExec: subqueries=1
@@ -4857,6 +4881,9 @@ data:
     physical_plan after EnforceDistribution:
     SAME TEXT AS ABOVE
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       ScalarSubqueryExec: subqueries=1
@@ -5287,6 +5314,9 @@ data:
               ProjectionExec: expr=[column1@0 as #5]
                 DataSourceExec: partitions=1, partition_sizes=[1]
   
+  
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
   
     physical_plan after CombinePartialFinalAggregate:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
@@ -5761,6 +5791,9 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after EnforceDistribution:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EliminateRedundantRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after CombinePartialFinalAggregate:
@@ -6245,6 +6278,9 @@ data:
                 DataSourceExec: partitions=1, partition_sizes=[1]
   
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       ScalarSubqueryExec: subqueries=1
@@ -6705,6 +6741,9 @@ data:
                 DataSourceExec: partitions=1, partition_sizes=[1]
   
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       ScalarSubqueryExec: subqueries=1
@@ -7147,6 +7186,9 @@ data:
               ProjectionExec: expr=[column1@0 as #5]
                 DataSourceExec: partitions=1, partition_sizes=[1]
   
+  
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
   
     physical_plan after CombinePartialFinalAggregate:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
@@ -7613,6 +7655,9 @@ data:
               ProjectionExec: expr=[column1@0 as #5]
                 DataSourceExec: partitions=1, partition_sizes=[1]
   
+  
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
   
     physical_plan after CombinePartialFinalAggregate:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
@@ -8116,6 +8161,9 @@ data:
     physical_plan after EnforceDistribution:
     SAME TEXT AS ABOVE
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       ScalarSubqueryExec: subqueries=1
@@ -8605,6 +8653,9 @@ data:
     physical_plan after EnforceDistribution:
     SAME TEXT AS ABOVE
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       ScalarSubqueryExec: subqueries=1
@@ -9062,6 +9113,9 @@ data:
                 DataSourceExec: partitions=1, partition_sizes=[1]
   
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       ScalarSubqueryExec: subqueries=1
@@ -9513,6 +9567,9 @@ data:
     physical_plan after EnforceDistribution:
     SAME TEXT AS ABOVE
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       ScalarSubqueryExec: subqueries=1
@@ -9931,6 +9988,9 @@ data:
     physical_plan after EnforceDistribution:
     SAME TEXT AS ABOVE
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       ScalarSubqueryExec: subqueries=1
@@ -10345,6 +10405,9 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after EnforceDistribution:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EliminateRedundantRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after CombinePartialFinalAggregate:
@@ -10779,6 +10842,9 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after EnforceDistribution:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EliminateRedundantRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after CombinePartialFinalAggregate:
@@ -11237,6 +11303,9 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after EnforceDistribution:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EliminateRedundantRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after CombinePartialFinalAggregate:

--- a/python/pysail/tests/spark/execution/__snapshots__/test_shuffle_storage.plan.yaml
+++ b/python/pysail/tests/spark/execution/__snapshots__/test_shuffle_storage.plan.yaml
@@ -430,6 +430,9 @@ data:
                           RangeExec
   
   
+    physical_plan after EliminateRedundantRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after CombinePartialFinalAggregate:
     SAME TEXT AS ABOVE
   

--- a/python/pysail/tests/spark/optimizer/__snapshots__/test_eliminate_redundant_repartition.plan.yaml
+++ b/python/pysail/tests/spark/optimizer/__snapshots__/test_eliminate_redundant_repartition.plan.yaml
@@ -14,319 +14,319 @@ data:
   |-
     == Codegen ==
     Whole-stage codegen is not supported; showing physical plan instead.
-  
+
     == Plan Steps ==
     initial_logical_plan:
     Filter: #0 % CASE WHEN Int32(2) = Int32(0) THEN raise_error(Utf8("Remainder by zero")) ELSE Int32(2) END = Int32(0)
       ExplicitRepartition: kind=hash, n=Some(3), expr=[#0]
         Range: start=0, end=6, step=1, num_partitions=1
-  
+
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after resolve_grouping_function:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after type_coercion:
     Filter: #0 % CAST(CASE WHEN Int32(2) = Int32(0) THEN CAST(raise_error(Utf8("Remainder by zero")) AS Int32) ELSE Int32(2) END AS Int64) = CAST(Int32(0) AS Int64)
       ExplicitRepartition: kind=hash, n=Some(3), expr=[#0]
         Range: start=0, end=6, step=1, num_partitions=1
-  
+
     analyzed_logical_plan:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_lateral_projection:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after rewrite_set_comparison:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after optimize_unions:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after unions_to_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after simplify_expressions:
     Filter: #0 % Int64(2) = Int64(0)
       ExplicitRepartition: kind=hash, n=Some(3), expr=[#0]
         Range: start=0, end=6, step=1, num_partitions=1
-  
+
     logical_plan after replace_distinct_aggregate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_predicate_subquery:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after scalar_subquery_to_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_lateral_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after extract_equijoin_predicate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_duplicated_expr:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_cross_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_limit:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after propagate_empty_relation:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after filter_null_join_keys:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_outer_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after push_down_limit:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after push_down_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after single_distinct_aggregation_to_group_by:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_group_by_constant:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after common_sub_expression_eliminate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after extract_leaf_expressions:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after optimize_projections:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_lateral_projection:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after rewrite_set_comparison:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after optimize_unions:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after unions_to_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after simplify_expressions:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after replace_distinct_aggregate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_predicate_subquery:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after scalar_subquery_to_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_lateral_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after extract_equijoin_predicate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_duplicated_expr:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_cross_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_limit:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after propagate_empty_relation:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after filter_null_join_keys:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_outer_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after push_down_limit:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after push_down_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after single_distinct_aggregation_to_group_by:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_group_by_constant:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after common_sub_expression_eliminate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after extract_leaf_expressions:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after optimize_projections:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-  
+
     logical_plan:
     Filter: #0 % Int64(2) = Int64(0)
       ExplicitRepartition: kind=hash, n=Some(3), expr=[#0]
         Range: start=0, end=6, step=1, num_partitions=1
-  
+
     initial_physical_plan:
     FilterExec: #0@0 % 2 = 0
       ExplicitRepartitionExec
         RangeExec
-  
-  
+
+
     initial_physical_plan_with_stats:
     FilterExec: #0@0 % 2 = 0, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
       ExplicitRepartitionExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
         RangeExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
-  
-  
+
+
     initial_physical_plan_with_schema:
     FilterExec: #0@0 % 2 = 0, schema=[#0:Int64]
       ExplicitRepartitionExec, schema=[#0:Int64]
         RangeExec, schema=[#0:Int64]
-  
-  
+
+
     physical_plan after OutputRequirements:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 % 2 = 0
         ExplicitRepartitionExec
           RangeExec
-  
-  
+
+
     physical_plan after aggregate_statistics:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after join_selection:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after LimitedDistinctAggregation:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after FilterPushdown:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after EnforceDistribution:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 % 2 = 0
         RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
           ExplicitRepartitionExec
             RangeExec
-  
-  
+
+
     physical_plan after EliminateRedundantRepartition:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 % 2 = 0
         ExplicitRepartitionExec
           RangeExec
-  
-  
+
+
     physical_plan after CombinePartialFinalAggregate:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after EnforceSorting:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after OptimizeAggregateOrder:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after WindowTopN:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after ProjectionPushdown:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after OutputRequirements:
     FilterExec: #0@0 % 2 = 0
       ExplicitRepartitionExec
         RangeExec
-  
-  
+
+
     physical_plan after LimitAggregation:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after LimitPushPastWindows:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after HashJoinBuffering:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after LimitPushdown:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after TopKRepartition:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after ProjectionPushdown:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after FilterPushdown(Post):
     SAME TEXT AS ABOVE
-  
+
     physical_plan after RewriteExplicitRepartition:
     FilterExec: #0@0 % 2 = 0
       RepartitionExec: partitioning=Hash([#0@0], 3), input_partitions=1
         RangeExec
-  
-  
+
+
     physical_plan after RewriteCollectLeftHashJoin:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after EnforceBarrierPartitioning:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after SanityCheckPlan:
     SAME TEXT AS ABOVE
-  
+
     physical_plan:
     ProjectionExec: expr=[#0@0 as id]
       FilterExec: #0@0 % 2 = 0
         RepartitionExec: partitioning=Hash([#0@0], 3), input_partitions=1
           RangeExec
-  
-  
+
+
     == Physical Plan ==
     ProjectionExec: expr=[#0@0 as id]
       FilterExec: #0@0 % 2 = 0
         RepartitionExec: partitioning=Hash([#0@0], 3), input_partitions=1
           RangeExec
-  
-  
+
+
     == Distributed Plan ==
     === stage 0 ===
     inputs=[]
@@ -335,7 +335,7 @@ data:
     distribution=Hash(keys=[#0@0], channels=3)
     placement=Worker
     RangeExec
-  
+
     === stage 1 ===
     inputs=[StageInput(stage=0, mode=Shuffle)]
     mode=Pipelined
@@ -351,316 +351,316 @@ data:
   |-
     == Codegen ==
     Whole-stage codegen is not supported; showing physical plan instead.
-  
+
     == Plan Steps ==
     initial_logical_plan:
     Filter: #0 % CASE WHEN Int32(2) = Int32(0) THEN raise_error(Utf8("Remainder by zero")) ELSE Int32(2) END = Int32(0)
       ExplicitRepartition: kind=round_robin, n=Some(3), expr=[]
         Range: start=0, end=6, step=1, num_partitions=1
-  
+
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after resolve_grouping_function:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after type_coercion:
     Filter: #0 % CAST(CASE WHEN Int32(2) = Int32(0) THEN CAST(raise_error(Utf8("Remainder by zero")) AS Int32) ELSE Int32(2) END AS Int64) = CAST(Int32(0) AS Int64)
       ExplicitRepartition: kind=round_robin, n=Some(3), expr=[]
         Range: start=0, end=6, step=1, num_partitions=1
-  
+
     analyzed_logical_plan:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_lateral_projection:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after rewrite_set_comparison:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after optimize_unions:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after unions_to_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after simplify_expressions:
     Filter: #0 % Int64(2) = Int64(0)
       ExplicitRepartition: kind=round_robin, n=Some(3), expr=[]
         Range: start=0, end=6, step=1, num_partitions=1
-  
+
     logical_plan after replace_distinct_aggregate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_predicate_subquery:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after scalar_subquery_to_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_lateral_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after extract_equijoin_predicate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_duplicated_expr:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_cross_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_limit:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after propagate_empty_relation:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after filter_null_join_keys:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_outer_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after push_down_limit:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after push_down_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after single_distinct_aggregation_to_group_by:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_group_by_constant:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after common_sub_expression_eliminate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after extract_leaf_expressions:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after optimize_projections:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_lateral_projection:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after rewrite_set_comparison:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after optimize_unions:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after unions_to_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after simplify_expressions:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after replace_distinct_aggregate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_predicate_subquery:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after scalar_subquery_to_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_lateral_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after extract_equijoin_predicate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_duplicated_expr:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_cross_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_limit:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after propagate_empty_relation:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after filter_null_join_keys:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_outer_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after push_down_limit:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after push_down_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after single_distinct_aggregation_to_group_by:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_group_by_constant:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after common_sub_expression_eliminate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after extract_leaf_expressions:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after optimize_projections:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-  
+
     logical_plan:
     Filter: #0 % Int64(2) = Int64(0)
       ExplicitRepartition: kind=round_robin, n=Some(3), expr=[]
         Range: start=0, end=6, step=1, num_partitions=1
-  
+
     initial_physical_plan:
     FilterExec: #0@0 % 2 = 0
       ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
         RangeExec
-  
-  
+
+
     initial_physical_plan_with_stats:
     FilterExec: #0@0 % 2 = 0, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
       ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
         RangeExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
-  
-  
+
+
     initial_physical_plan_with_schema:
     FilterExec: #0@0 % 2 = 0, schema=[#0:Int64]
       ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1, schema=[#0:Int64]
         RangeExec, schema=[#0:Int64]
-  
-  
+
+
     physical_plan after OutputRequirements:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 % 2 = 0
         ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
           RangeExec
-  
-  
+
+
     physical_plan after aggregate_statistics:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after join_selection:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after LimitedDistinctAggregation:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after FilterPushdown:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after EnforceDistribution:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 % 2 = 0
         RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
           ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
             RangeExec
-  
-  
+
+
     physical_plan after EliminateRedundantRepartition:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 % 2 = 0
         ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
           RangeExec
-  
-  
+
+
     physical_plan after CombinePartialFinalAggregate:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after EnforceSorting:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after OptimizeAggregateOrder:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after WindowTopN:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after ProjectionPushdown:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after OutputRequirements:
     FilterExec: #0@0 % 2 = 0
       ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
         RangeExec
-  
-  
+
+
     physical_plan after LimitAggregation:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after LimitPushPastWindows:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after HashJoinBuffering:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after LimitPushdown:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after TopKRepartition:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after ProjectionPushdown:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after FilterPushdown(Post):
     SAME TEXT AS ABOVE
-  
+
     physical_plan after RewriteExplicitRepartition:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after RewriteCollectLeftHashJoin:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after EnforceBarrierPartitioning:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after SanityCheckPlan:
     SAME TEXT AS ABOVE
-  
+
     physical_plan:
     ProjectionExec: expr=[#0@0 as id]
       FilterExec: #0@0 % 2 = 0
         ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
           RangeExec
-  
-  
+
+
     == Physical Plan ==
     ProjectionExec: expr=[#0@0 as id]
       FilterExec: #0@0 % 2 = 0
         ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
           RangeExec
-  
-  
+
+
     == Distributed Plan ==
     === stage 0 ===
     inputs=[]
@@ -669,7 +669,7 @@ data:
     distribution=RoundRobinRow(channels=3)
     placement=Worker
     RangeExec
-  
+
     === stage 1 ===
     inputs=[StageInput(stage=0, mode=Shuffle)]
     mode=Pipelined
@@ -680,240 +680,240 @@ data:
       FilterExec: #0@0 % 2 = 0
         StageInputExec: input=0, partitioning=RoundRobinBatch(3)
 ---
-name: "test_p1_eliminates_rr_repartition_above_unkown_explicit_plan"
+name: "test_p1_eliminates_rr_repartition_above_unknown_explicit_plan"
 data:
   |-
     == Codegen ==
     Whole-stage codegen is not supported; showing physical plan instead.
-  
+
     == Plan Steps ==
     initial_logical_plan:
     Filter: #0 = Int32(4)
       ExplicitRepartition: kind=coalesce, n=Some(1), expr=[]
         Filter: #0 % CASE WHEN Int32(2) = Int32(0) THEN raise_error(Utf8("Remainder by zero")) ELSE Int32(2) END = Int32(0)
           Range: start=0, end=6, step=1, num_partitions=1
-  
+
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after resolve_grouping_function:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after type_coercion:
     Filter: #0 = CAST(Int32(4) AS Int64)
       ExplicitRepartition: kind=coalesce, n=Some(1), expr=[]
         Filter: #0 % CAST(CASE WHEN Int32(2) = Int32(0) THEN CAST(raise_error(Utf8("Remainder by zero")) AS Int32) ELSE Int32(2) END AS Int64) = CAST(Int32(0) AS Int64)
           Range: start=0, end=6, step=1, num_partitions=1
-  
+
     analyzed_logical_plan:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_lateral_projection:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after rewrite_set_comparison:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after optimize_unions:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after unions_to_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after simplify_expressions:
     Filter: #0 = Int64(4)
       ExplicitRepartition: kind=coalesce, n=Some(1), expr=[]
         Filter: #0 % Int64(2) = Int64(0)
           Range: start=0, end=6, step=1, num_partitions=1
-  
+
     logical_plan after replace_distinct_aggregate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_predicate_subquery:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after scalar_subquery_to_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_lateral_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after extract_equijoin_predicate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_duplicated_expr:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_cross_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_limit:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after propagate_empty_relation:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after filter_null_join_keys:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_outer_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after push_down_limit:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after push_down_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after single_distinct_aggregation_to_group_by:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_group_by_constant:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after common_sub_expression_eliminate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after extract_leaf_expressions:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after optimize_projections:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_lateral_projection:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after rewrite_set_comparison:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after optimize_unions:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after unions_to_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after simplify_expressions:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after replace_distinct_aggregate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_predicate_subquery:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after scalar_subquery_to_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after decorrelate_lateral_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after extract_equijoin_predicate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_duplicated_expr:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_cross_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_limit:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after propagate_empty_relation:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after filter_null_join_keys:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_outer_join:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after push_down_limit:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after push_down_filter:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after single_distinct_aggregation_to_group_by:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after eliminate_group_by_constant:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after common_sub_expression_eliminate:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after extract_leaf_expressions:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after optimize_projections:
     SAME TEXT AS ABOVE
-  
+
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-  
+
     logical_plan:
     Filter: #0 = Int64(4)
       ExplicitRepartition: kind=coalesce, n=Some(1), expr=[]
         Filter: #0 % Int64(2) = Int64(0)
           Range: start=0, end=6, step=1, num_partitions=1
-  
+
     initial_physical_plan:
     FilterExec: #0@0 = 4
       ExplicitRepartitionExec
         FilterExec: #0@0 % 2 = 0
           RangeExec
-  
-  
+
+
     initial_physical_plan_with_stats:
     FilterExec: #0@0 = 4, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]: Min=Exact(Int64(4)) Max=Exact(Int64(4)) Distinct=Exact(1))]]
       ExplicitRepartitionExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
         FilterExec: #0@0 % 2 = 0, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
           RangeExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
-  
-  
+
+
     initial_physical_plan_with_schema:
     FilterExec: #0@0 = 4, schema=[#0:Int64]
       ExplicitRepartitionExec, schema=[#0:Int64]
         FilterExec: #0@0 % 2 = 0, schema=[#0:Int64]
           RangeExec, schema=[#0:Int64]
-  
-  
+
+
     physical_plan after OutputRequirements:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 = 4
         ExplicitRepartitionExec
           FilterExec: #0@0 % 2 = 0
             RangeExec
-  
-  
+
+
     physical_plan after aggregate_statistics:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after join_selection:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after LimitedDistinctAggregation:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after FilterPushdown:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after EnforceDistribution:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 = 4
@@ -922,8 +922,8 @@ data:
             FilterExec: #0@0 % 2 = 0
               RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
                 RangeExec
-  
-  
+
+
     physical_plan after EliminateRedundantRepartition:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 = 4
@@ -931,75 +931,75 @@ data:
           FilterExec: #0@0 % 2 = 0
             RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
               RangeExec
-  
-  
+
+
     physical_plan after CombinePartialFinalAggregate:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after EnforceSorting:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after OptimizeAggregateOrder:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after WindowTopN:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after ProjectionPushdown:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after OutputRequirements:
     FilterExec: #0@0 = 4
       ExplicitRepartitionExec
         FilterExec: #0@0 % 2 = 0
           RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
             RangeExec
-  
-  
+
+
     physical_plan after LimitAggregation:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after LimitPushPastWindows:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after HashJoinBuffering:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after LimitPushdown:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after TopKRepartition:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after ProjectionPushdown:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after FilterPushdown(Post):
     SAME TEXT AS ABOVE
-  
+
     physical_plan after RewriteExplicitRepartition:
     FilterExec: #0@0 = 4
       CoalescePartitionsExec
         FilterExec: #0@0 % 2 = 0
           RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
             RangeExec
-  
-  
+
+
     physical_plan after RewriteCollectLeftHashJoin:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after EnforceBarrierPartitioning:
     SAME TEXT AS ABOVE
-  
+
     physical_plan after SanityCheckPlan:
     SAME TEXT AS ABOVE
-  
+
     physical_plan:
     ProjectionExec: expr=[#0@0 as id]
       FilterExec: #0@0 = 4
@@ -1007,8 +1007,8 @@ data:
           FilterExec: #0@0 % 2 = 0
             RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
               RangeExec
-  
-  
+
+
     == Physical Plan ==
     ProjectionExec: expr=[#0@0 as id]
       FilterExec: #0@0 = 4
@@ -1016,8 +1016,8 @@ data:
           FilterExec: #0@0 % 2 = 0
             RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
               RangeExec
-  
-  
+
+
     == Distributed Plan ==
     === stage 0 ===
     inputs=[]
@@ -1026,7 +1026,7 @@ data:
     distribution=RoundRobin(channels=4)
     placement=Worker
     RangeExec
-  
+
     === stage 1 ===
     inputs=[StageInput(stage=0, mode=Shuffle)]
     mode=Pipelined
@@ -1035,7 +1035,7 @@ data:
     placement=Worker
     FilterExec: #0@0 % 2 = 0
       StageInputExec: input=0, partitioning=RoundRobinBatch(4)
-  
+
     === stage 2 ===
     inputs=[StageInput(stage=1, mode=Shuffle)]
     mode=Pipelined
@@ -1093,7 +1093,7 @@ data:
       RepartitionExec: partitioning=Hash([#0@0], 5), input_partitions=1
         RangeExec
 ---
-name: "test_p2_collapses_hash_over_unkown_plan"
+name: "test_p2_collapses_hash_over_unknown_plan"
 data:
   |-
     == Physical Plan ==

--- a/python/pysail/tests/spark/optimizer/__snapshots__/test_eliminate_redundant_repartition.plan.yaml
+++ b/python/pysail/tests/spark/optimizer/__snapshots__/test_eliminate_redundant_repartition.plan.yaml
@@ -14,319 +14,319 @@ data:
   |-
     == Codegen ==
     Whole-stage codegen is not supported; showing physical plan instead.
-
+  
     == Plan Steps ==
     initial_logical_plan:
     Filter: #0 % CASE WHEN Int32(2) = Int32(0) THEN raise_error(Utf8("Remainder by zero")) ELSE Int32(2) END = Int32(0)
       ExplicitRepartition: kind=hash, n=Some(3), expr=[#0]
         Range: start=0, end=6, step=1, num_partitions=1
-
+  
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after resolve_grouping_function:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after type_coercion:
     Filter: #0 % CAST(CASE WHEN Int32(2) = Int32(0) THEN CAST(raise_error(Utf8("Remainder by zero")) AS Int32) ELSE Int32(2) END AS Int64) = CAST(Int32(0) AS Int64)
       ExplicitRepartition: kind=hash, n=Some(3), expr=[#0]
         Range: start=0, end=6, step=1, num_partitions=1
-
+  
     analyzed_logical_plan:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_lateral_projection:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after rewrite_set_comparison:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after optimize_unions:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after unions_to_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after simplify_expressions:
     Filter: #0 % Int64(2) = Int64(0)
       ExplicitRepartition: kind=hash, n=Some(3), expr=[#0]
         Range: start=0, end=6, step=1, num_partitions=1
-
+  
     logical_plan after replace_distinct_aggregate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_predicate_subquery:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after scalar_subquery_to_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_lateral_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after extract_equijoin_predicate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_duplicated_expr:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_cross_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_limit:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after propagate_empty_relation:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after filter_null_join_keys:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_outer_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after push_down_limit:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after push_down_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after single_distinct_aggregation_to_group_by:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_group_by_constant:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after common_sub_expression_eliminate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after extract_leaf_expressions:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after optimize_projections:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_lateral_projection:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after rewrite_set_comparison:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after optimize_unions:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after unions_to_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after simplify_expressions:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after replace_distinct_aggregate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_predicate_subquery:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after scalar_subquery_to_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_lateral_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after extract_equijoin_predicate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_duplicated_expr:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_cross_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_limit:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after propagate_empty_relation:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after filter_null_join_keys:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_outer_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after push_down_limit:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after push_down_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after single_distinct_aggregation_to_group_by:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_group_by_constant:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after common_sub_expression_eliminate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after extract_leaf_expressions:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after optimize_projections:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-
+  
     logical_plan:
     Filter: #0 % Int64(2) = Int64(0)
       ExplicitRepartition: kind=hash, n=Some(3), expr=[#0]
         Range: start=0, end=6, step=1, num_partitions=1
-
+  
     initial_physical_plan:
     FilterExec: #0@0 % 2 = 0
       ExplicitRepartitionExec
         RangeExec
-
-
+  
+  
     initial_physical_plan_with_stats:
     FilterExec: #0@0 % 2 = 0, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
       ExplicitRepartitionExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
         RangeExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
-
-
+  
+  
     initial_physical_plan_with_schema:
     FilterExec: #0@0 % 2 = 0, schema=[#0:Int64]
       ExplicitRepartitionExec, schema=[#0:Int64]
         RangeExec, schema=[#0:Int64]
-
-
+  
+  
     physical_plan after OutputRequirements:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 % 2 = 0
         ExplicitRepartitionExec
           RangeExec
-
-
+  
+  
     physical_plan after aggregate_statistics:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after join_selection:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after LimitedDistinctAggregation:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after FilterPushdown:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after EnforceDistribution:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 % 2 = 0
         RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
           ExplicitRepartitionExec
             RangeExec
-
-
+  
+  
     physical_plan after EliminateRedundantRepartition:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 % 2 = 0
         ExplicitRepartitionExec
           RangeExec
-
-
+  
+  
     physical_plan after CombinePartialFinalAggregate:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after EnforceSorting:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after OptimizeAggregateOrder:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after WindowTopN:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after ProjectionPushdown:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after OutputRequirements:
     FilterExec: #0@0 % 2 = 0
       ExplicitRepartitionExec
         RangeExec
-
-
+  
+  
     physical_plan after LimitAggregation:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after LimitPushPastWindows:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after HashJoinBuffering:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after LimitPushdown:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after TopKRepartition:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after ProjectionPushdown:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after FilterPushdown(Post):
     SAME TEXT AS ABOVE
-
+  
     physical_plan after RewriteExplicitRepartition:
     FilterExec: #0@0 % 2 = 0
       RepartitionExec: partitioning=Hash([#0@0], 3), input_partitions=1
         RangeExec
-
-
+  
+  
     physical_plan after RewriteCollectLeftHashJoin:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after EnforceBarrierPartitioning:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after SanityCheckPlan:
     SAME TEXT AS ABOVE
-
+  
     physical_plan:
     ProjectionExec: expr=[#0@0 as id]
       FilterExec: #0@0 % 2 = 0
         RepartitionExec: partitioning=Hash([#0@0], 3), input_partitions=1
           RangeExec
-
-
+  
+  
     == Physical Plan ==
     ProjectionExec: expr=[#0@0 as id]
       FilterExec: #0@0 % 2 = 0
         RepartitionExec: partitioning=Hash([#0@0], 3), input_partitions=1
           RangeExec
-
-
+  
+  
     == Distributed Plan ==
     === stage 0 ===
     inputs=[]
@@ -335,7 +335,7 @@ data:
     distribution=Hash(keys=[#0@0], channels=3)
     placement=Worker
     RangeExec
-
+  
     === stage 1 ===
     inputs=[StageInput(stage=0, mode=Shuffle)]
     mode=Pipelined
@@ -351,316 +351,316 @@ data:
   |-
     == Codegen ==
     Whole-stage codegen is not supported; showing physical plan instead.
-
+  
     == Plan Steps ==
     initial_logical_plan:
     Filter: #0 % CASE WHEN Int32(2) = Int32(0) THEN raise_error(Utf8("Remainder by zero")) ELSE Int32(2) END = Int32(0)
       ExplicitRepartition: kind=round_robin, n=Some(3), expr=[]
         Range: start=0, end=6, step=1, num_partitions=1
-
+  
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after resolve_grouping_function:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after type_coercion:
     Filter: #0 % CAST(CASE WHEN Int32(2) = Int32(0) THEN CAST(raise_error(Utf8("Remainder by zero")) AS Int32) ELSE Int32(2) END AS Int64) = CAST(Int32(0) AS Int64)
       ExplicitRepartition: kind=round_robin, n=Some(3), expr=[]
         Range: start=0, end=6, step=1, num_partitions=1
-
+  
     analyzed_logical_plan:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_lateral_projection:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after rewrite_set_comparison:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after optimize_unions:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after unions_to_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after simplify_expressions:
     Filter: #0 % Int64(2) = Int64(0)
       ExplicitRepartition: kind=round_robin, n=Some(3), expr=[]
         Range: start=0, end=6, step=1, num_partitions=1
-
+  
     logical_plan after replace_distinct_aggregate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_predicate_subquery:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after scalar_subquery_to_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_lateral_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after extract_equijoin_predicate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_duplicated_expr:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_cross_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_limit:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after propagate_empty_relation:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after filter_null_join_keys:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_outer_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after push_down_limit:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after push_down_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after single_distinct_aggregation_to_group_by:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_group_by_constant:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after common_sub_expression_eliminate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after extract_leaf_expressions:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after optimize_projections:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_lateral_projection:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after rewrite_set_comparison:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after optimize_unions:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after unions_to_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after simplify_expressions:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after replace_distinct_aggregate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_predicate_subquery:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after scalar_subquery_to_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_lateral_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after extract_equijoin_predicate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_duplicated_expr:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_cross_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_limit:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after propagate_empty_relation:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after filter_null_join_keys:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_outer_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after push_down_limit:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after push_down_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after single_distinct_aggregation_to_group_by:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_group_by_constant:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after common_sub_expression_eliminate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after extract_leaf_expressions:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after optimize_projections:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-
+  
     logical_plan:
     Filter: #0 % Int64(2) = Int64(0)
       ExplicitRepartition: kind=round_robin, n=Some(3), expr=[]
         Range: start=0, end=6, step=1, num_partitions=1
-
+  
     initial_physical_plan:
     FilterExec: #0@0 % 2 = 0
       ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
         RangeExec
-
-
+  
+  
     initial_physical_plan_with_stats:
     FilterExec: #0@0 % 2 = 0, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
       ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
         RangeExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
-
-
+  
+  
     initial_physical_plan_with_schema:
     FilterExec: #0@0 % 2 = 0, schema=[#0:Int64]
       ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1, schema=[#0:Int64]
         RangeExec, schema=[#0:Int64]
-
-
+  
+  
     physical_plan after OutputRequirements:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 % 2 = 0
         ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
           RangeExec
-
-
+  
+  
     physical_plan after aggregate_statistics:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after join_selection:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after LimitedDistinctAggregation:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after FilterPushdown:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after EnforceDistribution:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 % 2 = 0
         RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
           ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
             RangeExec
-
-
+  
+  
     physical_plan after EliminateRedundantRepartition:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 % 2 = 0
         ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
           RangeExec
-
-
+  
+  
     physical_plan after CombinePartialFinalAggregate:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after EnforceSorting:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after OptimizeAggregateOrder:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after WindowTopN:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after ProjectionPushdown:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after OutputRequirements:
     FilterExec: #0@0 % 2 = 0
       ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
         RangeExec
-
-
+  
+  
     physical_plan after LimitAggregation:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after LimitPushPastWindows:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after HashJoinBuffering:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after LimitPushdown:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after TopKRepartition:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after ProjectionPushdown:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after FilterPushdown(Post):
     SAME TEXT AS ABOVE
-
+  
     physical_plan after RewriteExplicitRepartition:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after RewriteCollectLeftHashJoin:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after EnforceBarrierPartitioning:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after SanityCheckPlan:
     SAME TEXT AS ABOVE
-
+  
     physical_plan:
     ProjectionExec: expr=[#0@0 as id]
       FilterExec: #0@0 % 2 = 0
         ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
           RangeExec
-
-
+  
+  
     == Physical Plan ==
     ProjectionExec: expr=[#0@0 as id]
       FilterExec: #0@0 % 2 = 0
         ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
           RangeExec
-
-
+  
+  
     == Distributed Plan ==
     === stage 0 ===
     inputs=[]
@@ -669,7 +669,7 @@ data:
     distribution=RoundRobinRow(channels=3)
     placement=Worker
     RangeExec
-
+  
     === stage 1 ===
     inputs=[StageInput(stage=0, mode=Shuffle)]
     mode=Pipelined
@@ -685,235 +685,235 @@ data:
   |-
     == Codegen ==
     Whole-stage codegen is not supported; showing physical plan instead.
-
+  
     == Plan Steps ==
     initial_logical_plan:
     Filter: #0 = Int32(4)
       ExplicitRepartition: kind=coalesce, n=Some(1), expr=[]
         Filter: #0 % CASE WHEN Int32(2) = Int32(0) THEN raise_error(Utf8("Remainder by zero")) ELSE Int32(2) END = Int32(0)
           Range: start=0, end=6, step=1, num_partitions=1
-
+  
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after resolve_grouping_function:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after type_coercion:
     Filter: #0 = CAST(Int32(4) AS Int64)
       ExplicitRepartition: kind=coalesce, n=Some(1), expr=[]
         Filter: #0 % CAST(CASE WHEN Int32(2) = Int32(0) THEN CAST(raise_error(Utf8("Remainder by zero")) AS Int32) ELSE Int32(2) END AS Int64) = CAST(Int32(0) AS Int64)
           Range: start=0, end=6, step=1, num_partitions=1
-
+  
     analyzed_logical_plan:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_lateral_projection:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after rewrite_set_comparison:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after optimize_unions:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after unions_to_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after simplify_expressions:
     Filter: #0 = Int64(4)
       ExplicitRepartition: kind=coalesce, n=Some(1), expr=[]
         Filter: #0 % Int64(2) = Int64(0)
           Range: start=0, end=6, step=1, num_partitions=1
-
+  
     logical_plan after replace_distinct_aggregate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_predicate_subquery:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after scalar_subquery_to_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_lateral_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after extract_equijoin_predicate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_duplicated_expr:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_cross_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_limit:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after propagate_empty_relation:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after filter_null_join_keys:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_outer_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after push_down_limit:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after push_down_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after single_distinct_aggregation_to_group_by:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_group_by_constant:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after common_sub_expression_eliminate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after extract_leaf_expressions:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after optimize_projections:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_lateral_projection:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after rewrite_set_comparison:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after optimize_unions:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after unions_to_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after simplify_expressions:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after replace_distinct_aggregate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_predicate_subquery:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after scalar_subquery_to_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after decorrelate_lateral_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after extract_equijoin_predicate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_duplicated_expr:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_cross_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_limit:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after propagate_empty_relation:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after filter_null_join_keys:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_outer_join:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after push_down_limit:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after push_down_filter:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after single_distinct_aggregation_to_group_by:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after eliminate_group_by_constant:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after common_sub_expression_eliminate:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after extract_leaf_expressions:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after optimize_projections:
     SAME TEXT AS ABOVE
-
+  
     logical_plan after resolve_lambda_variables:
     SAME TEXT AS ABOVE
-
+  
     logical_plan:
     Filter: #0 = Int64(4)
       ExplicitRepartition: kind=coalesce, n=Some(1), expr=[]
         Filter: #0 % Int64(2) = Int64(0)
           Range: start=0, end=6, step=1, num_partitions=1
-
+  
     initial_physical_plan:
     FilterExec: #0@0 = 4
       ExplicitRepartitionExec
         FilterExec: #0@0 % 2 = 0
           RangeExec
-
-
+  
+  
     initial_physical_plan_with_stats:
     FilterExec: #0@0 = 4, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]: Min=Exact(Int64(4)) Max=Exact(Int64(4)) Distinct=Exact(1))]]
       ExplicitRepartitionExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
         FilterExec: #0@0 % 2 = 0, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
           RangeExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
-
-
+  
+  
     initial_physical_plan_with_schema:
     FilterExec: #0@0 = 4, schema=[#0:Int64]
       ExplicitRepartitionExec, schema=[#0:Int64]
         FilterExec: #0@0 % 2 = 0, schema=[#0:Int64]
           RangeExec, schema=[#0:Int64]
-
-
+  
+  
     physical_plan after OutputRequirements:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 = 4
         ExplicitRepartitionExec
           FilterExec: #0@0 % 2 = 0
             RangeExec
-
-
+  
+  
     physical_plan after aggregate_statistics:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after join_selection:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after LimitedDistinctAggregation:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after FilterPushdown:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after EnforceDistribution:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 = 4
@@ -922,8 +922,8 @@ data:
             FilterExec: #0@0 % 2 = 0
               RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
                 RangeExec
-
-
+  
+  
     physical_plan after EliminateRedundantRepartition:
     OutputRequirementExec: order_by=[], dist_by=Unspecified
       FilterExec: #0@0 = 4
@@ -931,75 +931,75 @@ data:
           FilterExec: #0@0 % 2 = 0
             RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
               RangeExec
-
-
+  
+  
     physical_plan after CombinePartialFinalAggregate:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after EnforceSorting:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after OptimizeAggregateOrder:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after WindowTopN:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after ProjectionPushdown:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after OutputRequirements:
     FilterExec: #0@0 = 4
       ExplicitRepartitionExec
         FilterExec: #0@0 % 2 = 0
           RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
             RangeExec
-
-
+  
+  
     physical_plan after LimitAggregation:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after LimitPushPastWindows:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after HashJoinBuffering:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after LimitPushdown:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after TopKRepartition:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after ProjectionPushdown:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after FilterPushdown(Post):
     SAME TEXT AS ABOVE
-
+  
     physical_plan after RewriteExplicitRepartition:
     FilterExec: #0@0 = 4
       CoalescePartitionsExec
         FilterExec: #0@0 % 2 = 0
           RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
             RangeExec
-
-
+  
+  
     physical_plan after RewriteCollectLeftHashJoin:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after EnforceBarrierPartitioning:
     SAME TEXT AS ABOVE
-
+  
     physical_plan after SanityCheckPlan:
     SAME TEXT AS ABOVE
-
+  
     physical_plan:
     ProjectionExec: expr=[#0@0 as id]
       FilterExec: #0@0 = 4
@@ -1007,8 +1007,8 @@ data:
           FilterExec: #0@0 % 2 = 0
             RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
               RangeExec
-
-
+  
+  
     == Physical Plan ==
     ProjectionExec: expr=[#0@0 as id]
       FilterExec: #0@0 = 4
@@ -1016,8 +1016,8 @@ data:
           FilterExec: #0@0 % 2 = 0
             RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
               RangeExec
-
-
+  
+  
     == Distributed Plan ==
     === stage 0 ===
     inputs=[]
@@ -1026,7 +1026,7 @@ data:
     distribution=RoundRobin(channels=4)
     placement=Worker
     RangeExec
-
+  
     === stage 1 ===
     inputs=[StageInput(stage=0, mode=Shuffle)]
     mode=Pipelined
@@ -1035,7 +1035,7 @@ data:
     placement=Worker
     FilterExec: #0@0 % 2 = 0
       StageInputExec: input=0, partitioning=RoundRobinBatch(4)
-
+  
     === stage 2 ===
     inputs=[StageInput(stage=1, mode=Shuffle)]
     mode=Pipelined

--- a/python/pysail/tests/spark/optimizer/__snapshots__/test_eliminate_redundant_repartition.plan.yaml
+++ b/python/pysail/tests/spark/optimizer/__snapshots__/test_eliminate_redundant_repartition.plan.yaml
@@ -1,0 +1,1099 @@
+# serializer version: 1
+---
+name: "test_p1_and_p2_combined_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      FilterExec: #0@0 % 2 = 0
+        ExplicitRepartitionExec: partitioning=RoundRobinBatch(5), input_partitions=1
+          RangeExec
+---
+name: "test_p1_eliminates_rr_repartition_above_hash_explicit_plan"
+data:
+  |-
+    == Codegen ==
+    Whole-stage codegen is not supported; showing physical plan instead.
+  
+    == Plan Steps ==
+    initial_logical_plan:
+    Filter: #0 % CASE WHEN Int32(2) = Int32(0) THEN raise_error(Utf8("Remainder by zero")) ELSE Int32(2) END = Int32(0)
+      ExplicitRepartition: kind=hash, n=Some(3), expr=[#0]
+        Range: start=0, end=6, step=1, num_partitions=1
+  
+    logical_plan after resolve_lambda_variables:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after resolve_grouping_function:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after type_coercion:
+    Filter: #0 % CAST(CASE WHEN Int32(2) = Int32(0) THEN CAST(raise_error(Utf8("Remainder by zero")) AS Int32) ELSE Int32(2) END AS Int64) = CAST(Int32(0) AS Int64)
+      ExplicitRepartition: kind=hash, n=Some(3), expr=[#0]
+        Range: start=0, end=6, step=1, num_partitions=1
+  
+    analyzed_logical_plan:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_projection:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after rewrite_set_comparison:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_unions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after unions_to_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after simplify_expressions:
+    Filter: #0 % Int64(2) = Int64(0)
+      ExplicitRepartition: kind=hash, n=Some(3), expr=[#0]
+        Range: start=0, end=6, step=1, num_partitions=1
+  
+    logical_plan after replace_distinct_aggregate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_predicate_subquery:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after scalar_subquery_to_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after extract_equijoin_predicate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_duplicated_expr:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_cross_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after propagate_empty_relation:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after filter_null_join_keys:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_outer_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after single_distinct_aggregation_to_group_by:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_group_by_constant:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after common_sub_expression_eliminate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after extract_leaf_expressions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_projections:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after resolve_lambda_variables:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_projection:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after rewrite_set_comparison:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_unions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after unions_to_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after simplify_expressions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after replace_distinct_aggregate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_predicate_subquery:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after scalar_subquery_to_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after extract_equijoin_predicate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_duplicated_expr:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_cross_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after propagate_empty_relation:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after filter_null_join_keys:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_outer_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after single_distinct_aggregation_to_group_by:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_group_by_constant:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after common_sub_expression_eliminate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after extract_leaf_expressions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_projections:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after resolve_lambda_variables:
+    SAME TEXT AS ABOVE
+  
+    logical_plan:
+    Filter: #0 % Int64(2) = Int64(0)
+      ExplicitRepartition: kind=hash, n=Some(3), expr=[#0]
+        Range: start=0, end=6, step=1, num_partitions=1
+  
+    initial_physical_plan:
+    FilterExec: #0@0 % 2 = 0
+      ExplicitRepartitionExec
+        RangeExec
+  
+  
+    initial_physical_plan_with_stats:
+    FilterExec: #0@0 % 2 = 0, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+      ExplicitRepartitionExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+        RangeExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+  
+  
+    initial_physical_plan_with_schema:
+    FilterExec: #0@0 % 2 = 0, schema=[#0:Int64]
+      ExplicitRepartitionExec, schema=[#0:Int64]
+        RangeExec, schema=[#0:Int64]
+  
+  
+    physical_plan after OutputRequirements:
+    OutputRequirementExec: order_by=[], dist_by=Unspecified
+      FilterExec: #0@0 % 2 = 0
+        ExplicitRepartitionExec
+          RangeExec
+  
+  
+    physical_plan after aggregate_statistics:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after join_selection:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after LimitedDistinctAggregation:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after FilterPushdown:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EnforceDistribution:
+    OutputRequirementExec: order_by=[], dist_by=Unspecified
+      FilterExec: #0@0 % 2 = 0
+        RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
+          ExplicitRepartitionExec
+            RangeExec
+  
+  
+    physical_plan after EliminateRedundantRepartition:
+    OutputRequirementExec: order_by=[], dist_by=Unspecified
+      FilterExec: #0@0 % 2 = 0
+        ExplicitRepartitionExec
+          RangeExec
+  
+  
+    physical_plan after CombinePartialFinalAggregate:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EnforceSorting:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after OptimizeAggregateOrder:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after WindowTopN:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after ProjectionPushdown:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after OutputRequirements:
+    FilterExec: #0@0 % 2 = 0
+      ExplicitRepartitionExec
+        RangeExec
+  
+  
+    physical_plan after LimitAggregation:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after LimitPushPastWindows:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after HashJoinBuffering:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after LimitPushdown:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after TopKRepartition:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after ProjectionPushdown:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after PushdownSort:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EnsureCooperative:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after FilterPushdown(Post):
+    SAME TEXT AS ABOVE
+  
+    physical_plan after RewriteExplicitRepartition:
+    FilterExec: #0@0 % 2 = 0
+      RepartitionExec: partitioning=Hash([#0@0], 3), input_partitions=1
+        RangeExec
+  
+  
+    physical_plan after RewriteCollectLeftHashJoin:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EnforceBarrierPartitioning:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after SanityCheckPlan:
+    SAME TEXT AS ABOVE
+  
+    physical_plan:
+    ProjectionExec: expr=[#0@0 as id]
+      FilterExec: #0@0 % 2 = 0
+        RepartitionExec: partitioning=Hash([#0@0], 3), input_partitions=1
+          RangeExec
+  
+  
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      FilterExec: #0@0 % 2 = 0
+        RepartitionExec: partitioning=Hash([#0@0], 3), input_partitions=1
+          RangeExec
+---
+name: "test_p1_eliminates_rr_repartition_above_rr_explicit_plan"
+data:
+  |-
+    == Codegen ==
+    Whole-stage codegen is not supported; showing physical plan instead.
+  
+    == Plan Steps ==
+    initial_logical_plan:
+    Filter: #0 % CASE WHEN Int32(2) = Int32(0) THEN raise_error(Utf8("Remainder by zero")) ELSE Int32(2) END = Int32(0)
+      ExplicitRepartition: kind=round_robin, n=Some(3), expr=[]
+        Range: start=0, end=6, step=1, num_partitions=1
+  
+    logical_plan after resolve_lambda_variables:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after resolve_grouping_function:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after type_coercion:
+    Filter: #0 % CAST(CASE WHEN Int32(2) = Int32(0) THEN CAST(raise_error(Utf8("Remainder by zero")) AS Int32) ELSE Int32(2) END AS Int64) = CAST(Int32(0) AS Int64)
+      ExplicitRepartition: kind=round_robin, n=Some(3), expr=[]
+        Range: start=0, end=6, step=1, num_partitions=1
+  
+    analyzed_logical_plan:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_projection:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after rewrite_set_comparison:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_unions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after unions_to_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after simplify_expressions:
+    Filter: #0 % Int64(2) = Int64(0)
+      ExplicitRepartition: kind=round_robin, n=Some(3), expr=[]
+        Range: start=0, end=6, step=1, num_partitions=1
+  
+    logical_plan after replace_distinct_aggregate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_predicate_subquery:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after scalar_subquery_to_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after extract_equijoin_predicate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_duplicated_expr:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_cross_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after propagate_empty_relation:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after filter_null_join_keys:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_outer_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after single_distinct_aggregation_to_group_by:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_group_by_constant:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after common_sub_expression_eliminate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after extract_leaf_expressions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_projections:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after resolve_lambda_variables:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_projection:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after rewrite_set_comparison:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_unions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after unions_to_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after simplify_expressions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after replace_distinct_aggregate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_predicate_subquery:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after scalar_subquery_to_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after extract_equijoin_predicate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_duplicated_expr:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_cross_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after propagate_empty_relation:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after filter_null_join_keys:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_outer_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after single_distinct_aggregation_to_group_by:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_group_by_constant:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after common_sub_expression_eliminate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after extract_leaf_expressions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_projections:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after resolve_lambda_variables:
+    SAME TEXT AS ABOVE
+  
+    logical_plan:
+    Filter: #0 % Int64(2) = Int64(0)
+      ExplicitRepartition: kind=round_robin, n=Some(3), expr=[]
+        Range: start=0, end=6, step=1, num_partitions=1
+  
+    initial_physical_plan:
+    FilterExec: #0@0 % 2 = 0
+      ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+        RangeExec
+  
+  
+    initial_physical_plan_with_stats:
+    FilterExec: #0@0 % 2 = 0, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+      ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+        RangeExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+  
+  
+    initial_physical_plan_with_schema:
+    FilterExec: #0@0 % 2 = 0, schema=[#0:Int64]
+      ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1, schema=[#0:Int64]
+        RangeExec, schema=[#0:Int64]
+  
+  
+    physical_plan after OutputRequirements:
+    OutputRequirementExec: order_by=[], dist_by=Unspecified
+      FilterExec: #0@0 % 2 = 0
+        ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+          RangeExec
+  
+  
+    physical_plan after aggregate_statistics:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after join_selection:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after LimitedDistinctAggregation:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after FilterPushdown:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EnforceDistribution:
+    OutputRequirementExec: order_by=[], dist_by=Unspecified
+      FilterExec: #0@0 % 2 = 0
+        RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
+          ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+            RangeExec
+  
+  
+    physical_plan after EliminateRedundantRepartition:
+    OutputRequirementExec: order_by=[], dist_by=Unspecified
+      FilterExec: #0@0 % 2 = 0
+        ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+          RangeExec
+  
+  
+    physical_plan after CombinePartialFinalAggregate:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EnforceSorting:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after OptimizeAggregateOrder:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after WindowTopN:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after ProjectionPushdown:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after OutputRequirements:
+    FilterExec: #0@0 % 2 = 0
+      ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+        RangeExec
+  
+  
+    physical_plan after LimitAggregation:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after LimitPushPastWindows:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after HashJoinBuffering:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after LimitPushdown:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after TopKRepartition:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after ProjectionPushdown:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after PushdownSort:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EnsureCooperative:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after FilterPushdown(Post):
+    SAME TEXT AS ABOVE
+  
+    physical_plan after RewriteExplicitRepartition:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after RewriteCollectLeftHashJoin:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EnforceBarrierPartitioning:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after SanityCheckPlan:
+    SAME TEXT AS ABOVE
+  
+    physical_plan:
+    ProjectionExec: expr=[#0@0 as id]
+      FilterExec: #0@0 % 2 = 0
+        ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+          RangeExec
+  
+  
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      FilterExec: #0@0 % 2 = 0
+        ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+          RangeExec
+---
+name: "test_p1_eliminates_rr_repartition_above_unkown_explicit_plan"
+data:
+  |-
+    == Codegen ==
+    Whole-stage codegen is not supported; showing physical plan instead.
+  
+    == Plan Steps ==
+    initial_logical_plan:
+    Filter: #0 = Int32(4)
+      ExplicitRepartition: kind=coalesce, n=Some(1), expr=[]
+        Filter: #0 % CASE WHEN Int32(2) = Int32(0) THEN raise_error(Utf8("Remainder by zero")) ELSE Int32(2) END = Int32(0)
+          Range: start=0, end=6, step=1, num_partitions=1
+  
+    logical_plan after resolve_lambda_variables:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after resolve_grouping_function:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after type_coercion:
+    Filter: #0 = CAST(Int32(4) AS Int64)
+      ExplicitRepartition: kind=coalesce, n=Some(1), expr=[]
+        Filter: #0 % CAST(CASE WHEN Int32(2) = Int32(0) THEN CAST(raise_error(Utf8("Remainder by zero")) AS Int32) ELSE Int32(2) END AS Int64) = CAST(Int32(0) AS Int64)
+          Range: start=0, end=6, step=1, num_partitions=1
+  
+    analyzed_logical_plan:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_projection:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after rewrite_set_comparison:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_unions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after unions_to_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after simplify_expressions:
+    Filter: #0 = Int64(4)
+      ExplicitRepartition: kind=coalesce, n=Some(1), expr=[]
+        Filter: #0 % Int64(2) = Int64(0)
+          Range: start=0, end=6, step=1, num_partitions=1
+  
+    logical_plan after replace_distinct_aggregate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_predicate_subquery:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after scalar_subquery_to_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after extract_equijoin_predicate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_duplicated_expr:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_cross_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after propagate_empty_relation:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after filter_null_join_keys:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_outer_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after single_distinct_aggregation_to_group_by:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_group_by_constant:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after common_sub_expression_eliminate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after extract_leaf_expressions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_projections:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after resolve_lambda_variables:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_projection:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after rewrite_set_comparison:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_unions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after unions_to_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after simplify_expressions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after replace_distinct_aggregate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_predicate_subquery:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after scalar_subquery_to_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after extract_equijoin_predicate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_duplicated_expr:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_cross_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after propagate_empty_relation:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after filter_null_join_keys:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_outer_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after single_distinct_aggregation_to_group_by:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_group_by_constant:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after common_sub_expression_eliminate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after extract_leaf_expressions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_projections:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after resolve_lambda_variables:
+    SAME TEXT AS ABOVE
+  
+    logical_plan:
+    Filter: #0 = Int64(4)
+      ExplicitRepartition: kind=coalesce, n=Some(1), expr=[]
+        Filter: #0 % Int64(2) = Int64(0)
+          Range: start=0, end=6, step=1, num_partitions=1
+  
+    initial_physical_plan:
+    FilterExec: #0@0 = 4
+      ExplicitRepartitionExec
+        FilterExec: #0@0 % 2 = 0
+          RangeExec
+  
+  
+    initial_physical_plan_with_stats:
+    FilterExec: #0@0 = 4, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]: Min=Exact(Int64(4)) Max=Exact(Int64(4)) Distinct=Exact(1))]]
+      ExplicitRepartitionExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+        FilterExec: #0@0 % 2 = 0, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+          RangeExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+  
+  
+    initial_physical_plan_with_schema:
+    FilterExec: #0@0 = 4, schema=[#0:Int64]
+      ExplicitRepartitionExec, schema=[#0:Int64]
+        FilterExec: #0@0 % 2 = 0, schema=[#0:Int64]
+          RangeExec, schema=[#0:Int64]
+  
+  
+    physical_plan after OutputRequirements:
+    OutputRequirementExec: order_by=[], dist_by=Unspecified
+      FilterExec: #0@0 = 4
+        ExplicitRepartitionExec
+          FilterExec: #0@0 % 2 = 0
+            RangeExec
+  
+  
+    physical_plan after aggregate_statistics:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after join_selection:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after LimitedDistinctAggregation:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after FilterPushdown:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EnforceDistribution:
+    OutputRequirementExec: order_by=[], dist_by=Unspecified
+      FilterExec: #0@0 = 4
+        RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+          ExplicitRepartitionExec
+            FilterExec: #0@0 % 2 = 0
+              RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+                RangeExec
+  
+  
+    physical_plan after EliminateRedundantRepartition:
+    OutputRequirementExec: order_by=[], dist_by=Unspecified
+      FilterExec: #0@0 = 4
+        ExplicitRepartitionExec
+          FilterExec: #0@0 % 2 = 0
+            RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+              RangeExec
+  
+  
+    physical_plan after CombinePartialFinalAggregate:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EnforceSorting:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after OptimizeAggregateOrder:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after WindowTopN:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after ProjectionPushdown:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after OutputRequirements:
+    FilterExec: #0@0 = 4
+      ExplicitRepartitionExec
+        FilterExec: #0@0 % 2 = 0
+          RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+            RangeExec
+  
+  
+    physical_plan after LimitAggregation:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after LimitPushPastWindows:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after HashJoinBuffering:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after LimitPushdown:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after TopKRepartition:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after ProjectionPushdown:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after PushdownSort:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EnsureCooperative:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after FilterPushdown(Post):
+    SAME TEXT AS ABOVE
+  
+    physical_plan after RewriteExplicitRepartition:
+    FilterExec: #0@0 = 4
+      CoalescePartitionsExec
+        FilterExec: #0@0 % 2 = 0
+          RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+            RangeExec
+  
+  
+    physical_plan after RewriteCollectLeftHashJoin:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EnforceBarrierPartitioning:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after SanityCheckPlan:
+    SAME TEXT AS ABOVE
+  
+    physical_plan:
+    ProjectionExec: expr=[#0@0 as id]
+      FilterExec: #0@0 = 4
+        CoalescePartitionsExec
+          FilterExec: #0@0 % 2 = 0
+            RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+              RangeExec
+  
+  
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      FilterExec: #0@0 = 4
+        CoalescePartitionsExec
+          FilterExec: #0@0 % 2 = 0
+            RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+              RangeExec
+---
+name: "test_p1_keeps_hash_repartition_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#1@0 as id1, #3@1 as id2]
+      HashJoinExec: mode=Partitioned, join_type=Inner, on=[(#1@0, #3@0)]
+        RepartitionExec: partitioning=Hash([#1@0], 4), input_partitions=3
+          ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+            ProjectionExec: expr=[id@0 as #1]
+              RangeExec
+        RepartitionExec: partitioning=Hash([#3@0], 4), input_partitions=1
+          ProjectionExec: expr=[id@0 as #3]
+            RangeExec
+---
+name: "test_p1_keeps_rr_repartition_when_child_is_not_explicit_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      FilterExec: #0@0 % 2 = 0
+        RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+          RangeExec
+---
+name: "test_p2_collapses_chain_of_three_explicits_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      ExplicitRepartitionExec: partitioning=RoundRobinBatch(7), input_partitions=1
+        RangeExec
+---
+name: "test_p2_collapses_hash_over_hash_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      RepartitionExec: partitioning=Hash([#0@0], 5), input_partitions=1
+        RangeExec
+---
+name: "test_p2_collapses_hash_over_rr_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      RepartitionExec: partitioning=Hash([#0@0], 5), input_partitions=1
+        RangeExec
+---
+name: "test_p2_collapses_hash_over_unkown_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      RepartitionExec: partitioning=Hash([#0@0], 5), input_partitions=4
+        FilterExec: #0@0 % 2 = 0
+          RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+            RangeExec
+---
+name: "test_p2_collapses_rr_over_hash_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      ExplicitRepartitionExec: partitioning=RoundRobinBatch(5), input_partitions=1
+        RangeExec
+---
+name: "test_p2_collapses_rr_over_rr_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      ExplicitRepartitionExec: partitioning=RoundRobinBatch(5), input_partitions=1
+        RangeExec
+---
+name: "test_p2_collapses_rr_over_unknown_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      ExplicitRepartitionExec: partitioning=RoundRobinBatch(5), input_partitions=4
+        FilterExec: #0@0 % 2 = 0
+          RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+            RangeExec
+---
+name: "test_p2_collapses_unknown_over_unknown_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      CoalesceExec: partitions=2
+        FilterExec: #0@0 % 2 = 0
+          ExplicitRepartitionExec: partitioning=RoundRobinBatch(5), input_partitions=1
+            RangeExec
+---
+name: "test_p2_keeps_unknown_over_hash_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      CoalesceExec: partitions=3
+        RepartitionExec: partitioning=Hash([#0@0], 5), input_partitions=1
+          RangeExec
+---
+name: "test_p2_keeps_unknown_over_rr_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      CoalesceExec: partitions=3
+        ExplicitRepartitionExec: partitioning=RoundRobinBatch(5), input_partitions=1
+          RangeExec
+---
+name: "test_p2_noop_when_child_is_not_explicit_plan"
+data:
+  |-
+    == Physical Plan ==
+    ProjectionExec: expr=[#0@0 as id]
+      ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=4
+        FilterExec: #0@0 % 2 = 0
+          RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+            RangeExec

--- a/python/pysail/tests/spark/optimizer/__snapshots__/test_eliminate_redundant_repartition.plan.yaml
+++ b/python/pysail/tests/spark/optimizer/__snapshots__/test_eliminate_redundant_repartition.plan.yaml
@@ -325,6 +325,26 @@ data:
       FilterExec: #0@0 % 2 = 0
         RepartitionExec: partitioning=Hash([#0@0], 3), input_partitions=1
           RangeExec
+  
+  
+    == Distributed Plan ==
+    === stage 0 ===
+    inputs=[]
+    mode=Pipelined
+    partitions=1
+    distribution=Hash(keys=[#0@0], channels=3)
+    placement=Worker
+    RangeExec
+  
+    === stage 1 ===
+    inputs=[StageInput(stage=0, mode=Shuffle)]
+    mode=Pipelined
+    partitions=3
+    distribution=RoundRobin(channels=1)
+    placement=Worker
+    ProjectionExec: expr=[#0@0 as id]
+      FilterExec: #0@0 % 2 = 0
+        StageInputExec: input=0, partitioning=Hash([#0@0], 3)
 ---
 name: "test_p1_eliminates_rr_repartition_above_rr_explicit_plan"
 data:
@@ -639,6 +659,26 @@ data:
       FilterExec: #0@0 % 2 = 0
         ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
           RangeExec
+  
+  
+    == Distributed Plan ==
+    === stage 0 ===
+    inputs=[]
+    mode=Pipelined
+    partitions=1
+    distribution=RoundRobinRow(channels=3)
+    placement=Worker
+    RangeExec
+  
+    === stage 1 ===
+    inputs=[StageInput(stage=0, mode=Shuffle)]
+    mode=Pipelined
+    partitions=3
+    distribution=RoundRobin(channels=1)
+    placement=Worker
+    ProjectionExec: expr=[#0@0 as id]
+      FilterExec: #0@0 % 2 = 0
+        StageInputExec: input=0, partitioning=RoundRobinBatch(3)
 ---
 name: "test_p1_eliminates_rr_repartition_above_unkown_explicit_plan"
 data:
@@ -976,6 +1016,35 @@ data:
           FilterExec: #0@0 % 2 = 0
             RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
               RangeExec
+  
+  
+    == Distributed Plan ==
+    === stage 0 ===
+    inputs=[]
+    mode=Pipelined
+    partitions=1
+    distribution=RoundRobin(channels=4)
+    placement=Worker
+    RangeExec
+  
+    === stage 1 ===
+    inputs=[StageInput(stage=0, mode=Shuffle)]
+    mode=Pipelined
+    partitions=4
+    distribution=RoundRobin(channels=1)
+    placement=Worker
+    FilterExec: #0@0 % 2 = 0
+      StageInputExec: input=0, partitioning=RoundRobinBatch(4)
+  
+    === stage 2 ===
+    inputs=[StageInput(stage=1, mode=Shuffle)]
+    mode=Pipelined
+    partitions=1
+    distribution=RoundRobin(channels=1)
+    placement=Worker
+    ProjectionExec: expr=[#0@0 as id]
+      FilterExec: #0@0 = 4
+        StageInputExec: input=0, partitioning=UnknownPartitioning(1)
 ---
 name: "test_p1_keeps_hash_repartition_plan"
 data:

--- a/python/pysail/tests/spark/optimizer/test_eliminate_redundant_repartition.py
+++ b/python/pysail/tests/spark/optimizer/test_eliminate_redundant_repartition.py
@@ -29,7 +29,7 @@ def test_p1_eliminates_rr_repartition_above_hash_explicit_plan(spark, snapshot):
 
 @pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
 @pytest.mark.yamlsnapshot(group="plan")
-def test_p1_eliminates_rr_repartition_above_unkown_explicit_plan(spark, snapshot):
+def test_p1_eliminates_rr_repartition_above_unknown_explicit_plan(spark, snapshot):
     df = spark.range(6).filter(F.col("id") % 2 == 0).coalesce(1).filter(F.col("id") == 4)  # noqa: PLR2004
     plan = normalized_plan(df, mode="codegen")
 
@@ -112,7 +112,7 @@ def test_p2_collapses_hash_over_hash_plan(spark, snapshot):
 
 @pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
 @pytest.mark.yamlsnapshot(group="plan")
-def test_p2_collapses_hash_over_unkown_plan(spark, snapshot):
+def test_p2_collapses_hash_over_unknown_plan(spark, snapshot):
     df = spark.range(6).filter(F.col("id") % 2 == 0).coalesce(1).repartition(5, "id")
     plan = normalized_plan(df)
 

--- a/python/pysail/tests/spark/optimizer/test_eliminate_redundant_repartition.py
+++ b/python/pysail/tests/spark/optimizer/test_eliminate_redundant_repartition.py
@@ -1,0 +1,173 @@
+import pyspark.sql.functions as F  # noqa: N812
+import pytest
+
+from pysail.testing.spark.steps.plan import normalize_plan_text
+from pysail.testing.spark.utils.common import is_jvm_spark
+
+
+def normalized_plan(df, mode="simple"):
+    return normalize_plan_text(df._explain_string(mode=mode))  # noqa: SLF001
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_p1_eliminates_rr_repartition_above_rr_explicit_plan(spark, snapshot):
+    df = spark.range(6).repartition(3).filter(F.col("id") % 2 == 0)
+    plan = normalized_plan(df, mode="codegen")
+
+    assert plan == snapshot
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_p1_eliminates_rr_repartition_above_hash_explicit_plan(spark, snapshot):
+    df = spark.range(6).repartition(3, "id").filter(F.col("id") % 2 == 0)
+    plan = normalized_plan(df, mode="codegen")
+
+    assert plan == snapshot
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_p1_eliminates_rr_repartition_above_unkown_explicit_plan(spark, snapshot):
+    df = spark.range(6).filter(F.col("id") % 2 == 0).coalesce(1).filter(F.col("id") == 4)  # noqa: PLR2004
+    plan = normalized_plan(df, mode="codegen")
+
+    assert plan == snapshot
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_p1_keeps_hash_repartition_plan(spark, snapshot):
+    df1 = spark.sql("SELECT id AS id1 FROM range(6)")
+    df2 = spark.sql("SELECT id AS id2 FROM range(6)")
+    df = df1.repartition(3).join(df2, df1.id1 == df2.id2)
+    plan = normalized_plan(df)
+
+    assert plan == snapshot
+
+
+def test_p1_keeps_hash_repartition_result(spark):
+    df1 = spark.sql("SELECT id AS id1 FROM range(6)")
+    df2 = spark.sql("SELECT id AS id2 FROM range(6)")
+    df = df1.repartition(3).join(df2, df1.id1 == df2.id2).orderBy("id1", "id2")
+    result = df.collect()
+
+    assert [(row["id1"], row["id2"]) for row in result] == [(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5)]
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_p1_keeps_rr_repartition_when_child_is_not_explicit_plan(spark, snapshot):
+    df = spark.range(6).filter(F.col("id") % 2 == 0)
+    plan = normalized_plan(df)
+
+    assert plan == snapshot
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_p2_collapses_rr_over_rr_plan(spark, snapshot):
+    df = spark.range(6).repartition(3).repartition(5)
+    plan = normalized_plan(df)
+
+    assert plan == snapshot
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_p2_collapses_rr_over_hash_plan(spark, snapshot):
+    df = spark.range(6).repartition(3, "id").repartition(5)
+    plan = normalized_plan(df)
+
+    assert plan == snapshot
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_p2_collapses_rr_over_unknown_plan(spark, snapshot):
+    df = spark.range(6).filter(F.col("id") % 2 == 0).coalesce(1).repartition(5)
+    plan = normalized_plan(df)
+
+    assert plan == snapshot
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_p2_collapses_hash_over_rr_plan(spark, snapshot):
+    df = spark.range(6).repartition(3).repartition(5, "id")
+    plan = normalized_plan(df)
+
+    assert plan == snapshot
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_p2_collapses_hash_over_hash_plan(spark, snapshot):
+    df = spark.range(6).repartition(3, "id").repartition(5, "id")
+    plan = normalized_plan(df)
+
+    assert plan == snapshot
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_p2_collapses_hash_over_unkown_plan(spark, snapshot):
+    df = spark.range(6).filter(F.col("id") % 2 == 0).coalesce(1).repartition(5, "id")
+    plan = normalized_plan(df)
+
+    assert plan == snapshot
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_p2_keeps_unknown_over_rr_plan(spark, snapshot):
+    df = spark.range(6).repartition(5).coalesce(3)
+    plan = normalized_plan(df)
+
+    assert plan == snapshot
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_p2_keeps_unknown_over_hash_plan(spark, snapshot):
+    df = spark.range(6).repartition(5, "id").coalesce(3)
+    plan = normalized_plan(df)
+
+    assert plan == snapshot
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_p2_collapses_unknown_over_unknown_plan(spark, snapshot):
+    df = spark.range(6).repartition(5).filter(F.col("id") % 2 == 0).coalesce(3).coalesce(2)
+    plan = normalized_plan(df)
+
+    assert plan == snapshot
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_p2_collapses_chain_of_three_explicits_plan(spark, snapshot):
+    df = spark.range(6).repartition(5).repartition(6).repartition(7)
+    plan = normalized_plan(df)
+
+    assert plan == snapshot
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_p2_noop_when_child_is_not_explicit_plan(spark, snapshot):
+    df = spark.range(6).filter(F.col("id") % 2 == 0).repartition(3)
+    plan = normalized_plan(df)
+
+    assert plan == snapshot
+
+
+@pytest.mark.skipif(is_jvm_spark(), reason="different plans in JVM Spark")
+@pytest.mark.yamlsnapshot(group="plan")
+def test_p1_and_p2_combined_plan(spark, snapshot):
+    df = spark.range(6).repartition(3).repartition(5).filter(F.col("id") % 2 == 0)
+    plan = normalized_plan(df)
+
+    assert plan == snapshot


### PR DESCRIPTION


## Summary

 Introduces an optimizer rule `EliminateRedundantRepartition` that  removes redundant repartition nodes from the physical  plan, and thereby optimizing repartition performance across the plan.


The rule targets two redundant patterns:

## Pattern 1 (issue: https://github.com/lakehq/sail/issues/2250):
```
>>> spark.range(6).repartition(3).filter(F.col("id") % 2 == 0).explain()
== Physical Plan ==
ProjectionExec: expr=[#0@0 as id]
  FilterExec: #0@0 % 2 = 0
    RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=3
      ExplicitRepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
        RangeExec
```

## Pattern 2:
```
>>> spark.range(6).repartition(5).repartition(7).explain()
== Physical Plan ==
ProjectionExec: expr=[#0@0 as id]
  ExplicitRepartitionExec: partitioning=RoundRobinBatch(7), input_partitions=5
    ExplicitRepartitionExec: partitioning=RoundRobinBatch(5), input_partitions=1
      RangeExec

```
