### PR TITLE
fix: improve path glob filtering

### DIFF
--- a/crates/sail-data-source/data/options/csv.yaml
+++ b/crates/sail-data-source/data/options/csv.yaml
@@ -1,6 +1,28 @@
 # References:
 #   - [1] https://spark.apache.org/docs/4.0.0/sql-data-sources-csv.html#data-source-option
 
+- key: path_glob_filter
+  description: |
+    A glob pattern to only include files with file names matching the pattern.
+  default:
+    value: ""
+    parser: crate::options::parsers::parse_optional_string
+  supported: true
+  rust_type: "Option<String>"
+  scopes:
+    - read
+  origins:
+    - type: option
+      keys:
+        - path_glob_filter
+        - pathGlobFilter
+      parser: crate::options::parsers::parse_optional_string
+    - type: table_property
+      keys:
+        - option.path_glob_filter
+        - option.pathGlobFilter
+      parser: crate::options::parsers::parse_optional_string
+
 # TODO: Delimiter can be one or more characters
 - key: delimiter
   description: |

--- a/crates/sail-data-source/data/options/json.yaml
+++ b/crates/sail-data-source/data/options/json.yaml
@@ -1,6 +1,28 @@
 # References:
 #   - [1] https://spark.apache.org/docs/4.0.0/sql-data-sources-json.html#data-source-option
 
+- key: path_glob_filter
+  description: |
+    A glob pattern to only include files with file names matching the pattern.
+  default:
+    value: ""
+    parser: crate::options::parsers::parse_optional_string
+  supported: true
+  rust_type: "Option<String>"
+  scopes:
+    - read
+  origins:
+    - type: option
+      keys:
+        - path_glob_filter
+        - pathGlobFilter
+      parser: crate::options::parsers::parse_optional_string
+    - type: table_property
+      keys:
+        - option.path_glob_filter
+        - option.pathGlobFilter
+      parser: crate::options::parsers::parse_optional_string
+
 - key: schema_infer_max_records
   description: |
     The maximum number of rows to read from JSON files for schema inference if needed.

--- a/crates/sail-data-source/data/options/parquet.yaml
+++ b/crates/sail-data-source/data/options/parquet.yaml
@@ -6,6 +6,28 @@
 # TODO: Spark global: https://spark.apache.org/docs/4.0.0/sql-data-sources-parquet.html#configuration
 # TODO: DataFusion `column_specific_options` and `key_value_metadata`
 
+- key: path_glob_filter
+  description: |
+    A glob pattern to only include files with file names matching the pattern.
+  default:
+    value: ""
+    parser: crate::options::parsers::parse_optional_string
+  supported: true
+  rust_type: "Option<String>"
+  scopes:
+    - read
+  origins:
+    - type: option
+      keys:
+        - path_glob_filter
+        - pathGlobFilter
+      parser: crate::options::parsers::parse_optional_string
+    - type: table_property
+      keys:
+        - option.path_glob_filter
+        - option.pathGlobFilter
+      parser: crate::options::parsers::parse_optional_string
+
 - key: extension
   description: |
     (Reading) The file extension used to filter files when listing a

--- a/crates/sail-data-source/data/options/text.yaml
+++ b/crates/sail-data-source/data/options/text.yaml
@@ -1,6 +1,28 @@
 # References:
 #   - https://spark.apache.org/docs/latest/sql-data-sources-text.html
 
+- key: path_glob_filter
+  description: |
+    A glob pattern to only include files with file names matching the pattern.
+  default:
+    value: ""
+    parser: crate::options::parsers::parse_optional_string
+  supported: true
+  rust_type: "Option<String>"
+  scopes:
+    - read
+  origins:
+    - type: option
+      keys:
+        - path_glob_filter
+        - pathGlobFilter
+      parser: crate::options::parsers::parse_optional_string
+    - type: table_property
+      keys:
+        - option.path_glob_filter
+        - option.pathGlobFilter
+      parser: crate::options::parsers::parse_optional_string
+
 - key: whole_text
   description: |
     If true, read each file from input path(s) as a single row.

--- a/crates/sail-data-source/src/formats/binary/mod.rs
+++ b/crates/sail-data-source/src/formats/binary/mod.rs
@@ -19,11 +19,6 @@ mod write;
 pub use read::BinaryReadFormat;
 pub use write::BinaryWriteFormat;
 
-#[derive(Default, Debug, Clone, PartialEq)]
-pub struct TableBinaryOptions {
-    pub path_glob_filter: Option<String>,
-}
-
 pub type BinaryTableFormat = ListingTableFormat<BinaryFormatFactory>;
 
 #[derive(Debug, Default)]

--- a/crates/sail-data-source/src/formats/binary/options.rs
+++ b/crates/sail-data-source/src/formats/binary/options.rs
@@ -2,16 +2,8 @@ use datafusion::catalog::Session;
 use sail_common_datafusion::datasource::OptionLayer;
 
 use crate::error::DataSourceResult;
