### PR TITLE
feat: support explicit Glue catalog IDs

### DIFF
--- a/crates/sail-catalog-glue/src/hive.rs
+++ b/crates/sail-catalog-glue/src/hive.rs
@@ -67,6 +67,7 @@ pub(crate) async fn create_hive_table(
 
     let result = client
         .create_table()
+        .set_catalog_id(provider.catalog_id())
         .database_name(&database_name)
         .table_input(table_input)
         .send()

--- a/crates/sail-catalog-glue/src/iceberg.rs
+++ b/crates/sail-catalog-glue/src/iceberg.rs
@@ -97,6 +97,7 @@ pub(crate) async fn create_iceberg_table(
 
     let result = client
         .create_table()
+        .set_catalog_id(provider.catalog_id())
         .database_name(&database_name)
         .name(table)
         .open_table_format_input(open_format_input)
@@ -198,6 +199,7 @@ async fn create_iceberg_table_via_table_input(
 
     let result = client
         .create_table()
+        .set_catalog_id(provider.catalog_id())
         .database_name(&database_name)
         .table_input(table_input)
         .send()

--- a/crates/sail-catalog-glue/src/provider.rs
+++ b/crates/sail-catalog-glue/src/provider.rs
@@ -26,6 +26,8 @@ use crate::{hive, iceberg, managed_table};
 /// Configuration for AWS Glue Data Catalog.
 #[derive(Debug, Clone, Default)]
 pub struct GlueCatalogConfig {
+    /// AWS Glue Data Catalog ID. If not set, AWS uses the caller's account ID.
+    pub catalog_id: Option<String>,
     /// AWS region (e.g., "us-east-1"). If not set, uses default from credential chain.
     pub region: Option<String>,
     /// Custom endpoint URL (optional). Useful for VPC endpoints or local development.
@@ -97,6 +99,11 @@ impl GlueCatalogProvider {
 
     pub(super) fn has_custom_endpoint(&self) -> bool {
         self.config.endpoint_url.is_some()
+    }
+
+    /// Returns the configured AWS Glue Data Catalog ID.
+    pub(super) fn catalog_id(&self) -> Option<String> {
+        self.config.catalog_id.clone()
     }
 
     pub(super) fn database_name(database: &Namespace) -> CatalogResult<String> {
@@ -433,6 +440,7 @@ impl CatalogProvider for GlueCatalogProvider {
 
         let result = client
             .create_database()
+            .set_catalog_id(self.catalog_id())
             .database_input(database_input)
             .send()
             .await;
@@ -463,7 +471,12 @@ impl CatalogProvider for GlueCatalogProvider {
         let client = self.get_client().await?;
         let database_name = Self::database_name(database)?;
 
-        let result = client.get_database().name(&database_name).send().await;
+        let result = client
+            .get_database()
+            .set_catalog_id(self.catalog_id())
+            .name(&database_name)
+            .send()
+            .await;
 
         match result {
             Ok(output) => {
@@ -495,7 +508,11 @@ impl CatalogProvider for GlueCatalogProvider {
         let client = self.get_client().await?;
 
         let mut databases = Vec::new();
-        let mut paginator = client.get_databases().into_paginator().send();
+        let mut paginator = client
+            .get_databases()
+            .set_catalog_id(self.catalog_id())
+            .into_paginator()
+            .send();
 
         while let Some(page) = paginator
             .next()
@@ -532,7 +549,12 @@ impl CatalogProvider for GlueCatalogProvider {
             cascade: _, // Glue requires database to be empty; cascade not directly supported
         } = options;
 
-        let result = client.delete_database().name(&database_name).send().await;
+        let result = client
+            .delete_database()
+            .set_catalog_id(self.catalog_id())
+            .name(&database_name)
+            .send()
+            .await;
 
         match result {
             Ok(_) => Ok(()),
@@ -603,6 +625,7 @@ impl CatalogProvider for GlueCatalogProvider {
 
         let result = client
             .get_table()
+            .set_catalog_id(self.catalog_id())
             .database_name(&database_name)
             .name(table)
             .send()
@@ -647,6 +670,7 @@ impl CatalogProvider for GlueCatalogProvider {
         let mut tables = Vec::new();
         let mut paginator = client
             .get_tables()
+            .set_catalog_id(self.catalog_id())
             .database_name(&database_name)
             .into_paginator()
             .send();
@@ -688,6 +712,7 @@ impl CatalogProvider for GlueCatalogProvider {
 
         let result = client
             .delete_table()
+            .set_catalog_id(self.catalog_id())
             .database_name(&database_name)
             .name(table)
             .send()
@@ -723,6 +748,7 @@ impl CatalogProvider for GlueCatalogProvider {
         let database_name = Self::database_name(database)?;
         let result = client
             .get_table()
+            .set_catalog_id(self.catalog_id())
             .database_name(&database_name)
             .name(table)
             .send()
@@ -752,6 +778,7 @@ impl CatalogProvider for GlueCatalogProvider {
         let table_input = Self::table_input_with_parameters(&table_value, parameters)?;
         let mut update_table = client
             .update_table()
+            .set_catalog_id(self.catalog_id())
             .database_name(&database_name)
             .table_input(table_input);
         if let Some(version_id) = table_value.version_id() {
@@ -819,6 +846,7 @@ impl CatalogProvider for GlueCatalogProvider {
 
         let result = client
             .create_table()
+            .set_catalog_id(self.catalog_id())
             .database_name(&database_name)
             .table_input(view_input)
             .send()
@@ -852,6 +880,7 @@ impl CatalogProvider for GlueCatalogProvider {
 
         let result = client
             .get_table()
+            .set_catalog_id(self.catalog_id())
             .database_name(&database_name)
             .name(view)
             .send()
@@ -896,6 +925,7 @@ impl CatalogProvider for GlueCatalogProvider {
         let mut views = Vec::new();
         let mut paginator = client
             .get_tables()
+            .set_catalog_id(self.catalog_id())
             .database_name(&database_name)
             .into_paginator()
             .send();
@@ -929,6 +959,7 @@ impl CatalogProvider for GlueCatalogProvider {
 
         let result = client
             .delete_table()
+            .set_catalog_id(self.catalog_id())
             .database_name(&database_name)
             .name(view)
             .send()

--- a/crates/sail-catalog-glue/tests/common/mod.rs
+++ b/crates/sail-catalog-glue/tests/common/mod.rs
@@ -48,6 +48,7 @@ pub async fn setup_glue_catalog(
     let endpoint = format!("http://{host}:{port}");
 
     let config = GlueCatalogConfig {
+        catalog_id: Some("123456789012".to_string()),
         region: Some("us-east-1".to_string()),
         endpoint_url: Some(endpoint),
     };

--- a/crates/sail-common/src/config/application.rs
+++ b/crates/sail-common/src/config/application.rs
@@ -585,6 +585,8 @@ pub enum CatalogType {
     Glue {
         name: String,
         #[serde(skip_serializing_if = "Option::is_none")]
+        catalog_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         region: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         endpoint_url: Option<String>,

--- a/crates/sail-session/src/catalog.rs
+++ b/crates/sail-session/src/catalog.rs
@@ -193,11 +193,13 @@ pub fn create_catalog_manager(
                 }
                 CatalogType::Glue {
                     name,
+                    catalog_id,
                     region,
                     endpoint_url,
                     cache,
                 } => {
                     let config = GlueCatalogConfig {
+                        catalog_id: catalog_id.clone(),
                         region: region.clone(),
                         endpoint_url: endpoint_url.clone(),
                     };
@@ -350,6 +352,7 @@ mod tests {
         let mut config = AppConfig::load().unwrap();
         config.catalog.list = vec![CatalogType::Glue {
             name: "glue".to_string(),
+            catalog_id: None,
             region: None,
             endpoint_url: None,
             cache: CatalogCacheConfig {
@@ -385,6 +388,7 @@ mod tests {
         let mut config = AppConfig::load().unwrap();
         config.catalog.list = vec![CatalogType::Glue {
             name: "glue".to_string(),
+            catalog_id: None,
             region: None,
             endpoint_url: None,
             cache: CatalogCacheConfig {

--- a/docs/guide/catalog/glue.md
+++ b/docs/guide/catalog/glue.md
@@ -11,6 +11,7 @@ AWS Glue catalog can be configured using the following options:
 
 - `type` (required): The string `glue`.
 - `name` (required): The name of the catalog.
+- `catalog_id` (optional): The AWS Glue Data Catalog ID. If not set, AWS uses the account ID associated with the active credentials.
 - `region` (optional): The AWS region (e.g., `us-east-1`). If not set, it uses the default region from the AWS credential provider chain.
 - `endpoint_url` (optional): The custom endpoint URL.
 
@@ -22,6 +23,9 @@ You can use any AWS credential provider supported by the AWS SDK to authenticate
 
 ```bash
 export SAIL_CATALOG__LIST='[{type="glue", name="sail", region="us-west-2"}]'
+
+# Using an explicit AWS Glue Data Catalog ID
+export SAIL_CATALOG__LIST='[{type="glue", name="sail", catalog_id="123456789012", region="us-west-2"}]'
 
 # Using a custom endpoint (e.g., LocalStack)
 export SAIL_CATALOG__LIST='[{type="glue", name="sail", region="us-east-1", endpoint_url="http://localhost:4566"}]'

--- a/python/pysail/tests/spark/catalog/glue/conftest.py
+++ b/python/pysail/tests/spark/catalog/glue/conftest.py
@@ -39,7 +39,9 @@ def moto_endpoint(moto_container: DockerContainer) -> str:
 @pytest.fixture(scope="module")
 def remote(moto_endpoint: str) -> Generator[str, None, None]:
     """Start Sail server with Glue catalog."""
-    catalog_config = f'[{{name="sail", type="glue", region="us-east-1", endpoint_url="{moto_endpoint}"}}]'
+    catalog_config = (
+        f'[{{name="sail", type="glue", catalog_id="123456789012", region="us-east-1", endpoint_url="{moto_endpoint}"}}]'
+    )
     with spark_connect_server(
         envs={
             "SAIL_CATALOG__LIST": catalog_config,


### PR DESCRIPTION
Adds optional catalog_id configuration to the Glue catalog provider and applies it consistently to database, table, and view requests.

Omitting catalog_id preserves the existing AWS account-default behavior. The Glue guide and catalog integration fixtures now cover explicit catalog IDs.