### PR TITLE
refactor: consolidate schema type merging logic

### DIFF
--- a/crates/sail-function/src/aggregate/schema_of_variant_agg.rs
+++ b/crates/sail-function/src/aggregate/schema_of_variant_agg.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use arrow::array::{Array, ArrayRef};
@@ -7,10 +6,13 @@ use datafusion::common::Result;
 use datafusion::logical_expr::function::{AccumulatorArgs, StateFieldsArgs};
 use datafusion::logical_expr::{Accumulator, AggregateUDFImpl, Signature, Volatility};
 use datafusion::scalar::ScalarValue;
-use parquet_variant::Variant;
 use parquet_variant_compute::VariantArray;
 
-use crate::scalar::variant::spark_schema_of_variant::variant_to_spark_type;
+use crate::scalar::variant::spark_schema_of_variant::{
+    merge_variant_types, variant_to_inferred_type, variant_type_from_spark_type,
+    variant_type_to_spark_type,
+};
+use crate::schema_inference::InferredType;
 
 /// Aggregate function that merges variant schemas across rows.
 ///
@@ -68,185 +70,9 @@ impl AggregateUDFImpl for SchemaOfVariantAggFunction {
     }
 }
 
-/// Internal representation of a merged variant schema.
-#[derive(Debug, Clone, PartialEq)]
-enum MergedType {
-    /// A concrete primitive type (e.g., "BIGINT", "STRING", "BOOLEAN")
-    Primitive(String),
-    /// VOID (from null values)
-    Void,
-    /// An object with merged fields (field_name → merged_type)
-    Object(BTreeMap<String, MergedType>),
-    /// An array with a merged element type
-    Array(Box<MergedType>),
-    /// Mixed types that cannot be unified → VARIANT
-    Variant,
-}
-
-impl MergedType {
-    /// Parse a Spark type string back into a MergedType.
-    fn from_spark_type(s: &str) -> Result<Self> {
-        if s == "VOID" {
-            return Ok(MergedType::Void);
-        }
-        if s == "VARIANT" {
-            return Ok(MergedType::Variant);
-        }
-        if let Some(inner) = s.strip_prefix("OBJECT<").and_then(|s| s.strip_suffix('>')) {
-            if inner.is_empty() {
-                return Ok(MergedType::Object(BTreeMap::new()));
-            }
-            let mut fields = BTreeMap::new();
-            for field_str in split_top_level(inner) {
-                let (name, type_str) = field_str.split_once(": ").ok_or_else(|| {
-                    datafusion::common::DataFusionError::Execution(format!(
-                        "schema_of_variant_agg: invalid object field entry '{field_str}'"
-                    ))
-                })?;
-                fields.insert(
-                    name.trim().to_string(),
-                    MergedType::from_spark_type(type_str.trim())?,
-                );
-            }
-            return Ok(MergedType::Object(fields));
-        }
-        if let Some(inner) = s.strip_prefix("ARRAY<").and_then(|s| s.strip_suffix('>')) {
-            return Ok(MergedType::Array(Box::new(MergedType::from_spark_type(
-                inner,
-            )?)));
-        }
-        Ok(MergedType::Primitive(s.to_string()))
-    }
-
-    /// Convert to Spark type string.
-    fn to_spark_type(&self) -> String {
-        match self {
-            MergedType::Void => "VOID".to_string(),
-            MergedType::Primitive(s) => s.clone(),
-            MergedType::Variant => "VARIANT".to_string(),
-            MergedType::Object(fields) => {
-                if fields.is_empty() {
-                    return "OBJECT<>".to_string();
-                }
-                let fields_str: Vec<String> = fields
-                    .iter()
-                    .map(|(name, ty)| format!("{name}: {}", ty.to_spark_type()))
-                    .collect();
-                format!("OBJECT<{}>", fields_str.join(", "))
-            }
-            MergedType::Array(elem) => {
-                format!("ARRAY<{}>", elem.to_spark_type())
-            }
-        }
-    }
-
-    /// Estimate heap memory usage recursively.
-    fn estimated_size(&self) -> usize {
-        match self {
-            MergedType::Void | MergedType::Variant => 0,
-            MergedType::Primitive(s) => s.len(),
-            MergedType::Object(fields) => fields
-                .iter()
-                .map(|(k, v)| {
-                    k.len() + v.estimated_size() + std::mem::size_of::<(String, MergedType)>()
-                })
-                .sum(),
-            MergedType::Array(elem) => std::mem::size_of::<MergedType>() + elem.estimated_size(),
-        }
-    }
-
-    /// Merge two types together.
-    fn merge(self, other: MergedType) -> MergedType {
-        match (self, other) {
-            // VOID merges with anything → the other type
-            (MergedType::Void, other) | (other, MergedType::Void) => other,
-            // VARIANT absorbs everything
-            (MergedType::Variant, _) | (_, MergedType::Variant) => MergedType::Variant,
-            // Same primitive → keep
-            (MergedType::Primitive(a), MergedType::Primitive(b)) if a == b => {
-                MergedType::Primitive(a)
-            }
-            // Different primitives → VARIANT
-            (MergedType::Primitive(_), MergedType::Primitive(_)) => MergedType::Variant,
-            // Object + Object → merge fields
-            (MergedType::Object(mut a), MergedType::Object(b)) => {
-                for (key, val) in b {
-                    match a.entry(key) {
-                        std::collections::btree_map::Entry::Occupied(mut entry) => {
-                            let old = std::mem::replace(entry.get_mut(), MergedType::Void);
-                            *entry.get_mut() = old.merge(val);
-                        }
-                        std::collections::btree_map::Entry::Vacant(entry) => {
-                            entry.insert(val);
-                        }
-                    }
-                }
-                MergedType::Object(a)
-            }
-            // Array + Array → merge element types
-            (MergedType::Array(a), MergedType::Array(b)) => {
-                MergedType::Array(Box::new(a.merge(*b)))
-            }
-            // Incompatible types → VARIANT
-            _ => MergedType::Variant,
-        }
-    }
-}
-
-/// Split a string by top-level commas (respecting nested angle brackets and parentheses).
-/// Handles types like `DECIMAL(10,2)` inside `OBJECT<...>` fields.
-fn split_top_level(s: &str) -> Vec<&str> {
-    let mut results = Vec::new();
-    let mut angle_depth: usize = 0;
-    let mut paren_depth: usize = 0;
-    let mut start = 0;
-    for (i, ch) in s.char_indices() {
-        match ch {
-            '<' => angle_depth += 1,
-            '>' => angle_depth = angle_depth.saturating_sub(1),
-            '(' => paren_depth += 1,
-            ')' => paren_depth = paren_depth.saturating_sub(1),
-            ',' if angle_depth == 0 && paren_depth == 0 => {
-                results.push(s[start..i].trim());
-                start = i + 1;
-            }
-            _ => {}
-        }
-    }
-    if start < s.len() {
-        results.push(s[start..].trim());
-    }
-    results
-}
-
-/// Convert a Variant to a MergedType.
-fn variant_to_merged_type(variant: &Variant) -> MergedType {
-    match variant {
-        Variant::Null => MergedType::Void,
-        Variant::Object(obj) => {
-            let mut fields = BTreeMap::new();
-            for (name, value) in obj.iter() {
-                fields.insert(name.to_string(), variant_to_merged_type(&value));
-            }
-            MergedType::Object(fields)
-        }
-        Variant::List(list) => {
-            let mut elem_type = MergedType::Void;
-            for elem in list.iter() {
-                elem_type = elem_type.merge(variant_to_merged_type(&elem));
-            }
-            MergedType::Array(Box::new(elem_type))
-        }
-        _ => {
-            // Use the same type string as schema_of_variant for primitives
-            MergedType::Primitive(variant_to_spark_type(variant))
-        }
-    }
-}
-
 #[derive(Debug)]
 struct SchemaOfVariantAggAccumulator {
-    merged_schema: Option<MergedType>,
+    merged_schema: Option<InferredType>,
 }
 
 impl Accumulator for SchemaOfVariantAggAccumulator {
@@ -255,9 +81,9 @@ impl Accumulator for SchemaOfVariantAggAccumulator {
         let variant_array = VariantArray::try_new(arr.as_ref())?;
 
         for variant in variant_array.iter().flatten() {
-            let current_type = variant_to_merged_type(&variant);
+            let current_type = variant_to_inferred_type(&variant);
             self.merged_schema = Some(match self.merged_schema.take() {
-                Some(existing) => existing.merge(current_type),
+                Some(existing) => merge_variant_types(existing, current_type),
                 None => current_type,
             });
         }
@@ -268,7 +94,7 @@ impl Accumulator for SchemaOfVariantAggAccumulator {
         let schema_str = self
             .merged_schema
             .as_ref()
-            .map_or_else(|| "VOID".to_string(), |t| t.to_spark_type());
+            .map_or_else(|| "VOID".to_string(), variant_type_to_spark_type);
         Ok(vec![ScalarValue::Utf8(Some(schema_str))])
     }
 
@@ -286,9 +112,9 @@ impl Accumulator for SchemaOfVariantAggAccumulator {
             if schema_arr.is_null(i) {
                 continue;
             }
-            let other_schema = MergedType::from_spark_type(schema_arr.value(i))?;
+            let other_schema = variant_type_from_spark_type(schema_arr.value(i))?;
             self.merged_schema = Some(match self.merged_schema.take() {
-                Some(existing) => existing.merge(other_schema),
+                Some(existing) => merge_variant_types(existing, other_schema),
                 None => other_schema,
             });
         }
@@ -300,7 +126,7 @@ impl Accumulator for SchemaOfVariantAggAccumulator {
         let result = self
             .merged_schema
             .as_ref()
-            .map_or_else(|| "VOID".to_string(), |t| t.to_spark_type());
+            .map_or_else(|| "VOID".to_string(), variant_type_to_spark_type);
         Ok(ScalarValue::Utf8(Some(result)))
     }
 

--- a/crates/sail-function/src/lib.rs
+++ b/crates/sail-function/src/lib.rs
@@ -4,6 +4,7 @@ mod functions_nested_utils;
 mod functions_utils;
 mod hll_sketch;
 pub mod scalar;
+mod schema_inference;
 pub mod sketch {
     pub use crate::hll_sketch::DEFAULT_LG_CONFIG_K as DEFAULT_HLL_LG_CONFIG_K;
     pub use crate::theta_sketch::DEFAULT_LG_NOM_ENTRIES as DEFAULT_THETA_LG_NOM_ENTRIES;

--- a/crates/sail-function/src/scalar/json/schema_of_json.rs
+++ b/crates/sail-function/src/scalar/json/schema_of_json.rs
@@ -17,6 +17,8 @@ use datafusion_expr_common::signature::Volatility;
 use datafusion_functions::downcast_arg;
 use datafusion_functions::utils::make_scalar_function;
 
+use crate::schema_inference::{InferredType, TypeMerger};
+
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct SparkSchemaOfJson {
     signature: Signature,
@@ -200,26 +202,6 @@ fn infer_json_schema_type(json_string: &str, options: &SparkSchemaOfJsonOptions)
 
 /// The maximum precision of Spark's `DecimalType`.
 const MAX_DECIMAL_PRECISION: usize = 38;
-
-/// A JSON type inferred from a literal JSON string, mirroring the types that
-/// Spark's `JsonInferSchema` can produce for `schema_of_json`.
-#[derive(Debug, Clone, PartialEq)]
-enum InferredType {
-    Null,
-    Boolean,
-    Long,
-    /// A number inferred as a decimal with the given precision and scale.
-    Decimal(u8, u8),
-    Double,
-    String,
-    /// A string inferred as a timestamp when the `inferTimestamp` option is
-    /// enabled and the value matches a recognized timestamp/date pattern.
-    Timestamp,
-    Array(Box<InferredType>),
-    /// Fields are sorted by name and duplicate names are preserved, matching
-    /// Spark's `JsonInferSchema`.
-    Struct(Vec<(String, InferredType)>),
-}
 
 /// A parser that infers the Spark type of a literal JSON string, mirroring
 /// the Jackson lexing behavior that Spark relies on for `schema_of_json`,
@@ -831,18 +813,22 @@ fn is_timestamp_string(s: &str) -> bool {
 /// Returns the most specific type that both types can be promoted to,
 /// mirroring Spark's `JsonInferSchema.compatibleType`.
 fn merge_types(left: InferredType, right: InferredType) -> InferredType {
-    use InferredType::*;
-    match (left, right) {
-        (Null, t) | (t, Null) => t,
-        (l, r) if l == r => l,
-        (Long, Double) | (Double, Long) => Double,
-        // A long is at most `DECIMAL(20, 0)` when promoted to a decimal.
-        (Long, Decimal(p, s)) | (Decimal(p, s), Long) => merge_decimals(p.max(20), s, 20, 0),
-        (Double, Decimal(_, _)) | (Decimal(_, _), Double) => Double,
-        (Decimal(p1, s1), Decimal(p2, s2)) => merge_decimals(p1, s1, p2, s2),
-        (Array(l), Array(r)) => Array(Box::new(merge_types(*l, *r))),
-        (Struct(l), Struct(r)) => Struct(merge_fields(l, r)),
-        _ => String,
+    left.merge_with(right, &JsonTypeMerger)
+}
+
+struct JsonTypeMerger;
+
+impl TypeMerger for JsonTypeMerger {
+    fn merge_atomic(&self, left: InferredType, right: InferredType) -> InferredType {
+        use InferredType::*;
+        match (left, right) {
+            (Long, Double) | (Double, Long) => Double,
+            // A long is at most `DECIMAL(20, 0)` when promoted to a decimal.
+            (Long, Decimal(p, s)) | (Decimal(p, s), Long) => merge_decimals(p.max(20), s, 20, 0),
+            (Double, Decimal(_, _)) | (Decimal(_, _), Double) => Double,
+            (Decimal(p1, s1), Decimal(p2, s2)) => merge_decimals(p1, s1, p2, s2),
+            _ => String,
+        }
     }
 }
 
@@ -859,27 +845,6 @@ fn merge_decimals(p1: u8, s1: u8, p2: u8, s2: u8) -> InferredType {
     }
 }
 
-/// Merges the fields of two structs by name, mirroring Spark's behavior of
-/// grouping fields by name and reducing each group with `compatibleType`.
-fn merge_fields(
-    left: Vec<(String, InferredType)>,
-    right: Vec<(String, InferredType)>,
-) -> Vec<(String, InferredType)> {
-    let mut fields = left;
-    fields.extend(right);
-    fields.sort_by(|(a, _), (b, _)| a.cmp(b));
-    let mut merged: Vec<(String, InferredType)> = Vec::new();
-    for (name, t) in fields {
-        match merged.last_mut() {
-            Some((last_name, last_type)) if *last_name == name => {
-                *last_type = merge_types(last_type.clone(), t);
-            }
-            _ => merged.push((name, t)),
-        }
-    }
-    merged
-}
-
 /// Writes the type as a Spark DDL string, returning `None` for types that
 /// Spark drops during canonicalization (empty structs, fields with empty
 /// names, and arrays of dropped types). `NULL` types become `STRING`.
@@ -888,10 +853,14 @@ fn canonicalize_ddl(t: &InferredType) -> Option<String> {
         InferredType::Null => Some("STRING".to_string()),
         InferredType::Boolean => Some("BOOLEAN".to_string()),
         InferredType::Long => Some("BIGINT".to_string()),
+        InferredType::Float => Some("FLOAT".to_string()),
         InferredType::Decimal(p, s) => Some(format!("DECIMAL({p},{s})")),
         InferredType::Double => Some("DOUBLE".to_string()),
         InferredType::String => Some("STRING".to_string()),
+        InferredType::Binary => Some("BINARY".to_string()),
+        InferredType::Date => Some("DATE".to_string()),
         InferredType::Timestamp => Some("TIMESTAMP".to_string()),
+        InferredType::TimestampNtz => Some("TIMESTAMP_NTZ".to_string()),
         InferredType::Array(element) => canonicalize_ddl(element).map(|e| format!("ARRAY<{e}>")),
         InferredType::Struct(fields) => {
             let fields = fields
@@ -907,6 +876,7 @@ fn canonicalize_ddl(t: &InferredType) -> Option<String> {
                 Some(format!("STRUCT<{}>", fields.join(", ")))
             }
         }
+        InferredType::Variant => Some("VARIANT".to_string()),
     }
 }
 

--- a/crates/sail-function/src/scalar/variant/spark_schema_of_variant.rs
+++ b/crates/sail-function/src/scalar/variant/spark_schema_of_variant.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use arrow::array::ArrayRef;
 use arrow_schema::DataType;
-use datafusion::common::{exec_datafusion_err, exec_err};
+use datafusion::common::{DataFusionError, exec_datafusion_err, exec_err};
 use datafusion::error::Result;
 use datafusion::logical_expr::{
     ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
@@ -13,6 +13,7 @@ use parquet_variant_compute::VariantArray;
 
 use crate::error::invalid_arg_count_exec_err;
 use crate::scalar::variant::utils::helper::{try_field_as_variant_array, try_parse_variant_scalar};
+use crate::schema_inference::{InferredType, TypeMerger};
 
 /// Returns the schema (type string) of a variant value using Spark type names.
 ///
@@ -115,145 +116,163 @@ impl ScalarUDFImpl for SparkSchemaOfVariantUdf {
 
 /// Convert a Variant value to its Spark type string representation.
 pub(crate) fn variant_to_spark_type(variant: &Variant) -> String {
+    variant_type_to_spark_type(&variant_to_inferred_type(variant))
+}
+
+pub(crate) fn variant_to_inferred_type(variant: &Variant) -> InferredType {
     match variant {
-        Variant::Null => "VOID".to_string(),
-        Variant::BooleanTrue | Variant::BooleanFalse => "BOOLEAN".to_string(),
+        Variant::Null => InferredType::Null,
+        Variant::BooleanTrue | Variant::BooleanFalse => InferredType::Boolean,
         Variant::Int8(_) | Variant::Int16(_) | Variant::Int32(_) | Variant::Int64(_) => {
-            "BIGINT".to_string()
+            InferredType::Long
         }
-        Variant::Float(_) => "FLOAT".to_string(),
-        Variant::Double(_) => "DOUBLE".to_string(),
-        Variant::Decimal4(d) => decimal_type_string(d.integer() as i128, d.scale()),
-        Variant::Decimal8(d) => decimal_type_string(d.integer() as i128, d.scale()),
-        Variant::Decimal16(d) => decimal_type_string(d.integer(), d.scale()),
-        Variant::String(_) | Variant::ShortString(_) => "STRING".to_string(),
-        Variant::Binary(_) => "BINARY".to_string(),
-        Variant::Date(_) => "DATE".to_string(),
-        Variant::TimestampMicros(_) | Variant::TimestampNanos(_) => "TIMESTAMP".to_string(),
+        Variant::Float(_) => InferredType::Float,
+        Variant::Double(_) => InferredType::Double,
+        Variant::Decimal4(d) => decimal_type(d.integer() as i128, d.scale()),
+        Variant::Decimal8(d) => decimal_type(d.integer() as i128, d.scale()),
+        Variant::Decimal16(d) => decimal_type(d.integer(), d.scale()),
+        Variant::String(_) | Variant::ShortString(_) => InferredType::String,
+        Variant::Binary(_) => InferredType::Binary,
+        Variant::Date(_) => InferredType::Date,
+        Variant::TimestampMicros(_) | Variant::TimestampNanos(_) => InferredType::Timestamp,
         Variant::TimestampNtzMicros(_) | Variant::TimestampNtzNanos(_) => {
-            "TIMESTAMP_NTZ".to_string()
+            InferredType::TimestampNtz
         }
-        Variant::Time(_) => "STRING".to_string(),
-        Variant::Uuid(_) => "STRING".to_string(),
+        Variant::Time(_) | Variant::Uuid(_) => InferredType::String,
         Variant::Object(obj) => {
-            if obj.is_empty() {
-                return "OBJECT<>".to_string();
-            }
-            // Collect fields, sorted by field name (Spark sorts alphabetically)
-            let mut fields: Vec<(String, String)> = Vec::with_capacity(obj.len());
+            let mut fields = Vec::with_capacity(obj.len());
             for (name, value) in obj.iter() {
-                fields.push((name.to_string(), variant_to_spark_type(&value)));
+                fields.push((name.to_string(), variant_to_inferred_type(&value)));
             }
             fields.sort_by(|a, b| a.0.cmp(&b.0));
-            let fields_str: Vec<String> = fields
-                .iter()
-                .map(|(name, ty)| format!("{name}: {ty}"))
-                .collect();
-            format!("OBJECT<{}>", fields_str.join(", "))
+            InferredType::Struct(fields)
         }
         Variant::List(list) => {
-            if list.is_empty() {
-                return "ARRAY<VOID>".to_string();
+            let mut element_type = InferredType::Null;
+            for element in list.iter() {
+                element_type =
+                    merge_variant_types(element_type, variant_to_inferred_type(&element));
             }
-            let element_types: Vec<String> =
-                list.iter().map(|e| variant_to_spark_type(&e)).collect();
-            let merged = merge_types(&element_types);
-            format!("ARRAY<{merged}>")
+            InferredType::Array(Box::new(element_type))
         }
     }
 }
 
-/// Merge a list of Spark type strings into a single type.
-///
-/// Rules (matching Spark behavior):
-/// - VOID is absorbed by any non-VOID type: `[VOID, BIGINT]` → `BIGINT`
-/// - OBJECT types with different fields are merged (field union): `[OBJECT<a: X>, OBJECT<b: Y>]` → `OBJECT<a: X, b: Y>`
-/// - All other mismatches → `VARIANT`
-fn merge_types(types: &[String]) -> String {
-    // Filter out VOIDs
-    let non_void: Vec<&String> = types.iter().filter(|t| t.as_str() != "VOID").collect();
-
-    if non_void.is_empty() {
-        return "VOID".to_string();
-    }
-
-    // Check if all non-void types are identical
-    if non_void.iter().all(|t| *t == non_void[0]) {
-        return non_void[0].clone();
-    }
-
-    // Try merging OBJECTs: if all non-void types are OBJECT<...>, union their fields
-    if non_void.iter().all(|t| t.starts_with("OBJECT<")) {
-        return merge_object_types(&non_void);
-    }
-
-    "VARIANT".to_string()
+pub(crate) fn merge_variant_types(left: InferredType, right: InferredType) -> InferredType {
+    left.merge_with(right, &VariantTypeMerger)
 }
 
-/// Merge multiple OBJECT<...> type strings by unioning their fields.
-fn merge_object_types(types: &[&String]) -> String {
-    let mut merged_fields: std::collections::BTreeMap<String, String> =
-        std::collections::BTreeMap::new();
+struct VariantTypeMerger;
 
-    for ty in types {
-        // Strip "OBJECT<" prefix and ">" suffix
-        let inner = ty
-            .strip_prefix("OBJECT<")
-            .and_then(|s| s.strip_suffix('>'))
-            .unwrap_or("");
-
-        if inner.is_empty() {
-            continue;
-        }
-
-        // Parse fields: "a: BIGINT, b: STRING" → [("a", "BIGINT"), ("b", "STRING")]
-        // Handle nested types by tracking angle bracket depth
-        for field_str in split_fields(inner) {
-            if let Some((name, field_type)) = field_str.split_once(':') {
-                let name = name.trim().to_string();
-                let field_type = field_type.trim().to_string();
-                merged_fields.entry(name).or_insert(field_type);
-            }
-        }
+impl TypeMerger for VariantTypeMerger {
+    fn merge_atomic(&self, _left: InferredType, _right: InferredType) -> InferredType {
+        InferredType::Variant
     }
-
-    if merged_fields.is_empty() {
-        return "OBJECT<>".to_string();
-    }
-
-    let fields_str: Vec<String> = merged_fields
-        .iter()
-        .map(|(name, ty)| format!("{name}: {ty}"))
-        .collect();
-    format!("OBJECT<{}>", fields_str.join(", "))
 }
 
-/// Split a comma-separated field list respecting nested angle brackets.
-/// e.g. "a: OBJECT<x: BIGINT>, b: ARRAY<STRING>" → ["a: OBJECT<x: BIGINT>", "b: ARRAY<STRING>"]
-fn split_fields(s: &str) -> Vec<&str> {
-    let mut result = Vec::new();
-    let mut depth = 0;
+pub(crate) fn variant_type_to_spark_type(inferred: &InferredType) -> String {
+    match inferred {
+        InferredType::Null => "VOID".to_string(),
+        InferredType::Boolean => "BOOLEAN".to_string(),
+        InferredType::Long => "BIGINT".to_string(),
+        InferredType::Float => "FLOAT".to_string(),
+        InferredType::Decimal(precision, scale) => format!("DECIMAL({precision},{scale})"),
+        InferredType::Double => "DOUBLE".to_string(),
+        InferredType::String => "STRING".to_string(),
+        InferredType::Binary => "BINARY".to_string(),
+        InferredType::Date => "DATE".to_string(),
+        InferredType::Timestamp => "TIMESTAMP".to_string(),
+        InferredType::TimestampNtz => "TIMESTAMP_NTZ".to_string(),
+        InferredType::Array(element) => {
+            format!("ARRAY<{}>", variant_type_to_spark_type(element))
+        }
+        InferredType::Struct(fields) => {
+            let fields = fields
+                .iter()
+                .map(|(name, ty)| format!("{name}: {}", variant_type_to_spark_type(ty)))
+                .collect::<Vec<_>>();
+            format!("OBJECT<{}>", fields.join(", "))
+        }
+        InferredType::Variant => "VARIANT".to_string(),
+    }
+}
+
+pub(crate) fn variant_type_from_spark_type(s: &str) -> Result<InferredType> {
+    match s {
+        "VOID" => return Ok(InferredType::Null),
+        "BOOLEAN" => return Ok(InferredType::Boolean),
+        "BIGINT" => return Ok(InferredType::Long),
+        "FLOAT" => return Ok(InferredType::Float),
+        "DOUBLE" => return Ok(InferredType::Double),
+        "STRING" => return Ok(InferredType::String),
+        "BINARY" => return Ok(InferredType::Binary),
+        "DATE" => return Ok(InferredType::Date),
+        "TIMESTAMP" => return Ok(InferredType::Timestamp),
+        "TIMESTAMP_NTZ" => return Ok(InferredType::TimestampNtz),
+        "VARIANT" => return Ok(InferredType::Variant),
+        _ => {}
+    }
+    if let Some(inner) = s.strip_prefix("DECIMAL(").and_then(|s| s.strip_suffix(')')) {
+        let (precision, scale) = inner.split_once(',').ok_or_else(|| {
+            DataFusionError::Execution(format!("invalid inferred decimal type '{s}'"))
+        })?;
+        let precision = precision.parse::<u8>().map_err(|_| {
+            DataFusionError::Execution(format!("invalid inferred decimal precision '{precision}'"))
+        })?;
+        let scale = scale.parse::<u8>().map_err(|_| {
+            DataFusionError::Execution(format!("invalid inferred decimal scale '{scale}'"))
+        })?;
+        return Ok(InferredType::Decimal(precision, scale));
+    }
+    if let Some(inner) = s.strip_prefix("ARRAY<").and_then(|s| s.strip_suffix('>')) {
+        return Ok(InferredType::Array(Box::new(variant_type_from_spark_type(
+            inner,
+        )?)));
+    }
+    if let Some(inner) = s.strip_prefix("OBJECT<").and_then(|s| s.strip_suffix('>')) {
+        let mut fields = Vec::new();
+        for field in split_top_level(inner) {
+            let (name, ty) = field.split_once(": ").ok_or_else(|| {
+                DataFusionError::Execution(format!("invalid inferred object field '{field}'"))
+            })?;
+            fields.push((
+                name.trim().to_string(),
+                variant_type_from_spark_type(ty.trim())?,
+            ));
+        }
+        return Ok(InferredType::Struct(fields));
+    }
+    Err(DataFusionError::Execution(format!(
+        "invalid inferred variant type '{s}'"
+    )))
+}
+
+fn split_top_level(s: &str) -> Vec<&str> {
+    let mut fields = Vec::new();
+    let mut angle_depth = 0usize;
+    let mut paren_depth = 0usize;
     let mut start = 0;
     for (i, ch) in s.char_indices() {
         match ch {
-            '<' => depth += 1,
-            '>' => depth -= 1,
-            ',' if depth == 0 => {
-                result.push(s[start..i].trim());
+            '<' => angle_depth += 1,
+            '>' => angle_depth = angle_depth.saturating_sub(1),
+            '(' => paren_depth += 1,
+            ')' => paren_depth = paren_depth.saturating_sub(1),
+            ',' if angle_depth == 0 && paren_depth == 0 => {
+                fields.push(s[start..i].trim());
                 start = i + 1;
             }
             _ => {}
         }
     }
-    let last = s[start..].trim();
-    if !last.is_empty() {
-        result.push(last);
+    if start < s.len() {
+        fields.push(s[start..].trim());
     }
-    result
+    fields
 }
 
 /// Compute the decimal precision from the integer value and scale.
-fn decimal_type_string(integer: i128, scale: u8) -> String {
+fn decimal_type(integer: i128, scale: u8) -> InferredType {
     let abs = integer.unsigned_abs();
     let int_digits = if abs == 0 {
         1u8
@@ -268,5 +287,5 @@ fn decimal_type_string(integer: i128, scale: u8) -> String {
         d
     };
     let precision = int_digits.max(scale);
-    format!("DECIMAL({precision},{scale})")
+    InferredType::Decimal(precision, scale)
 }

--- a/crates/sail-function/src/schema_inference.rs
+++ b/crates/sail-function/src/schema_inference.rs
@@ -1,0 +1,78 @@
+/// A recursively inferred schema before it is rendered as a Spark type string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum InferredType {
+    Null,
+    Boolean,
+    Long,
+    Float,
+    Decimal(u8, u8),
+    Double,
+    String,
+    Binary,
+    Date,
+    Timestamp,
+    TimestampNtz,
+    Array(Box<InferredType>),
+    Struct(Vec<(String, InferredType)>),
+    Variant,
+}
+
+/// Defines how format-specific incompatible scalar types are merged.
+pub(crate) trait TypeMerger {
+    fn merge_atomic(&self, left: InferredType, right: InferredType) -> InferredType;
+}
+
+impl InferredType {
+    /// Recursively merges two inferred types while delegating format-specific
+    /// scalar coercion and incompatible-type handling to the merger.
+    pub(crate) fn merge_with(self, other: InferredType, merger: &impl TypeMerger) -> InferredType {
+        match (self, other) {
+            (InferredType::Null, other) | (other, InferredType::Null) => other,
+            (left, right) if left == right => left,
+            (InferredType::Array(left), InferredType::Array(right)) => {
+                InferredType::Array(Box::new(left.merge_with(*right, merger)))
+            }
+            (InferredType::Struct(left), InferredType::Struct(right)) => {
+                InferredType::Struct(merge_fields(left, right, merger))
+            }
+            (left, right) => merger.merge_atomic(left, right),
+        }
+    }
+
+    pub(crate) fn estimated_size(&self) -> usize {
+        match self {
+            InferredType::Array(element) => {
+                std::mem::size_of::<InferredType>() + element.estimated_size()
+            }
+            InferredType::Struct(fields) => fields
+                .iter()
+                .map(|(name, ty)| {
+                    name.len() + ty.estimated_size() + std::mem::size_of::<(String, InferredType)>()
+                })
+                .sum(),
+            _ => 0,
+        }
+    }
+}
+
+fn merge_fields(
+    left: Vec<(String, InferredType)>,
+    right: Vec<(String, InferredType)>,
+    merger: &impl TypeMerger,
+) -> Vec<(String, InferredType)> {
+    let mut fields = left;
+    fields.extend(right);
+    fields.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+    let mut merged: Vec<(String, InferredType)> = Vec::new();
+    for (name, ty) in fields {
+        match merged.last_mut() {
+            Some((last_name, last_type)) if *last_name == name => {
+                let previous = std::mem::replace(last_type, InferredType::Null);
+                *last_type = previous.merge_with(ty, merger);
+            }
+            _ => merged.push((name, ty)),
+        }
+    }
+    merged
+}

--- a/python/pysail/tests/spark/function/features/variant/schema_of_variant.feature
+++ b/python/pysail/tests/spark/function/features/variant/schema_of_variant.feature
@@ -80,6 +80,22 @@ Feature: schema_of_variant
         | result                      |
         | ARRAY<ARRAY<ARRAY<BIGINT>>> |
 
+    Scenario: schema_of_variant merges object fields with decimal types
+      When query
+        """
+        SELECT schema_of_variant(
+          to_variant_object(
+            array(
+              map('a', CAST(1.23 AS DECIMAL(3,2))),
+              map('b', CAST(4.56 AS DECIMAL(3,2)))
+            )
+          )
+        ) AS result
+        """
+      Then query result
+        | result                                          |
+        | ARRAY<OBJECT<a: DECIMAL(3,2), b: DECIMAL(3,2)>> |
+
     Scenario Outline: Nested: <case>
       When query
         """


### PR DESCRIPTION
## Summary

- Introduce a shared internal `InferredType` representation and recursive type-merging logic.
- Reuse it across `schema_of_json`, `schema_of_variant`, and `schema_of_variant_agg`.
- Preserve the format-specific merging and rendering behavior for JSON and Variant schemas.
- Avoid rendering and reparsing type strings while recursively merging Variant arrays.
- Add regression coverage for merging object fields containing decimal types.

Previously, types such as `DECIMAL(3,2)` could be incorrectly parsed while merging rendered object schemas because the type string contains a comma.

Closes #1646

## Testing

- `cargo test -p sail-function`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Focused `schema_of_json`, `schema_of_variant`, and `schema_of_variant_agg` PySpark feature tests