### PR TITLE
feat: support copy-on-write Iceberg delete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7856,6 +7856,7 @@ dependencies = [
  "serde",
  "serde_arrow",
  "serde_json",
+ "tokio",
  "url",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7852,6 +7852,7 @@ dependencies = [
  "sail-common",
  "sail-common-datafusion",
  "sail-data-source",
+ "sail-logical-plan",
  "sail-sql-analyzer",
  "serde",
  "serde_arrow",

--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -965,6 +965,10 @@ message IcebergCommitExecNode {
   bool validate_read_snapshot = 4;
   // Absent when validation is required and the target had no current snapshot.
   optional int64 expected_snapshot_id = 5;
+  // Static live data-file paths selected for a copy-on-write rewrite.
+  repeated string removed_data_file_paths = 6;
+  // Optional Iceberg Operation serialized as JSON; empty means use the writer operation.
+  string operation_override_json = 7;
 }
 
 message IcebergManifestScanExecNode {

--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -961,6 +961,10 @@ message IcebergCommitExecNode {
   bytes input = 1;
   string table_url = 2;
   string lakehouse_table_json = 3;
+  // Whether the commit must validate the target snapshot captured while planning a mutation.
+  bool validate_read_snapshot = 4;
+  // Absent when validation is required and the target had no current snapshot.
+  optional int64 expected_snapshot_id = 5;
 }
 
 message IcebergManifestScanExecNode {

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -1371,16 +1371,30 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 lakehouse_table_json,
                 validate_read_snapshot,
                 expected_snapshot_id,
+                removed_data_file_paths,
+                operation_override_json,
             }) => {
                 let input = try_decode_physical_plan(ctx, self, &input)?;
                 let table_url = Url::parse(&table_url)
                     .map_err(|e| plan_datafusion_err!("failed to parse table URL: {e}"))?;
                 let lakehouse_table = self.try_decode_lakehouse_table(&lakehouse_table_json)?;
+                let operation_override = if operation_override_json.is_empty() {
+                    None
+                } else {
+                    Some(self.try_decode_json(
+                        &operation_override_json,
+                        "Iceberg commit operation override",
+                    )?)
+                };
 
                 Ok(Arc::new(
                     IcebergCommitExec::new(input, table_url, lakehouse_table)
                         .with_expected_snapshot_id(
                             validate_read_snapshot.then_some(expected_snapshot_id),
+                        )
+                        .with_optional_rewrite_data_files(
+                            removed_data_file_paths,
+                            operation_override,
                         ),
                 ))
             }
@@ -2229,6 +2243,13 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
         } else if let Some(iceberg_commit_exec) = node.downcast_ref::<IcebergCommitExec>() {
             let input = try_encode_physical_plan(self, iceberg_commit_exec.input().clone())?;
             let expected_snapshot_id = iceberg_commit_exec.expected_snapshot_id();
+            let operation_override_json = iceberg_commit_exec
+                .operation_override()
+                .map(|operation| {
+                    self.try_encode_json(operation, "Iceberg commit operation override")
+                })
+                .transpose()?
+                .unwrap_or_default();
             NodeKind::IcebergCommit(r#gen::IcebergCommitExecNode {
                 input,
                 table_url: iceberg_commit_exec.table_url().to_string(),
@@ -2236,6 +2257,8 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                     .try_encode_lakehouse_table(iceberg_commit_exec.lakehouse_table())?,
                 validate_read_snapshot: expected_snapshot_id.is_some(),
                 expected_snapshot_id: expected_snapshot_id.flatten(),
+                removed_data_file_paths: iceberg_commit_exec.removed_data_file_paths().to_vec(),
+                operation_override_json,
             })
         } else if let Some(manifest_scan) = node.downcast_ref::<IcebergManifestScanExec>() {
             let snapshot_json = serde_json::to_string(manifest_scan.snapshot())
@@ -4514,6 +4537,8 @@ mod tests {
 
     fn round_trip_iceberg_commit(
         expected_snapshot_id: Option<Option<i64>>,
+        removed_data_file_paths: Vec<String>,
+        operation_override: Option<sail_iceberg::spec::Operation>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         use datafusion::physical_plan::empty::EmptyExec;
 
@@ -4525,6 +4550,10 @@ mod tests {
             None,
         )
         .with_expected_snapshot_id(expected_snapshot_id);
+        let plan = match operation_override {
+            Some(operation) => plan.with_rewrite_data_files(removed_data_file_paths, operation),
+            None => plan,
+        };
         let codec = RemoteExecutionCodec;
         let bytes = try_encode_physical_plan(&codec, Arc::new(plan))?;
         try_decode_physical_plan(&TaskContext::default(), &codec, &bytes)
@@ -4533,12 +4562,34 @@ mod tests {
     #[test]
     fn iceberg_commit_snapshot_requirement_round_trip_preserves_tristate() -> Result<()> {
         for expected_snapshot_id in [Some(Some(41)), Some(None), None] {
-            let decoded = round_trip_iceberg_commit(expected_snapshot_id)?;
+            let decoded = round_trip_iceberg_commit(expected_snapshot_id, vec![], None)?;
             let decoded = decoded
                 .downcast_ref::<IcebergCommitExec>()
                 .ok_or_else(|| plan_datafusion_err!("decoded plan is not an IcebergCommitExec"))?;
             assert_eq!(decoded.expected_snapshot_id(), expected_snapshot_id);
         }
+        Ok(())
+    }
+
+    #[test]
+    fn iceberg_commit_rewrite_round_trip_preserves_paths_and_operation() -> Result<()> {
+        let decoded = round_trip_iceberg_commit(
+            Some(Some(41)),
+            vec!["data/affected.parquet".to_string()],
+            Some(sail_iceberg::spec::Operation::Delete),
+        )?;
+        let decoded = decoded
+            .downcast_ref::<IcebergCommitExec>()
+            .ok_or_else(|| plan_datafusion_err!("decoded plan is not an IcebergCommitExec"))?;
+
+        assert_eq!(
+            decoded.removed_data_file_paths(),
+            &["data/affected.parquet".to_string()]
+        );
+        assert_eq!(
+            decoded.operation_override(),
+            Some(&sail_iceberg::spec::Operation::Delete)
+        );
         Ok(())
     }
 

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -1369,17 +1369,20 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 input,
                 table_url,
                 lakehouse_table_json,
+                validate_read_snapshot,
+                expected_snapshot_id,
             }) => {
                 let input = try_decode_physical_plan(ctx, self, &input)?;
                 let table_url = Url::parse(&table_url)
                     .map_err(|e| plan_datafusion_err!("failed to parse table URL: {e}"))?;
                 let lakehouse_table = self.try_decode_lakehouse_table(&lakehouse_table_json)?;
 
-                Ok(Arc::new(IcebergCommitExec::new(
-                    input,
-                    table_url,
-                    lakehouse_table,
-                )))
+                Ok(Arc::new(
+                    IcebergCommitExec::new(input, table_url, lakehouse_table)
+                        .with_expected_snapshot_id(
+                            validate_read_snapshot.then_some(expected_snapshot_id),
+                        ),
+                ))
             }
             NodeKind::IcebergManifestScan(r#gen::IcebergManifestScanExecNode {
                 table_url,
@@ -2225,11 +2228,14 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             })
         } else if let Some(iceberg_commit_exec) = node.downcast_ref::<IcebergCommitExec>() {
             let input = try_encode_physical_plan(self, iceberg_commit_exec.input().clone())?;
+            let expected_snapshot_id = iceberg_commit_exec.expected_snapshot_id();
             NodeKind::IcebergCommit(r#gen::IcebergCommitExecNode {
                 input,
                 table_url: iceberg_commit_exec.table_url().to_string(),
                 lakehouse_table_json: self
                     .try_encode_lakehouse_table(iceberg_commit_exec.lakehouse_table())?,
+                validate_read_snapshot: expected_snapshot_id.is_some(),
+                expected_snapshot_id: expected_snapshot_id.flatten(),
             })
         } else if let Some(manifest_scan) = node.downcast_ref::<IcebergManifestScanExec>() {
             let snapshot_json = serde_json::to_string(manifest_scan.snapshot())
@@ -4505,6 +4511,36 @@ mod tests {
     use datafusion::physical_expr::HigherOrderFunctionExpr;
 
     use super::*;
+
+    fn round_trip_iceberg_commit(
+        expected_snapshot_id: Option<Option<i64>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        use datafusion::physical_plan::empty::EmptyExec;
+
+        let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(Arc::new(Schema::empty())));
+        let plan = IcebergCommitExec::new(
+            input,
+            Url::parse("file:///tmp/iceberg-table")
+                .map_err(|error| plan_datafusion_err!("{error}"))?,
+            None,
+        )
+        .with_expected_snapshot_id(expected_snapshot_id);
+        let codec = RemoteExecutionCodec;
+        let bytes = try_encode_physical_plan(&codec, Arc::new(plan))?;
+        try_decode_physical_plan(&TaskContext::default(), &codec, &bytes)
+    }
+
+    #[test]
+    fn iceberg_commit_snapshot_requirement_round_trip_preserves_tristate() -> Result<()> {
+        for expected_snapshot_id in [Some(Some(41)), Some(None), None] {
+            let decoded = round_trip_iceberg_commit(expected_snapshot_id)?;
+            let decoded = decoded
+                .downcast_ref::<IcebergCommitExec>()
+                .ok_or_else(|| plan_datafusion_err!("decoded plan is not an IcebergCommitExec"))?;
+            assert_eq!(decoded.expected_snapshot_id(), expected_snapshot_id);
+        }
+        Ok(())
+    }
 
     fn round_trip_udf(udf: ScalarUDF) -> Result<Arc<ScalarUDF>> {
         let codec = RemoteExecutionCodec;

--- a/crates/sail-iceberg/Cargo.toml
+++ b/crates/sail-iceberg/Cargo.toml
@@ -20,6 +20,7 @@ sail-catalog = { path = "../sail-catalog" }
 sail-common = { path = "../sail-common" }
 sail-common-datafusion = { path = "../sail-common-datafusion" }
 sail-data-source = { path = "../sail-data-source" }
+sail-logical-plan = { path = "../sail-logical-plan" }
 sail-sql-analyzer = { path = "../sail-sql-analyzer" }
 
 # DataFusion dependencies

--- a/crates/sail-iceberg/Cargo.toml
+++ b/crates/sail-iceberg/Cargo.toml
@@ -57,6 +57,9 @@ rust_decimal = { workspace = true }
 murmur3 = { workspace = true }
 educe = { workspace = true }
 
+[dev-dependencies]
+tokio = { workspace = true }
+
 [build-dependencies]
 sail-build-scripts = { path = "../sail-build-scripts" }
 

--- a/crates/sail-iceberg/src/datasource/provider.rs
+++ b/crates/sail-iceberg/src/datasource/provider.rs
@@ -40,6 +40,9 @@ use datafusion::physical_plan::limit::GlobalLimitExec;
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::physical_plan::union::UnionExec;
 use object_store::ObjectMeta;
+use sail_common_datafusion::catalog::CatalogPartitionField;
+use sail_common_datafusion::datasource::PhysicalSinkMode;
+use sail_common_datafusion::logical_expr::ExprWithSource;
 use sail_common_datafusion::schema_evolution::SchemaEvolutionPhysicalExprAdapterFactory;
 use url::Url;
 
@@ -51,9 +54,11 @@ use crate::datasource::type_converter::iceberg_schema_to_arrow;
 use crate::io::{
     StoreContext, load_manifest as io_load_manifest, load_manifest_list as io_load_manifest_list,
 };
+use crate::physical_plan::IcebergWriterExecOptions;
 use crate::physical_plan::delete_apply_exec::IcebergDeleteApplyExec;
 use crate::physical_plan::discovery_exec::IcebergDiscoveryExec;
 use crate::physical_plan::manifest_scan_exec::IcebergManifestScanExec;
+use crate::physical_plan::plan_builder::{IcebergPlanBuilder, IcebergTableConfig};
 use crate::spec::delete_index::{DeleteFileIndex, DeleteFileRef};
 use crate::spec::transform::Transform;
 use crate::spec::types::values::Literal;
@@ -62,6 +67,7 @@ use crate::spec::{
 };
 use crate::utils::conversions::primitive_to_scalar_default;
 use crate::utils::get_object_store_from_session;
+use crate::utils::partition_transform::catalog_partition_field_from_iceberg;
 
 /// Iceberg table provider for DataFusion
 #[derive(Debug)]
@@ -75,7 +81,6 @@ pub struct IcebergTableProvider {
     /// All partition specs referenced by the table
     partition_specs: Vec<PartitionSpec>,
     /// Default partition spec id (for schema ordering / partition metadata)
-    #[expect(unused)]
     default_spec_id: i32,
     /// Arrow schema for DataFusion
     arrow_schema: Arc<ArrowSchema>,
@@ -677,6 +682,134 @@ impl IcebergTableProvider {
             column_statistics,
         }
     }
+
+    fn current_partition_columns(&self) -> Result<Vec<CatalogPartitionField>> {
+        let spec = self
+            .partition_specs
+            .iter()
+            .find(|spec| spec.spec_id() == self.default_spec_id)
+            .ok_or_else(|| {
+                datafusion::common::DataFusionError::Plan(format!(
+                    "Iceberg default partition spec {} was not found",
+                    self.default_spec_id
+                ))
+            })?;
+        spec.fields()
+            .iter()
+            .map(|field| {
+                let source = self.schema.field_by_id(field.source_id).ok_or_else(|| {
+                    datafusion::common::DataFusionError::Plan(format!(
+                        "Iceberg partition field '{}' references missing source field id {}",
+                        field.name, field.source_id
+                    ))
+                })?;
+                catalog_partition_field_from_iceberg(source.name.clone(), field.transform)
+                    .map_err(datafusion::common::DataFusionError::Plan)
+            })
+            .collect()
+    }
+
+    fn scan_data_files(
+        &self,
+        session: &dyn Session,
+        store_ctx: &StoreContext,
+        data_files: Vec<DataFile>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if data_files.is_empty() {
+            return Ok(Arc::new(EmptyExec::new(self.arrow_schema.clone())));
+        }
+        let statistics = self.aggregate_statistics(&data_files);
+        let partitioned_files = self.create_partitioned_files(store_ctx, data_files)?;
+        let file_groups = self.create_file_groups(partitioned_files);
+        let parquet_source = self.build_parquet_source(session, None, &[], &[], false)?;
+        let file_scan_config = FileScanConfigBuilder::new(self.object_store_url()?, parquet_source)
+            .with_file_groups(file_groups)
+            .with_statistics(statistics)
+            .with_expr_adapter(Some(Arc::new(SchemaEvolutionPhysicalExprAdapterFactory {})
+                as Arc<dyn PhysicalExprAdapterFactory>))
+            .build();
+        Ok(DataSourceExec::from_data_source(file_scan_config))
+    }
+
+    fn retain_delete_survivors(
+        session: &dyn Session,
+        input: Arc<dyn ExecutionPlan>,
+        condition: Option<ExprWithSource>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let Some(condition) = condition else {
+            return Ok(Arc::new(EmptyExec::new(input.schema())));
+        };
+        let schema = input.schema().to_dfschema()?;
+        let survivor_expr = Expr::IsNotTrue(Box::new(condition.expr));
+        let physical_expr = session.create_physical_expr(survivor_expr, &schema)?;
+        Ok(Arc::new(FilterExec::try_new(physical_expr, input)?))
+    }
+
+    pub(crate) async fn build_cow_delete_plan(
+        &self,
+        session: &dyn Session,
+        condition: Option<ExprWithSource>,
+        writer_options: IcebergWriterExecOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let table_url = Url::parse(&self.table_uri)
+            .map_err(|error| datafusion::common::DataFusionError::External(Box::new(error)))?;
+        let expected_snapshot_id = Some(self.snapshot.as_ref().map(Snapshot::snapshot_id));
+        let (candidate_scan, removed_data_file_paths) = if self.snapshot.is_some() {
+            let object_store = get_object_store_from_session(session, &table_url)?;
+            let store_ctx = StoreContext::new(object_store, &table_url)?;
+            let manifest_list = self.load_manifest_list(&store_ctx).await?;
+            let delete_index = self
+                .build_delete_file_index(&store_ctx, &manifest_list)
+                .await?;
+            if !delete_index.is_empty() {
+                return plan_err!(
+                    "copy-on-write DELETE is not supported for Iceberg tables with active delete files"
+                );
+            }
+            let filters = condition
+                .iter()
+                .map(|condition| condition.expr.clone())
+                .collect::<Vec<_>>();
+            let candidates = self
+                .load_data_files_with_seq(session, &filters, &store_ctx, &manifest_list)
+                .await?
+                .into_iter()
+                .map(|(data_file, _)| data_file)
+                .collect::<Vec<_>>();
+            let removed_data_file_paths = candidates
+                .iter()
+                .map(|data_file| data_file.file_path.clone())
+                .collect();
+            (
+                self.scan_data_files(session, &store_ctx, candidates)?,
+                removed_data_file_paths,
+            )
+        } else {
+            (
+                Arc::new(EmptyExec::new(self.arrow_schema.clone())) as Arc<dyn ExecutionPlan>,
+                vec![],
+            )
+        };
+        let survivor_plan = Self::retain_delete_survivors(session, candidate_scan, condition)?;
+        let table_config = IcebergTableConfig {
+            table_url,
+            partition_columns: self.current_partition_columns()?,
+            table_exists: true,
+            options: writer_options,
+        };
+        IcebergPlanBuilder::new(
+            survivor_plan,
+            table_config,
+            PhysicalSinkMode::Append,
+            None,
+            Some(self.arrow_schema.clone()),
+            session,
+        )
+        .with_expected_snapshot_id(expected_snapshot_id)
+        .with_rewrite_data_files(removed_data_file_paths, crate::spec::Operation::Delete)
+        .build()
+        .await
+    }
 }
 
 #[async_trait]
@@ -1211,5 +1344,414 @@ impl IcebergTableProvider {
         );
 
         Ok(scan_exec)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use datafusion::arrow::array::{BooleanArray, Int64Array};
+    use datafusion::arrow::datatypes::{DataType, Field};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::prelude::SessionContext;
+    use object_store::ObjectStoreExt;
+    use object_store::memory::InMemory;
+    use sail_common_datafusion::logical_expr::ExprWithSource;
+
+    use super::*;
+    use crate::physical_plan::commit::commit_exec::IcebergCommitExec;
+    use crate::spec::manifest::{DataContentType, DataFileFormat, ManifestWriterBuilder};
+    use crate::spec::types::{NestedField, PrimitiveType, Type};
+    use crate::spec::{FormatVersion, ManifestListWriter, SnapshotBuilder};
+
+    fn test_schema() -> Result<Schema> {
+        Schema::builder()
+            .with_schema_id(0)
+            .with_fields(vec![Arc::new(NestedField::required(
+                1,
+                "id",
+                Type::Primitive(PrimitiveType::Long),
+            ))])
+            .build()
+            .map_err(datafusion::common::DataFusionError::Execution)
+    }
+
+    fn test_int_schema() -> Result<Schema> {
+        Schema::builder()
+            .with_schema_id(0)
+            .with_fields(vec![Arc::new(NestedField::optional(
+                1,
+                "id",
+                Type::Primitive(PrimitiveType::Int),
+            ))])
+            .build()
+            .map_err(datafusion::common::DataFusionError::Execution)
+    }
+
+    fn bounded_int_data_file(path: &str, lower: i32, upper: i32) -> DataFile {
+        DataFile {
+            content: DataContentType::Data,
+            file_path: path.to_string(),
+            file_format: DataFileFormat::Parquet,
+            partition: vec![],
+            record_count: 3,
+            file_size_in_bytes: 100,
+            column_sizes: HashMap::new(),
+            value_counts: HashMap::from([(1, 3)]),
+            null_value_counts: HashMap::from([(1, 0)]),
+            nan_value_counts: HashMap::new(),
+            lower_bounds: HashMap::from([(
+                1,
+                crate::spec::Datum::new(
+                    PrimitiveType::Int,
+                    crate::spec::types::values::PrimitiveLiteral::Int(lower),
+                ),
+            )]),
+            upper_bounds: HashMap::from([(
+                1,
+                crate::spec::Datum::new(
+                    PrimitiveType::Int,
+                    crate::spec::types::values::PrimitiveLiteral::Int(upper),
+                ),
+            )]),
+            block_size_in_bytes: None,
+            key_metadata: None,
+            split_offsets: vec![],
+            equality_ids: vec![],
+            sort_order_id: None,
+            first_row_id: None,
+            partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
+        }
+    }
+
+    fn positional_delete_file(path: &str) -> DataFile {
+        DataFile {
+            content: DataContentType::PositionDeletes,
+            file_path: path.to_string(),
+            file_format: DataFileFormat::Parquet,
+            partition: vec![],
+            record_count: 1,
+            file_size_in_bytes: 100,
+            column_sizes: HashMap::new(),
+            value_counts: HashMap::new(),
+            null_value_counts: HashMap::new(),
+            nan_value_counts: HashMap::new(),
+            lower_bounds: HashMap::new(),
+            upper_bounds: HashMap::new(),
+            block_size_in_bytes: None,
+            key_metadata: None,
+            split_offsets: vec![],
+            equality_ids: vec![],
+            sort_order_id: None,
+            first_row_id: None,
+            partition_spec_id: 0,
+            referenced_data_file: Some("data/target.parquet".to_string()),
+            content_offset: None,
+            content_size_in_bytes: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn cow_delete_rejects_active_delete_files() -> Result<()> {
+        let table_url = Url::parse("memory://delete-files/table")
+            .map_err(|error| datafusion::common::DataFusionError::Plan(error.to_string()))?;
+        let object_store = Arc::new(InMemory::new());
+        let store_ctx = StoreContext::new(object_store.clone(), &table_url)?;
+        let schema = test_schema()?;
+        let partition_spec = PartitionSpec::unpartitioned_spec();
+        let manifest_metadata = crate::spec::manifest::ManifestMetadata::new(
+            Arc::new(schema.clone()),
+            schema.schema_id(),
+            partition_spec.clone(),
+            FormatVersion::V2,
+            ManifestContentType::Deletes,
+        );
+        let snapshot_id = 7;
+        let sequence_number = 1;
+        let mut manifest_writer =
+            ManifestWriterBuilder::new(Some(snapshot_id), None, manifest_metadata).build();
+        manifest_writer.add(positional_delete_file("data/delete.parquet"));
+        let manifest_bytes = manifest_writer
+            .to_avro_bytes_v2()
+            .map_err(|error| datafusion::common::DataFusionError::Execution(error.to_string()))?;
+        let mut manifest_file = manifest_writer.into_manifest_file(
+            "metadata/delete-manifest.avro".to_string(),
+            sequence_number,
+            snapshot_id,
+        );
+        manifest_file.manifest_length = manifest_bytes.len() as i64;
+        store_ctx
+            .prefixed
+            .put(
+                &object_store::path::Path::from("metadata/delete-manifest.avro"),
+                object_store::PutPayload::from(Bytes::from(manifest_bytes)),
+            )
+            .await
+            .map_err(|error| datafusion::common::DataFusionError::External(Box::new(error)))?;
+        let mut manifest_list_writer = ManifestListWriter::new();
+        manifest_list_writer.append(manifest_file);
+        let manifest_list_bytes = manifest_list_writer
+            .to_bytes(FormatVersion::V2)
+            .map_err(datafusion::common::DataFusionError::Execution)?;
+        store_ctx
+            .prefixed
+            .put(
+                &object_store::path::Path::from("metadata/snap-delete.avro"),
+                object_store::PutPayload::from(Bytes::from(manifest_list_bytes)),
+            )
+            .await
+            .map_err(|error| datafusion::common::DataFusionError::External(Box::new(error)))?;
+        let snapshot = SnapshotBuilder::new()
+            .with_snapshot_id(snapshot_id)
+            .with_sequence_number(sequence_number)
+            .with_manifest_list("metadata/snap-delete.avro")
+            .with_summary(crate::spec::snapshots::Summary::new(
+                crate::spec::Operation::Delete,
+            ))
+            .with_schema_id(schema.schema_id())
+            .build()
+            .map_err(datafusion::common::DataFusionError::Execution)?;
+        let provider = IcebergTableProvider::new(
+            table_url.clone(),
+            schema,
+            snapshot,
+            vec![partition_spec],
+            0,
+        )?;
+        let context = SessionContext::new();
+        context.runtime_env().register_object_store(
+            &Url::parse("memory://delete-files")
+                .map_err(|error| datafusion::common::DataFusionError::Plan(error.to_string()))?,
+            object_store,
+        );
+
+        let error = provider
+            .build_cow_delete_plan(&context.state(), None, IcebergWriterExecOptions::default())
+            .await
+            .err()
+            .ok_or_else(|| {
+                datafusion::common::DataFusionError::Internal(
+                    "active delete files must fail closed".to_string(),
+                )
+            })?;
+        assert!(error.to_string().contains("active delete files"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cow_delete_prunes_non_matching_bounded_manifest_file() -> Result<()> {
+        let table_url = Url::parse("memory://bounded-delete/table")
+            .map_err(|error| datafusion::common::DataFusionError::Plan(error.to_string()))?;
+        let object_store = Arc::new(InMemory::new());
+        let store_ctx = StoreContext::new(object_store.clone(), &table_url)?;
+        let schema = test_int_schema()?;
+        let partition_spec = PartitionSpec::unpartitioned_spec();
+        let manifest_metadata = crate::spec::manifest::ManifestMetadata::new(
+            Arc::new(schema.clone()),
+            schema.schema_id(),
+            partition_spec.clone(),
+            FormatVersion::V2,
+            ManifestContentType::Data,
+        );
+        let snapshot_id = 7;
+        let sequence_number = 1;
+        let mut manifest_writer =
+            ManifestWriterBuilder::new(Some(snapshot_id), None, manifest_metadata).build();
+        manifest_writer.add(bounded_int_data_file("data/target.parquet", 1, 3));
+        let manifest_bytes = manifest_writer
+            .to_avro_bytes_v2()
+            .map_err(datafusion::common::DataFusionError::Execution)?;
+        let mut manifest_file = manifest_writer.into_manifest_file(
+            "metadata/data-manifest.avro".to_string(),
+            sequence_number,
+            snapshot_id,
+        );
+        manifest_file.manifest_length = manifest_bytes.len() as i64;
+        store_ctx
+            .prefixed
+            .put(
+                &object_store::path::Path::from("metadata/data-manifest.avro"),
+                object_store::PutPayload::from(Bytes::from(manifest_bytes)),
+            )
+            .await
+            .map_err(|error| datafusion::common::DataFusionError::External(Box::new(error)))?;
+        let decoded_manifest = io_load_manifest(&store_ctx, "metadata/data-manifest.avro").await?;
+        let decoded_file = &decoded_manifest.entries()[0].data_file;
+        assert_eq!(
+            decoded_file.lower_bounds.get(&1),
+            Some(&crate::spec::Datum::new(
+                PrimitiveType::Int,
+                crate::spec::types::values::PrimitiveLiteral::Int(1),
+            ))
+        );
+        assert_eq!(
+            decoded_file.upper_bounds.get(&1),
+            Some(&crate::spec::Datum::new(
+                PrimitiveType::Int,
+                crate::spec::types::values::PrimitiveLiteral::Int(3),
+            ))
+        );
+        let mut manifest_list_writer = ManifestListWriter::new();
+        manifest_list_writer.append(manifest_file);
+        let manifest_list_bytes = manifest_list_writer
+            .to_bytes(FormatVersion::V2)
+            .map_err(datafusion::common::DataFusionError::Execution)?;
+        store_ctx
+            .prefixed
+            .put(
+                &object_store::path::Path::from("metadata/snap-data.avro"),
+                object_store::PutPayload::from(Bytes::from(manifest_list_bytes)),
+            )
+            .await
+            .map_err(|error| datafusion::common::DataFusionError::External(Box::new(error)))?;
+        let snapshot = SnapshotBuilder::new()
+            .with_snapshot_id(snapshot_id)
+            .with_sequence_number(sequence_number)
+            .with_manifest_list("metadata/snap-data.avro")
+            .with_summary(crate::spec::snapshots::Summary::new(
+                crate::spec::Operation::Append,
+            ))
+            .with_schema_id(schema.schema_id())
+            .build()
+            .map_err(datafusion::common::DataFusionError::Execution)?;
+        let provider = IcebergTableProvider::new(
+            table_url.clone(),
+            schema,
+            snapshot,
+            vec![partition_spec],
+            0,
+        )?;
+        let context = SessionContext::new();
+        context.runtime_env().register_object_store(
+            &Url::parse("memory://bounded-delete")
+                .map_err(|error| datafusion::common::DataFusionError::Plan(error.to_string()))?,
+            object_store,
+        );
+        let condition = ExprWithSource::new(
+            datafusion_expr::col("id").eq(datafusion_expr::lit(999_i32)),
+            Some("id = 999".to_string()),
+        );
+        let loaded_manifest_list = provider.load_manifest_list(&store_ctx).await?;
+        let candidates = provider
+            .load_data_files_with_seq(
+                &context.state(),
+                std::slice::from_ref(&condition.expr),
+                &store_ctx,
+                &loaded_manifest_list,
+            )
+            .await?;
+        assert!(candidates.is_empty());
+
+        let plan = provider
+            .build_cow_delete_plan(
+                &context.state(),
+                Some(condition),
+                IcebergWriterExecOptions::default(),
+            )
+            .await?;
+        let commit = plan.downcast_ref::<IcebergCommitExec>().ok_or_else(|| {
+            datafusion::common::DataFusionError::Internal(
+                "delete plan root must be IcebergCommitExec".to_string(),
+            )
+        })?;
+
+        assert!(commit.removed_data_file_paths().is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn empty_table_delete_plan_preserves_strict_empty_snapshot_validation() -> Result<()> {
+        let provider = IcebergTableProvider::new_empty(
+            "file:///tmp/iceberg-empty-delete",
+            test_schema()?,
+            vec![PartitionSpec::unpartitioned_spec()],
+            0,
+        )?;
+        let context = SessionContext::new();
+        let plan = provider
+            .build_cow_delete_plan(&context.state(), None, IcebergWriterExecOptions::default())
+            .await?;
+        let commit = plan.downcast_ref::<IcebergCommitExec>().ok_or_else(|| {
+            datafusion::common::DataFusionError::Internal(
+                "delete plan root must be IcebergCommitExec".to_string(),
+            )
+        })?;
+
+        assert_eq!(commit.expected_snapshot_id(), Some(None));
+        assert_eq!(
+            commit.operation_override(),
+            Some(&crate::spec::Operation::Delete)
+        );
+        assert!(commit.removed_data_file_paths().is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn delete_survivors_retain_false_and_null_predicate_rows() -> Result<()> {
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("matches", DataType::Boolean, true),
+            Field::new("id", DataType::Int64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(BooleanArray::from(vec![Some(true), Some(false), None])),
+                Arc::new(Int64Array::from(vec![1, 2, 3])),
+            ],
+        )?;
+        let input: Arc<dyn ExecutionPlan> =
+            MemorySourceConfig::try_new_from_batches(schema, vec![batch])?;
+        let context = SessionContext::new();
+        let survivors = IcebergTableProvider::retain_delete_survivors(
+            &context.state(),
+            input,
+            Some(ExprWithSource::new(
+                datafusion_expr::col("matches"),
+                Some("matches".to_string()),
+            )),
+        )?;
+
+        let batches = datafusion::physical_plan::collect(survivors, context.task_ctx()).await?;
+        let mut ids = Vec::new();
+        for batch in &batches {
+            let array = batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .ok_or_else(|| {
+                    datafusion::common::DataFusionError::Internal(
+                        "id column must remain Int64".to_string(),
+                    )
+                })?;
+            ids.extend(array.values().iter().copied());
+        }
+        assert_eq!(ids, vec![2, 3]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn conditionless_delete_retains_no_rows() -> Result<()> {
+        let schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "id",
+            DataType::Int64,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int64Array::from(vec![1, 2, 3]))],
+        )?;
+        let input: Arc<dyn ExecutionPlan> =
+            MemorySourceConfig::try_new_from_batches(schema, vec![batch])?;
+        let context = SessionContext::new();
+        let survivors =
+            IcebergTableProvider::retain_delete_survivors(&context.state(), input, None)?;
+
+        let batches = datafusion::physical_plan::collect(survivors, context.task_ctx()).await?;
+        assert!(batches.is_empty());
+        Ok(())
     }
 }

--- a/crates/sail-iceberg/src/datasource/provider.rs
+++ b/crates/sail-iceberg/src/datasource/provider.rs
@@ -31,7 +31,9 @@ use datafusion::logical_expr::{
     BinaryExpr, Expr, LogicalPlan, Operator, TableProviderFilterPushDown,
 };
 use datafusion::physical_expr::PhysicalExpr;
-use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::expressions::{
+    BinaryExpr as PhysicalBinaryExpr, Column, Literal as PhysicalLiteral,
+};
 use datafusion::physical_expr_adapter::PhysicalExprAdapterFactory;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::empty::EmptyExec;
@@ -754,7 +756,10 @@ impl IcebergTableProvider {
         let table_url = Url::parse(&self.table_uri)
             .map_err(|error| datafusion::common::DataFusionError::External(Box::new(error)))?;
         let expected_snapshot_id = Some(self.snapshot.as_ref().map(Snapshot::snapshot_id));
-        let (candidate_scan, removed_data_file_paths) = if self.snapshot.is_some() {
+        let (candidate_scan, removed_data_file_paths, candidate_row_count) = if self
+            .snapshot
+            .is_some()
+        {
             let object_store = get_object_store_from_session(session, &table_url)?;
             let store_ctx = StoreContext::new(object_store, &table_url)?;
             let manifest_list = self.load_manifest_list(&store_ctx).await?;
@@ -776,6 +781,13 @@ impl IcebergTableProvider {
                 .into_iter()
                 .map(|(data_file, _)| data_file)
                 .collect::<Vec<_>>();
+            let candidate_row_count = candidates.iter().try_fold(0_u64, |count, data_file| {
+                count.checked_add(data_file.record_count()).ok_or_else(|| {
+                    datafusion::common::DataFusionError::Execution(
+                        "Iceberg DELETE candidate row count overflow".to_string(),
+                    )
+                })
+            })?;
             let removed_data_file_paths = candidates
                 .iter()
                 .map(|data_file| data_file.file_path.clone())
@@ -783,11 +795,13 @@ impl IcebergTableProvider {
             (
                 self.scan_data_files(session, &store_ctx, candidates)?,
                 removed_data_file_paths,
+                candidate_row_count,
             )
         } else {
             (
                 Arc::new(EmptyExec::new(self.arrow_schema.clone())) as Arc<dyn ExecutionPlan>,
                 vec![],
+                0,
             )
         };
         let survivor_plan = Self::retain_delete_survivors(session, candidate_scan, condition)?;
@@ -797,7 +811,7 @@ impl IcebergTableProvider {
             table_exists: true,
             options: writer_options,
         };
-        IcebergPlanBuilder::new(
+        let commit_plan = IcebergPlanBuilder::new(
             survivor_plan,
             table_config,
             PhysicalSinkMode::Append,
@@ -808,7 +822,24 @@ impl IcebergTableProvider {
         .with_expected_snapshot_id(expected_snapshot_id)
         .with_rewrite_data_files(removed_data_file_paths, crate::spec::Operation::Delete)
         .build()
-        .await
+        .await?;
+
+        // The writer/commit plan returns the number of survivor rows rewritten.
+        // Spark DELETE must instead report affected rows. Every row in a candidate
+        // data file is either emitted as a survivor or matched by the predicate,
+        // so candidate rows minus rewritten survivors is the exact delete count,
+        // including conservative metric-pruning false positives.
+        let affected_count: Arc<dyn PhysicalExpr> = Arc::new(PhysicalBinaryExpr::new(
+            Arc::new(PhysicalLiteral::new(ScalarValue::UInt64(Some(
+                candidate_row_count,
+            )))),
+            Operator::Minus,
+            Arc::new(Column::new("count", 0)),
+        ));
+        Ok(Arc::new(ProjectionExec::try_new(
+            vec![(affected_count, "count".to_string())],
+            commit_plan,
+        )?))
     }
 }
 
@@ -1653,11 +1684,19 @@ mod tests {
                 IcebergWriterExecOptions::default(),
             )
             .await?;
-        let commit = plan.downcast_ref::<IcebergCommitExec>().ok_or_else(|| {
+        let projection = plan.downcast_ref::<ProjectionExec>().ok_or_else(|| {
             datafusion::common::DataFusionError::Internal(
-                "delete plan root must be IcebergCommitExec".to_string(),
+                "delete plan root must project the affected row count".to_string(),
             )
         })?;
+        let commit = projection
+            .input()
+            .downcast_ref::<IcebergCommitExec>()
+            .ok_or_else(|| {
+                datafusion::common::DataFusionError::Internal(
+                    "delete count projection input must be IcebergCommitExec".to_string(),
+                )
+            })?;
 
         assert!(commit.removed_data_file_paths().is_empty());
         Ok(())
@@ -1675,11 +1714,19 @@ mod tests {
         let plan = provider
             .build_cow_delete_plan(&context.state(), None, IcebergWriterExecOptions::default())
             .await?;
-        let commit = plan.downcast_ref::<IcebergCommitExec>().ok_or_else(|| {
+        let projection = plan.downcast_ref::<ProjectionExec>().ok_or_else(|| {
             datafusion::common::DataFusionError::Internal(
-                "delete plan root must be IcebergCommitExec".to_string(),
+                "delete plan root must project the affected row count".to_string(),
             )
         })?;
+        let commit = projection
+            .input()
+            .downcast_ref::<IcebergCommitExec>()
+            .ok_or_else(|| {
+                datafusion::common::DataFusionError::Internal(
+                    "delete count projection input must be IcebergCommitExec".to_string(),
+                )
+            })?;
 
         assert_eq!(commit.expected_snapshot_id(), Some(None));
         assert_eq!(

--- a/crates/sail-iceberg/src/datasource/pruning.rs
+++ b/crates/sail-iceberg/src/datasource/pruning.rs
@@ -148,10 +148,10 @@ impl PruningStatistics for IcebergPruningStats {
         if let Some(arr) = self.nulls_cache.borrow().get(&field_id) {
             return Some(arr.clone());
         }
-        let counts: Vec<u64> = self
+        let counts: Vec<Option<u64>> = self
             .files
             .iter()
-            .map(|f| f.null_value_counts().get(&field_id).copied().unwrap_or(0))
+            .map(|f| f.null_value_counts().get(&field_id).copied())
             .collect();
         let arr: ArrayRef = Arc::new(UInt64Array::from(counts));
         self.nulls_cache.borrow_mut().insert(field_id, arr.clone());
@@ -171,30 +171,11 @@ impl PruningStatistics for IcebergPruningStats {
     fn contained(
         &self,
         _column: &Column,
-        _value: &std::collections::HashSet<datafusion::common::scalar::ScalarValue>,
+        _values: &std::collections::HashSet<datafusion::common::scalar::ScalarValue>,
     ) -> Option<BooleanArray> {
-        let field_id = self.field_id_for(_column)?;
-        let mut result = Vec::with_capacity(self.files.len());
-        for f in &self.files {
-            let lower = f.lower_bounds().get(&field_id);
-            let upper = f.upper_bounds().get(&field_id);
-            if let (Some(lb), Some(ub)) = (lower, upper) {
-                let lb_sv = self.datum_to_scalar_for_field(field_id, lb);
-                let ub_sv = self.datum_to_scalar_for_field(field_id, ub);
-                let mut any_match = false;
-                for v in _value.iter() {
-                    if &lb_sv == v && &ub_sv == v {
-                        any_match = true;
-                        break;
-                    }
-                }
-                result.push(any_match);
-            } else {
-                // If stats are missing, we cannot safely prune the file.
-                result.push(true);
-            }
-        }
-        Some(BooleanArray::from(result))
+        // Iceberg min/max bounds cannot prove set containment or disjointness in general.
+        // Returning unknown lets DataFusion use the independent min/max statistics safely.
+        None
     }
 }
 
@@ -807,4 +788,174 @@ fn collect_source_range_filters(
         visit_expr(&mut result, schema, expr);
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::array::Array;
+    use datafusion::arrow::datatypes::{DataType, Field};
+    use datafusion::prelude::SessionContext;
+
+    use super::*;
+    use crate::spec::manifest::{DataContentType, DataFileFormat};
+    use crate::spec::types::NestedField;
+
+    fn test_schema() -> Result<Schema> {
+        Schema::builder()
+            .with_schema_id(0)
+            .with_fields(vec![Arc::new(NestedField::required(
+                1,
+                "id",
+                Type::Primitive(PrimitiveType::Long),
+            ))])
+            .build()
+            .map_err(datafusion::common::DataFusionError::Execution)
+    }
+
+    fn test_int_schema() -> Result<Schema> {
+        Schema::builder()
+            .with_schema_id(0)
+            .with_fields(vec![Arc::new(NestedField::optional(
+                1,
+                "id",
+                Type::Primitive(PrimitiveType::Int),
+            ))])
+            .build()
+            .map_err(datafusion::common::DataFusionError::Execution)
+    }
+
+    fn data_file(
+        path: &str,
+        lower: Option<i64>,
+        upper: Option<i64>,
+        null_count: Option<u64>,
+    ) -> DataFile {
+        let bound = |value| Datum::new(PrimitiveType::Long, PrimitiveLiteral::Long(value));
+        DataFile {
+            content: DataContentType::Data,
+            file_path: path.to_string(),
+            file_format: DataFileFormat::Parquet,
+            partition: vec![],
+            record_count: 2,
+            file_size_in_bytes: 100,
+            column_sizes: HashMap::new(),
+            value_counts: HashMap::new(),
+            null_value_counts: null_count
+                .map(|count| HashMap::from([(1, count)]))
+                .unwrap_or_default(),
+            nan_value_counts: HashMap::new(),
+            lower_bounds: lower
+                .map(|value| HashMap::from([(1, bound(value))]))
+                .unwrap_or_default(),
+            upper_bounds: upper
+                .map(|value| HashMap::from([(1, bound(value))]))
+                .unwrap_or_default(),
+            block_size_in_bytes: None,
+            key_metadata: None,
+            split_offsets: vec![],
+            equality_ids: vec![],
+            sort_order_id: None,
+            first_row_id: None,
+            partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
+        }
+    }
+
+    #[test]
+    fn ranged_file_is_not_pruned_for_equality_inside_bounds() -> Result<()> {
+        let files = vec![
+            data_file("data/matching.parquet", Some(1), Some(2), Some(0)),
+            data_file("data/non-matching.parquet", Some(3), Some(4), Some(0)),
+        ];
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "id",
+            DataType::Int64,
+            false,
+        )]));
+        let context = SessionContext::new();
+        let iceberg_schema = test_schema()?;
+
+        let (kept, _) = prune_files(
+            &context.state(),
+            &[datafusion_expr::col("id").eq(datafusion_expr::lit(1_i64))],
+            None,
+            arrow_schema,
+            files,
+            &iceberg_schema,
+        )?;
+
+        assert_eq!(
+            kept.iter()
+                .map(|file| file.file_path.as_str())
+                .collect::<Vec<_>>(),
+            vec!["data/matching.parquet"]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn int_file_is_pruned_for_equality_outside_bounds() -> Result<()> {
+        let mut file = data_file("data/non-matching.parquet", None, None, Some(0));
+        file.lower_bounds =
+            HashMap::from([(1, Datum::new(PrimitiveType::Int, PrimitiveLiteral::Int(1)))]);
+        file.upper_bounds =
+            HashMap::from([(1, Datum::new(PrimitiveType::Int, PrimitiveLiteral::Int(3)))]);
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "id",
+            DataType::Int32,
+            true,
+        )]));
+        let context = SessionContext::new();
+        let iceberg_schema = test_int_schema()?;
+
+        let (kept, _) = prune_files(
+            &context.state(),
+            &[datafusion_expr::col("id").eq(datafusion_expr::lit(999_i32))],
+            None,
+            arrow_schema,
+            vec![file],
+            &iceberg_schema,
+        )?;
+
+        assert!(kept.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn missing_null_count_is_reported_as_unknown() -> Result<()> {
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![Field::new(
+            "id",
+            DataType::Int64,
+            true,
+        )]));
+        let iceberg_schema = test_schema()?;
+        let stats = IcebergPruningStats::new(
+            vec![
+                data_file("data/unknown.parquet", None, None, None),
+                data_file("data/no-nulls.parquet", None, None, Some(0)),
+            ],
+            arrow_schema,
+            &iceberg_schema,
+        );
+
+        let counts = stats.null_counts(&Column::from_name("id")).ok_or_else(|| {
+            datafusion::common::DataFusionError::Internal(
+                "null count statistics are unavailable".to_string(),
+            )
+        })?;
+        let counts = counts
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .ok_or_else(|| {
+                datafusion::common::DataFusionError::Internal(
+                    "null counts must be UInt64".to_string(),
+                )
+            })?;
+        assert!(counts.is_null(0));
+        assert!(!counts.is_null(1));
+        assert_eq!(counts.value(1), 0);
+        Ok(())
+    }
 }

--- a/crates/sail-iceberg/src/operations/mod.rs
+++ b/crates/sail-iceberg/src/operations/mod.rs
@@ -15,6 +15,7 @@ pub mod append;
 pub mod bootstrap;
 pub mod helpers;
 pub mod overwrite;
+pub mod rewrite;
 pub mod snapshot;
 pub mod write;
 
@@ -22,6 +23,7 @@ pub use action::*;
 pub use append::*;
 pub use bootstrap::*;
 pub use overwrite::*;
+pub use rewrite::*;
 pub use snapshot::*;
 
 use crate::spec::Snapshot;

--- a/crates/sail-iceberg/src/operations/rewrite.rs
+++ b/crates/sail-iceberg/src/operations/rewrite.rs
@@ -1,0 +1,41 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::SnapshotProduceOperation;
+
+/// A snapshot operation that replaces a specific set of live data files.
+#[derive(Debug, Clone)]
+pub struct RewriteFilesOperation {
+    deleted_data_file_paths: Vec<String>,
+}
+
+impl RewriteFilesOperation {
+    pub fn new(deleted_data_file_paths: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            deleted_data_file_paths: deleted_data_file_paths.into_iter().collect(),
+        }
+    }
+
+    pub fn deleted_data_file_paths(&self) -> &[String] {
+        &self.deleted_data_file_paths
+    }
+}
+
+impl SnapshotProduceOperation for RewriteFilesOperation {
+    fn operation(&self) -> &'static str {
+        "overwrite"
+    }
+
+    fn deleted_data_file_paths_for_rewrite(&self) -> Option<&[String]> {
+        Some(&self.deleted_data_file_paths)
+    }
+}

--- a/crates/sail-iceberg/src/operations/rewrite.rs
+++ b/crates/sail-iceberg/src/operations/rewrite.rs
@@ -39,3 +39,32 @@ impl SnapshotProduceOperation for RewriteFilesOperation {
         Some(&self.deleted_data_file_paths)
     }
 }
+
+/// A snapshot operation that removes and optionally replaces specific live data files as a
+/// logical row-level delete.
+#[derive(Debug, Clone)]
+pub struct DeleteFilesOperation {
+    deleted_data_file_paths: Vec<String>,
+}
+
+impl DeleteFilesOperation {
+    pub fn new(deleted_data_file_paths: impl IntoIterator<Item = String>) -> Self {
+        Self {
+            deleted_data_file_paths: deleted_data_file_paths.into_iter().collect(),
+        }
+    }
+
+    pub fn deleted_data_file_paths(&self) -> &[String] {
+        &self.deleted_data_file_paths
+    }
+}
+
+impl SnapshotProduceOperation for DeleteFilesOperation {
+    fn operation(&self) -> &'static str {
+        "delete"
+    }
+
+    fn deleted_data_file_paths_for_rewrite(&self) -> Option<&[String]> {
+        Some(&self.deleted_data_file_paths)
+    }
+}

--- a/crates/sail-iceberg/src/operations/snapshot.rs
+++ b/crates/sail-iceberg/src/operations/snapshot.rs
@@ -10,21 +10,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
+
 use bytes::Bytes;
 use object_store::ObjectStoreExt;
 
 use super::{ActionCommit, Transaction};
 use crate::io::StoreContext;
-use crate::spec::manifest::ManifestWriterBuilder;
+use crate::spec::manifest::{ManifestEntry, ManifestStatus, ManifestWriter, ManifestWriterBuilder};
 use crate::spec::manifest_list::ManifestListWriter;
 use crate::spec::{
-    DataFile, FormatVersion, MAIN_BRANCH, ManifestContentType, Operation, PartitionSpec, Schema,
-    SnapshotBuilder, SnapshotReference, SnapshotRetention, TableRequirement, TableUpdate,
+    DataFile, FormatVersion, MAIN_BRANCH, ManifestContentType, ManifestFile, Operation,
+    PartitionSpec, Schema, SnapshotBuilder, SnapshotReference, SnapshotRetention, TableRequirement,
+    TableUpdate,
 };
 use crate::utils::join_table_uri;
 
 pub trait SnapshotProduceOperation: Send + Sync {
     fn operation(&self) -> &'static str;
+
+    fn deleted_data_file_paths_for_rewrite(&self) -> Option<&[String]> {
+        None
+    }
 }
 
 pub struct SnapshotProducer<'a> {
@@ -78,14 +85,211 @@ impl<'a> SnapshotProducer<'a> {
         Ok(())
     }
 
+    async fn write_manifest(
+        &self,
+        store_ctx: &StoreContext,
+        writer: ManifestWriter,
+        sequence_number: i64,
+        snapshot_id: i64,
+        first_row_id: Option<i64>,
+    ) -> Result<ManifestFile, String> {
+        let manifest_bytes = writer.to_avro_bytes_v2()?;
+        let manifest_len = i64::try_from(manifest_bytes.len())
+            .map_err(|_| "manifest length exceeds i64".to_string())?;
+        let manifest_rel = format!("metadata/manifest-{}.avro", uuid::Uuid::new_v4());
+        let mut manifest_file = writer.into_manifest_file(
+            join_table_uri(self.tx.table_uri(), &manifest_rel, &self.write_path_mode),
+            sequence_number,
+            snapshot_id,
+        );
+        manifest_file.manifest_length = manifest_len;
+        manifest_file.first_row_id = first_row_id;
+
+        store_ctx
+            .prefixed
+            .put(
+                &object_store::path::Path::from(manifest_rel.as_str()),
+                object_store::PutPayload::from(Bytes::from(manifest_bytes)),
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(manifest_file)
+    }
+
+    fn materialize_inherited_entry(
+        mut entry: ManifestEntry,
+        manifest_file: &ManifestFile,
+        inherited_next_row_id: &mut Option<i64>,
+    ) -> Result<ManifestEntry, String> {
+        entry.snapshot_id = entry.snapshot_id.or(Some(manifest_file.added_snapshot_id));
+        // V1 entries have no sequence columns and default to 0. In V2 and later,
+        // only Added entries may inherit sequence numbers from manifest metadata.
+        if matches!(entry.status, ManifestStatus::Added) || manifest_file.sequence_number == 0 {
+            entry.sequence_number = entry
+                .sequence_number
+                .or(Some(manifest_file.sequence_number));
+            entry.file_sequence_number = entry
+                .file_sequence_number
+                .or(Some(manifest_file.sequence_number));
+        } else if entry.sequence_number.is_none() || entry.file_sequence_number.is_none() {
+            return Err(
+                "existing and deleted manifest entries require explicit data and file sequence numbers"
+                    .to_string(),
+            );
+        }
+
+        if entry.data_file.first_row_id.is_none() {
+            entry.data_file.first_row_id = *inherited_next_row_id;
+            if let Some(next_row_id) = inherited_next_row_id {
+                let record_count = i64::try_from(entry.data_file.record_count)
+                    .map_err(|_| "data file record count exceeds i64".to_string())?;
+                *next_row_id = next_row_id
+                    .checked_add(record_count)
+                    .ok_or_else(|| "row lineage id overflow".to_string())?;
+            }
+        }
+        Ok(entry)
+    }
+
+    async fn rewrite_parent_manifests(
+        &self,
+        store_ctx: &StoreContext,
+        parent_manifests: Vec<ManifestFile>,
+        deleted_data_file_paths: &HashSet<String>,
+        sequence_number: i64,
+        snapshot_id: i64,
+    ) -> Result<(Vec<ManifestFile>, i64, i64, i64, i64), String> {
+        enum PlannedManifest {
+            Reuse(ManifestFile),
+            Rewrite(ManifestWriter),
+        }
+
+        let mut planned_manifests = Vec::with_capacity(parent_manifests.len());
+        let mut found_paths = HashSet::new();
+        let mut parent_live_files = 0i64;
+        let mut parent_live_rows = 0i64;
+
+        for parent_manifest_file in parent_manifests {
+            if !matches!(parent_manifest_file.content, ManifestContentType::Data) {
+                planned_manifests.push((parent_manifest_file, None));
+                continue;
+            }
+
+            let manifest = crate::io::load_manifest(store_ctx, &parent_manifest_file.manifest_path)
+                .await
+                .map_err(|e| format!("failed to load parent manifest: {e}"))?;
+            let mut contains_deleted_path = false;
+            for entry in manifest.entries().iter().filter(|entry| {
+                matches!(
+                    entry.status,
+                    ManifestStatus::Added | ManifestStatus::Existing
+                )
+            }) {
+                parent_live_files = parent_live_files
+                    .checked_add(1)
+                    .ok_or_else(|| "parent data file count overflow".to_string())?;
+                let record_count = i64::try_from(entry.data_file.record_count)
+                    .map_err(|_| "data file record count exceeds i64".to_string())?;
+                parent_live_rows = parent_live_rows
+                    .checked_add(record_count)
+                    .ok_or_else(|| "parent record count overflow".to_string())?;
+                if deleted_data_file_paths.contains(&entry.data_file.file_path) {
+                    contains_deleted_path = true;
+                    found_paths.insert(entry.data_file.file_path.clone());
+                }
+            }
+            planned_manifests.push((
+                parent_manifest_file,
+                contains_deleted_path.then_some(manifest),
+            ));
+        }
+
+        let mut missing_paths = deleted_data_file_paths
+            .difference(&found_paths)
+            .cloned()
+            .collect::<Vec<_>>();
+        if !missing_paths.is_empty() {
+            missing_paths.sort();
+            return Err(format!(
+                "rewrite data files are not live in the parent snapshot: {}",
+                missing_paths.join(", ")
+            ));
+        }
+
+        let mut output_plan = Vec::with_capacity(planned_manifests.len());
+        let mut deleted_files = 0i64;
+        let mut deleted_rows = 0i64;
+        for (parent_manifest_file, manifest) in planned_manifests {
+            let Some(manifest) = manifest else {
+                output_plan.push(PlannedManifest::Reuse(parent_manifest_file));
+                continue;
+            };
+
+            let (entries, metadata) = manifest.into_parts();
+            let mut writer = ManifestWriterBuilder::new(Some(snapshot_id), None, metadata).build();
+            let mut inherited_next_row_id = parent_manifest_file.first_row_id;
+            for entry in entries {
+                if !matches!(
+                    entry.status,
+                    ManifestStatus::Added | ManifestStatus::Existing
+                ) {
+                    continue;
+                }
+                let entry = Self::materialize_inherited_entry(
+                    entry.as_ref().clone(),
+                    &parent_manifest_file,
+                    &mut inherited_next_row_id,
+                )?;
+                if deleted_data_file_paths.contains(&entry.data_file.file_path) {
+                    deleted_files = deleted_files
+                        .checked_add(1)
+                        .ok_or_else(|| "deleted data file count overflow".to_string())?;
+                    let record_count = i64::try_from(entry.data_file.record_count)
+                        .map_err(|_| "data file record count exceeds i64".to_string())?;
+                    deleted_rows = deleted_rows
+                        .checked_add(record_count)
+                        .ok_or_else(|| "deleted record count overflow".to_string())?;
+                    writer.add_deleted_entry(entry)?;
+                } else {
+                    writer.add_existing_entry(entry)?;
+                }
+            }
+            output_plan.push(PlannedManifest::Rewrite(writer));
+        }
+
+        let mut output_manifests = Vec::with_capacity(output_plan.len());
+        for manifest in output_plan {
+            match manifest {
+                PlannedManifest::Reuse(manifest_file) => output_manifests.push(manifest_file),
+                PlannedManifest::Rewrite(writer) => output_manifests.push(
+                    self.write_manifest(store_ctx, writer, sequence_number, snapshot_id, None)
+                        .await?,
+                ),
+            }
+        }
+
+        Ok((
+            output_manifests,
+            parent_live_files,
+            parent_live_rows,
+            deleted_files,
+            deleted_rows,
+        ))
+    }
+
     pub async fn commit(self, op: impl SnapshotProduceOperation) -> Result<ActionCommit, String> {
         let timestamp_ms = crate::utils::timestamp::monotonic_timestamp_ms();
         let is_overwrite = op.operation() == Operation::Overwrite.as_str();
-        let summary = if is_overwrite {
-            crate::spec::snapshots::Summary::new(Operation::Overwrite)
-        } else {
-            crate::spec::snapshots::Summary::new(Operation::Append)
-        };
+        let deleted_data_file_paths = op
+            .deleted_data_file_paths_for_rewrite()
+            .map(|paths| paths.iter().cloned().collect::<HashSet<_>>());
+        if deleted_data_file_paths
+            .as_ref()
+            .is_some_and(HashSet::is_empty)
+        {
+            return Err("rewrite requires at least one data file path to delete".to_string());
+        }
+        let is_rewrite = deleted_data_file_paths.is_some();
 
         // Build manifest metadata: prefer caller-provided metadata derived from table schema/spec
         // Fall back to deriving from the current transaction snapshot if not provided
@@ -127,7 +331,10 @@ impl<'a> SnapshotProducer<'a> {
         let parent_manifest_list_path_str = parent_snapshot.manifest_list();
         let mut parent_manifest_entries = Vec::new();
 
-        if !self.is_bootstrap && !is_overwrite && !parent_manifest_list_path_str.is_empty() {
+        if !self.is_bootstrap
+            && (!is_overwrite || is_rewrite)
+            && !parent_manifest_list_path_str.is_empty()
+        {
             let (store_ref, manifest_list_path) = store_ctx
                 .resolve(parent_manifest_list_path_str)
                 .map_err(|e| format!("{}", e))?;
@@ -152,11 +359,14 @@ impl<'a> SnapshotProducer<'a> {
             parent_manifest_entries.extend(parent_manifest_list.entries().iter().cloned());
         }
 
-        let new_added_rows: i64 = self
-            .added_data_files
-            .iter()
-            .map(|df| df.record_count as i64)
-            .sum();
+        let mut new_added_rows = 0i64;
+        for data_file in &self.added_data_files {
+            let record_count = i64::try_from(data_file.record_count)
+                .map_err(|_| "data file record count exceeds i64".to_string())?;
+            new_added_rows = new_added_rows
+                .checked_add(record_count)
+                .ok_or_else(|| "added record count overflow".to_string())?;
+        }
         let mut row_lineage_next_row_id = self.row_lineage_start_row_id;
         let mut snapshot_added_rows = 0;
 
@@ -179,48 +389,53 @@ impl<'a> SnapshotProducer<'a> {
             snapshot_added_rows += new_added_rows;
         }
 
-        let mut writer = ManifestWriterBuilder::new(None, None, metadata.clone()).build();
         let added_data_files = self.added_data_files.clone();
-        for df in &added_data_files {
-            writer.add(df.clone());
-        }
-        let manifest = writer.finish();
-        let manifest_bytes = manifest.to_avro_bytes_v2()?;
-
-        let manifest_len = manifest_bytes.len() as i64;
-        let manifest_rel = format!("metadata/manifest-{}.avro", uuid::Uuid::new_v4());
-        let manifest_path = object_store::path::Path::from(manifest_rel.as_str());
-        store_ctx
-            .prefixed
-            .put(
-                &manifest_path,
-                object_store::PutPayload::from(Bytes::from(manifest_bytes)),
+        let added_files = i64::try_from(added_data_files.len())
+            .map_err(|_| "added data file count exceeds i64".to_string())?;
+        let (
+            parent_manifest_entries,
+            parent_live_files,
+            parent_live_rows,
+            deleted_files,
+            deleted_rows,
+        ) = if let Some(paths) = deleted_data_file_paths.as_ref() {
+            self.rewrite_parent_manifests(
+                store_ctx,
+                parent_manifest_entries,
+                paths,
+                new_sequence_number,
+                new_snapshot_id,
             )
-            .await
-            .map_err(|e| format!("{}", e))?;
+            .await?
+        } else {
+            (parent_manifest_entries, 0, 0, 0, 0)
+        };
 
-        let mut manifest_file_builder = crate::spec::manifest_list::ManifestFile::builder()
-            .with_manifest_path(join_table_uri(
-                self.tx.table_uri(),
-                &manifest_rel,
-                &self.write_path_mode,
-            ))
-            .with_manifest_length(manifest_len)
-            .with_partition_spec_id(metadata.partition_spec.spec_id())
-            .with_content(ManifestContentType::Data)
-            .with_sequence_number(new_sequence_number)
-            .with_min_sequence_number(new_sequence_number)
-            .with_added_snapshot_id(new_snapshot_id)
-            .with_file_counts(added_data_files.len() as i32, 0, 0)
-            .with_row_counts(new_added_rows, 0, 0);
-        if let Some(first_row_id) = new_manifest_first_row_id {
-            manifest_file_builder = manifest_file_builder.with_first_row_id(first_row_id);
+        let mut summary = if is_overwrite {
+            crate::spec::snapshots::Summary::new(Operation::Overwrite)
+        } else {
+            crate::spec::snapshots::Summary::new(Operation::Append)
+        };
+        if is_rewrite {
+            let total_data_files = parent_live_files
+                .checked_sub(deleted_files)
+                .and_then(|count| count.checked_add(added_files))
+                .ok_or_else(|| "total data file count overflow".to_string())?;
+            let total_records = parent_live_rows
+                .checked_sub(deleted_rows)
+                .and_then(|count| count.checked_add(new_added_rows))
+                .ok_or_else(|| "total record count overflow".to_string())?;
+            summary = summary
+                .with_property("added-data-files", added_files)
+                .with_property("deleted-data-files", deleted_files)
+                .with_property("added-records", new_added_rows)
+                .with_property("deleted-records", deleted_rows)
+                .with_property("total-data-files", total_data_files)
+                .with_property("total-records", total_records);
         }
-        let manifest_file = manifest_file_builder.build()?;
 
         let mut list_writer = ManifestListWriter::new();
-        let mut total_manifest_count = 0;
-
+        let mut total_manifest_count = 0usize;
         for entry in parent_manifest_entries {
             list_writer.append(entry);
             total_manifest_count += 1;
@@ -233,8 +448,23 @@ impl<'a> SnapshotProducer<'a> {
             self.tx.snapshot().snapshot_id()
         );
 
-        list_writer.append(manifest_file);
-        total_manifest_count += 1;
+        if !is_rewrite || !added_data_files.is_empty() {
+            let mut writer = ManifestWriterBuilder::new(None, None, metadata.clone()).build();
+            for data_file in added_data_files {
+                writer.add(data_file);
+            }
+            list_writer.append(
+                self.write_manifest(
+                    store_ctx,
+                    writer,
+                    new_sequence_number,
+                    new_snapshot_id,
+                    new_manifest_first_row_id,
+                )
+                .await?,
+            );
+            total_manifest_count += 1;
+        }
         log::trace!(
             "snapshot producer: new manifest list will have files: {}",
             total_manifest_count
@@ -313,5 +543,649 @@ impl<'a> SnapshotProducer<'a> {
         }];
 
         Ok(ActionCommit::new(updates, requirements))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::unwrap_used)]
+
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use datafusion::arrow::array::Int64Array;
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::datasource::TableProvider;
+    use datafusion::prelude::SessionContext;
+    use futures::TryStreamExt;
+    use object_store::memory::InMemory;
+    use parquet::arrow::ArrowWriter;
+    use url::Url;
+
+    use super::*;
+    use crate::datasource::IcebergTableProvider;
+    use crate::datasource::type_converter::iceberg_schema_to_arrow;
+    use crate::io::{load_manifest, load_manifest_list};
+    use crate::operations::RewriteFilesOperation;
+    use crate::spec::manifest::{ManifestEntry, ManifestStatus};
+    use crate::spec::types::{NestedField, PrimitiveType, Type};
+    use crate::spec::{DataContentType, DataFileFormat, ManifestListWriter};
+    use crate::utils::WritePathMode;
+
+    fn test_schema() -> Schema {
+        Schema::builder()
+            .with_schema_id(0)
+            .with_fields(vec![Arc::new(NestedField::required(
+                1,
+                "id",
+                Type::Primitive(PrimitiveType::Long),
+            ))])
+            .build()
+            .unwrap()
+    }
+
+    fn data_file(path: &str, record_count: u64, file_size_in_bytes: u64) -> DataFile {
+        DataFile {
+            content: DataContentType::Data,
+            file_path: path.to_string(),
+            file_format: DataFileFormat::Parquet,
+            partition: vec![],
+            record_count,
+            file_size_in_bytes,
+            column_sizes: HashMap::new(),
+            value_counts: HashMap::new(),
+            null_value_counts: HashMap::new(),
+            nan_value_counts: HashMap::new(),
+            lower_bounds: HashMap::new(),
+            upper_bounds: HashMap::new(),
+            block_size_in_bytes: None,
+            key_metadata: None,
+            split_offsets: vec![],
+            equality_ids: vec![],
+            sort_order_id: None,
+            first_row_id: None,
+            partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
+        }
+    }
+
+    fn parquet_bytes(schema: Arc<datafusion::arrow::datatypes::Schema>, ids: Vec<i64>) -> Vec<u8> {
+        let batch =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(Int64Array::from(ids))]).unwrap();
+        let mut bytes = Vec::new();
+        let mut writer = ArrowWriter::try_new(&mut bytes, schema, None).unwrap();
+        writer.write(&batch).unwrap();
+        writer.close().unwrap();
+        bytes
+    }
+
+    struct SingleFileParent {
+        store_ctx: StoreContext,
+        manifest_metadata: crate::spec::manifest::ManifestMetadata,
+        tx: Transaction,
+        live_file: DataFile,
+    }
+
+    async fn single_file_parent(table_url: &str) -> SingleFileParent {
+        let table_url = Url::parse(table_url).unwrap();
+        let object_store = Arc::new(InMemory::new());
+        let store_ctx = StoreContext::new(object_store, &table_url).unwrap();
+        let schema = test_schema();
+        let partition_spec = PartitionSpec::builder().with_spec_id(0).build();
+        let manifest_metadata = crate::spec::manifest::ManifestMetadata::new(
+            Arc::new(schema.clone()),
+            schema.schema_id(),
+            partition_spec,
+            FormatVersion::V2,
+            ManifestContentType::Data,
+        );
+        let parent_snapshot_id = 10;
+        let parent_sequence_number = 1;
+        let live_file = data_file("data/live.parquet", 1, 100);
+        let mut parent_writer =
+            ManifestWriterBuilder::new(Some(parent_snapshot_id), None, manifest_metadata.clone())
+                .build();
+        parent_writer.add(live_file.clone());
+        let parent_manifest_bytes = parent_writer.to_avro_bytes_v2().unwrap();
+        let mut parent_manifest_file = parent_writer.into_manifest_file(
+            "metadata/manifest-parent.avro".to_string(),
+            parent_sequence_number,
+            parent_snapshot_id,
+        );
+        parent_manifest_file.manifest_length = parent_manifest_bytes.len() as i64;
+        store_ctx
+            .prefixed
+            .put(
+                &object_store::path::Path::from("metadata/manifest-parent.avro"),
+                object_store::PutPayload::from(Bytes::from(parent_manifest_bytes)),
+            )
+            .await
+            .unwrap();
+
+        let mut parent_list_writer = ManifestListWriter::new();
+        parent_list_writer.append(parent_manifest_file);
+        let parent_list_bytes = parent_list_writer.to_bytes(FormatVersion::V2).unwrap();
+        store_ctx
+            .prefixed
+            .put(
+                &object_store::path::Path::from("metadata/snap-parent.avro"),
+                object_store::PutPayload::from(Bytes::from(parent_list_bytes)),
+            )
+            .await
+            .unwrap();
+
+        let parent_snapshot = SnapshotBuilder::new()
+            .with_snapshot_id(parent_snapshot_id)
+            .with_sequence_number(parent_sequence_number)
+            .with_manifest_list("metadata/snap-parent.avro")
+            .with_summary(crate::spec::snapshots::Summary::new(Operation::Append))
+            .with_schema_id(schema.schema_id())
+            .build()
+            .unwrap();
+        let tx = Transaction::new(table_url.to_string(), parent_snapshot);
+        SingleFileParent {
+            store_ctx,
+            manifest_metadata,
+            tx,
+            live_file,
+        }
+    }
+
+    #[test]
+    fn inherited_row_ids_do_not_advance_for_preassigned_files() {
+        let parent_manifest = ManifestFile::builder()
+            .with_manifest_path("metadata/parent.avro")
+            .with_sequence_number(1)
+            .with_min_sequence_number(1)
+            .with_added_snapshot_id(10)
+            .with_file_counts(2, 0, 0)
+            .with_row_counts(15, 0, 0)
+            .with_first_row_id(100)
+            .build()
+            .unwrap();
+        let mut assigned_file = data_file("data/assigned.parquet", 10, 100);
+        assigned_file.first_row_id = Some(50);
+        let assigned_entry = ManifestEntry::new(
+            ManifestStatus::Added,
+            Some(10),
+            Some(1),
+            Some(1),
+            assigned_file,
+        );
+        let unassigned_entry = ManifestEntry::new(
+            ManifestStatus::Added,
+            Some(10),
+            Some(1),
+            Some(1),
+            data_file("data/unassigned.parquet", 5, 100),
+        );
+        let mut inherited_next_row_id = parent_manifest.first_row_id;
+
+        let assigned_entry = SnapshotProducer::<'static>::materialize_inherited_entry(
+            assigned_entry,
+            &parent_manifest,
+            &mut inherited_next_row_id,
+        )
+        .unwrap();
+        let unassigned_entry = SnapshotProducer::<'static>::materialize_inherited_entry(
+            unassigned_entry,
+            &parent_manifest,
+            &mut inherited_next_row_id,
+        )
+        .unwrap();
+
+        assert_eq!(assigned_entry.data_file.first_row_id, Some(50));
+        assert_eq!(unassigned_entry.data_file.first_row_id, Some(100));
+        assert_eq!(inherited_next_row_id, Some(105));
+    }
+
+    #[test]
+    fn existing_entries_only_inherit_sequence_numbers_for_v1() {
+        let parent_manifest = ManifestFile::builder()
+            .with_manifest_path("metadata/parent.avro")
+            .with_sequence_number(2)
+            .with_min_sequence_number(1)
+            .with_added_snapshot_id(20)
+            .with_file_counts(0, 1, 0)
+            .with_row_counts(0, 1, 0)
+            .build()
+            .unwrap();
+        let entry = ManifestEntry::new(
+            ManifestStatus::Existing,
+            Some(10),
+            None,
+            None,
+            data_file("data/existing.parquet", 1, 100),
+        );
+
+        let result = SnapshotProducer::<'static>::materialize_inherited_entry(
+            entry,
+            &parent_manifest,
+            &mut None,
+        );
+
+        assert!(matches!(
+            result,
+            Err(message) if message.contains("sequence numbers")
+        ));
+
+        let mut v1_manifest = parent_manifest;
+        v1_manifest.sequence_number = 0;
+        let v1_entry = ManifestEntry::new(
+            ManifestStatus::Existing,
+            Some(10),
+            None,
+            None,
+            data_file("data/v1-existing.parquet", 1, 100),
+        );
+        let v1_entry = SnapshotProducer::<'static>::materialize_inherited_entry(
+            v1_entry,
+            &v1_manifest,
+            &mut None,
+        )
+        .unwrap();
+        assert_eq!(v1_entry.sequence_number, Some(0));
+        assert_eq!(v1_entry.file_sequence_number, Some(0));
+    }
+
+    #[tokio::test]
+    async fn rewrite_files_marks_removed_files_and_preserves_survivor_rows() {
+        let table_url = Url::parse("memory://rewrite-test/table/").unwrap();
+        let object_store = Arc::new(InMemory::new());
+        let store_ctx = StoreContext::new(object_store.clone(), &table_url).unwrap();
+        let schema = test_schema();
+        let arrow_schema = Arc::new(iceberg_schema_to_arrow(&schema).unwrap());
+        let partition_spec = PartitionSpec::builder().with_spec_id(0).build();
+        let manifest_metadata = crate::spec::manifest::ManifestMetadata::new(
+            Arc::new(schema.clone()),
+            schema.schema_id(),
+            partition_spec.clone(),
+            FormatVersion::V2,
+            ManifestContentType::Data,
+        );
+
+        let old_bytes = parquet_bytes(arrow_schema.clone(), vec![1]);
+        let survivor_bytes = parquet_bytes(arrow_schema.clone(), vec![2]);
+        let replacement_bytes = parquet_bytes(arrow_schema.clone(), vec![3]);
+        let unaffected_bytes = parquet_bytes(arrow_schema, vec![4]);
+        store_ctx
+            .prefixed
+            .put(
+                &object_store::path::Path::from("data/old.parquet"),
+                object_store::PutPayload::from(Bytes::from(old_bytes.clone())),
+            )
+            .await
+            .unwrap();
+        store_ctx
+            .prefixed
+            .put(
+                &object_store::path::Path::from("data/survivor.parquet"),
+                object_store::PutPayload::from(Bytes::from(survivor_bytes.clone())),
+            )
+            .await
+            .unwrap();
+        store_ctx
+            .prefixed
+            .put(
+                &object_store::path::Path::from("data/replacement.parquet"),
+                object_store::PutPayload::from(Bytes::from(replacement_bytes.clone())),
+            )
+            .await
+            .unwrap();
+        store_ctx
+            .prefixed
+            .put(
+                &object_store::path::Path::from("data/unaffected.parquet"),
+                object_store::PutPayload::from(Bytes::from(unaffected_bytes.clone())),
+            )
+            .await
+            .unwrap();
+
+        let old_file = data_file("data/old.parquet", 1, old_bytes.len() as u64);
+        let survivor_file = data_file("data/survivor.parquet", 1, survivor_bytes.len() as u64);
+        let replacement_file = data_file(
+            "data/replacement.parquet",
+            1,
+            replacement_bytes.len() as u64,
+        );
+        let unaffected_file =
+            data_file("data/unaffected.parquet", 1, unaffected_bytes.len() as u64);
+
+        let parent_snapshot_id = 10;
+        let parent_sequence_number = 1;
+        let mut parent_writer =
+            ManifestWriterBuilder::new(Some(parent_snapshot_id), None, manifest_metadata.clone())
+                .build();
+        parent_writer.add(old_file.clone());
+        parent_writer.add(survivor_file.clone());
+        let parent_manifest_bytes = parent_writer.to_avro_bytes_v2().unwrap();
+        let mut parent_manifest_file = parent_writer.into_manifest_file(
+            "metadata/manifest-parent.avro".to_string(),
+            parent_sequence_number,
+            parent_snapshot_id,
+        );
+        parent_manifest_file.manifest_length = parent_manifest_bytes.len() as i64;
+        store_ctx
+            .prefixed
+            .put(
+                &object_store::path::Path::from("metadata/manifest-parent.avro"),
+                object_store::PutPayload::from(Bytes::from(parent_manifest_bytes)),
+            )
+            .await
+            .unwrap();
+
+        let mut unaffected_writer =
+            ManifestWriterBuilder::new(Some(parent_snapshot_id), None, manifest_metadata.clone())
+                .build();
+        unaffected_writer.add(unaffected_file.clone());
+        let unaffected_manifest_bytes = unaffected_writer.to_avro_bytes_v2().unwrap();
+        let mut unaffected_manifest_file = unaffected_writer.into_manifest_file(
+            "metadata/manifest-unaffected.avro".to_string(),
+            parent_sequence_number,
+            parent_snapshot_id,
+        );
+        unaffected_manifest_file.manifest_length = unaffected_manifest_bytes.len() as i64;
+        store_ctx
+            .prefixed
+            .put(
+                &object_store::path::Path::from("metadata/manifest-unaffected.avro"),
+                object_store::PutPayload::from(Bytes::from(unaffected_manifest_bytes)),
+            )
+            .await
+            .unwrap();
+
+        let delete_manifest_metadata = crate::spec::manifest::ManifestMetadata::new(
+            Arc::new(schema.clone()),
+            schema.schema_id(),
+            partition_spec.clone(),
+            FormatVersion::V2,
+            ManifestContentType::Deletes,
+        );
+        let delete_writer =
+            ManifestWriterBuilder::new(Some(parent_snapshot_id), None, delete_manifest_metadata)
+                .build();
+        let delete_manifest_bytes = delete_writer.to_avro_bytes_v2().unwrap();
+        let mut delete_manifest_file = delete_writer.into_manifest_file(
+            "metadata/manifest-deletes.avro".to_string(),
+            parent_sequence_number,
+            parent_snapshot_id,
+        );
+        delete_manifest_file.manifest_length = delete_manifest_bytes.len() as i64;
+        store_ctx
+            .prefixed
+            .put(
+                &object_store::path::Path::from("metadata/manifest-deletes.avro"),
+                object_store::PutPayload::from(Bytes::from(delete_manifest_bytes)),
+            )
+            .await
+            .unwrap();
+
+        let mut parent_list_writer = ManifestListWriter::new();
+        parent_list_writer.append(parent_manifest_file);
+        parent_list_writer.append(unaffected_manifest_file);
+        parent_list_writer.append(delete_manifest_file);
+        let parent_list_bytes = parent_list_writer.to_bytes(FormatVersion::V2).unwrap();
+        store_ctx
+            .prefixed
+            .put(
+                &object_store::path::Path::from("metadata/snap-parent.avro"),
+                object_store::PutPayload::from(Bytes::from(parent_list_bytes)),
+            )
+            .await
+            .unwrap();
+
+        let parent_snapshot = SnapshotBuilder::new()
+            .with_snapshot_id(parent_snapshot_id)
+            .with_sequence_number(parent_sequence_number)
+            .with_manifest_list("metadata/snap-parent.avro")
+            .with_summary(
+                crate::spec::snapshots::Summary::new(Operation::Append)
+                    .with_property("total-data-files", 3)
+                    .with_property("total-records", 3),
+            )
+            .with_schema_id(schema.schema_id())
+            .build()
+            .unwrap();
+        let tx = Transaction::new(table_url.to_string(), parent_snapshot);
+
+        let action_commit = SnapshotProducer::new(
+            &tx,
+            vec![replacement_file.clone()],
+            Some(store_ctx.clone()),
+            Some(manifest_metadata),
+        )
+        .with_write_path_mode(WritePathMode::Relative)
+        .commit(RewriteFilesOperation::new(vec![old_file.file_path.clone()]))
+        .await
+        .unwrap();
+
+        let new_snapshot = action_commit
+            .updates()
+            .iter()
+            .find_map(|update| match update {
+                TableUpdate::AddSnapshot { snapshot } => Some(snapshot.clone()),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(new_snapshot.parent_snapshot_id(), Some(parent_snapshot_id));
+        assert_eq!(new_snapshot.summary.operation, Operation::Overwrite);
+        assert_eq!(
+            new_snapshot
+                .summary
+                .additional_properties
+                .get("added-data-files"),
+            Some(&"1".to_string())
+        );
+        assert_eq!(
+            new_snapshot
+                .summary
+                .additional_properties
+                .get("deleted-data-files"),
+            Some(&"1".to_string())
+        );
+        assert_eq!(
+            new_snapshot
+                .summary
+                .additional_properties
+                .get("total-data-files"),
+            Some(&"3".to_string())
+        );
+        assert_eq!(
+            new_snapshot
+                .summary
+                .additional_properties
+                .get("total-records"),
+            Some(&"3".to_string())
+        );
+
+        let manifest_list = load_manifest_list(&store_ctx, new_snapshot.manifest_list())
+            .await
+            .unwrap();
+        assert!(
+            manifest_list
+                .entries()
+                .iter()
+                .any(|manifest| { manifest.manifest_path == "metadata/manifest-unaffected.avro" })
+        );
+        assert!(
+            manifest_list
+                .entries()
+                .iter()
+                .any(|manifest| { manifest.manifest_path == "metadata/manifest-deletes.avro" })
+        );
+        let mut entries_by_path = HashMap::<String, ManifestEntry>::new();
+        for manifest_file in manifest_list.entries() {
+            let manifest = load_manifest(&store_ctx, &manifest_file.manifest_path)
+                .await
+                .unwrap();
+            for entry in manifest.entries() {
+                entries_by_path.insert(entry.data_file.file_path.clone(), (**entry).clone());
+            }
+        }
+        assert_eq!(
+            entries_by_path["data/old.parquet"].status,
+            ManifestStatus::Deleted
+        );
+        assert_eq!(
+            entries_by_path["data/survivor.parquet"].status,
+            ManifestStatus::Existing
+        );
+        assert_eq!(
+            entries_by_path["data/replacement.parquet"].status,
+            ManifestStatus::Added
+        );
+        assert_eq!(
+            entries_by_path["data/replacement.parquet"].snapshot_id,
+            None
+        );
+        assert_eq!(
+            entries_by_path["data/unaffected.parquet"].status,
+            ManifestStatus::Added
+        );
+        assert_eq!(
+            entries_by_path["data/old.parquet"].snapshot_id,
+            Some(new_snapshot.snapshot_id())
+        );
+        assert_eq!(
+            entries_by_path["data/old.parquet"].sequence_number,
+            Some(parent_sequence_number)
+        );
+        assert_eq!(
+            entries_by_path["data/old.parquet"].file_sequence_number,
+            Some(parent_sequence_number)
+        );
+        assert_eq!(
+            entries_by_path["data/survivor.parquet"].snapshot_id,
+            Some(parent_snapshot_id)
+        );
+        assert_eq!(
+            entries_by_path["data/survivor.parquet"].sequence_number,
+            Some(parent_sequence_number)
+        );
+        assert_eq!(
+            entries_by_path["data/survivor.parquet"].file_sequence_number,
+            Some(parent_sequence_number)
+        );
+
+        let context = SessionContext::new();
+        context
+            .runtime_env()
+            .register_object_store(&Url::parse("memory://rewrite-test/").unwrap(), object_store);
+        let provider =
+            IcebergTableProvider::new(table_url, schema, new_snapshot, vec![partition_spec], 0)
+                .unwrap();
+        let plan = provider
+            .scan(&context.state(), None, &[], None)
+            .await
+            .unwrap();
+        let batches = datafusion::physical_plan::collect(plan, context.task_ctx())
+            .await
+            .unwrap();
+        let mut ids = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column(0)
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .unwrap()
+                    .values()
+                    .iter()
+                    .copied()
+            })
+            .collect::<Vec<_>>();
+        ids.sort_unstable();
+        assert_eq!(ids, vec![2, 3, 4]);
+    }
+
+    #[tokio::test]
+    async fn rewrite_files_rejects_paths_not_live_without_writing_orphan_manifests() {
+        let fixture = single_file_parent("memory://rewrite-missing-test/table/").await;
+
+        let result = SnapshotProducer::new(
+            &fixture.tx,
+            vec![],
+            Some(fixture.store_ctx.clone()),
+            Some(fixture.manifest_metadata),
+        )
+        .with_write_path_mode(WritePathMode::Relative)
+        .commit(RewriteFilesOperation::new(vec![
+            fixture.live_file.file_path,
+            "data/missing.parquet".to_string(),
+        ]))
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(message) if message.contains("not live in the parent snapshot")
+        ));
+        let metadata_objects = fixture
+            .store_ctx
+            .prefixed
+            .list(Some(&object_store::path::Path::from("metadata")))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(metadata_objects.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn rewrite_files_supports_pure_deletes_without_an_empty_added_manifest() {
+        let fixture = single_file_parent("memory://rewrite-pure-delete-test/table/").await;
+
+        let action_commit = SnapshotProducer::new(
+            &fixture.tx,
+            vec![],
+            Some(fixture.store_ctx.clone()),
+            Some(fixture.manifest_metadata),
+        )
+        .with_write_path_mode(WritePathMode::Relative)
+        .commit(RewriteFilesOperation::new(vec![
+            fixture.live_file.file_path,
+        ]))
+        .await
+        .unwrap();
+
+        let new_snapshot = action_commit
+            .updates()
+            .iter()
+            .find_map(|update| match update {
+                TableUpdate::AddSnapshot { snapshot } => Some(snapshot),
+                _ => None,
+            })
+            .unwrap();
+        for (key, expected) in [
+            ("added-data-files", "0"),
+            ("deleted-data-files", "1"),
+            ("added-records", "0"),
+            ("deleted-records", "1"),
+            ("total-data-files", "0"),
+            ("total-records", "0"),
+        ] {
+            assert_eq!(
+                new_snapshot
+                    .summary
+                    .additional_properties
+                    .get(key)
+                    .map(String::as_str),
+                Some(expected)
+            );
+        }
+
+        let manifest_list = load_manifest_list(&fixture.store_ctx, new_snapshot.manifest_list())
+            .await
+            .unwrap();
+        assert_eq!(manifest_list.entries().len(), 1);
+        let manifest = load_manifest(
+            &fixture.store_ctx,
+            &manifest_list.entries()[0].manifest_path,
+        )
+        .await
+        .unwrap();
+        assert_eq!(manifest.entries().len(), 1);
+        assert_eq!(manifest.entries()[0].status, ManifestStatus::Deleted);
     }
 }

--- a/crates/sail-iceberg/src/operations/snapshot.rs
+++ b/crates/sail-iceberg/src/operations/snapshot.rs
@@ -279,17 +279,28 @@ impl<'a> SnapshotProducer<'a> {
 
     pub async fn commit(self, op: impl SnapshotProduceOperation) -> Result<ActionCommit, String> {
         let timestamp_ms = crate::utils::timestamp::monotonic_timestamp_ms();
-        let is_overwrite = op.operation() == Operation::Overwrite.as_str();
+        let operation = match op.operation() {
+            "append" => Operation::Append,
+            "replace" => Operation::Replace,
+            "overwrite" => Operation::Overwrite,
+            "delete" => Operation::Delete,
+            operation => return Err(format!("unsupported snapshot operation: {operation}")),
+        };
+        let is_overwrite = matches!(operation, Operation::Overwrite);
         let deleted_data_file_paths = op
             .deleted_data_file_paths_for_rewrite()
             .map(|paths| paths.iter().cloned().collect::<HashSet<_>>());
+        let is_rewrite = deleted_data_file_paths.is_some();
+        if is_rewrite && matches!(operation, Operation::Append) {
+            return Err("selective manifest rewrite cannot use an append operation".to_string());
+        }
         if deleted_data_file_paths
             .as_ref()
             .is_some_and(HashSet::is_empty)
+            && self.added_data_files.is_empty()
         {
-            return Err("rewrite requires at least one data file path to delete".to_string());
+            return Err("rewrite requires at least one data file addition or deletion".to_string());
         }
-        let is_rewrite = deleted_data_file_paths.is_some();
 
         // Build manifest metadata: prefer caller-provided metadata derived from table schema/spec
         // Fall back to deriving from the current transaction snapshot if not provided
@@ -411,11 +422,7 @@ impl<'a> SnapshotProducer<'a> {
             (parent_manifest_entries, 0, 0, 0, 0)
         };
 
-        let mut summary = if is_overwrite {
-            crate::spec::snapshots::Summary::new(Operation::Overwrite)
-        } else {
-            crate::spec::snapshots::Summary::new(Operation::Append)
-        };
+        let mut summary = crate::spec::snapshots::Summary::new(operation);
         if is_rewrite {
             let total_data_files = parent_live_files
                 .checked_sub(deleted_files)
@@ -1102,6 +1109,147 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rewrite_paths_reject_append_operation() {
+        struct AppendWithRewritePaths {
+            paths: Vec<String>,
+        }
+
+        impl SnapshotProduceOperation for AppendWithRewritePaths {
+            fn operation(&self) -> &'static str {
+                Operation::Append.as_str()
+            }
+
+            fn deleted_data_file_paths_for_rewrite(&self) -> Option<&[String]> {
+                Some(&self.paths)
+            }
+        }
+
+        let fixture = single_file_parent("memory://rewrite-operation-test/table/").await;
+        let result = SnapshotProducer::new(
+            &fixture.tx,
+            vec![],
+            Some(fixture.store_ctx),
+            Some(fixture.manifest_metadata),
+        )
+        .with_write_path_mode(WritePathMode::Relative)
+        .commit(AppendWithRewritePaths {
+            paths: vec![fixture.live_file.file_path],
+        })
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(message) if message.contains("cannot use an append operation")
+        ));
+    }
+
+    #[tokio::test]
+    async fn rewrite_paths_preserve_delete_snapshot_operation() {
+        struct DeleteWithRewritePaths {
+            paths: Vec<String>,
+        }
+
+        impl SnapshotProduceOperation for DeleteWithRewritePaths {
+            fn operation(&self) -> &'static str {
+                Operation::Delete.as_str()
+            }
+
+            fn deleted_data_file_paths_for_rewrite(&self) -> Option<&[String]> {
+                Some(&self.paths)
+            }
+        }
+
+        let fixture = single_file_parent("memory://rewrite-delete-operation-test/table/").await;
+        let action_commit = SnapshotProducer::new(
+            &fixture.tx,
+            vec![],
+            Some(fixture.store_ctx),
+            Some(fixture.manifest_metadata),
+        )
+        .with_write_path_mode(WritePathMode::Relative)
+        .commit(DeleteWithRewritePaths {
+            paths: vec![fixture.live_file.file_path],
+        })
+        .await
+        .unwrap();
+        let operation = action_commit
+            .updates()
+            .iter()
+            .find_map(|update| match update {
+                TableUpdate::AddSnapshot { snapshot } => Some(&snapshot.summary.operation),
+                _ => None,
+            });
+
+        assert_eq!(operation, Some(&Operation::Delete));
+    }
+
+    #[tokio::test]
+    async fn rewrite_files_rejects_empty_additions_and_deletions() {
+        let fixture = single_file_parent("memory://rewrite-empty-test/table/").await;
+        let result = SnapshotProducer::new(
+            &fixture.tx,
+            vec![],
+            Some(fixture.store_ctx),
+            Some(fixture.manifest_metadata),
+        )
+        .with_write_path_mode(WritePathMode::Relative)
+        .commit(RewriteFilesOperation::new(vec![]))
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(message) if message.contains("at least one data file addition or deletion")
+        ));
+    }
+
+    #[tokio::test]
+    async fn rewrite_files_supports_add_only_overwrite() {
+        let fixture = single_file_parent("memory://rewrite-add-only-test/table/").await;
+        let new_file = data_file("data/new.parquet", 2, 200);
+        let action_commit = SnapshotProducer::new(
+            &fixture.tx,
+            vec![new_file],
+            Some(fixture.store_ctx.clone()),
+            Some(fixture.manifest_metadata),
+        )
+        .with_write_path_mode(WritePathMode::Relative)
+        .commit(RewriteFilesOperation::new(vec![]))
+        .await
+        .unwrap();
+
+        let new_snapshot = action_commit
+            .updates()
+            .iter()
+            .find_map(|update| match update {
+                TableUpdate::AddSnapshot { snapshot } => Some(snapshot),
+                _ => None,
+            })
+            .unwrap();
+        for (key, expected) in [
+            ("added-data-files", "1"),
+            ("deleted-data-files", "0"),
+            ("added-records", "2"),
+            ("deleted-records", "0"),
+            ("total-data-files", "2"),
+            ("total-records", "3"),
+        ] {
+            assert_eq!(
+                new_snapshot
+                    .summary
+                    .additional_properties
+                    .get(key)
+                    .map(String::as_str),
+                Some(expected)
+            );
+        }
+
+        let manifest_list = load_manifest_list(&fixture.store_ctx, new_snapshot.manifest_list())
+            .await
+            .unwrap();
+        assert_eq!(manifest_list.entries().len(), 2);
+    }
+
+    #[tokio::test]
     async fn rewrite_files_rejects_paths_not_live_without_writing_orphan_manifests() {
         let fixture = single_file_parent("memory://rewrite-missing-test/table/").await;
 
@@ -1179,6 +1327,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(manifest_list.entries().len(), 1);
+        assert_eq!(manifest_list.entries()[0].min_sequence_number, 2);
         let manifest = load_manifest(
             &fixture.store_ctx,
             &manifest_list.entries()[0].manifest_path,

--- a/crates/sail-iceberg/src/operations/snapshot.rs
+++ b/crates/sail-iceberg/src/operations/snapshot.rs
@@ -574,7 +574,7 @@ mod tests {
     use crate::datasource::IcebergTableProvider;
     use crate::datasource::type_converter::iceberg_schema_to_arrow;
     use crate::io::{load_manifest, load_manifest_list};
-    use crate::operations::RewriteFilesOperation;
+    use crate::operations::{DeleteFilesOperation, RewriteFilesOperation};
     use crate::spec::manifest::{ManifestEntry, ManifestStatus};
     use crate::spec::types::{NestedField, PrimitiveType, Type};
     use crate::spec::{DataContentType, DataFileFormat, ManifestListWriter};
@@ -1278,6 +1278,32 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(metadata_objects.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn delete_file_rewrite_records_delete_snapshot_operation() {
+        let fixture = single_file_parent("memory://delete-rewrite-test/table/").await;
+
+        let action_commit = SnapshotProducer::new(
+            &fixture.tx,
+            vec![],
+            Some(fixture.store_ctx.clone()),
+            Some(fixture.manifest_metadata),
+        )
+        .with_write_path_mode(WritePathMode::Relative)
+        .commit(DeleteFilesOperation::new(vec![fixture.live_file.file_path]))
+        .await
+        .unwrap();
+
+        let new_snapshot = action_commit
+            .updates()
+            .iter()
+            .find_map(|update| match update {
+                TableUpdate::AddSnapshot { snapshot } => Some(snapshot),
+                _ => None,
+            })
+            .unwrap();
+        assert_eq!(new_snapshot.summary.operation, Operation::Delete);
     }
 
     #[tokio::test]

--- a/crates/sail-iceberg/src/operations/write/base_writer/data_file_writer.rs
+++ b/crates/sail-iceberg/src/operations/write/base_writer/data_file_writer.rs
@@ -10,12 +10,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+
+use ordered_float::OrderedFloat;
+use parquet::file::statistics::{Statistics, ValueStatistics};
 
 use crate::operations::write::WriteOutcome;
 use crate::operations::write::arrow_parquet::ParquetFileMeta;
-use crate::spec::types::values::Literal;
-use crate::spec::{DataContentType, DataFile, DataFileFormat, Datum};
+use crate::spec::types::values::{Literal, PrimitiveLiteral};
+use crate::spec::types::{PrimitiveType, Type};
+use crate::spec::{DataContentType, DataFile, DataFileFormat, Datum, Schema};
 
 pub struct DataFileWriter {
     pub partition_spec_id: i32,
@@ -36,7 +40,11 @@ impl DataFileWriter {
         }
     }
 
-    pub fn finish(self, meta: ParquetFileMeta) -> Result<WriteOutcome, String> {
+    pub fn finish(
+        self,
+        meta: ParquetFileMeta,
+        iceberg_schema: &Schema,
+    ) -> Result<WriteOutcome, String> {
         let (
             column_sizes,
             value_counts,
@@ -44,7 +52,7 @@ impl DataFileWriter {
             lower_bounds,
             upper_bounds,
             split_offsets,
-        ) = aggregate_from_parquet_metadata(&meta.parquet_metadata)?;
+        ) = aggregate_from_parquet_metadata(&meta.parquet_metadata, iceberg_schema)?;
 
         let data_file = DataFile {
             content: DataContentType::Data,
@@ -83,8 +91,150 @@ type AggregatedMetadata = (
     Vec<i64>,
 );
 
+fn typed_statistics_bounds<T>(
+    statistics: &ValueStatistics<T>,
+    iceberg_type: &PrimitiveType,
+    to_literal: impl Fn(&T) -> Option<PrimitiveLiteral>,
+) -> (Option<Datum>, Option<Datum>) {
+    let lower = if statistics.min_is_exact() {
+        statistics
+            .min_opt()
+            .and_then(&to_literal)
+            .map(|literal| Datum::new(iceberg_type.clone(), literal))
+    } else {
+        None
+    };
+    let upper = if statistics.max_is_exact() {
+        statistics
+            .max_opt()
+            .and_then(to_literal)
+            .map(|literal| Datum::new(iceberg_type.clone(), literal))
+    } else {
+        None
+    };
+    (lower, upper)
+}
+
+fn signed_bytes_to_i128(bytes: &[u8]) -> Option<i128> {
+    if bytes.is_empty() || bytes.len() > size_of::<i128>() {
+        return None;
+    }
+    let fill = if bytes[0] & 0x80 == 0 { 0 } else { u8::MAX };
+    let mut value = [fill; size_of::<i128>()];
+    let offset = value.len() - bytes.len();
+    value[offset..].copy_from_slice(bytes);
+    Some(i128::from_be_bytes(value))
+}
+
+fn bytes_to_literal(bytes: &[u8], iceberg_type: &PrimitiveType) -> Option<PrimitiveLiteral> {
+    match iceberg_type {
+        PrimitiveType::String => std::str::from_utf8(bytes)
+            .ok()
+            .map(|value| PrimitiveLiteral::String(value.to_string())),
+        PrimitiveType::Uuid => bytes
+            .try_into()
+            .ok()
+            .map(u128::from_be_bytes)
+            .map(PrimitiveLiteral::UInt128),
+        PrimitiveType::Fixed(length) if bytes.len() == *length as usize => {
+            Some(PrimitiveLiteral::Binary(bytes.to_vec()))
+        }
+        PrimitiveType::Binary => Some(PrimitiveLiteral::Binary(bytes.to_vec())),
+        PrimitiveType::Decimal { .. } => signed_bytes_to_i128(bytes).map(PrimitiveLiteral::Int128),
+        _ => None,
+    }
+}
+
+fn parquet_statistics_bounds(
+    statistics: &Statistics,
+    iceberg_type: &PrimitiveType,
+) -> (Option<Datum>, Option<Datum>) {
+    match (statistics, iceberg_type) {
+        (Statistics::Boolean(statistics), PrimitiveType::Boolean) => {
+            typed_statistics_bounds(statistics, iceberg_type, |value| {
+                Some(PrimitiveLiteral::Boolean(*value))
+            })
+        }
+        (Statistics::Int32(statistics), PrimitiveType::Int | PrimitiveType::Date) => {
+            typed_statistics_bounds(statistics, iceberg_type, |value| {
+                Some(PrimitiveLiteral::Int(*value))
+            })
+        }
+        (Statistics::Int32(statistics), PrimitiveType::Decimal { .. }) => {
+            typed_statistics_bounds(statistics, iceberg_type, |value| {
+                Some(PrimitiveLiteral::Int128(i128::from(*value)))
+            })
+        }
+        (
+            Statistics::Int64(statistics),
+            PrimitiveType::Long
+            | PrimitiveType::Time
+            | PrimitiveType::Timestamp
+            | PrimitiveType::Timestamptz
+            | PrimitiveType::TimestampNs
+            | PrimitiveType::TimestamptzNs,
+        ) => typed_statistics_bounds(statistics, iceberg_type, |value| {
+            Some(PrimitiveLiteral::Long(*value))
+        }),
+        (Statistics::Int64(statistics), PrimitiveType::Decimal { .. }) => {
+            typed_statistics_bounds(statistics, iceberg_type, |value| {
+                Some(PrimitiveLiteral::Int128(i128::from(*value)))
+            })
+        }
+        (Statistics::Float(statistics), PrimitiveType::Float) => {
+            typed_statistics_bounds(statistics, iceberg_type, |value| {
+                Some(PrimitiveLiteral::Float(OrderedFloat(*value)))
+            })
+        }
+        (Statistics::Double(statistics), PrimitiveType::Double) => {
+            typed_statistics_bounds(statistics, iceberg_type, |value| {
+                Some(PrimitiveLiteral::Double(OrderedFloat(*value)))
+            })
+        }
+        (Statistics::ByteArray(statistics), _) => {
+            typed_statistics_bounds(statistics, iceberg_type, |value| {
+                bytes_to_literal(value.data(), iceberg_type)
+            })
+        }
+        (Statistics::FixedLenByteArray(statistics), _) => {
+            typed_statistics_bounds(statistics, iceberg_type, |value| {
+                bytes_to_literal(value.data(), iceberg_type)
+            })
+        }
+        _ => (None, None),
+    }
+}
+
+fn update_bound(
+    bounds: &mut HashMap<i32, Datum>,
+    unknown: &mut HashSet<i32>,
+    field_id: i32,
+    value: Option<Datum>,
+    lower: bool,
+) {
+    if unknown.contains(&field_id) {
+        return;
+    }
+    let Some(value) = value else {
+        bounds.remove(&field_id);
+        unknown.insert(field_id);
+        return;
+    };
+    bounds
+        .entry(field_id)
+        .and_modify(|current| {
+            if (lower && value.literal < current.literal)
+                || (!lower && value.literal > current.literal)
+            {
+                *current = value.clone();
+            }
+        })
+        .or_insert(value);
+}
+
 fn aggregate_from_parquet_metadata(
     parquet_meta: &parquet::file::metadata::ParquetMetaData,
+    iceberg_schema: &Schema,
 ) -> Result<AggregatedMetadata, String> {
     let row_groups = parquet_meta.row_groups();
     let schema_descr = parquet_meta.file_metadata().schema_descr();
@@ -92,38 +242,67 @@ fn aggregate_from_parquet_metadata(
     let mut col_sizes: HashMap<i32, u64> = HashMap::new();
     let mut val_counts: HashMap<i32, u64> = HashMap::new();
     let mut null_counts: HashMap<i32, u64> = HashMap::new();
-    let lower_bounds: HashMap<i32, Datum> = HashMap::new();
-    let upper_bounds: HashMap<i32, Datum> = HashMap::new();
+    let mut null_counts_unknown: HashSet<i32> = HashSet::new();
+    let mut lower_bounds: HashMap<i32, Datum> = HashMap::new();
+    let mut lower_bounds_unknown: HashSet<i32> = HashSet::new();
+    let mut upper_bounds: HashMap<i32, Datum> = HashMap::new();
+    let mut upper_bounds_unknown: HashSet<i32> = HashSet::new();
     let mut split_offsets: Vec<i64> = Vec::new();
 
     for rg in row_groups {
         if let Some(off) = rg.file_offset() {
             split_offsets.push(off);
         }
-        for (column_index, c) in rg.columns().iter().enumerate() {
-            let _path = c.column_descr().path().string();
-            let leaf_info = c.column_descr().self_type().get_basic_info();
+        for (column_index, column) in rg.columns().iter().enumerate() {
+            let leaf_info = column.column_descr().self_type().get_basic_info();
             let Some(field_id) = (if leaf_info.has_id() {
                 Some(leaf_info.id())
             } else {
                 let root_info = schema_descr.get_column_root(column_index).get_basic_info();
-                if root_info.has_id() {
-                    Some(root_info.id())
+                root_info.has_id().then(|| root_info.id())
+            }) else {
+                continue;
+            };
+            *col_sizes.entry(field_id).or_insert(0) += column.compressed_size() as u64;
+            *val_counts.entry(field_id).or_insert(0) += column.num_values() as u64;
+
+            let statistics = column.statistics();
+            let null_count = statistics.and_then(Statistics::null_count_opt);
+            if !null_counts_unknown.contains(&field_id) {
+                if let Some(null_count) = null_count {
+                    *null_counts.entry(field_id).or_insert(0) += null_count;
                 } else {
-                    None
+                    // A missing row-group statistic makes the file-level count unknown.
+                    null_counts.remove(&field_id);
+                    null_counts_unknown.insert(field_id);
+                }
+            }
+
+            let Some(primitive_type) = iceberg_schema.field_by_id(field_id).and_then(|field| {
+                match field.field_type.as_ref() {
+                    Type::Primitive(primitive_type) => Some(primitive_type),
+                    Type::Struct(_) | Type::List(_) | Type::Map(_) => None,
                 }
             }) else {
                 continue;
             };
-            *col_sizes.entry(field_id).or_insert(0) += c.compressed_size() as u64;
-            *val_counts.entry(field_id).or_insert(0) += c.num_values() as u64;
-            if let Some(stats) = c.statistics() {
-                if let Some(n) = stats.null_count_opt() {
-                    *null_counts.entry(field_id).or_insert(0) += n;
-                }
-                // Do not attempt to parse typed bounds here; leave empty per-field for now
-                let _ = _path; // silence unused
-            }
+            let (lower, upper) = statistics
+                .map(|statistics| parquet_statistics_bounds(statistics, primitive_type))
+                .unwrap_or((None, None));
+            update_bound(
+                &mut lower_bounds,
+                &mut lower_bounds_unknown,
+                field_id,
+                lower,
+                true,
+            );
+            update_bound(
+                &mut upper_bounds,
+                &mut upper_bounds_unknown,
+                field_id,
+                upper,
+                false,
+            );
         }
     }
 
@@ -135,4 +314,109 @@ fn aggregate_from_parquet_metadata(
         upper_bounds,
         split_offsets,
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::arrow::array::Int32Array;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use parquet::arrow::PARQUET_FIELD_ID_META_KEY;
+    use parquet::data_type::ByteArray;
+    use parquet::file::properties::WriterProperties;
+    use parquet::file::statistics::Statistics;
+
+    use super::*;
+    use crate::operations::write::arrow_parquet::ArrowParquetWriter;
+    use crate::spec::types::NestedField;
+    use crate::spec::types::PrimitiveType;
+    use crate::spec::types::values::PrimitiveLiteral;
+
+    #[test]
+    fn parquet_integer_statistics_produce_iceberg_bounds() {
+        let statistics = Statistics::int32(Some(1), Some(3), None, Some(0), false);
+
+        let (lower, upper) = parquet_statistics_bounds(&statistics, &PrimitiveType::Int);
+
+        assert_eq!(
+            lower,
+            Some(Datum::new(PrimitiveType::Int, PrimitiveLiteral::Int(1)))
+        );
+        assert_eq!(
+            upper,
+            Some(Datum::new(PrimitiveType::Int, PrimitiveLiteral::Int(3)))
+        );
+    }
+
+    #[tokio::test]
+    async fn data_file_writer_preserves_parquet_integer_bounds() -> Result<(), String> {
+        let arrow_schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false).with_metadata(HashMap::from([(
+                PARQUET_FIELD_ID_META_KEY.to_string(),
+                "1".to_string(),
+            )])),
+        ]));
+        let batch = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .map_err(|error| error.to_string())?;
+        let mut parquet_writer = ArrowParquetWriter::try_new(
+            arrow_schema.as_ref(),
+            WriterProperties::builder().build(),
+        )?;
+        parquet_writer.write_batch(&batch).await?;
+        let (_, metadata) = parquet_writer.close().await?;
+        let iceberg_schema = Schema::builder()
+            .with_schema_id(0)
+            .with_fields(vec![Arc::new(NestedField::required(
+                1,
+                "id",
+                Type::Primitive(PrimitiveType::Int),
+            ))])
+            .build()?;
+
+        let outcome = DataFileWriter::new(0, "data.parquet".to_string(), vec![])
+            .finish(metadata, &iceberg_schema)?;
+
+        assert_eq!(
+            outcome.data_file.lower_bounds.get(&1),
+            Some(&Datum::new(PrimitiveType::Int, PrimitiveLiteral::Int(1)))
+        );
+        assert_eq!(
+            outcome.data_file.upper_bounds.get(&1),
+            Some(&Datum::new(PrimitiveType::Int, PrimitiveLiteral::Int(3)))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn parquet_string_statistics_produce_iceberg_bounds() {
+        let statistics = Statistics::byte_array(
+            Some(ByteArray::from("alpha")),
+            Some(ByteArray::from("omega")),
+            None,
+            Some(0),
+            false,
+        );
+
+        let (lower, upper) = parquet_statistics_bounds(&statistics, &PrimitiveType::String);
+
+        assert_eq!(
+            lower,
+            Some(Datum::new(
+                PrimitiveType::String,
+                PrimitiveLiteral::String("alpha".to_string())
+            ))
+        );
+        assert_eq!(
+            upper,
+            Some(Datum::new(
+                PrimitiveType::String,
+                PrimitiveLiteral::String("omega".to_string())
+            ))
+        );
+    }
 }

--- a/crates/sail-iceberg/src/operations/write/table_writer.rs
+++ b/crates/sail-iceberg/src/operations/write/table_writer.rs
@@ -292,7 +292,7 @@ impl IcebergTableWriter {
                 }
             };
             let df = DataFileWriter::new(self.partition_spec_id, file_path, partition_values)
-                .finish(meta)?
+                .finish(meta, self.config.iceberg_schema.as_ref())?
                 .data_file;
             self.written.push(df);
         }

--- a/crates/sail-iceberg/src/physical/table_scan_planner.rs
+++ b/crates/sail-iceberg/src/physical/table_scan_planner.rs
@@ -1,16 +1,24 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datafusion::common::Result;
+use datafusion::common::{Result, not_impl_err};
 use datafusion::datasource::TableProvider;
 use datafusion::execution::SessionState;
 use datafusion::logical_expr::expr_rewriter::unnormalize_cols;
 use datafusion::logical_expr::{LogicalPlan, TableScan, UserDefinedLogicalNode};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
+use sail_common_datafusion::datasource::{RowLevelCommand, SourceInfo};
+use sail_data_source::options::ResolveOptions;
+use sail_logical_plan::merge::RowLevelWriteNode;
 
 use crate::logical::IcebergTableSource;
-use crate::table_format::{IcebergWriteNode, plan_iceberg_write};
+use crate::options::r#gen::IcebergWriteOptions;
+use crate::physical_plan::IcebergWriterExecOptions;
+use crate::table_format::{
+    IcebergWriteNode, build_iceberg_provider, plan_iceberg_write,
+    split_iceberg_write_options_and_table_properties,
+};
 
 pub struct IcebergPhysicalPlanner;
 
@@ -24,22 +32,30 @@ impl ExtensionPlanner for IcebergPhysicalPlanner {
         physical_inputs: &[Arc<dyn ExecutionPlan>],
         session_state: &SessionState,
     ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
-        let Some(node) = node.as_any().downcast_ref::<IcebergWriteNode>() else {
-            return Ok(None);
-        };
-        let [logical_input] = logical_inputs else {
-            return datafusion_common::internal_err!(
-                "IcebergWriteNode requires exactly one logical input"
-            );
-        };
-        let [physical_input] = physical_inputs else {
-            return datafusion_common::internal_err!(
-                "IcebergWriteNode requires exactly one physical input"
-            );
-        };
-        plan_iceberg_write(session_state, logical_input, physical_input.clone(), node)
-            .await
-            .map(Some)
+        if let Some(node) = node.as_any().downcast_ref::<IcebergWriteNode>() {
+            let [logical_input] = logical_inputs else {
+                return datafusion_common::internal_err!(
+                    "IcebergWriteNode requires exactly one logical input"
+                );
+            };
+            let [physical_input] = physical_inputs else {
+                return datafusion_common::internal_err!(
+                    "IcebergWriteNode requires exactly one physical input"
+                );
+            };
+            return plan_iceberg_write(session_state, logical_input, physical_input.clone(), node)
+                .await
+                .map(Some);
+        }
+        if let Some(node) = node.as_any().downcast_ref::<RowLevelWriteNode>() {
+            if !node.target_format().eq_ignore_ascii_case("iceberg") {
+                return Ok(None);
+            }
+            return plan_iceberg_row_level_write(session_state, node)
+                .await
+                .map(Some);
+        }
+        Ok(None)
     }
 
     async fn plan_table_scan(
@@ -62,5 +78,43 @@ impl ExtensionPlanner for IcebergPhysicalPlanner {
             )
             .await?;
         Ok(Some(plan))
+    }
+}
+
+async fn plan_iceberg_row_level_write(
+    session_state: &SessionState,
+    node: &RowLevelWriteNode,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    match node.command() {
+        RowLevelCommand::Delete => {
+            let source_info = SourceInfo {
+                paths: vec![node.target_location().to_string()],
+                lakehouse_table: node.target_lakehouse_table().cloned(),
+                schema: None,
+                constraints: Default::default(),
+                partition_by: vec![],
+                bucket_by: None,
+                sort_order: vec![],
+                options: node.target_options().to_vec(),
+                read_case_sensitive: true,
+            };
+            let provider = build_iceberg_provider(session_state, source_info).await?;
+            let (clean_options, table_properties) =
+                split_iceberg_write_options_and_table_properties(node.target_options().to_vec())?;
+            let variant_shredding_option_presence =
+                IcebergWriterExecOptions::variant_shredding_option_presence(&clean_options);
+            let iceberg_options = IcebergWriteOptions::resolve(session_state, clean_options)?;
+            let mut writer_options = IcebergWriterExecOptions::from(iceberg_options);
+            writer_options
+                .apply_variant_shredding_option_presence(variant_shredding_option_presence);
+            writer_options.table_properties = table_properties;
+            writer_options.lakehouse_table = node.target_lakehouse_table().cloned();
+            provider
+                .build_cow_delete_plan(session_state, node.condition().cloned(), writer_options)
+                .await
+        }
+        RowLevelCommand::Update | RowLevelCommand::Merge => {
+            not_impl_err!("Iceberg {:?} row-level write", node.command())
+        }
     }
 }

--- a/crates/sail-iceberg/src/physical_plan/action_schema.rs
+++ b/crates/sail-iceberg/src/physical_plan/action_schema.rs
@@ -9,7 +9,8 @@ use datafusion_common::{DataFusionError, Result};
 use sail_common_datafusion::catalog::LakehouseExecutionContext;
 use serde::{Deserialize, Serialize};
 
-use crate::spec::types::values::{Literal, PrimitiveLiteral};
+use crate::spec::types::PrimitiveType;
+use crate::spec::types::values::{Datum, Literal, PrimitiveLiteral};
 use crate::spec::{
     DataContentType, DataFile, DataFileFormat, Operation, PartitionSpec, Schema as IcebergSchema,
     TableRequirement,
@@ -84,8 +85,107 @@ pub struct AddFileAction {
     pub column_sizes: BTreeMap<i32, u64>,
     pub value_counts: BTreeMap<i32, u64>,
     pub null_value_counts: BTreeMap<i32, u64>,
+    pub nan_value_counts: BTreeMap<i32, u64>,
+    pub lower_bounds_json: String,
+    pub upper_bounds_json: String,
     pub split_offsets: Vec<i64>,
     pub partition_spec_id: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct BoundAction {
+    field_id: i32,
+    primitive_type: PrimitiveType,
+    value: BoundValue,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "value")]
+enum BoundValue {
+    Boolean(bool),
+    Int(i32),
+    Long(i64),
+    FloatBits(u32),
+    DoubleBits(u64),
+    Int128(String),
+    UInt128(String),
+    String(String),
+    Binary(Vec<u8>),
+}
+
+impl From<&PrimitiveLiteral> for BoundValue {
+    fn from(value: &PrimitiveLiteral) -> Self {
+        match value {
+            PrimitiveLiteral::Boolean(value) => Self::Boolean(*value),
+            PrimitiveLiteral::Int(value) => Self::Int(*value),
+            PrimitiveLiteral::Long(value) => Self::Long(*value),
+            PrimitiveLiteral::Float(value) => Self::FloatBits(value.to_bits()),
+            PrimitiveLiteral::Double(value) => Self::DoubleBits(value.to_bits()),
+            PrimitiveLiteral::Int128(value) => Self::Int128(value.to_string()),
+            PrimitiveLiteral::UInt128(value) => Self::UInt128(value.to_string()),
+            PrimitiveLiteral::String(value) => Self::String(value.clone()),
+            PrimitiveLiteral::Binary(value) => Self::Binary(value.clone()),
+        }
+    }
+}
+
+impl TryFrom<BoundValue> for PrimitiveLiteral {
+    type Error = DataFusionError;
+
+    fn try_from(value: BoundValue) -> Result<Self> {
+        match value {
+            BoundValue::Boolean(value) => Ok(Self::Boolean(value)),
+            BoundValue::Int(value) => Ok(Self::Int(value)),
+            BoundValue::Long(value) => Ok(Self::Long(value)),
+            BoundValue::FloatBits(value) => Ok(Self::Float(ordered_float::OrderedFloat(
+                f32::from_bits(value),
+            ))),
+            BoundValue::DoubleBits(value) => Ok(Self::Double(ordered_float::OrderedFloat(
+                f64::from_bits(value),
+            ))),
+            BoundValue::Int128(value) => value.parse::<i128>().map(Self::Int128).map_err(|error| {
+                DataFusionError::Plan(format!("failed to parse i128 bound literal: {error}"))
+            }),
+            BoundValue::UInt128(value) => {
+                value.parse::<u128>().map(Self::UInt128).map_err(|error| {
+                    DataFusionError::Plan(format!("failed to parse u128 bound literal: {error}"))
+                })
+            }
+            BoundValue::String(value) => Ok(Self::String(value)),
+            BoundValue::Binary(value) => Ok(Self::Binary(value)),
+        }
+    }
+}
+
+fn encode_bounds(bounds: &std::collections::HashMap<i32, Datum>) -> Result<String> {
+    let mut actions = bounds
+        .iter()
+        .map(|(field_id, datum)| BoundAction {
+            field_id: *field_id,
+            primitive_type: datum.r#type.clone(),
+            value: BoundValue::from(&datum.literal),
+        })
+        .collect::<Vec<_>>();
+    actions.sort_by_key(|action| action.field_id);
+    serde_json::to_string(&actions).map_err(|error| DataFusionError::External(Box::new(error)))
+}
+
+fn decode_bounds(value: &str) -> Result<std::collections::HashMap<i32, Datum>> {
+    let actions = serde_json::from_str::<Vec<BoundAction>>(value)
+        .map_err(|error| DataFusionError::External(Box::new(error)))?;
+    actions
+        .into_iter()
+        .map(|action| {
+            let literal = PrimitiveLiteral::try_from(action.value)?;
+            if !action.primitive_type.compatible(&literal) {
+                return Err(DataFusionError::Plan(format!(
+                    "bound literal is not compatible with Iceberg type {} for field {}",
+                    action.primitive_type, action.field_id
+                )));
+            }
+            Ok((action.field_id, Datum::new(action.primitive_type, literal)))
+        })
+        .collect()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -172,6 +272,12 @@ fn iceberg_action_tracing_options()
             opts.overwrite(
                 "action.add.null_value_counts",
                 Field::new("null_value_counts", map_type_i32_u64(), false),
+            )
+        })
+        .and_then(|opts| {
+            opts.overwrite(
+                "action.add.nan_value_counts",
+                Field::new("nan_value_counts", map_type_i32_u64(), false),
             )
         })
         .and_then(|opts| {
@@ -272,6 +378,8 @@ impl TryFrom<DataFile> for AddFileAction {
     type Error = DataFusionError;
 
     fn try_from(df: DataFile) -> Result<Self> {
+        let lower_bounds_json = encode_bounds(&df.lower_bounds)?;
+        let upper_bounds_json = encode_bounds(&df.upper_bounds)?;
         let partition = df
             .partition
             .into_iter()
@@ -294,6 +402,9 @@ impl TryFrom<DataFile> for AddFileAction {
             column_sizes: df.column_sizes.into_iter().collect(),
             value_counts: df.value_counts.into_iter().collect(),
             null_value_counts: df.null_value_counts.into_iter().collect(),
+            nan_value_counts: df.nan_value_counts.into_iter().collect(),
+            lower_bounds_json,
+            upper_bounds_json,
             split_offsets: df.split_offsets,
             partition_spec_id: df.partition_spec_id,
         })
@@ -334,6 +445,8 @@ impl TryFrom<AddFileAction> for DataFile {
                 Some(pv) => Ok(Some(Literal::Primitive(pv.try_into()?))),
             })
             .collect::<Result<Vec<_>>>()?;
+        let lower_bounds = decode_bounds(&a.lower_bounds_json)?;
+        let upper_bounds = decode_bounds(&a.upper_bounds_json)?;
 
         Ok(DataFile {
             content,
@@ -345,9 +458,9 @@ impl TryFrom<AddFileAction> for DataFile {
             column_sizes: a.column_sizes.into_iter().collect(),
             value_counts: a.value_counts.into_iter().collect(),
             null_value_counts: a.null_value_counts.into_iter().collect(),
-            nan_value_counts: Default::default(),
-            lower_bounds: Default::default(),
-            upper_bounds: Default::default(),
+            nan_value_counts: a.nan_value_counts.into_iter().collect(),
+            lower_bounds,
+            upper_bounds,
             block_size_in_bytes: None,
             key_metadata: None,
             split_offsets: a.split_offsets,
@@ -506,9 +619,39 @@ mod tests {
             column_sizes: HashMap::from([(1, 10u64)]),
             value_counts: HashMap::from([(1, 10u64)]),
             null_value_counts: HashMap::new(),
-            nan_value_counts: HashMap::new(),
-            lower_bounds: HashMap::new(),
-            upper_bounds: HashMap::new(),
+            nan_value_counts: HashMap::from([(1, 0)]),
+            lower_bounds: HashMap::from([
+                (
+                    1,
+                    crate::spec::Datum::new(
+                        crate::spec::types::PrimitiveType::Int,
+                        PrimitiveLiteral::Int(1),
+                    ),
+                ),
+                (
+                    2,
+                    crate::spec::Datum::new(
+                        crate::spec::types::PrimitiveType::Double,
+                        PrimitiveLiteral::Double(ordered_float::OrderedFloat(f64::NEG_INFINITY)),
+                    ),
+                ),
+            ]),
+            upper_bounds: HashMap::from([
+                (
+                    1,
+                    crate::spec::Datum::new(
+                        crate::spec::types::PrimitiveType::Int,
+                        PrimitiveLiteral::Int(3),
+                    ),
+                ),
+                (
+                    2,
+                    crate::spec::Datum::new(
+                        crate::spec::types::PrimitiveType::Double,
+                        PrimitiveLiteral::Double(ordered_float::OrderedFloat(f64::INFINITY)),
+                    ),
+                ),
+            ]),
             block_size_in_bytes: None,
             key_metadata: None,
             split_offsets: vec![0],
@@ -544,6 +687,9 @@ mod tests {
         assert_eq!(adds.len(), 1);
         assert_eq!(adds[0].file_path, df.file_path);
         assert_eq!(adds[0].record_count, df.record_count);
+        assert_eq!(adds[0].nan_value_counts, df.nan_value_counts);
+        assert_eq!(adds[0].lower_bounds, df.lower_bounds);
+        assert_eq!(adds[0].upper_bounds, df.upper_bounds);
         assert!(meta.is_some());
         Ok(())
     }

--- a/crates/sail-iceberg/src/physical_plan/commit/commit_exec.rs
+++ b/crates/sail-iceberg/src/physical_plan/commit/commit_exec.rs
@@ -64,6 +64,7 @@ pub struct IcebergCommitExec {
     input: Arc<dyn ExecutionPlan>,
     table_url: Url,
     lakehouse_table: Option<LakehouseExecutionContext>,
+    expected_snapshot_id: Option<Option<i64>>,
     cache: Arc<PlanProperties>,
 }
 
@@ -88,8 +89,14 @@ impl IcebergCommitExec {
             input,
             table_url,
             lakehouse_table,
+            expected_snapshot_id: None,
             cache,
         }
+    }
+
+    pub fn with_expected_snapshot_id(mut self, expected_snapshot_id: Option<Option<i64>>) -> Self {
+        self.expected_snapshot_id = expected_snapshot_id;
+        self
     }
 
     pub fn table_url(&self) -> &Url {
@@ -102,6 +109,26 @@ impl IcebergCommitExec {
 
     pub fn lakehouse_table(&self) -> Option<&LakehouseExecutionContext> {
         self.lakehouse_table.as_ref()
+    }
+
+    pub fn expected_snapshot_id(&self) -> Option<Option<i64>> {
+        self.expected_snapshot_id
+    }
+
+    fn add_expected_snapshot_requirement(
+        requirements: &mut Vec<TableRequirement>,
+        expected_snapshot_id: Option<Option<i64>>,
+    ) {
+        let Some(snapshot_id) = expected_snapshot_id else {
+            return;
+        };
+        let requirement = TableRequirement::RefSnapshotIdMatch {
+            r#ref: MAIN_BRANCH.to_string(),
+            snapshot_id,
+        };
+        if !requirements.contains(&requirement) {
+            requirements.push(requirement);
+        }
     }
 
     fn apply_schema_update(table_meta: &mut TableMetadata, new_schema: IcebergSchema) {
@@ -394,11 +421,14 @@ impl ExecutionPlan for IcebergCommitExec {
         if children.len() != 1 {
             return internal_err!("IcebergCommitExec requires exactly one child");
         }
-        Ok(Arc::new(Self::new(
-            Arc::clone(&children[0]),
-            self.table_url.clone(),
-            self.lakehouse_table.clone(),
-        )))
+        Ok(Arc::new(
+            Self::new(
+                Arc::clone(&children[0]),
+                self.table_url.clone(),
+                self.lakehouse_table.clone(),
+            )
+            .with_expected_snapshot_id(self.expected_snapshot_id),
+        ))
     }
 
     fn execute(
@@ -421,6 +451,7 @@ impl ExecutionPlan for IcebergCommitExec {
 
         let table_url = self.table_url.clone();
         let lakehouse_table = self.lakehouse_table.clone();
+        let expected_snapshot_id = self.expected_snapshot_id;
         let schema = self.schema();
         let future = async move {
             let object_store = get_object_store_from_context(&context, &table_url)?;
@@ -455,7 +486,7 @@ impl ExecutionPlan for IcebergCommitExec {
                 )
             })?;
 
-            let commit_info = IcebergCommitInfo {
+            let mut commit_info = IcebergCommitInfo {
                 table_uri: commit_meta.table_uri,
                 row_count: commit_meta.row_count,
                 data_files: added_data_files,
@@ -469,6 +500,10 @@ impl ExecutionPlan for IcebergCommitExec {
                 schema: commit_meta.schema,
                 partition_spec: commit_meta.partition_spec,
             };
+            Self::add_expected_snapshot_requirement(
+                &mut commit_info.requirements,
+                expected_snapshot_id,
+            );
 
             let catalog_table = commit_info
                 .lakehouse_table
@@ -1115,4 +1150,110 @@ fn commit_conflict_error() -> DataFusionError {
     DataFusionError::Execution(format!(
         "Iceberg commit failed after {MAX_COMMIT_RETRIES} retries due to concurrent metadata updates"
     ))
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::spec::FormatVersion;
+
+    fn table_metadata_at_snapshot(snapshot_id: Option<i64>) -> TableMetadata {
+        TableMetadata {
+            format_version: FormatVersion::V2,
+            table_uuid: None,
+            location: "file:///tmp/table".to_string(),
+            last_sequence_number: 2,
+            last_updated_ms: 0,
+            last_column_id: 0,
+            schemas: vec![],
+            current_schema_id: 0,
+            partition_specs: vec![],
+            default_spec_id: 0,
+            last_partition_id: 0,
+            properties: HashMap::new(),
+            current_snapshot_id: snapshot_id,
+            next_row_id: None,
+            encryption_keys: vec![],
+            snapshots: vec![],
+            snapshot_log: vec![],
+            metadata_log: vec![],
+            sort_orders: vec![],
+            default_sort_order_id: None,
+            refs: HashMap::new(),
+            statistics: vec![],
+            partition_statistics: vec![],
+        }
+    }
+
+    #[test]
+    fn replacing_commit_child_preserves_snapshot_requirement() {
+        use datafusion::arrow::datatypes::Schema;
+        use datafusion::physical_plan::empty::EmptyExec;
+
+        let child: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(Arc::new(Schema::empty())));
+        let commit = Arc::new(
+            IcebergCommitExec::new(
+                Arc::clone(&child),
+                Url::parse("file:///tmp/table").expect("valid table URL"),
+                None,
+            )
+            .with_expected_snapshot_id(Some(Some(41))),
+        );
+
+        let rewritten = commit
+            .with_new_children(vec![child])
+            .expect("one replacement child is valid");
+        let rewritten = rewritten
+            .downcast_ref::<IcebergCommitExec>()
+            .expect("rewritten plan remains an Iceberg commit");
+
+        assert_eq!(rewritten.expected_snapshot_id(), Some(Some(41)));
+    }
+
+    #[test]
+    fn planned_snapshot_requirement_rejects_advanced_table() {
+        let mut requirements = vec![];
+        IcebergCommitExec::add_expected_snapshot_requirement(&mut requirements, Some(Some(1)));
+
+        let error = IcebergCommitExec::validate_requirements(
+            Some(&table_metadata_at_snapshot(Some(2))),
+            &requirements,
+        )
+        .expect_err("planned snapshot 1 must conflict with current snapshot 2");
+
+        assert!(error.to_string().contains("expected snapshot Some(1)"));
+        assert!(error.to_string().contains("found Some(2)"));
+    }
+
+    #[test]
+    fn empty_target_snapshot_requirement_is_not_flattened_away() {
+        let mut requirements = vec![];
+        IcebergCommitExec::add_expected_snapshot_requirement(&mut requirements, Some(None));
+
+        assert!(
+            IcebergCommitExec::validate_requirements(
+                Some(&table_metadata_at_snapshot(None)),
+                &requirements,
+            )
+            .is_ok()
+        );
+        assert!(
+            IcebergCommitExec::validate_requirements(
+                Some(&table_metadata_at_snapshot(Some(2))),
+                &requirements,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn unvalidated_commit_adds_no_snapshot_requirement() {
+        let mut requirements = vec![];
+        IcebergCommitExec::add_expected_snapshot_requirement(&mut requirements, None);
+
+        assert!(requirements.is_empty());
+    }
 }

--- a/crates/sail-iceberg/src/physical_plan/commit/commit_exec.rs
+++ b/crates/sail-iceberg/src/physical_plan/commit/commit_exec.rs
@@ -42,14 +42,18 @@ use crate::operations::bootstrap::{
     bootstrap_new_table_with_style, bootstrap_snapshot_action_commit,
 };
 use crate::operations::helpers::format_version_for_schema;
-use crate::operations::{SnapshotProduceOperation, Transaction, TransactionAction};
+use crate::operations::{
+    DeleteFilesOperation, SnapshotProduceOperation, Transaction, TransactionAction,
+};
 use crate::physical_plan::action_schema::{CommitMeta, decode_actions_and_meta_from_batch};
 use crate::physical_plan::commit::IcebergCommitInfo;
 use crate::spec::catalog::TableUpdate;
 use crate::spec::metadata::table_metadata::SnapshotLog;
 use crate::spec::partition::{UnboundPartitionField, UnboundPartitionSpec};
 use crate::spec::snapshots::MAIN_BRANCH;
-use crate::spec::{PartitionSpec, Schema as IcebergSchema, TableMetadata, TableRequirement};
+use crate::spec::{
+    Operation, PartitionSpec, Schema as IcebergSchema, TableMetadata, TableRequirement,
+};
 use crate::table::metadata_loader::{
     encode_metadata_file, load_metadata_file_bytes, metadata_file_extension_from_properties,
     metadata_file_version_from_path, metadata_location_to_object_path_string,
@@ -65,6 +69,8 @@ pub struct IcebergCommitExec {
     table_url: Url,
     lakehouse_table: Option<LakehouseExecutionContext>,
     expected_snapshot_id: Option<Option<i64>>,
+    removed_data_file_paths: Vec<String>,
+    operation_override: Option<Operation>,
     cache: Arc<PlanProperties>,
 }
 
@@ -90,12 +96,34 @@ impl IcebergCommitExec {
             table_url,
             lakehouse_table,
             expected_snapshot_id: None,
+            removed_data_file_paths: vec![],
+            operation_override: None,
             cache,
         }
     }
 
     pub fn with_expected_snapshot_id(mut self, expected_snapshot_id: Option<Option<i64>>) -> Self {
         self.expected_snapshot_id = expected_snapshot_id;
+        self
+    }
+
+    pub fn with_rewrite_data_files(
+        self,
+        removed_data_file_paths: Vec<String>,
+        operation: Operation,
+    ) -> Self {
+        self.with_optional_rewrite_data_files(removed_data_file_paths, Some(operation))
+    }
+
+    pub fn with_optional_rewrite_data_files(
+        mut self,
+        mut removed_data_file_paths: Vec<String>,
+        operation: Option<Operation>,
+    ) -> Self {
+        removed_data_file_paths.sort();
+        removed_data_file_paths.dedup();
+        self.removed_data_file_paths = removed_data_file_paths;
+        self.operation_override = operation;
         self
     }
 
@@ -113,6 +141,14 @@ impl IcebergCommitExec {
 
     pub fn expected_snapshot_id(&self) -> Option<Option<i64>> {
         self.expected_snapshot_id
+    }
+
+    pub fn removed_data_file_paths(&self) -> &[String] {
+        &self.removed_data_file_paths
+    }
+
+    pub fn operation_override(&self) -> Option<&Operation> {
+        self.operation_override.as_ref()
     }
 
     fn add_expected_snapshot_requirement(
@@ -427,7 +463,11 @@ impl ExecutionPlan for IcebergCommitExec {
                 self.table_url.clone(),
                 self.lakehouse_table.clone(),
             )
-            .with_expected_snapshot_id(self.expected_snapshot_id),
+            .with_expected_snapshot_id(self.expected_snapshot_id)
+            .with_optional_rewrite_data_files(
+                self.removed_data_file_paths.clone(),
+                self.operation_override.clone(),
+            ),
         ))
     }
 
@@ -452,6 +492,8 @@ impl ExecutionPlan for IcebergCommitExec {
         let table_url = self.table_url.clone();
         let lakehouse_table = self.lakehouse_table.clone();
         let expected_snapshot_id = self.expected_snapshot_id;
+        let removed_data_file_paths = self.removed_data_file_paths.clone();
+        let operation_override = self.operation_override.clone();
         let schema = self.schema();
         let future = async move {
             let object_store = get_object_store_from_context(&context, &table_url)?;
@@ -475,6 +517,12 @@ impl ExecutionPlan for IcebergCommitExec {
 
             // No-op path (e.g. IgnoreIfExists on existing table): no rows, no meta.
             if commit_meta.is_none() && added_data_files.is_empty() {
+                if expected_snapshot_id.is_some() || operation_override.is_some() {
+                    return Err(DataFusionError::Internal(
+                        "missing commit_meta action from validated mutation writer output"
+                            .to_string(),
+                    ));
+                }
                 let array = Arc::new(UInt64Array::from(vec![0u64]));
                 let batch = RecordBatch::try_new(schema, vec![array])?;
                 return Ok(batch);
@@ -490,13 +538,14 @@ impl ExecutionPlan for IcebergCommitExec {
                 table_uri: commit_meta.table_uri,
                 row_count: commit_meta.row_count,
                 data_files: added_data_files,
+                files_to_remove: removed_data_file_paths,
                 manifest_path: String::new(),
                 manifest_list_path: String::new(),
                 updates: vec![],
                 requirements: commit_meta.requirements,
                 table_properties: commit_meta.table_properties,
                 lakehouse_table: commit_meta.lakehouse_table.or(lakehouse_table),
-                operation: commit_meta.operation,
+                operation: operation_override.unwrap_or(commit_meta.operation),
                 schema: commit_meta.schema,
                 partition_spec: commit_meta.partition_spec,
             };
@@ -642,6 +691,13 @@ impl ExecutionPlan for IcebergCommitExec {
                 let mut table_meta = TableMetadata::from_json(&bytes)
                     .map_err(|e| DataFusionError::External(Box::new(e)))?;
                 Self::validate_requirements(Some(&table_meta), &commit_info.requirements)?;
+                if matches!(commit_info.operation, Operation::Delete)
+                    && commit_info.files_to_remove.is_empty()
+                {
+                    let array = Arc::new(UInt64Array::from(vec![0u64]));
+                    let batch = RecordBatch::try_new(schema, vec![array])?;
+                    return Ok(batch);
+                }
                 let original_format_version = table_meta.format_version;
                 let mut metadata_updates = Vec::new();
                 if let Some(new_schema) = commit_info.schema.clone() {
@@ -893,6 +949,21 @@ impl ExecutionPlan for IcebergCommitExec {
                         }
                         producer
                             .commit(LocalOverwriteOperation)
+                            .await
+                            .map_err(DataFusionError::Execution)?
+                    }
+                    crate::spec::Operation::Delete => {
+                        let producer = crate::operations::SnapshotProducer::new(
+                            &tx,
+                            commit_info.data_files.clone(),
+                            Some(store_ctx.clone()),
+                            Some(manifest_meta),
+                        )
+                        .with_row_lineage_start_row_id(row_lineage_start_row_id);
+                        producer
+                            .commit(DeleteFilesOperation::new(
+                                commit_info.files_to_remove.clone(),
+                            ))
                             .await
                             .map_err(DataFusionError::Execution)?
                     }
@@ -1157,7 +1228,13 @@ fn commit_conflict_error() -> DataFusionError {
 mod tests {
     use std::collections::HashMap;
 
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::prelude::SessionContext;
+    use futures::TryStreamExt;
+    use object_store::memory::InMemory;
+
     use super::*;
+    use crate::physical_plan::action_schema::{encode_commit_meta, iceberg_action_schema};
     use crate::spec::FormatVersion;
 
     fn table_metadata_at_snapshot(snapshot_id: Option<i64>) -> TableMetadata {
@@ -1200,7 +1277,11 @@ mod tests {
                 Url::parse("file:///tmp/table").expect("valid table URL"),
                 None,
             )
-            .with_expected_snapshot_id(Some(Some(41))),
+            .with_expected_snapshot_id(Some(Some(41)))
+            .with_rewrite_data_files(
+                vec!["data/affected.parquet".to_string()],
+                crate::spec::Operation::Delete,
+            ),
         );
 
         let rewritten = commit
@@ -1211,6 +1292,119 @@ mod tests {
             .expect("rewritten plan remains an Iceberg commit");
 
         assert_eq!(rewritten.expected_snapshot_id(), Some(Some(41)));
+        assert_eq!(
+            rewritten.removed_data_file_paths(),
+            &["data/affected.parquet".to_string()]
+        );
+        assert_eq!(
+            rewritten.operation_override(),
+            Some(&crate::spec::Operation::Delete)
+        );
+    }
+
+    fn validation_only_delete_input(table_url: &Url) -> Result<Arc<dyn ExecutionPlan>> {
+        let batch = encode_commit_meta(CommitMeta {
+            table_uri: table_url.to_string(),
+            row_count: 0,
+            operation: Operation::Append,
+            requirements: vec![],
+            table_properties: vec![],
+            lakehouse_table: None,
+            schema: None,
+            partition_spec: None,
+        })?;
+        let schema = iceberg_action_schema()?;
+        let input: Arc<dyn ExecutionPlan> =
+            MemorySourceConfig::try_new_from_batches(schema, vec![batch])?;
+        Ok(input)
+    }
+
+    #[tokio::test]
+    async fn validated_mutation_rejects_missing_writer_commit_meta() -> Result<()> {
+        use datafusion::arrow::datatypes::Schema;
+        use datafusion::physical_plan::empty::EmptyExec;
+
+        let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(Arc::new(Schema::empty())));
+        let commit: Arc<dyn ExecutionPlan> = Arc::new(
+            IcebergCommitExec::new(
+                input,
+                Url::parse("file:///tmp/iceberg-missing-mutation-meta")
+                    .map_err(|error| DataFusionError::Plan(error.to_string()))?,
+                None,
+            )
+            .with_expected_snapshot_id(Some(None))
+            .with_rewrite_data_files(vec![], Operation::Delete),
+        );
+        let context = SessionContext::new();
+
+        let error = datafusion::physical_plan::collect(commit, context.task_ctx())
+            .await
+            .expect_err("validated mutation without commit metadata must fail closed");
+        assert!(error.to_string().contains("missing commit_meta"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn validation_only_delete_rejects_stale_snapshot_and_writes_no_metadata() -> Result<()> {
+        let table_url = Url::parse("memory://strict-delete/table")
+            .map_err(|error| DataFusionError::Plan(error.to_string()))?;
+        let object_store = Arc::new(InMemory::new());
+        let store_ctx = StoreContext::new(object_store.clone(), &table_url)?;
+        let metadata = table_metadata_at_snapshot(Some(2))
+            .to_json()
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
+        store_ctx
+            .prefixed
+            .put(
+                &object_store::path::Path::from("metadata/v1.metadata.json"),
+                object_store::PutPayload::from(Bytes::from(metadata)),
+            )
+            .await
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
+        let context = SessionContext::new();
+        context.runtime_env().register_object_store(
+            &Url::parse("memory://strict-delete")
+                .map_err(|error| DataFusionError::Plan(error.to_string()))?,
+            object_store,
+        );
+
+        let stale: Arc<dyn ExecutionPlan> = Arc::new(
+            IcebergCommitExec::new(
+                validation_only_delete_input(&table_url)?,
+                table_url.clone(),
+                None,
+            )
+            .with_expected_snapshot_id(Some(Some(1)))
+            .with_rewrite_data_files(vec![], Operation::Delete),
+        );
+        let error = datafusion::physical_plan::collect(stale, context.task_ctx())
+            .await
+            .expect_err("advanced snapshot must reject a validation-only delete");
+        assert!(error.to_string().contains("expected snapshot Some(1)"));
+        assert!(error.to_string().contains("found Some(2)"));
+
+        let current: Arc<dyn ExecutionPlan> = Arc::new(
+            IcebergCommitExec::new(validation_only_delete_input(&table_url)?, table_url, None)
+                .with_expected_snapshot_id(Some(Some(2)))
+                .with_rewrite_data_files(vec![], Operation::Delete),
+        );
+        let batches = datafusion::physical_plan::collect(current, context.task_ctx()).await?;
+        assert_eq!(batches.len(), 1);
+        let counts = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .ok_or_else(|| DataFusionError::Internal("count must be UInt64".to_string()))?;
+        assert_eq!(counts.value(0), 0);
+
+        let metadata_objects = store_ctx
+            .prefixed
+            .list(Some(&object_store::path::Path::from("metadata")))
+            .try_collect::<Vec<_>>()
+            .await
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
+        assert_eq!(metadata_objects.len(), 1);
+        Ok(())
     }
 
     #[test]

--- a/crates/sail-iceberg/src/physical_plan/commit/mod.rs
+++ b/crates/sail-iceberg/src/physical_plan/commit/mod.rs
@@ -22,6 +22,8 @@ pub struct IcebergCommitInfo {
     pub table_uri: String,
     pub row_count: u64,
     pub data_files: Vec<DataFile>,
+    #[serde(default)]
+    pub files_to_remove: Vec<String>,
     pub manifest_path: String,
     pub manifest_list_path: String,
     pub updates: Vec<TableUpdate>,

--- a/crates/sail-iceberg/src/physical_plan/plan_builder.rs
+++ b/crates/sail-iceberg/src/physical_plan/plan_builder.rs
@@ -26,6 +26,7 @@ use url::Url;
 
 use crate::physical_plan::writer_exec::IcebergWriterExec;
 use crate::physical_plan::writer_options::IcebergWriterExecOptions;
+use crate::spec::Operation;
 use crate::utils::partition_transform::format_partition_expr;
 
 pub struct IcebergTableConfig {
@@ -41,6 +42,9 @@ pub struct IcebergPlanBuilder<'a> {
     sink_mode: PhysicalSinkMode,
     sort_order: Option<Vec<PhysicalSortExpr>>,
     logical_input_schema: Option<SchemaRef>,
+    expected_snapshot_id: Option<Option<i64>>,
+    removed_data_file_paths: Vec<String>,
+    operation_override: Option<Operation>,
     #[expect(unused)]
     session: &'a dyn Session,
 }
@@ -60,8 +64,26 @@ impl<'a> IcebergPlanBuilder<'a> {
             sink_mode,
             sort_order,
             logical_input_schema,
+            expected_snapshot_id: None,
+            removed_data_file_paths: vec![],
+            operation_override: None,
             session,
         }
+    }
+
+    pub fn with_expected_snapshot_id(mut self, expected_snapshot_id: Option<Option<i64>>) -> Self {
+        self.expected_snapshot_id = expected_snapshot_id;
+        self
+    }
+
+    pub fn with_rewrite_data_files(
+        mut self,
+        removed_data_file_paths: Vec<String>,
+        operation: Operation,
+    ) -> Self {
+        self.removed_data_file_paths = removed_data_file_paths;
+        self.operation_override = Some(operation);
+        self
     }
 
     pub async fn build(self) -> Result<Arc<dyn ExecutionPlan>> {
@@ -157,6 +179,11 @@ impl<'a> IcebergPlanBuilder<'a> {
                 input,
                 self.table_config.table_url.clone(),
                 self.table_config.options.lakehouse_table.clone(),
+            )
+            .with_expected_snapshot_id(self.expected_snapshot_id)
+            .with_optional_rewrite_data_files(
+                self.removed_data_file_paths.clone(),
+                self.operation_override.clone(),
             ),
         ))
     }

--- a/crates/sail-iceberg/src/spec/manifest/_serde.rs
+++ b/crates/sail-iceberg/src/spec/manifest/_serde.rs
@@ -32,9 +32,58 @@ pub(super) struct IntLongMapEntry {
     value: i64,
 }
 
+fn serialize_byte_vec<S>(value: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_bytes(value)
+}
+
+fn deserialize_byte_vec<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct ByteVecVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for ByteVecVisitor {
+        type Value = Vec<u8>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            formatter.write_str("an Avro bytes value")
+        }
+
+        fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(value.to_vec())
+        }
+
+        fn visit_borrowed_bytes<E>(self, value: &'de [u8]) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(value.to_vec())
+        }
+
+        fn visit_byte_buf<E>(self, value: Vec<u8>) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            Ok(value)
+        }
+    }
+
+    deserializer.deserialize_byte_buf(ByteVecVisitor)
+}
+
 #[derive(Serialize, Deserialize)]
 pub(super) struct IntBytesMapEntry {
     key: i32,
+    #[serde(
+        serialize_with = "serialize_byte_vec",
+        deserialize_with = "deserialize_byte_vec"
+    )]
     value: Vec<u8>,
 }
 

--- a/crates/sail-iceberg/src/spec/manifest/writer.rs
+++ b/crates/sail-iceberg/src/spec/manifest/writer.rs
@@ -79,6 +79,31 @@ impl ManifestWriter {
         self.entries.push(Arc::new(entry));
     }
 
+    pub fn add_existing_entry(&mut self, mut entry: ManifestEntry) -> Result<(), String> {
+        entry.status = ManifestStatus::Existing;
+        self.add_rewritten_entry(entry)
+    }
+
+    pub fn add_deleted_entry(&mut self, mut entry: ManifestEntry) -> Result<(), String> {
+        entry.status = ManifestStatus::Deleted;
+        entry.snapshot_id = self.snapshot_id;
+        self.add_rewritten_entry(entry)
+    }
+
+    fn add_rewritten_entry(&mut self, entry: ManifestEntry) -> Result<(), String> {
+        if entry.snapshot_id.is_none()
+            || entry.sequence_number.is_none()
+            || entry.file_sequence_number.is_none()
+        {
+            return Err(
+                "existing and deleted manifest entries require snapshot, data, and file sequence metadata"
+                    .to_string(),
+            );
+        }
+        self.entries.push(Arc::new(entry));
+        Ok(())
+    }
+
     pub fn finish(self) -> Manifest {
         Manifest::new(
             self.metadata,
@@ -125,13 +150,20 @@ impl ManifestWriter {
             .filter(|e| matches!(e.status, ManifestStatus::Deleted))
             .map(|e| e.data_file.record_count as i64)
             .sum();
+        let min_sequence_number = self
+            .entries
+            .iter()
+            .filter(|entry| !matches!(entry.status, ManifestStatus::Deleted))
+            .filter_map(|entry| entry.sequence_number)
+            .min()
+            .unwrap_or(sequence_number);
         ManifestFile {
             manifest_path,
             manifest_length: 0,
             partition_spec_id: self.metadata.partition_spec.spec_id(),
-            content: ManifestContentType::Data,
+            content: self.metadata.content,
             sequence_number,
-            min_sequence_number: sequence_number,
+            min_sequence_number,
             added_snapshot_id: snapshot_id,
             added_files_count: Some(added),
             existing_files_count: Some(existing),
@@ -206,5 +238,107 @@ impl ManifestWriter {
         writer
             .into_inner()
             .map_err(|e| format!("Avro writer finalize error: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![expect(clippy::unwrap_used)]
+
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::spec::{
+        DataContentType, DataFileFormat, ManifestContentType, PartitionSpec, Schema,
+    };
+
+    fn data_file(path: &str, record_count: u64) -> DataFile {
+        DataFile {
+            content: DataContentType::Data,
+            file_path: path.to_string(),
+            file_format: DataFileFormat::Parquet,
+            partition: vec![],
+            record_count,
+            file_size_in_bytes: 100,
+            column_sizes: HashMap::new(),
+            value_counts: HashMap::new(),
+            null_value_counts: HashMap::new(),
+            nan_value_counts: HashMap::new(),
+            lower_bounds: HashMap::new(),
+            upper_bounds: HashMap::new(),
+            block_size_in_bytes: None,
+            key_metadata: None,
+            split_offsets: vec![],
+            equality_ids: vec![],
+            sort_order_id: None,
+            first_row_id: None,
+            partition_spec_id: 0,
+            referenced_data_file: None,
+            content_offset: None,
+            content_size_in_bytes: None,
+        }
+    }
+
+    fn manifest_metadata() -> ManifestMetadata {
+        let schema = Schema::builder().with_fields(vec![]).build().unwrap();
+        ManifestMetadata::new(
+            Arc::new(schema),
+            0,
+            PartitionSpec::builder().with_spec_id(0).build(),
+            FormatVersion::V2,
+            ManifestContentType::Data,
+        )
+    }
+
+    #[test]
+    fn existing_and_deleted_entries_preserve_sequence_metadata_and_counts() {
+        let original = ManifestEntry::new(
+            ManifestStatus::Added,
+            Some(10),
+            Some(1),
+            Some(1),
+            data_file("data/original.parquet", 3),
+        );
+        let mut writer = ManifestWriterBuilder::new(Some(20), None, manifest_metadata()).build();
+
+        writer.add_existing_entry(original.clone()).unwrap();
+        writer.add_deleted_entry(original).unwrap();
+
+        let bytes = writer.to_avro_bytes_v2().unwrap();
+        let manifest_file = writer.into_manifest_file("metadata/rewrite.avro".to_string(), 2, 20);
+        let manifest = Manifest::parse_avro(&bytes).unwrap();
+
+        assert_eq!(manifest.entries.len(), 2);
+        assert_eq!(manifest.entries[0].status, ManifestStatus::Existing);
+        assert_eq!(manifest.entries[0].snapshot_id, Some(10));
+        assert_eq!(manifest.entries[0].sequence_number, Some(1));
+        assert_eq!(manifest.entries[0].file_sequence_number, Some(1));
+        assert_eq!(manifest.entries[1].status, ManifestStatus::Deleted);
+        assert_eq!(manifest.entries[1].snapshot_id, Some(20));
+        assert_eq!(manifest.entries[1].sequence_number, Some(1));
+        assert_eq!(manifest.entries[1].file_sequence_number, Some(1));
+
+        assert_eq!(manifest_file.content, ManifestContentType::Data);
+        assert_eq!(manifest_file.added_files_count, Some(0));
+        assert_eq!(manifest_file.existing_files_count, Some(1));
+        assert_eq!(manifest_file.deleted_files_count, Some(1));
+        assert_eq!(manifest_file.added_rows_count, Some(0));
+        assert_eq!(manifest_file.existing_rows_count, Some(3));
+        assert_eq!(manifest_file.deleted_rows_count, Some(3));
+        assert_eq!(manifest_file.min_sequence_number, 1);
+    }
+
+    #[test]
+    fn existing_entries_require_their_original_snapshot_id() {
+        let entry = ManifestEntry::new(
+            ManifestStatus::Added,
+            None,
+            Some(1),
+            Some(1),
+            data_file("data/original.parquet", 3),
+        );
+        let mut writer = ManifestWriterBuilder::new(Some(20), None, manifest_metadata()).build();
+
+        assert!(writer.add_existing_entry(entry).is_err());
     }
 }

--- a/crates/sail-iceberg/src/table_format.rs
+++ b/crates/sail-iceberg/src/table_format.rs
@@ -16,7 +16,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use datafusion::arrow::datatypes::{Field as ArrowField, Schema as ArrowSchema};
 use datafusion::catalog::{Session, TableProvider};
-use datafusion::common::{DataFusionError, Result, not_impl_err, plan_err};
+use datafusion::common::{DFSchema, DataFusionError, Result, not_impl_err, plan_err};
 use datafusion::execution::SessionState;
 use datafusion::logical_expr::{LogicalPlan, TableSource};
 use datafusion::physical_plan::ExecutionPlan;
@@ -31,13 +31,15 @@ use sail_common_datafusion::catalog::{
     CatalogPartitionField, CommitAuthority, LakehouseExecutionContext, ScanAuthority,
 };
 use sail_common_datafusion::datasource::{
-    BucketBy, OptionLayer, PhysicalSinkMode, SinkInfo, SinkMode, SourceInfo, TableFormat,
-    TableFormatAlterTableOperation, TableFormatCreateTableColumn, TableFormatCreateTableInfo,
-    TableFormatCreateTableResult, TableFormatRegistry, create_sort_order, find_path_in_options,
+    BucketBy, DeleteInfo, OptionLayer, PhysicalSinkMode, SinkInfo, SinkMode, SourceInfo,
+    TableFormat, TableFormatAlterTableOperation, TableFormatCreateTableColumn,
+    TableFormatCreateTableInfo, TableFormatCreateTableResult, TableFormatRegistry,
+    create_sort_order, find_path_in_options,
 };
 use sail_common_datafusion::utils::items::ItemTaker;
 use sail_common_datafusion::variant::with_variant_extension_if_marked_storage;
 use sail_data_source::options::ResolveOptions;
+use sail_logical_plan::merge::RowLevelWriteNode;
 use url::Url;
 
 use crate::datasource::provider::IcebergTableProvider;
@@ -139,6 +141,35 @@ impl TableFormat for IcebergTableFormat {
                     lakehouse_table,
                 },
             )),
+        }))
+    }
+
+    async fn create_deleter(&self, _ctx: &dyn Session, info: DeleteInfo) -> Result<LogicalPlan> {
+        let DeleteInfo {
+            table_name,
+            path,
+            condition,
+            lakehouse_table,
+            options,
+        } = info;
+        let write_node = RowLevelWriteNode::new_delete(
+            Arc::new(LogicalPlan::EmptyRelation(
+                datafusion_expr::logical_plan::EmptyRelation {
+                    produce_one_row: false,
+                    schema: Arc::new(DFSchema::empty()),
+                },
+            )),
+            Arc::new(DFSchema::empty()),
+            condition,
+            self.name().to_string(),
+            path,
+            table_name,
+            options,
+            lakehouse_table,
+        );
+
+        Ok(LogicalPlan::Extension(Extension {
+            node: Arc::new(write_node),
         }))
     }
 
@@ -619,10 +650,10 @@ impl IcebergTableFormat {
         }
     }
 
-    // TODO: Implement row-level DELETE/UPDATE/MERGE for this format. Expanded
-    // inputs should consume Sail row intent tags to decide which rows rewrite
-    // data files and which rows produce low-level delete artifacts, then strip
-    // all internal metadata before writing user data.
+    // TODO: Implement row-level UPDATE/MERGE for this format. Expanded inputs
+    // should consume Sail row intent tags to decide which rows rewrite data files
+    // and which rows produce low-level delete artifacts, then strip all internal
+    // metadata before writing user data.
 }
 
 /// Create an Iceberg table provider for reading.
@@ -647,7 +678,7 @@ pub async fn create_iceberg_provider_concrete(
     Ok(Arc::new(provider))
 }
 
-async fn build_iceberg_provider(
+pub(crate) async fn build_iceberg_provider(
     ctx: &dyn Session,
     info: SourceInfo,
 ) -> Result<Arc<IcebergTableProvider>> {
@@ -1056,6 +1087,42 @@ mod tests {
     };
 
     use super::*;
+
+    #[tokio::test]
+    async fn create_deleter_builds_conditionless_iceberg_row_level_node() -> Result<()> {
+        use datafusion::execution::context::SessionContext;
+
+        let state = SessionContext::default().state();
+        let plan = IcebergTableFormat
+            .create_deleter(
+                &state,
+                DeleteInfo {
+                    table_name: vec!["catalog".to_string(), "table".to_string()],
+                    path: "file:///tmp/iceberg-delete".to_string(),
+                    condition: None,
+                    lakehouse_table: None,
+                    options: vec![],
+                },
+            )
+            .await?;
+        let LogicalPlan::Extension(extension) = plan else {
+            return plan_err!("Iceberg DELETE must produce an extension node");
+        };
+        let node = extension
+            .node
+            .as_any()
+            .downcast_ref::<RowLevelWriteNode>()
+            .ok_or_else(|| {
+                DataFusionError::Plan(
+                    "Iceberg DELETE extension must be a RowLevelWriteNode".to_string(),
+                )
+            })?;
+
+        assert_eq!(node.target_format(), "iceberg");
+        assert_eq!(node.target_location(), "file:///tmp/iceberg-delete");
+        assert!(node.condition().is_none());
+        Ok(())
+    }
 
     #[test]
     fn split_iceberg_write_options_keeps_catalog_options_out_of_table_properties() -> Result<()> {

--- a/python/pysail/testing/spark/steps/iceberg.py
+++ b/python/pysail/testing/spark/steps/iceberg.py
@@ -637,6 +637,34 @@ def check_iceberg_metadata_contains(variables, datatable):
         assert actual == expected, f"path {path!r} expected {expected!r}, got {actual!r}"
 
 
+@given("remember current iceberg data manifest paths")
+def remember_current_iceberg_data_manifest_paths(variables):
+    location = variables.get("location")
+    assert location is not None, "expected variable `location` to be defined for iceberg manifest inspection"
+
+    metadata = _find_latest_metadata(Path(location.path))
+    manifest_list = _current_manifest_list(metadata)
+    variables["remembered_iceberg_data_manifest_paths"] = {
+        manifest["manifest-path"] for manifest in manifest_list["manifests"] if manifest.get("content") == "data"
+    }
+
+
+@then(parsers.parse("iceberg current data manifests reuse {count:d} remembered paths"))
+def check_iceberg_data_manifest_reuse(variables, count: int):
+    location = variables.get("location")
+    assert location is not None, "expected variable `location` to be defined for iceberg manifest inspection"
+    remembered = variables.get("remembered_iceberg_data_manifest_paths")
+    assert remembered is not None, "expected remembered Iceberg data manifest paths"
+
+    metadata = _find_latest_metadata(Path(location.path))
+    manifest_list = _current_manifest_list(metadata)
+    current = {
+        manifest["manifest-path"] for manifest in manifest_list["manifests"] if manifest.get("content") == "data"
+    }
+    reused = current & remembered
+    assert len(reused) == count, f"expected {count} reused data manifests, found {len(reused)}: {reused!r}"
+
+
 @then("iceberg current manifest list matches snapshot")
 def check_iceberg_current_manifest_list_matches_snapshot(variables, snapshot: SnapshotAssertion):
     location = variables.get("location")

--- a/python/pysail/tests/spark/iceberg/features/delete.feature
+++ b/python/pysail/tests/spark/iceberg/features/delete.feature
@@ -1,0 +1,115 @@
+Feature: Iceberg copy-on-write DELETE
+
+  Background:
+    Given variable location for temporary directory iceberg_delete
+    Given final statement
+      """
+      DROP TABLE IF EXISTS iceberg_delete_table
+      """
+
+  Scenario: DELETE rewrites only candidate files and records a delete snapshot
+    Given statement template
+      """
+      CREATE TABLE iceberg_delete_table (id INT, value STRING)
+      USING iceberg
+      LOCATION {{ location.uri }}
+      """
+    Given statement
+      """
+      INSERT INTO iceberg_delete_table VALUES (1, 'remove'), (2, 'keep-first-file')
+      """
+    Given statement
+      """
+      INSERT INTO iceberg_delete_table VALUES (10, 'keep-second-file')
+      """
+    Given remember current iceberg data manifest paths
+    Given statement
+      """
+      DELETE FROM iceberg_delete_table WHERE id = 1
+      """
+    Then iceberg snapshot operation is delete
+    Then iceberg current data manifests reuse 1 remembered paths
+    Then iceberg snapshot count is 3
+    When query
+      """
+      SELECT * FROM iceberg_delete_table ORDER BY id
+      """
+    Then query result ordered
+      | id | value            |
+      | 2  | keep-first-file  |
+      | 10 | keep-second-file |
+
+  Scenario: DELETE retains rows where the predicate is false or null
+    Given statement template
+      """
+      CREATE TABLE iceberg_delete_table (id INT, score INT)
+      USING iceberg
+      LOCATION {{ location.uri }}
+      """
+    Given statement
+      """
+      INSERT INTO iceberg_delete_table VALUES (1, NULL), (2, 10), (3, 1)
+      """
+    Given statement
+      """
+      DELETE FROM iceberg_delete_table WHERE score > 5
+      """
+    When query
+      """
+      SELECT * FROM iceberg_delete_table ORDER BY id
+      """
+    Then query result collected ordered
+      | id | score |
+      | 1  | NULL  |
+      | 3  | 1     |
+
+  Scenario: DELETE without WHERE removes all rows
+    Given statement template
+      """
+      CREATE TABLE iceberg_delete_table (id INT)
+      USING iceberg
+      LOCATION {{ location.uri }}
+      """
+    Given statement
+      """
+      INSERT INTO iceberg_delete_table VALUES (1), (2), (3)
+      """
+    Given statement
+      """
+      DELETE FROM iceberg_delete_table
+      """
+    Then iceberg snapshot operation is delete
+    Then iceberg snapshot count is 2
+    When query
+      """
+      SELECT * FROM iceberg_delete_table
+      """
+    Then query result
+      | id |
+
+  Scenario: DELETE with no candidate files is a validated no-op
+    Given statement template
+      """
+      CREATE TABLE iceberg_delete_table (id INT)
+      USING iceberg
+      LOCATION {{ location.uri }}
+      """
+    Given statement
+      """
+      INSERT INTO iceberg_delete_table VALUES (1), (2), (3)
+      """
+    Given statement
+      """
+      DELETE FROM iceberg_delete_table WHERE id = 999
+      """
+    Then iceberg snapshot count is 1
+    Then iceberg snapshot operation is append
+    When query
+      """
+      SELECT * FROM iceberg_delete_table ORDER BY id
+      """
+    Then query result ordered
+      | id |
+      | 1  |
+      | 2  |
+      | 3  |

--- a/python/pysail/tests/spark/iceberg/test_iceberg_delete_count.py
+++ b/python/pysail/tests/spark/iceberg/test_iceberg_delete_count.py
@@ -1,0 +1,21 @@
+def test_iceberg_delete_returns_affected_row_count(spark, tmp_path):
+    table_name = "iceberg_delete_affected_count"
+    location = (tmp_path / table_name).as_uri()
+    spark.sql(f"DROP TABLE IF EXISTS {table_name}")
+    spark.sql(f"CREATE TABLE {table_name} (id BIGINT, category STRING) USING iceberg LOCATION '{location}'")
+    try:
+        spark.sql(f"INSERT INTO {table_name} VALUES (1, 'delete'), (2, 'delete'), (3, 'keep')")
+
+        result = (
+            spark.sql(f"DELETE FROM {table_name} WHERE category = 'delete'")
+            .selectExpr("CAST(count AS BIGINT) AS count")
+            .collect()
+        )
+
+        assert [row["count"] for row in result] == [2]
+        remaining = spark.table(table_name).collect()
+        assert len(remaining) == 1
+        assert remaining[0]["id"] == 3
+        assert remaining[0]["category"] == "keep"
+    finally:
+        spark.sql(f"DROP TABLE IF EXISTS {table_name}")


### PR DESCRIPTION
## Summary

- plan Iceberg `DELETE` as a strict-snapshot, manifest-pruned copy-on-write mutation
- scan and rewrite only candidate data files, preserving SQL `NULL` semantics with `IS NOT TRUE` and supporting conditionless delete-all
- reject tables with active merge-on-read delete files to prevent row resurrection
- carry removed paths and `Operation::Delete` through optimizer rewrites and the distributed physical-plan codec
- write conservative Parquet-derived Iceberg bounds and preserve them through action batches and Avro manifest decoding so sparse predicates can safely reuse unaffected manifests

## Stack

- depends on #2309 (strict Iceberg snapshot conflicts)
- #2309 depends on #2300 (selective Iceberg rewrite)

## Validation

- `cargo test -p sail-iceberg --lib` — 105 passed
- `cargo test -p sail-execution iceberg_commit_rewrite_round_trip_preserves_paths_and_operation --lib` — passed
- `cargo clippy -p sail-iceberg -p sail-execution --lib --tests -- -D warnings` — passed
- current-wheel Iceberg DELETE BDD — 4 passed (selective manifest reuse, SQL NULL retention, delete-all, validated no-candidate no-op)
- `cargo fmt --all -- --check` — passed
- Ruff check and format check for the changed Python step module — passed
