### PR TITLE
fix: propagate swallowed cascade errors in Iceberg drop_database

### DIFF
--- a/crates/sail-catalog-iceberg/src/provider.rs
+++ b/crates/sail-catalog-iceberg/src/provider.rs
@@ -975,42 +975,99 @@ impl CatalogProvider for IcebergRestCatalogProvider {
             // For CASCADE, first drop all tables and views in the namespace before dropping the namespace.
             // Each request re-reads the credential and retries once on a 401, so a token that rotates
             // partway through the cascade is recovered per request instead of leaving a partial drop.
-            let tables_result = self
+            match self
                 .with_auth_retry(|client| {
                     let prefix = prefix.clone();
                     let ns_string = ns_string.clone();
                     async move { client.list_tables(prefix, ns_string, None, None).await }
                 })
-                .await?;
-            if let Ok(tables) = tables_result {
-                for identifier in tables.inner.identifiers.unwrap_or_default() {
-                    let _ = self
-                        .with_auth_retry(|client| {
-                            let prefix = prefix.clone();
-                            let ns_string = ns_string.clone();
-                            let name = identifier.name.clone();
-                            async move { client.drop_table(prefix, ns_string, name, Some(true)).await }
-                        })
-                        .await?;
+                .await?
+            {
+                Ok(tables) => {
+                    for identifier in tables.inner.identifiers.unwrap_or_default() {
+                        match self
+                            .with_auth_retry(|client| {
+                                let prefix = prefix.clone();
+                                let ns_string = ns_string.clone();
+                                let name = identifier.name.clone();
+                                async move {
+                                    client.drop_table(prefix, ns_string, name, Some(true)).await
+                                }
+                            })
+                            .await?
+                        {
+                            Ok(_) => {}
+                            // The table was already removed (a concurrent drop), which is
+                            // an acceptable outcome for a cascade, so keep going.
+                            Err(e) if e.status() == Some(reqwest::StatusCode::NOT_FOUND) => {}
+                            Err(e) => {
+                                return Err(CatalogError::External(format!(
+                                    "Failed to drop table '{}' while cascading namespace drop: {e}",
+                                    identifier.name
+                                )));
+                            }
+                        }
+                    }
+                }
+                // The namespace itself is already gone; fall through to drop_namespace,
+                // which applies the canonical if_exists handling below.
+                Err(e) if e.status() == Some(reqwest::StatusCode::NOT_FOUND) => {}
+                Err(e) => {
+                    return Err(CatalogError::External(format!(
+                        "Failed to list tables while cascading namespace drop: {e}"
+                    )));
                 }
             }
-            let views_result = self
+            match self
                 .with_auth_retry(|client| {
                     let prefix = prefix.clone();
                     let ns_string = ns_string.clone();
                     async move { client.list_views(prefix, ns_string, None, None).await }
                 })
-                .await?;
-            if let Ok(views) = views_result {
-                for identifier in views.inner.identifiers.unwrap_or_default() {
-                    let _ = self
-                        .with_auth_retry(|client| {
-                            let prefix = prefix.clone();
-                            let ns_string = ns_string.clone();
-                            let name = identifier.name.clone();
-                            async move { client.drop_view(prefix, ns_string, name).await }
-                        })
-                        .await?;
+                .await?
+            {
+                Ok(views) => {
+                    for identifier in views.inner.identifiers.unwrap_or_default() {
+                        match self
+                            .with_auth_retry(|client| {
+                                let prefix = prefix.clone();
+                                let ns_string = ns_string.clone();
+                                let name = identifier.name.clone();
+                                async move { client.drop_view(prefix, ns_string, name).await }
+                            })
+                            .await?
+                        {
+                            Ok(_) => {}
+                            // The view was already removed (a concurrent drop), which is
+                            // an acceptable outcome for a cascade, so keep going.
+                            Err(e) if e.status() == Some(reqwest::StatusCode::NOT_FOUND) => {}
+                            Err(e) => {
+                                return Err(CatalogError::External(format!(
+                                    "Failed to drop view '{}' while cascading namespace drop: {e}",
+                                    identifier.name
+                                )));
+                            }
+                        }
+                    }
+                }
+                // The namespace itself is already gone; fall through to drop_namespace,
+                // which applies the canonical if_exists handling below.
+                Err(e) if e.status() == Some(reqwest::StatusCode::NOT_FOUND) => {}
+                // The views endpoint is optional in the Iceberg REST spec, so a catalog
+                // that does not implement it answers 405 or 501. There are then no views
+                // to cascade, so tolerate it and continue to the namespace drop. The tables
+                // endpoint is mandatory, so the list_tables arm above does not tolerate these
+                // statuses and a 405 or 501 there is surfaced as a genuine failure.
+                Err(e)
+                    if matches!(
+                        e.status(),
+                        Some(reqwest::StatusCode::METHOD_NOT_ALLOWED)
+                            | Some(reqwest::StatusCode::NOT_IMPLEMENTED)
+                    ) => {}
+                Err(e) => {
+                    return Err(CatalogError::External(format!(
+                        "Failed to list views while cascading namespace drop: {e}"
+                    )));
                 }
             }
         }
@@ -2740,6 +2797,329 @@ mod tests {
     async fn test_drop_database() {
         test_drop_database_impl(None).await;
         test_drop_database_impl(Some("test")).await;
+    }
+
+    async fn test_drop_database_cascade_propagates_table_drop_failure_impl(name: Option<&str>) {
+        let ctx = TestContext::new(name).await;
+        let namespace = Namespace::try_from(vec!["ns1".to_string()]).unwrap();
+
+        ctx.mock_get_json(
+            &ctx.path("/namespaces/ns1/tables"),
+            serde_json::json!({
+                "identifiers": [
+                    {
+                        "namespace": ["ns1"],
+                        "name": "table1"
+                    }
+                ]
+            }),
+        )
+        .await;
+
+        // The per-object table drop hits a real server error, so the cascade must abort.
+        Mock::given(method("DELETE"))
+            .and(path(ctx.path("/namespaces/ns1/tables/table1").as_str()))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&ctx.server)
+            .await;
+
+        // The namespace drop must never be attempted once a table drop fails.
+        Mock::given(method("DELETE"))
+            .and(path(ctx.path("/namespaces/ns1").as_str()))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(0)
+            .mount(&ctx.server)
+            .await;
+
+        let result = ctx
+            .catalog
+            .drop_database(
+                &namespace,
+                DropDatabaseOptions {
+                    if_exists: false,
+                    cascade: true,
+                },
+            )
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_drop_database_cascade_propagates_table_drop_failure() {
+        test_drop_database_cascade_propagates_table_drop_failure_impl(None).await;
+        test_drop_database_cascade_propagates_table_drop_failure_impl(Some("test")).await;
+    }
+
+    async fn test_drop_database_cascade_tolerates_missing_table_impl(name: Option<&str>) {
+        let ctx = TestContext::new(name).await;
+        let namespace = Namespace::try_from(vec!["ns1".to_string()]).unwrap();
+
+        ctx.mock_get_json(
+            &ctx.path("/namespaces/ns1/tables"),
+            serde_json::json!({
+                "identifiers": [
+                    {
+                        "namespace": ["ns1"],
+                        "name": "table1"
+                    }
+                ]
+            }),
+        )
+        .await;
+
+        // A concurrent removal leaves the table already gone; the cascade tolerates that.
+        ctx.mock_delete_404(
+            &ctx.path("/namespaces/ns1/tables/table1"),
+            "NoSuchTableException",
+            "The given table does not exist",
+        )
+        .await;
+
+        ctx.mock_get_json(
+            &ctx.path("/namespaces/ns1/views"),
+            serde_json::json!({ "identifiers": [] }),
+        )
+        .await;
+
+        // The cascade proceeds and drops the namespace itself.
+        Mock::given(method("DELETE"))
+            .and(path(ctx.path("/namespaces/ns1").as_str()))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&ctx.server)
+            .await;
+
+        let result = ctx
+            .catalog
+            .drop_database(
+                &namespace,
+                DropDatabaseOptions {
+                    if_exists: false,
+                    cascade: true,
+                },
+            )
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_drop_database_cascade_tolerates_missing_table() {
+        test_drop_database_cascade_tolerates_missing_table_impl(None).await;
+        test_drop_database_cascade_tolerates_missing_table_impl(Some("test")).await;
+    }
+
+    async fn test_drop_database_cascade_propagates_list_tables_failure_impl(name: Option<&str>) {
+        let ctx = TestContext::new(name).await;
+        let namespace = Namespace::try_from(vec!["ns1".to_string()]).unwrap();
+
+        // Listing the tables fails outright, which the cascade must surface.
+        Mock::given(method("GET"))
+            .and(path(ctx.path("/namespaces/ns1/tables").as_str()))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&ctx.server)
+            .await;
+
+        // The namespace drop must never be attempted once the listing fails.
+        Mock::given(method("DELETE"))
+            .and(path(ctx.path("/namespaces/ns1").as_str()))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(0)
+            .mount(&ctx.server)
+            .await;
+
+        let result = ctx
+            .catalog
+            .drop_database(
+                &namespace,
+                DropDatabaseOptions {
+                    if_exists: false,
+                    cascade: true,
+                },
+            )
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_drop_database_cascade_propagates_list_tables_failure() {
+        test_drop_database_cascade_propagates_list_tables_failure_impl(None).await;
+        test_drop_database_cascade_propagates_list_tables_failure_impl(Some("test")).await;
+    }
+
+    async fn test_drop_database_cascade_tolerates_missing_views_endpoint_impl(name: Option<&str>) {
+        let ctx = TestContext::new(name).await;
+        let namespace = Namespace::try_from(vec!["ns1".to_string()]).unwrap();
+
+        ctx.mock_get_json(
+            &ctx.path("/namespaces/ns1/tables"),
+            serde_json::json!({ "identifiers": [] }),
+        )
+        .await;
+
+        // A catalog without a views endpoint answers 405, which must not abort the cascade.
+        Mock::given(method("GET"))
+            .and(path(ctx.path("/namespaces/ns1/views").as_str()))
+            .respond_with(ResponseTemplate::new(405))
+            .mount(&ctx.server)
+            .await;
+
+        Mock::given(method("DELETE"))
+            .and(path(ctx.path("/namespaces/ns1").as_str()))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&ctx.server)
+            .await;
+
+        let result = ctx
+            .catalog
+            .drop_database(
+                &namespace,
+                DropDatabaseOptions {
+                    if_exists: false,
+                    cascade: true,
+                },
+            )
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_drop_database_cascade_tolerates_missing_views_endpoint() {
+        test_drop_database_cascade_tolerates_missing_views_endpoint_impl(None).await;
+        test_drop_database_cascade_tolerates_missing_views_endpoint_impl(Some("test")).await;
+    }
+
+    async fn test_drop_database_cascade_tolerates_unimplemented_views_endpoint_impl(
+        name: Option<&str>,
+    ) {
+        let ctx = TestContext::new(name).await;
+        let namespace = Namespace::try_from(vec!["ns1".to_string()]).unwrap();
+
+        ctx.mock_get_json(
+            &ctx.path("/namespaces/ns1/tables"),
+            serde_json::json!({ "identifiers": [] }),
+        )
+        .await;
+
+        // A catalog without a views endpoint may answer 501 instead of 405, which
+        // must also be tolerated so the cascade still drops the namespace.
+        Mock::given(method("GET"))
+            .and(path(ctx.path("/namespaces/ns1/views").as_str()))
+            .respond_with(ResponseTemplate::new(501))
+            .mount(&ctx.server)
+            .await;
+
+        Mock::given(method("DELETE"))
+            .and(path(ctx.path("/namespaces/ns1").as_str()))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&ctx.server)
+            .await;
+
+        let result = ctx
+            .catalog
+            .drop_database(
+                &namespace,
+                DropDatabaseOptions {
+                    if_exists: false,
+                    cascade: true,
+                },
+            )
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_drop_database_cascade_tolerates_unimplemented_views_endpoint() {
+        test_drop_database_cascade_tolerates_unimplemented_views_endpoint_impl(None).await;
+        test_drop_database_cascade_tolerates_unimplemented_views_endpoint_impl(Some("test")).await;
+    }
+
+    async fn test_drop_database_cascade_propagates_list_views_failure_impl(name: Option<&str>) {
+        let ctx = TestContext::new(name).await;
+        let namespace = Namespace::try_from(vec!["ns1".to_string()]).unwrap();
+
+        ctx.mock_get_json(
+            &ctx.path("/namespaces/ns1/tables"),
+            serde_json::json!({ "identifiers": [] }),
+        )
+        .await;
+
+        // A genuine views listing failure (not a missing endpoint) must abort the cascade.
+        Mock::given(method("GET"))
+            .and(path(ctx.path("/namespaces/ns1/views").as_str()))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&ctx.server)
+            .await;
+
+        // The namespace drop must never be attempted once the listing fails.
+        Mock::given(method("DELETE"))
+            .and(path(ctx.path("/namespaces/ns1").as_str()))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(0)
+            .mount(&ctx.server)
+            .await;
+
+        let result = ctx
+            .catalog
+            .drop_database(
+                &namespace,
+                DropDatabaseOptions {
+                    if_exists: false,
+                    cascade: true,
+                },
+            )
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_drop_database_cascade_propagates_list_views_failure() {
+        test_drop_database_cascade_propagates_list_views_failure_impl(None).await;
+        test_drop_database_cascade_propagates_list_views_failure_impl(Some("test")).await;
+    }
+
+    async fn test_drop_database_cascade_tolerates_missing_namespace_impl(name: Option<&str>) {
+        let ctx = TestContext::new(name).await;
+        let namespace = Namespace::try_from(vec!["ns1".to_string()]).unwrap();
+
+        // The namespace disappeared before the cascade started; both listings answer 404.
+        Mock::given(method("GET"))
+            .and(path(ctx.path("/namespaces/ns1/tables").as_str()))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&ctx.server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(ctx.path("/namespaces/ns1/views").as_str()))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&ctx.server)
+            .await;
+
+        // With if_exists set, the trailing namespace 404 is the success path.
+        ctx.mock_delete_404(
+            &ctx.path("/namespaces/ns1"),
+            "NoSuchNamespaceException",
+            "The given namespace does not exist",
+        )
+        .await;
+
+        let result = ctx
+            .catalog
+            .drop_database(
+                &namespace,
+                DropDatabaseOptions {
+                    if_exists: true,
+                    cascade: true,
+                },
+            )
+            .await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_drop_database_cascade_tolerates_missing_namespace() {
+        test_drop_database_cascade_tolerates_missing_namespace_impl(None).await;
+        test_drop_database_cascade_tolerates_missing_namespace_impl(Some("test")).await;
     }
 
     async fn test_drop_table_impl(name: Option<&str>) {

--- a/crates/sail-catalog-iceberg/src/provider.rs
+++ b/crates/sail-catalog-iceberg/src/provider.rs
@@ -967,9 +967,24 @@ impl CatalogProvider for IcebergRestCatalogProvider {
         let catalog_config = self.resolved_catalog_config().await?;
 
         let DropDatabaseOptions { if_exists, cascade } = options;
-
         let prefix = catalog_config.prefix().map(ToOwned::to_owned);
         let ns_string = catalog_config.namespace_string(database)?;
+        let drop_namespace = || async {
+            match self
+                .with_auth_retry(|client| {
+                    let prefix = prefix.clone();
+                    let ns_string = ns_string.clone();
+                    async move { client.drop_namespace(prefix, ns_string).await }
+                })
+                .await?
+            {
+                Ok(_) => Ok(()),
+                Err(e) if e.status() == Some(reqwest::StatusCode::NOT_FOUND) && if_exists => Ok(()),
+                Err(e) => Err(CatalogError::External(format!(
+                    "Failed to drop namespace: {e}"
+                ))),
+            }
+        };
 
         if cascade {
             // For CASCADE, first drop all tables and views in the namespace before dropping the namespace.
@@ -1009,9 +1024,11 @@ impl CatalogProvider for IcebergRestCatalogProvider {
                         }
                     }
                 }
-                // The namespace itself is already gone; fall through to drop_namespace,
-                // which applies the canonical if_exists handling below.
-                Err(e) if e.status() == Some(reqwest::StatusCode::NOT_FOUND) => {}
+                // The namespace itself is already gone. Skip the optional views endpoint and
+                // fall through to drop_namespace, which applies canonical if_exists handling.
+                Err(e) if e.status() == Some(reqwest::StatusCode::NOT_FOUND) => {
+                    return drop_namespace().await;
+                }
                 Err(e) => {
                     return Err(CatalogError::External(format!(
                         "Failed to list tables while cascading namespace drop: {e}"
@@ -1072,20 +1089,7 @@ impl CatalogProvider for IcebergRestCatalogProvider {
             }
         }
 
-        match self
-            .with_auth_retry(|client| {
-                let prefix = prefix.clone();
-                let ns_string = ns_string.clone();
-                async move { client.drop_namespace(prefix, ns_string).await }
-            })
-            .await?
-        {
-            Ok(_) => Ok(()),
-            Err(e) if e.status() == Some(reqwest::StatusCode::NOT_FOUND) && if_exists => Ok(()),
-            Err(e) => Err(CatalogError::External(format!(
-                "Failed to drop namespace: {e}"
-            ))),
-        }
+        drop_namespace().await
     }
 
     async fn create_table(
@@ -3035,6 +3039,61 @@ mod tests {
         test_drop_database_cascade_tolerates_unimplemented_views_endpoint_impl(Some("test")).await;
     }
 
+    async fn test_drop_database_cascade_propagates_view_drop_failure_impl(name: Option<&str>) {
+        let ctx = TestContext::new(name).await;
+        let namespace = Namespace::try_from(vec!["ns1".to_string()]).unwrap();
+
+        ctx.mock_get_json(
+            &ctx.path("/namespaces/ns1/tables"),
+            serde_json::json!({ "identifiers": [] }),
+        )
+        .await;
+        ctx.mock_get_json(
+            &ctx.path("/namespaces/ns1/views"),
+            serde_json::json!({
+                "identifiers": [
+                    {
+                        "namespace": ["ns1"],
+                        "name": "view1"
+                    }
+                ]
+            }),
+        )
+        .await;
+
+        Mock::given(method("DELETE"))
+            .and(path(ctx.path("/namespaces/ns1/views/view1").as_str()))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&ctx.server)
+            .await;
+
+        // The namespace drop must never be attempted once a view drop fails.
+        Mock::given(method("DELETE"))
+            .and(path(ctx.path("/namespaces/ns1").as_str()))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(0)
+            .mount(&ctx.server)
+            .await;
+
+        let result = ctx
+            .catalog
+            .drop_database(
+                &namespace,
+                DropDatabaseOptions {
+                    if_exists: false,
+                    cascade: true,
+                },
+            )
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_drop_database_cascade_propagates_view_drop_failure() {
+        test_drop_database_cascade_propagates_view_drop_failure_impl(None).await;
+        test_drop_database_cascade_propagates_view_drop_failure_impl(Some("test")).await;
+    }
+
     async fn test_drop_database_cascade_propagates_list_views_failure_impl(name: Option<&str>) {
         let ctx = TestContext::new(name).await;
         let namespace = Namespace::try_from(vec!["ns1".to_string()]).unwrap();
@@ -3083,7 +3142,8 @@ mod tests {
         let ctx = TestContext::new(name).await;
         let namespace = Namespace::try_from(vec!["ns1".to_string()]).unwrap();
 
-        // The namespace disappeared before the cascade started; both listings answer 404.
+        // The mandatory tables endpoint reports that the namespace is gone. No
+        // optional views request should run after that definitive result.
         Mock::given(method("GET"))
             .and(path(ctx.path("/namespaces/ns1/tables").as_str()))
             .respond_with(ResponseTemplate::new(404))
@@ -3091,7 +3151,8 @@ mod tests {
             .await;
         Mock::given(method("GET"))
             .and(path(ctx.path("/namespaces/ns1/views").as_str()))
-            .respond_with(ResponseTemplate::new(404))
+            .respond_with(ResponseTemplate::new(500))
+            .expect(0)
             .mount(&ctx.server)
             .await;
 

--- a/python/pysail/tests/spark/catalog/iceberg_rest/features/namespace.feature
+++ b/python/pysail/tests/spark/catalog/iceberg_rest/features/namespace.feature
@@ -370,3 +370,45 @@ Feature: Iceberg REST catalog namespace (database) operations
       """
     Then query result
       | name | catalog | description | locationUri |
+
+  Scenario: Drop a namespace with CASCADE removes its tables and views
+    Given statement
+      """
+      CREATE DATABASE cascade_drop_ns
+      """
+    Given final statement
+      """
+      DROP DATABASE IF EXISTS cascade_drop_ns CASCADE
+      """
+    Given statement
+      """
+      CREATE TABLE cascade_drop_ns.table_to_drop (id INT) USING iceberg
+      """
+    Given statement
+      """
+      CREATE VIEW cascade_drop_ns.view_to_drop AS SELECT 1 AS id
+      """
+    Given statement
+      """
+      DROP DATABASE cascade_drop_ns CASCADE
+      """
+    When query
+      """
+      SHOW DATABASES LIKE 'cascade_drop_ns'
+      """
+    Then query result
+      | name | catalog | description | locationUri |
+    Given statement
+      """
+      CREATE DATABASE cascade_drop_ns
+      """
+    When query
+      """
+      DESCRIBE TABLE cascade_drop_ns.table_to_drop
+      """
+    Then query error .*
+    When query
+      """
+      DESCRIBE TABLE cascade_drop_ns.view_to_drop
+      """
+    Then query error .*


### PR DESCRIPTION
## What

Rework `IcebergRestCatalogProvider::drop_database` so the CASCADE path no longer discards per-object and listing failures. Every `list_tables`, `list_views`, `drop_table` and `drop_view` call now propagates a genuine failure as an error, and only specific benign statuses are tolerated.

## Why

The previous code used `if let Ok(...)` around the table and view listings and `let _ =` around each per-object drop. Any error was silently swallowed, so a DROP DATABASE ... CASCADE could report success while tables or views were left behind. A transient 500 on a table drop, or a permission error on a listing, produced a half applied cascade that still deleted (or claimed to delete) the namespace. The failure was invisible to the caller.

## Tolerance rationale

- NOT_FOUND on a per-object drop means a concurrent drop already removed the object, which is an acceptable outcome for a cascade, so we keep going.
- NOT_FOUND on a listing means the namespace itself is already gone. We fall through to `drop_namespace`, which applies the canonical `if_exists` handling (a 404 there succeeds when `if_exists` is set and errors otherwise).
- 405 METHOD_NOT_ALLOWED and 501 NOT_IMPLEMENTED on `list_views` mean the catalog has no views endpoint, which is optional in the Iceberg REST spec. The pre-fix `if let Ok(views)` tolerated any views-list failure, so a view-less catalog must still succeed. These two statuses stay tolerated for `list_views` only. The tables endpoint is mandatory, so a 405 or 501 on `list_tables` is surfaced as a genuine failure.

## Tests

Added regression tests against the existing wiremock harness:

- `test_drop_database_cascade_propagates_table_drop_failure`: a per-object table drop 500 makes `drop_database` return an error and the namespace drop is never sent (asserted with `expect(0)`).
- `test_drop_database_cascade_tolerates_missing_table`: a per-object table drop 404 is tolerated and the cascade proceeds to drop the namespace.
- `test_drop_database_cascade_propagates_list_tables_failure`: a `list_tables` 500 propagates and the namespace drop is never sent.
- `test_drop_database_cascade_propagates_list_views_failure`: a `list_views` 500 propagates and the namespace drop is never sent.
- `test_drop_database_cascade_tolerates_missing_views_endpoint`: a `list_views` 405 is tolerated and the cascade still drops the namespace.
- `test_drop_database_cascade_tolerates_unimplemented_views_endpoint`: a `list_views` 501 is tolerated the same way.
- `test_drop_database_cascade_tolerates_missing_namespace`: listings return 404 and, with `if_exists` set, the trailing namespace 404 succeeds.

## Verification

- `cargo test -p sail-catalog-iceberg`: all pass.
- `cargo clippy -p sail-catalog-iceberg --all-targets --all-features -- -D warnings`: exit 0.
- `cargo fmt --check`: clean.

## Note

This addresses the swallowed-error observation raised in the review of the open bearer-token-file PR (#2288). It touches the same `drop_database` method, so a mechanical rebase is expected once one of the two merges.
