### PR TITLE
feat: heartbeat for command execution

### DIFF
--- a/crates/sail-spark-connect/src/executor.rs
+++ b/crates/sail-spark-connect/src/executor.rs
@@ -62,6 +62,7 @@ impl ExecutorOutput {
 pub type ExecutorOutputStream = Pin<Box<dyn Stream<Item = SparkResult<ExecutorOutput>> + Send>>;
 
 struct ExecutorBuffer {
+    capacity: usize,
     inner: VecDeque<ExecutorOutput>,
 }
 
@@ -72,15 +73,19 @@ const EXECUTOR_BUFFER_CAPACITY: usize = 128;
 impl ExecutorBuffer {
     fn new(capacity: usize) -> Self {
         Self {
+            capacity,
             inner: VecDeque::with_capacity(capacity),
         }
     }
 
     fn add(&mut self, output: ExecutorOutput) {
-        self.inner.push_back(output);
-        if self.inner.len() > self.inner.capacity() {
+        if self.capacity == 0 {
+            return;
+        }
+        if self.inner.len() >= self.capacity {
             self.inner.pop_front();
         }
+        self.inner.push_back(output);
     }
 
     fn remove_until(&mut self, id: &str) {
@@ -180,7 +185,10 @@ impl ExecutorTaskContext {
         let span = Span::enter_with_local_parent("ExecutorTaskContext::next");
         tokio::select! {
             batch = stream.next().in_span(span) => Ok(ExecutorTaskItem::Batch(batch.transpose()?)),
-            _ = tokio::time::sleep(heartbeat_interval) => Ok(ExecutorTaskItem::Heartbeat),
+            _ = tokio::time::sleep(heartbeat_interval) => {
+                // FIXME: non-reattachable clients cannot refresh session activity by releasing heartbeat responses
+                Ok(ExecutorTaskItem::Heartbeat)
+            }
         }
     }
 
@@ -282,7 +290,6 @@ impl Executor {
                                 ExecutorOutput::new(ExecutorBatch::Heartbeat),
                             )
                             .await?;
-                            empty = false;
                         }
                     }
                 }
@@ -364,6 +371,7 @@ impl Executor {
             Err(SparkError::SendError(_)) => ExecutorTaskResult::Paused(context),
             Err(e) => {
                 let _ = tx.send(Err(e)).await;
+                // TODO: track the original error in the task result
                 ExecutorTaskResult::Failed(SparkError::internal(
                     "task failed while executing the plan",
                 ))

--- a/crates/sail-spark-connect/src/executor.rs
+++ b/crates/sail-spark-connect/src/executor.rs
@@ -7,12 +7,13 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::ipc::writer::StreamWriter;
 use datafusion::execution::SendableRecordBatchStream;
 use fastrace::Span;
 use fastrace::future::FutureExt;
 use futures::Stream;
-use futures::stream::{StreamExt, TryStreamExt};
+use futures::stream::StreamExt;
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tonic::codegen::tokio_stream::wrappers::ReceiverStream;
@@ -28,6 +29,7 @@ use crate::spark::connect::{
 
 #[derive(Clone, Debug)]
 pub enum ExecutorBatch {
+    Heartbeat,
     ArrowBatch(ArrowBatch),
     SqlCommandResult(Box<SqlCommandResult>),
     WriteStreamOperationStartResult(Box<WriteStreamOperationStartResult>),
@@ -57,26 +59,28 @@ impl ExecutorOutput {
     }
 }
 
-pub type ExecutorOutputStream = Pin<Box<dyn Stream<Item = ExecutorOutput> + Send>>;
+pub type ExecutorOutputStream = Pin<Box<dyn Stream<Item = SparkResult<ExecutorOutput>> + Send>>;
 
 struct ExecutorBuffer {
     inner: VecDeque<ExecutorOutput>,
 }
 
+// TODO: use "spark.connect.execute.reattachable.observerRetryBufferSize"
+// TODO: limit the size based on serialized message size instead of element count
+const EXECUTOR_BUFFER_CAPACITY: usize = 128;
+
 impl ExecutorBuffer {
-    fn new() -> Self {
-        // TODO: use "spark.connect.execute.reattachable.observerRetryBufferSize"
-        // TODO: limit the size based on serialized message size instead of element count
+    fn new(capacity: usize) -> Self {
         Self {
-            inner: VecDeque::with_capacity(128),
+            inner: VecDeque::with_capacity(capacity),
         }
     }
 
     fn add(&mut self, output: ExecutorOutput) {
-        if self.inner.len() >= self.inner.capacity() {
+        self.inner.push_back(output);
+        if self.inner.len() > self.inner.capacity() {
             self.inner.pop_front();
         }
-        self.inner.push_back(output);
     }
 
     fn remove_until(&mut self, id: &str) {
@@ -125,37 +129,72 @@ struct ExecutorTask {
 struct ExecutorTaskContext {
     stream: SendableRecordBatchStream,
     heartbeat_interval: Duration,
+    state: ExecutorTaskState,
     buffer: Arc<Mutex<ExecutorBuffer>>,
 }
 
-impl ExecutorTaskContext {
-    fn new(stream: SendableRecordBatchStream, heartbeat_interval: Duration) -> Self {
-        Self {
-            stream,
-            heartbeat_interval,
-            buffer: Arc::new(Mutex::new(ExecutorBuffer::new())),
-        }
+pub(crate) enum ExecutorMode {
+    Query,
+    Command {
+        completion: CommandCompletionHandler,
+    },
+}
+
+impl ExecutorMode {
+    pub(crate) fn command() -> Self {
+        Self::command_with_completion(|_, _| Ok(None))
     }
 
-    async fn next(&mut self) -> SparkResult<Option<RecordBatch>> {
+    pub(crate) fn command_with_completion(
+        completion: impl FnOnce(SchemaRef, Vec<RecordBatch>) -> SparkResult<Option<ExecutorOutput>>
+        + Send
+        + 'static,
+    ) -> Self {
+        Self::Command {
+            completion: Box::new(completion),
+        }
+    }
+}
+
+pub(crate) enum ExecutorTaskState {
+    Query,
+    Command {
+        batches: Vec<RecordBatch>,
+        completion: Option<CommandCompletionHandler>,
+    },
+}
+
+enum ExecutorTaskItem {
+    Batch(Option<RecordBatch>),
+    Heartbeat,
+}
+
+pub(crate) type CommandCompletionHandler =
+    Box<dyn FnOnce(SchemaRef, Vec<RecordBatch>) -> SparkResult<Option<ExecutorOutput>> + Send>;
+
+impl ExecutorTaskContext {
+    async fn next(
+        stream: &mut SendableRecordBatchStream,
+        heartbeat_interval: Duration,
+    ) -> SparkResult<ExecutorTaskItem> {
         let span = Span::enter_with_local_parent("ExecutorTaskContext::next");
         tokio::select! {
-            batch = self.stream.next().in_span(span) => Ok(batch.transpose()?),
-            _ = tokio::time::sleep(self.heartbeat_interval) => {
-                Ok(Some(RecordBatch::new_empty(self.stream.schema())))
-            }
+            batch = stream.next().in_span(span) => Ok(ExecutorTaskItem::Batch(batch.transpose()?)),
+            _ = tokio::time::sleep(heartbeat_interval) => Ok(ExecutorTaskItem::Heartbeat),
         }
     }
 
-    fn save_output(&self, output: &ExecutorOutput) -> SparkResult<()> {
-        let mut buffer = self.buffer.lock()?;
-        buffer.add(output.clone());
+    async fn send_output(
+        buffer: &Arc<Mutex<ExecutorBuffer>>,
+        tx: &mpsc::Sender<SparkResult<ExecutorOutput>>,
+        output: ExecutorOutput,
+    ) -> SparkResult<()> {
+        {
+            let mut buffer = buffer.lock()?;
+            buffer.add(output.clone());
+        }
+        tx.send(Ok(output)).await?;
         Ok(())
-    }
-
-    fn replay_outputs(&self) -> SparkResult<Vec<ExecutorOutput>> {
-        let buffer = self.buffer.lock()?;
-        Ok(buffer.iter().cloned().collect())
     }
 }
 
@@ -170,11 +209,29 @@ impl Executor {
         metadata: ExecutorMetadata,
         stream: SendableRecordBatchStream,
         heartbeat_interval: Duration,
+        mode: ExecutorMode,
     ) -> Self {
+        let state = match mode {
+            ExecutorMode::Query => ExecutorTaskState::Query,
+            ExecutorMode::Command { completion } => ExecutorTaskState::Command {
+                batches: vec![],
+                completion: Some(completion),
+            },
+        };
+        let buffer = if metadata.reattachable {
+            ExecutorBuffer::new(EXECUTOR_BUFFER_CAPACITY)
+        } else {
+            ExecutorBuffer::new(0)
+        };
         Self {
             metadata,
             state: Mutex::new(ExecutorState::Pending {
-                context: ExecutorTaskContext::new(stream, heartbeat_interval),
+                context: ExecutorTaskContext {
+                    stream,
+                    heartbeat_interval,
+                    state,
+                    buffer: Arc::new(Mutex::new(buffer)),
+                },
                 span: Span::enter_with_local_parent("Executor::new"),
             }),
         }
@@ -182,55 +239,139 @@ impl Executor {
 
     async fn run_internal(
         context: &mut ExecutorTaskContext,
-        tx: mpsc::Sender<ExecutorOutput>,
+        tx: &mpsc::Sender<SparkResult<ExecutorOutput>>,
+        reattachable: bool,
     ) -> SparkResult<()> {
-        for out in context.replay_outputs()? {
-            tx.send(out).await?;
+        let outputs = {
+            let buffer = context.buffer.lock()?;
+            buffer.iter().cloned().collect::<Vec<_>>()
+        };
+        for output in outputs {
+            tx.send(Ok(output)).await?;
         }
-        let schema = to_spark_schema(context.stream.schema())?;
-        let out = ExecutorOutput::new(ExecutorBatch::Schema(Box::new(schema)));
-        context.save_output(&out)?;
-        tx.send(out).await?;
+        match &mut context.state {
+            ExecutorTaskState::Query => {
+                let schema = to_spark_schema(context.stream.schema())?;
+                ExecutorTaskContext::send_output(
+                    &context.buffer,
+                    tx,
+                    ExecutorOutput::new(ExecutorBatch::Schema(Box::new(schema))),
+                )
+                .await?;
 
-        let mut empty = true;
-        while let Some(batch) = context.next().await? {
-            let batch = to_arrow_batch(&batch)?;
-            let out = ExecutorOutput::new(ExecutorBatch::ArrowBatch(batch));
-            context.save_output(&out)?;
-            tx.send(out).await?;
-            empty = false;
+                let mut empty = true;
+                loop {
+                    match ExecutorTaskContext::next(&mut context.stream, context.heartbeat_interval)
+                        .await?
+                    {
+                        ExecutorTaskItem::Batch(Some(batch)) => {
+                            let batch = to_arrow_batch(&batch)?;
+                            ExecutorTaskContext::send_output(
+                                &context.buffer,
+                                tx,
+                                ExecutorOutput::new(ExecutorBatch::ArrowBatch(batch)),
+                            )
+                            .await?;
+                            empty = false;
+                        }
+                        ExecutorTaskItem::Batch(None) => break,
+                        ExecutorTaskItem::Heartbeat => {
+                            ExecutorTaskContext::send_output(
+                                &context.buffer,
+                                tx,
+                                ExecutorOutput::new(ExecutorBatch::Heartbeat),
+                            )
+                            .await?;
+                            empty = false;
+                        }
+                    }
+                }
+                if empty {
+                    let batch = RecordBatch::new_empty(context.stream.schema());
+                    let batch = to_arrow_batch(&batch)?;
+                    ExecutorTaskContext::send_output(
+                        &context.buffer,
+                        tx,
+                        ExecutorOutput::new(ExecutorBatch::ArrowBatch(batch)),
+                    )
+                    .await?;
+                }
+                if reattachable {
+                    ExecutorTaskContext::send_output(
+                        &context.buffer,
+                        tx,
+                        ExecutorOutput::complete(),
+                    )
+                    .await?;
+                }
+            }
+            ExecutorTaskState::Command {
+                batches,
+                completion,
+            } => {
+                loop {
+                    match ExecutorTaskContext::next(&mut context.stream, context.heartbeat_interval)
+                        .await?
+                    {
+                        ExecutorTaskItem::Batch(Some(batch)) => {
+                            batches.push(batch);
+                        }
+                        ExecutorTaskItem::Batch(None) => break,
+                        ExecutorTaskItem::Heartbeat => {
+                            ExecutorTaskContext::send_output(
+                                &context.buffer,
+                                tx,
+                                ExecutorOutput::new(ExecutorBatch::Heartbeat),
+                            )
+                            .await?;
+                        }
+                    }
+                }
+                let schema = context.stream.schema();
+                let output = completion
+                    .take()
+                    .map(|completion| completion(schema, mem::take(batches)))
+                    .transpose()?
+                    .flatten();
+                if let Some(output) = output {
+                    ExecutorTaskContext::send_output(&context.buffer, tx, output).await?;
+                }
+                if reattachable {
+                    ExecutorTaskContext::send_output(
+                        &context.buffer,
+                        tx,
+                        ExecutorOutput::complete(),
+                    )
+                    .await?;
+                }
+            }
         }
-        if empty {
-            let batch = RecordBatch::new_empty(context.stream.schema());
-            let batch = to_arrow_batch(&batch)?;
-            let out = ExecutorOutput::new(ExecutorBatch::ArrowBatch(batch));
-            context.save_output(&out)?;
-            tx.send(out).await?;
-        }
-
-        let out = ExecutorOutput::new(ExecutorBatch::Complete);
-        context.save_output(&out)?;
-        tx.send(out).await?;
         Ok(())
     }
 
     async fn run(
         mut context: ExecutorTaskContext,
         listener: oneshot::Receiver<()>,
-        tx: mpsc::Sender<ExecutorOutput>,
+        tx: mpsc::Sender<SparkResult<ExecutorOutput>>,
+        reattachable: bool,
     ) -> ExecutorTaskResult {
         let out = tokio::select! {
-            x = Executor::run_internal(&mut context, tx) => x,
+            x = Executor::run_internal(&mut context, &tx, reattachable) => x,
             _ = listener => return ExecutorTaskResult::Paused(context),
         };
         match out {
             Ok(()) => ExecutorTaskResult::Completed,
             Err(SparkError::SendError(_)) => ExecutorTaskResult::Paused(context),
-            Err(e) => ExecutorTaskResult::Failed(e),
+            Err(e) => {
+                let _ = tx.send(Err(e)).await;
+                ExecutorTaskResult::Failed(SparkError::internal(
+                    "task failed while executing the plan",
+                ))
+            }
         }
     }
 
-    pub(crate) fn start(&self) -> SparkResult<ReceiverStream<ExecutorOutput>> {
+    pub(crate) fn start(&self) -> SparkResult<ExecutorOutputStream> {
         let mut state = self.state.lock()?;
         let (context, span) = match mem::replace(state.deref_mut(), ExecutorState::Idle) {
             ExecutorState::Pending { context, span } => (context, span),
@@ -256,9 +397,14 @@ impl Executor {
         let (tx, rx) = mpsc::channel(1);
         let (notifier, listener) = oneshot::channel();
         let buffer = Arc::clone(&context.buffer);
+        let reattachable = self.metadata.reattachable;
         let handle = {
             let span = { Span::enter_with_parent("Executor::run", &span) };
-            tokio::spawn(async move { Executor::run(context, listener, tx).in_span(span).await })
+            tokio::spawn(async move {
+                Executor::run(context, listener, tx, reattachable)
+                    .in_span(span)
+                    .await
+            })
         };
         *state = ExecutorState::Running {
             task: ExecutorTask {
@@ -268,7 +414,7 @@ impl Executor {
             },
             span,
         };
-        Ok(ReceiverStream::new(rx))
+        Ok(Box::pin(ReceiverStream::new(rx)))
     }
 
     pub(crate) async fn pause_if_running(&self) -> SparkResult<()> {
@@ -295,7 +441,7 @@ impl Executor {
         Ok(())
     }
 
-    pub(crate) fn release(&self, response_id: Option<String>) -> SparkResult<()> {
+    pub(crate) fn release(&self, response_id: String) -> SparkResult<()> {
         let state = self.state.lock()?;
         let buffer = match state.deref() {
             ExecutorState::Running { task, span: _ } => &task.buffer,
@@ -304,17 +450,9 @@ impl Executor {
                 return Ok(());
             }
         };
-        if let Some(response_id) = response_id {
-            buffer.lock()?.remove_until(&response_id);
-        }
+        buffer.lock()?.remove_until(&response_id);
         Ok(())
     }
-}
-
-pub(crate) async fn read_stream(
-    stream: SendableRecordBatchStream,
-) -> SparkResult<Vec<RecordBatch>> {
-    stream.err_into().try_collect::<Vec<_>>().await
 }
 
 pub(crate) fn to_arrow_batch(batch: &RecordBatch) -> SparkResult<ArrowBatch> {

--- a/crates/sail-spark-connect/src/proto/function.rs
+++ b/crates/sail-spark-connect/src/proto/function.rs
@@ -7,6 +7,7 @@ mod tests {
     use datafusion::arrow::array::RecordBatch;
     use datafusion::arrow::error::ArrowError;
     use datafusion::arrow::util::display::{ArrayFormatter, FormatOptions};
+    use futures::stream::TryStreamExt;
     use pyo3::Python;
     use sail_common::config::AppConfig;
     use sail_common::runtime::RuntimeManager;
@@ -17,7 +18,6 @@ mod tests {
     use serde::{Deserialize, Serialize};
 
     use crate::error::{SparkError, SparkResult};
-    use crate::executor::read_stream;
     use crate::proto::data_type_json::JsonDataType;
     use crate::session::SparkSession;
     use crate::session_manager::create_spark_session_manager;
@@ -91,7 +91,7 @@ mod tests {
                         let (plan, _) =
                             resolve_and_execute_plan(&context, spark.plan_config()?, plan).await?;
                         let stream = service.runner().execute(&context, plan).await?;
-                        read_stream(stream).await
+                        stream.err_into().try_collect::<Vec<_>>().await
                     });
                     // TODO: validate the result against the expected output
                     // TODO: handle non-deterministic results and error messages

--- a/crates/sail-spark-connect/src/service/plan_executor.rs
+++ b/crates/sail-spark-connect/src/service/plan_executor.rs
@@ -14,11 +14,10 @@ use sail_common_datafusion::session::job::JobService;
 use sail_plan::resolve_and_execute_plan;
 use tonic::Status;
 use tonic::codegen::tokio_stream::Stream;
-use tonic::codegen::tokio_stream::wrappers::ReceiverStream;
 
 use crate::error::{ProtoFieldExt, SparkError, SparkResult};
 use crate::executor::{
-    Executor, ExecutorBatch, ExecutorMetadata, ExecutorOutput, ExecutorOutputStream, read_stream,
+    Executor, ExecutorBatch, ExecutorMetadata, ExecutorMode, ExecutorOutput, ExecutorOutputStream,
     to_arrow_batch,
 };
 use crate::session::SparkSession;
@@ -62,12 +61,14 @@ impl Stream for ExecutePlanResponseStream {
     ) -> Poll<Option<Result<ExecutePlanResponse, Status>>> {
         self.inner.as_mut().poll_next(cx).map(|poll| {
             poll.map(|item| {
+                let item = item.map_err(Status::from)?;
                 let mut response = ExecutePlanResponse::default();
                 response.session_id.clone_from(&self.session_id);
                 response.server_side_session_id.clone_from(&self.session_id);
                 response.operation_id.clone_from(&self.operation_id.clone());
                 response.response_id = item.id;
                 match item.batch {
+                    ExecutorBatch::Heartbeat => {}
                     ExecutorBatch::ArrowBatch(batch) => {
                         response.response_type = Some(ResponseType::ArrowBatch(batch));
                     }
@@ -109,19 +110,11 @@ impl Stream for ExecutePlanResponseStream {
     }
 }
 
-enum ExecutePlanMode {
-    /// Execute the plan lazily as the client reads the response stream.
-    Lazy,
-    /// Execute the plan eagerly and return an empty response stream.
-    /// This is useful for executing command plans.
-    EagerSilent,
-}
-
 async fn handle_execute_plan(
     ctx: &SessionContext,
     plan: spec::Plan,
     metadata: ExecutorMetadata,
-    mode: ExecutePlanMode,
+    mode: ExecutorMode,
 ) -> SparkResult<ExecutePlanResponseStream> {
     let span = Span::root("handle_execute_plan", SpanContext::random());
     let spark = ctx.extension::<SparkSession>()?;
@@ -132,31 +125,19 @@ async fn handle_execute_plan(
         let span = Span::enter_with_parent("JobRunner::execute", &span);
         service.runner().execute(ctx, plan).in_span(span).await?
     };
-    let rx = match mode {
-        ExecutePlanMode::Lazy => {
-            let _guard = span.set_local_parent();
-            let executor = Executor::new(
-                metadata,
-                stream,
-                spark.options().execution_heartbeat_interval,
-            );
-            let rx = executor.start()?;
-            spark.add_executor(executor)?;
-            rx
-        }
-        ExecutePlanMode::EagerSilent => {
-            let _ = read_stream(stream).in_span(span).await?;
-            let (tx, rx) = tokio::sync::mpsc::channel(1);
-            if metadata.reattachable {
-                tx.send(ExecutorOutput::complete()).await?;
-            }
-            ReceiverStream::new(rx)
-        }
-    };
+    let _guard = span.set_local_parent();
+    let executor = Executor::new(
+        metadata,
+        stream,
+        spark.options().execution_heartbeat_interval,
+        mode,
+    );
+    let rx = executor.start()?;
+    spark.add_executor(executor)?;
     Ok(ExecutePlanResponseStream::new(
         spark.session_id().to_string(),
         operation_id,
-        Box::pin(rx),
+        rx,
     ))
 }
 
@@ -166,7 +147,7 @@ pub(crate) async fn handle_execute_relation(
     metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
     let plan = relation.try_into()?;
-    handle_execute_plan(ctx, plan, metadata, ExecutePlanMode::Lazy).await
+    handle_execute_plan(ctx, plan, metadata, ExecutorMode::Query).await
 }
 
 pub(crate) async fn handle_execute_register_function(
@@ -177,7 +158,8 @@ pub(crate) async fn handle_execute_register_function(
     let plan = spec::Plan::Command(spec::CommandPlan::new(spec::CommandNode::RegisterFunction(
         udf.try_into()?,
     )));
-    handle_execute_plan(ctx, plan, metadata, ExecutePlanMode::EagerSilent).await
+    let mode = ExecutorMode::command();
+    handle_execute_plan(ctx, plan, metadata, mode).await
 }
 
 pub(crate) async fn handle_execute_write_operation(
@@ -188,7 +170,8 @@ pub(crate) async fn handle_execute_write_operation(
     let plan = spec::Plan::Command(spec::CommandPlan::new(spec::CommandNode::Write(
         write.try_into()?,
     )));
-    handle_execute_plan(ctx, plan, metadata, ExecutePlanMode::EagerSilent).await
+    let mode = ExecutorMode::command();
+    handle_execute_plan(ctx, plan, metadata, mode).await
 }
 
 pub(crate) async fn handle_execute_create_dataframe_view(
@@ -197,7 +180,8 @@ pub(crate) async fn handle_execute_create_dataframe_view(
     metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
     let plan = spec::Plan::Command(spec::CommandPlan::new(view.try_into()?));
-    handle_execute_plan(ctx, plan, metadata, ExecutePlanMode::EagerSilent).await
+    let mode = ExecutorMode::command();
+    handle_execute_plan(ctx, plan, metadata, mode).await
 }
 
 pub(crate) async fn handle_execute_write_operation_v2(
@@ -208,7 +192,8 @@ pub(crate) async fn handle_execute_write_operation_v2(
     let plan = spec::Plan::Command(spec::CommandPlan::new(spec::CommandNode::WriteTo(
         write.try_into()?,
     )));
-    handle_execute_plan(ctx, plan, metadata, ExecutePlanMode::EagerSilent).await
+    let mode = ExecutorMode::command();
+    handle_execute_plan(ctx, plan, metadata, mode).await
 }
 
 pub(crate) async fn handle_execute_merge_into_table_command(
@@ -217,7 +202,8 @@ pub(crate) async fn handle_execute_merge_into_table_command(
     metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
     let plan = spec::Plan::Command(spec::CommandPlan::new(command.try_into()?));
-    handle_execute_plan(ctx, plan, metadata, ExecutePlanMode::EagerSilent).await
+    let mode = ExecutorMode::command();
+    handle_execute_plan(ctx, plan, metadata, mode).await
 }
 
 /// Handles execution of a SQL command.
@@ -228,7 +214,6 @@ pub(crate) async fn handle_execute_sql_command(
     metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
     let spark = ctx.extension::<SparkSession>()?;
-    let service = ctx.extension::<JobService>()?;
     let relation = if let Some(input) = sql.input {
         input
     } else {
@@ -245,35 +230,40 @@ pub(crate) async fn handle_execute_sql_command(
         }
     };
     let plan: spec::Plan = relation.clone().try_into()?;
-    let relation = match plan {
-        spec::Plan::Query(_) => relation,
-        command @ spec::Plan::Command(_) => {
-            let (plan, _) = resolve_and_execute_plan(ctx, spark.plan_config()?, command).await?;
-            let stream = service.runner().execute(ctx, plan).await?;
-            let schema = stream.schema();
-            let data = read_stream(stream).await?;
-            let data = concat_batches(&schema, data.iter())?;
-            Relation {
-                common: None,
-                rel_type: Some(relation::RelType::LocalRelation(LocalRelation {
-                    data: Some(to_arrow_batch(&data)?.data),
-                    schema: None,
-                })),
-            }
+    match plan {
+        spec::Plan::Command(command) => {
+            let mode = ExecutorMode::command_with_completion(move |schema, data| {
+                let data = concat_batches(&schema, data.iter())?;
+                let relation = Relation {
+                    common: None,
+                    rel_type: Some(relation::RelType::LocalRelation(LocalRelation {
+                        data: Some(to_arrow_batch(&data)?.data),
+                        schema: None,
+                    })),
+                };
+                Ok(Some(ExecutorOutput::new(ExecutorBatch::SqlCommandResult(
+                    Box::new(SqlCommandResult {
+                        relation: Some(relation),
+                    }),
+                ))))
+            });
+            handle_execute_plan(ctx, spec::Plan::Command(command), metadata, mode).await
         }
-    };
-    let result = ExecutorBatch::SqlCommandResult(Box::new(SqlCommandResult {
-        relation: Some(relation),
-    }));
-    let mut output = vec![ExecutorOutput::new(result)];
-    if metadata.reattachable {
-        output.push(ExecutorOutput::complete());
+        spec::Plan::Query(_) => {
+            let result = ExecutorBatch::SqlCommandResult(Box::new(SqlCommandResult {
+                relation: Some(relation),
+            }));
+            let mut output = vec![ExecutorOutput::new(result)];
+            if metadata.reattachable {
+                output.push(ExecutorOutput::complete());
+            }
+            Ok(ExecutePlanResponseStream::new(
+                spark.session_id().to_string(),
+                metadata.operation_id,
+                Box::pin(stream::iter(output.into_iter().map(Ok))),
+            ))
+        }
     }
-    Ok(ExecutePlanResponseStream::new(
-        spark.session_id().to_string(),
-        metadata.operation_id,
-        Box::pin(stream::iter(output)),
-    ))
 }
 
 pub(crate) async fn handle_execute_write_stream_operation_start(
@@ -305,7 +295,7 @@ pub(crate) async fn handle_execute_write_stream_operation_start(
     Ok(ExecutePlanResponseStream::new(
         spark.session_id().to_string(),
         operation_id,
-        Box::pin(stream::iter(output)),
+        Box::pin(stream::iter(output.into_iter().map(Ok))),
     ))
 }
 
@@ -406,7 +396,7 @@ pub(crate) async fn handle_execute_streaming_query_command(
     Ok(ExecutePlanResponseStream::new(
         spark.session_id().to_string(),
         metadata.operation_id,
-        Box::pin(stream::iter(output)),
+        Box::pin(stream::iter(output.into_iter().map(Ok))),
     ))
 }
 
@@ -489,7 +479,7 @@ pub(crate) async fn handle_execute_streaming_query_manager_command(
     Ok(ExecutePlanResponseStream::new(
         spark.session_id().to_string(),
         metadata.operation_id,
-        Box::pin(stream::iter(output)),
+        Box::pin(stream::iter(output.into_iter().map(Ok))),
     ))
 }
 
@@ -501,7 +491,8 @@ pub(crate) async fn handle_execute_register_table_function(
     let plan = spec::Plan::Command(spec::CommandPlan::new(
         spec::CommandNode::RegisterTableFunction(udtf.try_into()?),
     ));
-    handle_execute_plan(ctx, plan, metadata, ExecutePlanMode::EagerSilent).await
+    let mode = ExecutorMode::command();
+    handle_execute_plan(ctx, plan, metadata, mode).await
 }
 
 pub(crate) async fn handle_execute_streaming_query_listener_bus_command(
@@ -519,7 +510,6 @@ pub(crate) async fn handle_execute_checkpoint_command(
     checkpoint: CheckpointCommand,
     metadata: ExecutorMetadata,
 ) -> SparkResult<ExecutePlanResponseStream> {
-    let spark = ctx.extension::<SparkSession>()?;
     let CheckpointCommand {
         relation,
         local: _,
@@ -543,24 +533,14 @@ pub(crate) async fn handle_execute_checkpoint_command(
             input: Box::new(query),
         },
     ));
-    let (plan, _) = resolve_and_execute_plan(ctx, spark.plan_config()?, plan).await?;
-    let service = ctx.extension::<JobService>()?;
-    let stream = service.runner().execute(ctx, plan).await?;
-    let _ = read_stream(stream).await?;
-    let result = ExecutorOutput::new(ExecutorBatch::CheckpointCommandResult(Box::new(
-        CheckpointCommandResult {
-            relation: Some(CachedRemoteRelation { relation_id }),
-        },
-    )));
-    let mut output = vec![result];
-    if metadata.reattachable {
-        output.push(ExecutorOutput::complete());
-    }
-    Ok(ExecutePlanResponseStream::new(
-        spark.session_id().to_string(),
-        metadata.operation_id,
-        Box::pin(stream::iter(output)),
-    ))
+    let mode = ExecutorMode::command_with_completion(move |_, _| {
+        Ok(Some(ExecutorOutput::new(
+            ExecutorBatch::CheckpointCommandResult(Box::new(CheckpointCommandResult {
+                relation: Some(CachedRemoteRelation { relation_id }),
+            })),
+        )))
+    });
+    handle_execute_plan(ctx, plan, metadata, mode).await
 }
 
 pub(crate) async fn handle_execute_remove_cached_remote_relation_command(
@@ -579,7 +559,7 @@ pub(crate) async fn handle_execute_remove_cached_remote_relation_command(
     Ok(ExecutePlanResponseStream::new(
         spark.session_id().to_string(),
         metadata.operation_id,
-        Box::pin(stream::iter(output)),
+        Box::pin(stream::iter(output.into_iter().map(Ok))),
     ))
 }
 
@@ -635,12 +615,14 @@ pub(crate) async fn handle_reattach_execute(
         )));
     }
     executor.pause_if_running().await?;
-    executor.release(response_id)?;
+    if let Some(response_id) = response_id {
+        executor.release(response_id)?;
+    }
     let rx = executor.start()?;
     Ok(ExecutePlanResponseStream::new(
         spark.session_id().to_string(),
         operation_id,
-        Box::pin(rx),
+        rx,
     ))
 }
 
@@ -650,10 +632,14 @@ pub(crate) async fn handle_release_execute(
     response_id: Option<String>,
 ) -> SparkResult<()> {
     let spark = ctx.extension::<SparkSession>()?;
-    // Some operations may not have an executor (e.g. DDL statements),
-    // so it is a no-op if the executor is not found.
-    if let Some(executor) = spark.get_executor(operation_id.as_str())? {
+    let executor = spark.get_executor(operation_id.as_str())?;
+    let Some(executor) = executor.filter(|executor| executor.metadata.reattachable) else {
+        return Ok(());
+    };
+    if let Some(response_id) = response_id {
         executor.release(response_id)?;
+    } else if let Some(executor) = spark.remove_executor(operation_id.as_str())? {
+        executor.pause_if_running().await?;
     }
     Ok(())
 }
@@ -717,6 +703,6 @@ pub(crate) async fn handle_execute_register_datasource(
     Ok(ExecutePlanResponseStream::new(
         spark.session_id().to_string(),
         metadata.operation_id,
-        Box::pin(stream::iter(output)),
+        Box::pin(stream::iter(output.into_iter().map(Ok))),
     ))
 }

--- a/crates/sail-spark-connect/src/service/plan_executor.rs
+++ b/crates/sail-spark-connect/src/service/plan_executor.rs
@@ -633,6 +633,7 @@ pub(crate) async fn handle_release_execute(
 ) -> SparkResult<()> {
     let spark = ctx.extension::<SparkSession>()?;
     let executor = spark.get_executor(operation_id.as_str())?;
+    // TODO: clean up non-reattachable executors which the client does not release explicitly
     let Some(executor) = executor.filter(|executor| executor.metadata.reattachable) else {
         return Ok(());
     };

--- a/python/pysail/tests/spark/session/test_heartbeat.py
+++ b/python/pysail/tests/spark/session/test_heartbeat.py
@@ -1,0 +1,74 @@
+import time
+
+import pyspark.sql.functions as F  # noqa: N812
+import pytest
+from pyspark.errors.exceptions.connect import SparkConnectGrpcException
+from pyspark.sql.types import LongType, Row
+
+from pysail.testing.spark.session import spark_connect_server, spark_session_factory
+
+pytestmark = pytest.mark.skip(reason="slow tests that should be run manually")
+
+
+@pytest.fixture(scope="module")
+def bad_sessions():
+    envs = {
+        "SAIL_SPARK__SESSION_TIMEOUT_SECS": "2",
+        "SAIL_SPARK__EXECUTION_HEARTBEAT_INTERVAL_SECS": "4",
+    }
+    with spark_connect_server(envs=envs) as server, spark_session_factory(server.remote) as sessions:
+        yield sessions
+
+
+@pytest.fixture(scope="module")
+def good_sessions():
+    envs = {
+        "SAIL_SPARK__SESSION_TIMEOUT_SECS": "2",
+        "SAIL_SPARK__EXECUTION_HEARTBEAT_INTERVAL_SECS": "1",
+    }
+    with spark_connect_server(envs=envs) as server, spark_session_factory(server.remote) as sessions:
+        yield sessions
+
+
+@pytest.fixture(scope="module")
+def identity():
+    @F.udf(LongType())
+    def _identity(value):
+        time.sleep(5)
+        return value
+
+    return _identity
+
+
+@pytest.fixture(scope="module")
+def data(identity):
+    def _data(spark):
+        return spark.range(1).select(identity("id").alias("id"))
+
+    return _data
+
+
+def test_query_fails_when_session_timeout_precedes_heartbeat(bad_sessions, data):
+    spark = bad_sessions.create()
+    with pytest.raises(SparkConnectGrpcException):
+        data(spark).collect()
+
+
+def test_command_fails_when_session_timeout_precedes_heartbeat(bad_sessions, data):
+    spark = bad_sessions.create()
+    with pytest.raises(SparkConnectGrpcException):
+        data(spark).write.format("noop").mode("overwrite").save()
+
+
+def test_query_succeeds_when_heartbeat_precedes_session_timeout(good_sessions, data):
+    spark = good_sessions.create()
+    assert data(spark).collect() == [Row(id=0)]
+    # Send another request to make sure the session is still alive.
+    assert spark.range(1).count() == 1
+
+
+def test_command_succeeds_when_heartbeat_precedes_session_timeout(good_sessions, data):
+    spark = good_sessions.create()
+    data(spark).write.format("noop").mode("overwrite").save()
+    # Send another request to make sure the session is still alive.
+    assert spark.range(1).count() == 1

--- a/python/pysail/tests/spark/session/test_reattachable_execution.py
+++ b/python/pysail/tests/spark/session/test_reattachable_execution.py
@@ -1,0 +1,31 @@
+import pyspark.sql.connect.functions as F  # noqa: N812
+import pytest
+from pyspark.errors.exceptions.connect import SparkConnectGrpcException
+
+from pysail.testing.spark.session import spark_session_factory
+from pysail.testing.spark.utils.common import is_jvm_spark
+
+pytestmark = pytest.mark.skipif(is_jvm_spark(), reason="Sail only")
+
+
+@pytest.fixture(scope="module")
+def fail():
+    @F.udf("long")
+    def _fail(_value):
+        msg = "expected failure"
+        raise RuntimeError(msg)
+
+    return _fail
+
+
+def test_execution_error_without_reattachment(remote, fail):
+    """Error handling for reattachable execution (the default) is exercised frequently in other tests.
+    This test ensures that the error can still be propagated for (non-default) non-reattachable execution.
+    """
+    with spark_session_factory(remote) as sessions:
+        spark = sessions.create()
+        spark._client.disable_reattachable_execute()  # noqa: SLF001
+        with pytest.raises(SparkConnectGrpcException, match="expected failure"):
+            spark.range(1).select(fail("id")).write.format("noop").mode("overwrite").save()
+        with pytest.raises(SparkConnectGrpcException, match="expected failure"):
+            spark.range(1).select(fail("id")).collect()


### PR DESCRIPTION
Currently, command execution in the Spark Connect server does not use the executor so the heartbeat is not involved to keep the session active, and long-running command would have issues due to premature idle session removal. The fix was first explored in <https://github.com/lakehq/sail/pull/2270#discussion_r3642698215>.

This PR implement a proper solution for the problem by using executor for command execution. It also fixes issue around error propagation and skips response buffering for non-reattachable execution. 