### PR TITLE
test: configure stack size for function gold tests

### DIFF
--- a/crates/sail-spark-connect/src/proto/function.rs
+++ b/crates/sail-spark-connect/src/proto/function.rs
@@ -2,6 +2,7 @@
 mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
+    use std::thread;
 
     use datafusion::arrow::array::RecordBatch;
     use datafusion::arrow::error::ArrowError;
@@ -68,39 +69,49 @@ mod tests {
         let context = handle
             .primary()
             .block_on(manager.get_or_create_session_context("test".to_string(), "".to_string()))?;
-        test_gold_set(
-            "tests/gold_data/function/*.json",
-            |example: FunctionExample| -> SparkResult<String> {
-                let relation = Relation {
-                    common: None,
-                    #[expect(deprecated)]
-                    rel_type: Some(RelType::Sql(Sql {
-                        query: example.query,
-                        args: HashMap::new(),
-                        pos_args: vec![],
-                        named_arguments: HashMap::new(),
-                        pos_arguments: vec![],
-                    })),
-                };
-                let plan = relation.try_into()?;
-                let result = handle.primary().block_on(async {
-                    let spark = context.extension::<SparkSession>()?;
-                    let service = context.extension::<JobService>()?;
-                    let (plan, _) =
-                        resolve_and_execute_plan(&context, spark.plan_config()?, plan).await?;
-                    let stream = service.runner().execute(&context, plan).await?;
-                    read_stream(stream).await
-                });
-                // TODO: validate the result against the expected output
-                // TODO: handle non-deterministic results and error messages
-                match result {
-                    // FIXME: the output can be non-deterministic
-                    Ok(_) => Ok("ok".to_string()),
-                    Err(x) => Err(x),
-                }
-            },
-            SparkError::internal,
-        )
-        .map_err(|e| e.into())
+        let test = move || {
+            test_gold_set(
+                "tests/gold_data/function/*.json",
+                |example: FunctionExample| -> SparkResult<String> {
+                    let relation = Relation {
+                        common: None,
+                        #[expect(deprecated)]
+                        rel_type: Some(RelType::Sql(Sql {
+                            query: example.query,
+                            args: HashMap::new(),
+                            pos_args: vec![],
+                            named_arguments: HashMap::new(),
+                            pos_arguments: vec![],
+                        })),
+                    };
+                    let plan = relation.try_into()?;
+                    let result = handle.primary().block_on(async {
+                        let spark = context.extension::<SparkSession>()?;
+                        let service = context.extension::<JobService>()?;
+                        let (plan, _) =
+                            resolve_and_execute_plan(&context, spark.plan_config()?, plan).await?;
+                        let stream = service.runner().execute(&context, plan).await?;
+                        read_stream(stream).await
+                    });
+                    // TODO: validate the result against the expected output
+                    // TODO: handle non-deterministic results and error messages
+                    match result {
+                        // FIXME: the output can be non-deterministic
+                        Ok(_) => Ok("ok".to_string()),
+                        Err(x) => Err(x),
+                    }
+                },
+                SparkError::internal,
+            )
+        };
+        // `Handle::block_on` polls futures on the calling thread, so use a larger stack than the
+        // default to avoid stack overflow.
+        // Note that increasing the Tokio runtime stack size does not have an effect here.
+        thread::Builder::new()
+            .stack_size(8 * 1024 * 1024)
+            .spawn(test)?
+            .join()
+            .map_err(|_| SparkError::internal("test thread panicked"))?
+            .map_err(|e| e.into())
     }
 }


### PR DESCRIPTION
The test uses `Handle::block_on` which waits for futures on the current thread with a default stack size of 2 MB defined by the standard library ([link](https://doc.rust-lang.org/std/thread/index.html#stack-size)). The Tokio runtime stack size is larger according to the default Sail application configuration, but it does not affect the test thread stack size here. Therefore, we must configure the stack size for tests explicitly.

I encountered this issue when working on #2289 where some newly added test cases involving `SELECT ... FROM (... UNION ALL ...)` cause stack overflow.