-use crate::formats::binary::TableBinaryOptions;
 use crate::options::r#gen::{BinaryReadOptions, BinaryReadPartialOptions};
 use crate::options::{BuildPartialOptions, PartialOptions, ResolveOptions};
-
-impl BinaryReadOptions {
-    pub fn into_table_options(self) -> TableBinaryOptions {
-        let BinaryReadOptions { path_glob_filter } = self;
-        TableBinaryOptions { path_glob_filter }
-    }
-}
 
 impl ResolveOptions for BinaryReadOptions {
     fn resolve(_ctx: &dyn Session, options: Vec<OptionLayer>) -> DataSourceResult<Self> {
@@ -37,20 +29,17 @@ mod tests {
 
         let kv = option_list(&[]);
         let options = BinaryReadOptions::resolve(&state, vec![kv])
-            .map_err(datafusion_common::DataFusionError::from)?
-            .into_table_options();
+            .map_err(datafusion_common::DataFusionError::from)?;
         assert_eq!(options.path_glob_filter, None);
 
         let kv = option_list(&[("path_glob_filter", "*.png")]);
         let options = BinaryReadOptions::resolve(&state, vec![kv])
-            .map_err(datafusion_common::DataFusionError::from)?
-            .into_table_options();
+            .map_err(datafusion_common::DataFusionError::from)?;
         assert_eq!(options.path_glob_filter, Some("*.png".to_string()));
 
         let kv = option_list(&[("pathGlobFilter", "*.pdf")]);
         let options = BinaryReadOptions::resolve(&state, vec![kv])
-            .map_err(datafusion_common::DataFusionError::from)?
-            .into_table_options();
+            .map_err(datafusion_common::DataFusionError::from)?;
         assert_eq!(options.path_glob_filter, Some("*.pdf".to_string()));
 
         Ok(())

--- a/crates/sail-data-source/src/formats/binary/read.rs
+++ b/crates/sail-data-source/src/formats/binary/read.rs
@@ -43,12 +43,7 @@ impl ReadFormat for BinaryReadFormat {
     }
 
     async fn scan(&self, _ctx: &dyn Session, input: ListingScanInput) -> Result<FileScanConfig> {
-        let options = self.options.clone().into_table_options();
-
-        let file_source = Arc::new(BinarySource::new(
-            input.schema,
-            options.path_glob_filter.clone(),
-        ));
+        let file_source = Arc::new(BinarySource::new(input.schema));
 
         let config = FileScanConfigBuilder::new(input.object_store_url, file_source)
             .with_file_groups(input.file_groups)
@@ -64,7 +59,7 @@ impl ReadFormat for BinaryReadFormat {
         Ok(config)
     }
 
-    fn input_file_name_glob(&self) -> Option<&str> {
+    fn path_glob_filter(&self) -> Option<&str> {
         self.options.path_glob_filter.as_deref()
     }
 }

--- a/crates/sail-data-source/src/formats/binary/source.rs
+++ b/crates/sail-data-source/src/formats/binary/source.rs
@@ -16,31 +16,20 @@ use crate::formats::binary::reader::{BinaryFileMetadata, BinaryFileReader};
 #[derive(Debug, Clone)]
 pub struct BinarySource {
     table_schema: TableSchema,
-    path_glob_filter: Option<String>,
     batch_size: Option<usize>,
     metrics: ExecutionPlanMetricsSet,
     projection: SplitProjection,
 }
 
 impl BinarySource {
-    pub fn new(table_schema: impl Into<TableSchema>, path_glob_filter: Option<String>) -> Self {
+    pub fn new(table_schema: impl Into<TableSchema>) -> Self {
         let table_schema = table_schema.into();
         Self {
             projection: SplitProjection::unprojected(&table_schema),
             table_schema,
-            path_glob_filter,
             batch_size: None,
             metrics: ExecutionPlanMetricsSet::new(),
         }
-    }
-
-    pub fn with_path_glob_filter(mut self, path_glob_filter: Option<String>) -> Self {
-        self.path_glob_filter = path_glob_filter;
-        self
-    }
-
-    pub fn path_glob_filter(&self) -> Option<&String> {
-        self.path_glob_filter.as_ref()
     }
 }
 
@@ -118,17 +107,6 @@ impl BinaryOpener {
 
 impl FileOpener for BinaryOpener {
     fn open(&self, file: PartitionedFile) -> Result<FileOpenFuture> {
-        if let Some(ref glob_pattern) = self.config.path_glob_filter {
-            let file_name = file.object_meta.location.filename().unwrap_or("");
-            let pattern = glob::Pattern::new(glob_pattern)
-                .map_err(|e| DataFusionError::External(Box::new(e)))?;
-            if !pattern.matches(file_name) {
-                return Ok(Box::pin(
-                    async move { Ok(futures::stream::empty().boxed()) },
-                ));
-            }
-        }
-
         let store = Arc::clone(&self.object_store);
         let location = file.object_meta.location.clone();
         let last_modified = file.object_meta.last_modified;

--- a/crates/sail-data-source/src/formats/csv/options.rs
+++ b/crates/sail-data-source/src/formats/csv/options.rs
@@ -28,6 +28,7 @@ impl BuildPartialOptions<CsvReadPartialOptions> for CsvOptions {
             multi_line: self.newlines_in_values,
             compression: Some(self.compression.to_string()),
             allow_truncated_rows: self.truncated_rows,
+            path_glob_filter: None,
         })
     }
 }
@@ -62,6 +63,7 @@ impl CsvReadOptions {
             multi_line,
             compression,
             allow_truncated_rows,
+            path_glob_filter: _,
         } = self;
         let null_regex = match (null_value.as_str(), null_regex.as_str()) {
             (nv, nr) if !nv.is_empty() && !nr.is_empty() => {

--- a/crates/sail-data-source/src/formats/csv/read.rs
+++ b/crates/sail-data-source/src/formats/csv/read.rs
@@ -130,4 +130,8 @@ impl ReadFormat for CsvReadFormat {
 
         Ok(config)
     }
+
+    fn path_glob_filter(&self) -> Option<&str> {
+        self.options.path_glob_filter.as_deref()
+    }
 }

--- a/crates/sail-data-source/src/formats/json/options.rs
+++ b/crates/sail-data-source/src/formats/json/options.rs
@@ -16,6 +16,7 @@ impl BuildPartialOptions<JsonReadPartialOptions> for JsonOptions {
         Ok(JsonReadPartialOptions {
             schema_infer_max_records: self.schema_infer_max_rec,
             compression: Some(self.compression.to_string()),
+            path_glob_filter: None,
         })
     }
 }
@@ -33,6 +34,7 @@ impl JsonReadOptions {
         let JsonReadOptions {
             schema_infer_max_records,
             compression,
+            path_glob_filter: _,
         } = self;
         let compression = FileCompressionType::from_str(&compression)
             .map_err(|e| DataSourceError::InvalidOption {

--- a/crates/sail-data-source/src/formats/json/read.rs
+++ b/crates/sail-data-source/src/formats/json/read.rs
@@ -116,6 +116,10 @@ impl ReadFormat for JsonReadFormat {
 
         Ok(config)
     }
+
+    fn path_glob_filter(&self) -> Option<&str> {
+        self.options.path_glob_filter.as_deref()
+    }
 }
 
 /// A tuple of (Schema, records_consumed) where records_consumed is the number of records that were

--- a/crates/sail-data-source/src/formats/parquet/options.rs
+++ b/crates/sail-data-source/src/formats/parquet/options.rs
@@ -40,6 +40,7 @@ impl BuildPartialOptions<ParquetReadPartialOptions> for TableParquetOptions {
             coerce_int96: self.global.coerce_int96.map(Some),
             bloom_filter_on_read: Some(self.global.bloom_filter_on_read),
             max_predicate_cache_size: Some(self.global.max_predicate_cache_size),
+            path_glob_filter: None,
         })
     }
 }
@@ -59,6 +60,7 @@ impl ParquetReadOptions {
             coerce_int96,
             bloom_filter_on_read,
             max_predicate_cache_size,
+            path_glob_filter: _,
         } = self;
         let global = ParquetOptions {
             enable_page_index,

--- a/crates/sail-data-source/src/formats/parquet/read.rs
+++ b/crates/sail-data-source/src/formats/parquet/read.rs
@@ -166,6 +166,10 @@ impl ReadFormat for ParquetReadFormat {
 
         Ok(config)
     }
+
+    fn path_glob_filter(&self) -> Option<&str> {
+        self.options.path_glob_filter.as_deref()
+    }
 }
 
 /// Clears all metadata (Schema level and field level) for a schema.

--- a/crates/sail-data-source/src/formats/text/options.rs
+++ b/crates/sail-data-source/src/formats/text/options.rs
@@ -15,6 +15,7 @@ impl TextReadOptions {
         let TextReadOptions {
             whole_text,
             line_sep,
+            path_glob_filter: _,
         } = self;
         // Validate that line_sep (if set) is a valid ASCII byte character
         if let Some(c) = line_sep {

--- a/crates/sail-data-source/src/formats/text/read.rs
+++ b/crates/sail-data-source/src/formats/text/read.rs
@@ -73,4 +73,8 @@ impl ReadFormat for TextReadFormat {
 
         Ok(config)
     }
+
+    fn path_glob_filter(&self) -> Option<&str> {
+        self.options.path_glob_filter.as_deref()
+    }
 }

--- a/crates/sail-data-source/src/listing/input_files.rs
+++ b/crates/sail-data-source/src/listing/input_files.rs
@@ -6,7 +6,6 @@ use datafusion::logical_expr::{LogicalPlan, TableScan};
 use datafusion::prelude::SessionContext;
 use datafusion_common::{DataFusionError, Result};
 use futures::TryStreamExt;
-use glob::Pattern;
 use url::Url;
 
 use crate::listing::table::ListingTableSource;
@@ -36,29 +35,19 @@ pub async fn input_files(ctx: &SessionContext, plan: LogicalPlan) -> Result<Vec<
     let mut listed: HashSet<(String, Option<String>)> = HashSet::new();
 
     for source in &listing_sources {
-        // Apply the format-level name filter (e.g. binary `pathGlobFilter`).
-        let raw_glob = source.config().read_format.input_file_name_glob();
-        let name_glob = raw_glob
-            .map(Pattern::new)
-            .transpose()
-            .map_err(|e| DataFusionError::Plan(format!("invalid path glob filter: {e}")))?;
+        let path_glob_filter = source.config().path_glob_filter.as_ref();
         for table_path in &source.config().table_paths {
             if !listed.insert((
                 table_path.as_str().to_string(),
-                raw_glob.map(str::to_string),
+                path_glob_filter.map(|filter| filter.as_str().to_string()),
             )) {
                 continue;
             }
             let store = ctx.runtime_env().object_store(table_path)?;
             let base = Url::parse(table_path.object_store().as_str())
                 .map_err(|e| DataFusionError::Internal(format!("invalid object store URL: {e}")))?;
-            let metas = list_all_files(table_path, &state, store.as_ref())
+            let metas = list_all_files(table_path, &state, store.as_ref(), path_glob_filter)
                 .await?
-                .try_filter(|meta| {
-                    let name = meta.location.filename().unwrap_or_default();
-                    let included = name_glob.as_ref().is_none_or(|glob| glob.matches(name));
-                    futures::future::ready(included)
-                })
                 .try_collect::<Vec<_>>()
                 .await?;
             for meta in metas {

--- a/crates/sail-data-source/src/listing/planner.rs
+++ b/crates/sail-data-source/src/listing/planner.rs
@@ -35,7 +35,9 @@ use sail_physical_plan::barrier::BarrierExec;
 use crate::listing::delete::FileDeleteExec;
 use crate::listing::source::{ListingScanInput, ListingSinkInput};
 use crate::listing::table::ListingTableSource;
-use crate::listing::utils::{can_be_evaluated_for_partition_pruning, has_hidden_path_component};
+use crate::listing::utils::{
+    can_be_evaluated_for_partition_pruning, has_hidden_path_component, matches_path_glob_filter,
+};
 use crate::listing::write::{FileWriteNode, FileWriteOptions};
 
 /// Result of a file listing operation for listing table scans.
@@ -352,17 +354,19 @@ async fn list_files_for_scan<'a>(
 
     let store_ref = store.as_ref();
     let partition_cols_ref = partition_cols.as_slice();
+    let path_glob_filter = source.config().path_glob_filter.as_ref();
     let file_list = future::try_join_all(source.config().table_paths.iter().map(
         |table_path| async move {
             let files =
                 pruned_partition_list(ctx, store_ref, table_path, filters, "", partition_cols_ref)
                     .await?;
-            // Skip hidden files so scans agree with `inputFiles` and schema sampling.
+            // Apply listing-level file-name filters so scans agree with `inputFiles` and sampling.
             let files = files.try_filter(move |file| {
-                futures::future::ready(!has_hidden_path_component(
-                    table_path,
-                    &file.object_meta.location,
-                ))
+                let location = &file.object_meta.location;
+                futures::future::ready(
+                    !has_hidden_path_component(table_path, location)
+                        && matches_path_glob_filter(path_glob_filter, location),
+                )
             });
             Ok::<_, datafusion_common::DataFusionError>(files.boxed())
         },

--- a/crates/sail-data-source/src/listing/source.rs
+++ b/crates/sail-data-source/src/listing/source.rs
@@ -30,7 +30,7 @@ use crate::listing::utils::{
 };
 use crate::listing::write::{FileWriteNode, FileWriteOptions};
 use crate::resolve_listing_urls;
-use crate::url::resolve_listing_writer_url;
+use crate::url::{PathGlobFilter, resolve_listing_writer_url};
 
 /// A trait for creating format instances when reading and writing listing files.
 pub trait FormatFactory: Debug + Send + Sync + 'static {
@@ -84,8 +84,8 @@ pub trait ReadFormat: Debug + Send + Sync + 'static {
     /// Build a scan configuration for listing reads.
     async fn scan(&self, ctx: &dyn Session, input: ListingScanInput) -> Result<FileScanConfig>;
 
-    /// File-name glob restricting which listed files compose the dataset (e.g. binary `pathGlobFilter`).
-    fn input_file_name_glob(&self) -> Option<&str> {
+    /// File-name glob restricting which listed files compose the dataset.
+    fn path_glob_filter(&self) -> Option<&str> {
         None
     }
 }
@@ -164,8 +164,12 @@ impl<T: FormatFactory> TableFormat for ListingTableFormat<T> {
         } = info;
 
         let read_format = T::read(ctx, options)?;
+        let path_glob_filter = read_format
+            .path_glob_filter()
+            .map(PathGlobFilter::parse)
+            .transpose()?;
         let urls = resolve_listing_urls(ctx, paths).await?;
-        let sampled_files = sample_listing_files(ctx, &urls).await?;
+        let sampled_files = sample_listing_files(ctx, &urls, path_glob_filter.as_ref()).await?;
         let compression = read_format.infer_compression(ctx, &sampled_files).await?;
 
         let (schema, partition_fields) = match schema {
@@ -242,6 +246,7 @@ impl<T: FormatFactory> TableFormat for ListingTableFormat<T> {
             collect_stat: ctx.config().collect_statistics(),
             target_partitions: ctx.config().target_partitions(),
             read_format: Arc::new(read_format),
+            path_glob_filter,
             compression,
         })?;
         Ok(Arc::new(source))

--- a/crates/sail-data-source/src/listing/table.rs
+++ b/crates/sail-data-source/src/listing/table.rs
@@ -12,6 +12,7 @@ use datafusion_datasource::{ListingTableUrl, TableSchema};
 
 use crate::listing::source::ReadFormat;
 use crate::listing::utils::can_be_evaluated_for_partition_pruning;
+use crate::url::PathGlobFilter;
 
 #[derive(Clone, Debug)]
 pub struct ListingTableSourceConfig {
@@ -22,6 +23,7 @@ pub struct ListingTableSourceConfig {
     pub collect_stat: bool,
     pub target_partitions: usize,
     pub read_format: Arc<dyn ReadFormat>,
+    pub path_glob_filter: Option<PathGlobFilter>,
     pub compression: CompressionTypeVariant,
 }
 

--- a/crates/sail-data-source/src/listing/utils.rs
+++ b/crates/sail-data-source/src/listing/utils.rs
@@ -18,6 +18,7 @@ use object_store::path::Path;
 use object_store::{ObjectMeta, ObjectStore, ObjectStoreExt};
 
 use crate::listing::source::ListingFileSample;
+use crate::url::PathGlobFilter;
 
 pub fn rewrite_utf8view_fields(schema: Arc<Schema>) -> Arc<Schema> {
     // TODO: Spark doesn't support Utf8View
@@ -89,11 +90,12 @@ pub fn infer_listing_compression(
 pub async fn sample_listing_files<'a>(
     ctx: &dyn Session,
     urls: &'a [ListingTableUrl],
+    path_glob_filter: Option<&'a PathGlobFilter>,
 ) -> Result<Vec<ListingFileSample<'a>>> {
     let mut samples = vec![];
     for url in urls {
         let store = ctx.runtime_env().object_store(url)?;
-        let objects: Vec<_> = list_all_files(url, ctx, store.as_ref())
+        let objects: Vec<_> = list_all_files(url, ctx, store.as_ref(), path_glob_filter)
             .await?
             // Empty files can't contribute to schema / partition inference and may error when read.
             .try_filter(|meta| futures::future::ready(meta.size > 0))
@@ -198,6 +200,7 @@ pub async fn list_all_files<'a>(
     url: &'a ListingTableUrl,
     ctx: &'a dyn Session,
     store: &'a dyn ObjectStore,
+    path_glob_filter: Option<&'a PathGlobFilter>,
 ) -> Result<BoxStream<'a, Result<ObjectMeta>>> {
     let exec_options = &ctx.config_options().execution;
     let ignore_subdirectory = exec_options.listing_table_ignore_subdirectory;
@@ -226,12 +229,24 @@ pub async fn list_all_files<'a>(
     Ok(list
         .try_filter(move |meta| {
             let path = &meta.location;
-            let included =
-                url.contains(path, ignore_subdirectory) && !has_hidden_path_component(url, path);
+            let included = url.contains(path, ignore_subdirectory)
+                && !has_hidden_path_component(url, path)
+                && matches_path_glob_filter(path_glob_filter, path);
             futures::future::ready(included)
         })
         .map_err(|e| DataFusionError::ObjectStore(Box::new(e)))
         .boxed())
+}
+
+pub fn matches_path_glob_filter(
+    path_glob_filter: Option<&PathGlobFilter>,
+    location: &Path,
+) -> bool {
+    path_glob_filter.is_none_or(|filter| {
+        location
+            .filename()
+            .is_some_and(|filename| filter.matches(filename))
+    })
 }
 
 /// Returns `true` if the path is hidden per Spark's `HadoopFSUtils.shouldFilterOutPathName`.

--- a/crates/sail-data-source/src/url.rs
+++ b/crates/sail-data-source/src/url.rs
@@ -224,6 +224,14 @@ impl PatternSegment {
     }
 }
 
+fn expand_glob_pattern(pattern: &str) -> Result<Vec<String>> {
+    let patterns = PatternSegment::sequence_parser()
+        .parse(pattern)
+        .into_result()
+        .map_err(|_| plan_datafusion_err!("glob pattern: {pattern}"))?;
+    Ok(PatternSegment::expand_sequence(patterns))
+}
+
 /// A parsed URL that may contain glob patterns.
 /// The parsing is coarse-grained and permissive since we only need to
 /// identify the path that may contain glob patterns.
@@ -389,11 +397,7 @@ impl GlobUrl {
     }
 
     fn parse_glob_path(path: &str) -> Result<Vec<(String, Option<Pattern>)>> {
-        let patterns = PatternSegment::sequence_parser()
-            .parse(path)
-            .into_result()
-            .map_err(|_| plan_datafusion_err!("glob path: {path}"))?;
-        let paths = PatternSegment::expand_sequence(patterns)
+        let paths = expand_glob_pattern(path)?
             .into_iter()
             .map(|x| {
                 let (prefix, suffix) = Self::split_glob_path(&x)?;
@@ -472,6 +476,39 @@ impl GlobUrl {
             return plan_err!("empty path in URL: {s}");
         }
         Ok((prefix, suffix))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PathGlobFilter {
+    raw: String,
+    patterns: Vec<Pattern>,
+}
+
+impl PathGlobFilter {
+    pub fn parse(pattern: &str) -> Result<Self> {
+        let parse = || -> Result<Self> {
+            let patterns = expand_glob_pattern(pattern)?
+                .into_iter()
+                .map(|pattern| {
+                    GlobUrl::create_percent_decoded_pattern(&pattern)?
+                        .ok_or_else(|| plan_datafusion_err!("path glob filter cannot be empty"))
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(Self {
+                raw: pattern.to_string(),
+                patterns,
+            })
+        };
+        parse().map_err(|e| DataFusionError::Plan(format!("invalid path glob filter: {e}")))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.raw
+    }
+
+    pub fn matches(&self, value: &str) -> bool {
+        self.patterns.iter().any(|pattern| pattern.matches(value))
     }
 }
 
@@ -744,6 +781,18 @@ mod tests {
         test("{a,b{c/**,d}}/x", &["a/x", "bc/**/x", "bd/x"]);
         test("{a,b{c,d},?e{f}}", &["a", "bc", "bd", "?ef"]);
         test("{a,b{c,d}{e,f}}", &["a", "bce", "bcf", "bde", "bdf"]);
+    }
+
+    #[test]
+    fn test_path_glob_filter() {
+        let filter = PathGlobFilter::parse("*.{json,csv}").unwrap();
+        assert!(filter.matches("data.json"));
+        assert!(filter.matches("data.csv"));
+        assert!(!filter.matches("data.parquet"));
+        assert_eq!(filter.as_str(), "*.{json,csv}");
+
+        let error = PathGlobFilter::parse("[").unwrap_err();
+        assert!(error.to_string().contains("invalid path glob filter"));
     }
 
     #[test]

--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -623,7 +623,6 @@ message TextExecNode {
 
 message BinarySourceExecNode {
   bytes base_config = 1;
-  optional string path_glob_filter = 2;
 }
 
 message AvroExecNode {

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -580,10 +580,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                     .build();
                 Ok(Arc::new(DataSourceExec::new(Arc::new(source))))
             }
-            NodeKind::BinarySource(r#gen::BinarySourceExecNode {
-                base_config,
-                path_glob_filter: _,
-            }) => {
+            NodeKind::BinarySource(r#gen::BinarySourceExecNode { base_config }) => {
                 let base_config = try_decode_message(&base_config)?;
                 let table_schema = parse_table_schema_from_proto(&base_config)?;
                 let source = parse_protobuf_file_scan_config(
@@ -1610,16 +1607,13 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                         whole_text: text_source.whole_text(),
                         line_sep: text_source.line_sep().map(|x| vec![x]),
                     })
-                } else if file_source.downcast_ref::<BinarySource>().is_some() {
+                } else if file_source.is::<BinarySource>() {
                     let base_config = try_encode_message(serialize_file_scan_config(
                         file_scan,
                         self,
                         &RemotePhysicalProtoConverter {},
                     )?)?;
-                    NodeKind::BinarySource(r#gen::BinarySourceExecNode {
-                        base_config,
-                        path_glob_filter: None,
-                    })
+                    NodeKind::BinarySource(r#gen::BinarySourceExecNode { base_config })
                 } else if let Some(csv_source) = file_source.downcast_ref::<CsvSource>() {
                     let base_config = try_encode_message(serialize_file_scan_config(
                         file_scan,

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -582,7 +582,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             }
             NodeKind::BinarySource(r#gen::BinarySourceExecNode {
                 base_config,
-                path_glob_filter,
+                path_glob_filter: _,
             }) => {
                 let base_config = try_decode_message(&base_config)?;
                 let table_schema = parse_table_schema_from_proto(&base_config)?;
@@ -590,7 +590,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                     &base_config,
                     &PhysicalPlanDecodeContext::new(ctx, self),
                     &RemotePhysicalProtoConverter {},
-                    Arc::new(BinarySource::new(table_schema, path_glob_filter)),
+                    Arc::new(BinarySource::new(table_schema)),
                 )?;
                 let source = FileScanConfigBuilder::from(source).build();
                 Ok(Arc::new(DataSourceExec::new(Arc::new(source))))
@@ -1610,7 +1610,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                         whole_text: text_source.whole_text(),
                         line_sep: text_source.line_sep().map(|x| vec![x]),
                     })
-                } else if let Some(binary_source) = file_source.downcast_ref::<BinarySource>() {
+                } else if file_source.downcast_ref::<BinarySource>().is_some() {
                     let base_config = try_encode_message(serialize_file_scan_config(
                         file_scan,
                         self,
@@ -1618,7 +1618,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                     )?)?;
                     NodeKind::BinarySource(r#gen::BinarySourceExecNode {
                         base_config,
-                        path_glob_filter: binary_source.path_glob_filter().cloned(),
+                        path_glob_filter: None,
                     })
                 } else if let Some(csv_source) = file_source.downcast_ref::<CsvSource>() {
                     let base_config = try_encode_message(serialize_file_scan_config(

--- a/python/pysail/tests/spark/dataframe/test_input_files.py
+++ b/python/pysail/tests/spark/dataframe/test_input_files.py
@@ -97,30 +97,25 @@ def test_input_files_excludes_explicitly_targeted_hidden_file(spark, tmp_path):
 
 
 def test_input_files_honors_path_glob_filter(spark, tmp_path):
-    """The binary ``pathGlobFilter`` restricts the files that compose the dataset."""
-    (tmp_path / "keep.png").write_bytes(b"\x89PNG")
-    (tmp_path / "drop.pdf").write_bytes(b"%PDF")
-    df = spark.read.format("binaryFile").option("pathGlobFilter", "*.png").load(str(tmp_path))
+    """A listing-format ``pathGlobFilter`` restricts the files that compose the dataset."""
+    (tmp_path / "keep.json").write_text('{"id": 1}\n')
+    (tmp_path / "drop.json").write_text('{"id": 2}\n')
+    df = spark.read.format("json").option("pathGlobFilter", "keep.*").load(str(tmp_path))
 
     files = df.inputFiles()
     assert len(files) == 1
-    assert files[0].endswith("keep.png")
+    assert files[0].endswith("keep.json")
 
 
 def test_input_files_matches_scan_under_glob_alternation(spark, tmp_path):
-    """``inputFiles`` applies ``pathGlobFilter`` with the same matcher as the scan for ``{a,b}`` syntax.
-
-    The binary scan matches ``pathGlobFilter`` with ``glob::Pattern``, which treats ``{...}``
-    as literal characters rather than expanding the alternation. ``inputFiles`` mirrors that
-    matcher, so it must report exactly the files the scan reads -- never more.
-    """
+    """``inputFiles`` and scans both support ``{a,b}`` alternation."""
     (tmp_path / "a.png").write_bytes(b"\x89PNG")
     (tmp_path / "b.jpg").write_bytes(b"\xff\xd8\xff")
+    (tmp_path / "c.pdf").write_bytes(b"%PDF")
     df = spark.read.format("binaryFile").option("pathGlobFilter", "*.{png,jpg}").load(str(tmp_path))
 
-    # `{png,jpg}` is literal, so it matches neither file; the scan and inputFiles must still agree.
     assert df.count() == len(df.inputFiles())
-    assert df.inputFiles() == []
+    assert {file.rsplit("/", 1)[-1] for file in df.inputFiles()} == {"a.png", "b.jpg"}
 
 
 def test_input_files_rejects_invalid_path_glob_filter(spark, tmp_path):

--- a/python/pysail/tests/spark/datasource/test_binary.py
+++ b/python/pysail/tests/spark/datasource/test_binary.py
@@ -92,6 +92,10 @@ def test_binary_read_options(spark, tmp_path):
     expected_single_count = 2
     assert single_char_df.count() == expected_single_count
 
+    alternation_df = spark.read.format("binaryFile").option("pathGlobFilter", "*.{png,jpeg}").load(str(tmp_path))
+    expected_alternation_count = 3
+    assert alternation_df.count() == expected_alternation_count
+
     all_df = spark.read.format("binaryFile").load(str(tmp_path))
     expected_all_count = 7
     assert all_df.count() == expected_all_count

--- a/python/pysail/tests/spark/datasource/test_csv.py
+++ b/python/pysail/tests/spark/datasource/test_csv.py
@@ -42,6 +42,17 @@ def test_csv_read_write_basic(spark, sample_df, tmp_path, infer_schema):
     assert sorted(read_df.collect(), key=safe_sort_key) == sorted(expected, key=safe_sort_key)
 
 
+def test_csv_path_glob_filter(spark, tmp_path):
+    path = tmp_path / "csv_path_glob_filter"
+    path.mkdir()
+    (path / "keep.csv").write_text("value\n1\n")
+    (path / "drop.csv").write_text("value\n2\n")
+
+    df = spark.read.option("header", True).option("inferSchema", True).option("pathGlobFilter", "keep.*").csv(str(path))
+
+    assert df.collect() == [Row(value=1)]
+
+
 @pytest.mark.parametrize("infer_schema", [True, False])
 def test_csv_read_write_compressed(spark, sample_df, sample_pandas_df, tmp_path, infer_schema):
     # Round-tripped values are typed under `inferSchema=True` and STRING-only

--- a/python/pysail/tests/spark/datasource/test_json.py
+++ b/python/pysail/tests/spark/datasource/test_json.py
@@ -20,6 +20,18 @@ def test_json_read_write_basic(spark, sample_df, tmp_path):
     assert sorted(sample_df.collect(), key=safe_sort_key) == sorted(read_df.collect(), key=safe_sort_key)
 
 
+def test_json_path_glob_filter_applies_before_schema_inference(spark, tmp_path):
+    path = tmp_path / "json_path_glob_filter"
+    path.mkdir()
+    (path / "keep.json").write_text('{"id": 1}\n')
+    (path / "drop.json").write_text('{"excluded": true}\n')
+
+    df = spark.read.option("pathGlobFilter", "keep.*").json(str(path))
+
+    assert df.columns == ["id"]
+    assert df.collect() == [Row(id=1)]
+
+
 def test_json_write_compression(spark, sample_df, tmp_path):
     """Test JSON write with compression."""
     path = str(tmp_path / "json_compressed")

--- a/python/pysail/tests/spark/datasource/test_parquet.py
+++ b/python/pysail/tests/spark/datasource/test_parquet.py
@@ -24,6 +24,22 @@ def test_parquet_read_write_basic(spark, sample_df, tmp_path):
     assert sorted(sample_df.collect(), key=safe_sort_key) == sorted(read_df.collect(), key=safe_sort_key)
 
 
+def test_parquet_path_glob_filter(spark, tmp_path):
+    keep_source = tmp_path / "parquet_keep_source"
+    drop_source = tmp_path / "parquet_drop_source"
+    spark.createDataFrame([(1,)], "id INT").coalesce(1).write.parquet(str(keep_source))
+    spark.createDataFrame([(2,)], "id INT").coalesce(1).write.parquet(str(drop_source))
+
+    path = tmp_path / "parquet_path_glob_filter"
+    path.mkdir()
+    next(keep_source.glob("*.parquet")).rename(path / "keep.parquet")
+    next(drop_source.glob("*.parquet")).rename(path / "drop.parquet")
+
+    df = spark.read.option("pathGlobFilter", "keep.*").parquet(str(path))
+
+    assert df.collect() == [Row(id=1)]
+
+
 def test_parquet_write_modes(spark, tmp_path):
     path = str(tmp_path / "parquet_write_modes")
 

--- a/python/pysail/tests/spark/datasource/test_text.py
+++ b/python/pysail/tests/spark/datasource/test_text.py
@@ -23,6 +23,17 @@ def test_text_read_write_basic(spark, sample_df, tmp_path):
     assert sorted(joined_df.collect(), key=safe_sort_key) == sorted(read_df.collect(), key=safe_sort_key)
 
 
+def test_text_path_glob_filter(spark, tmp_path):
+    path = tmp_path / "text_path_glob_filter"
+    path.mkdir()
+    (path / "keep.txt").write_text("keep\n")
+    (path / "drop.txt").write_text("drop\n")
+
+    df = spark.read.option("pathGlobFilter", "keep.*").text(str(path))
+
+    assert df.collect() == [Row(value="keep")]
+
+
 def test_text_read_write_compressed(spark, sample_df, tmp_path):
     path = str(tmp_path / "text_compressed_gzip")
     sample_df = sample_df.select("col1")


### PR DESCRIPTION
fix: improve path glob filtering

Closes #2275

Moves `pathGlobFilter` into the shared listing layer so CSV, JSON, Parquet, text, binary, and `inputFiles()` use the same filtered file set. Filtering now happens before schema inference, statistics collection, and file grouping.

Added `GlobUrl`-compatible alternation such as `*.{json,csv}`, removes binary-only filtering, and added cross-format tests.