### PR TITLE
feat!: remove the `extension` option for Parquet data source

### DIFF
--- a/crates/sail-data-source/data/options/parquet.yaml
+++ b/crates/sail-data-source/data/options/parquet.yaml
@@ -28,31 +28,6 @@
         - option.pathGlobFilter
       parser: crate::options::parsers::parse_optional_string
 
-- key: extension
-  description: |
-    (Reading) The file extension used to filter files when listing a
-    directory of Parquet files. Defaults to `.parquet`. Setting this to
-    an empty string disables extension filtering entirely, which allows
-    reading Parquet files written under non-standard suffixes (e.g. `.hive`).
-  default:
-    value: ".parquet"
-    parser: crate::options::parsers::parse_string
-  supported: true
-  rust_type: String
-  scopes:
-    - read
-  origins:
-    - type: option
-      keys:
-        - extension
-        - fileExtension
-      parser: crate::options::parsers::parse_string
-    - type: table_property
-      keys:
-        - option.extension
-        - option.fileExtension
-      parser: crate::options::parsers::parse_string
-
 - key: enable_page_index
   description: |
     (Reading) Whether to enable page index when reading Parquet files.

--- a/crates/sail-data-source/src/formats/parquet/options.rs
+++ b/crates/sail-data-source/src/formats/parquet/options.rs
@@ -27,7 +27,6 @@ fn check_parquet_level_is_none(codec: &str, level: &Option<u32>) -> DataSourceRe
 impl BuildPartialOptions<ParquetReadPartialOptions> for TableParquetOptions {
     fn build_partial_options(self) -> DataSourceResult<ParquetReadPartialOptions> {
         Ok(ParquetReadPartialOptions {
-            extension: None,
             enable_page_index: Some(self.global.enable_page_index),
             pruning: Some(self.global.pruning),
             skip_metadata: Some(self.global.skip_metadata),
@@ -48,7 +47,6 @@ impl BuildPartialOptions<ParquetReadPartialOptions> for TableParquetOptions {
 impl ParquetReadOptions {
     pub fn into_table_options(self) -> TableParquetOptions {
         let ParquetReadOptions {
-            extension: _,
             enable_page_index,
             pruning,
             skip_metadata,
@@ -365,36 +363,6 @@ mod tests {
             .map_err(datafusion_common::DataFusionError::from)?
             .into_table_options();
         assert_eq!(options.global.metadata_size_hint, None);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_resolve_parquet_read_extension() -> datafusion_common::Result<()> {
-        let ctx = SessionContext::default();
-        let state = ctx.state();
-
-        // default: no option layer → ".parquet"
-        let opts = ParquetReadOptions::resolve(&state, vec![option_list(&[])])
-            .map_err(datafusion_common::DataFusionError::from)?;
-        assert_eq!(opts.extension, ".parquet");
-
-        // snake_case override
-        let opts =
-            ParquetReadOptions::resolve(&state, vec![option_list(&[("extension", ".hive")])])
-                .map_err(datafusion_common::DataFusionError::from)?;
-        assert_eq!(opts.extension, ".hive");
-
-        // camelCase alias
-        let opts =
-            ParquetReadOptions::resolve(&state, vec![option_list(&[("fileExtension", ".pq")])])
-                .map_err(datafusion_common::DataFusionError::from)?;
-        assert_eq!(opts.extension, ".pq");
-
-        // empty string disables filtering
-        let opts = ParquetReadOptions::resolve(&state, vec![option_list(&[("extension", "")])])
-            .map_err(datafusion_common::DataFusionError::from)?;
-        assert_eq!(opts.extension, "");
 
         Ok(())
     }

--- a/python/pysail/tests/spark/datasource/test_parquet.py
+++ b/python/pysail/tests/spark/datasource/test_parquet.py
@@ -206,15 +206,12 @@ def test_parquet_format_path(spark, sample_df, tmp_path):
 
 
 def test_parquet_read_with_custom_extension(spark, sample_pandas_df, tmp_path):
-    """Parquet files written under a non-standard suffix (e.g. `.hive`, as
-    emitted by Hive-managed tables) can be read via the `extension` /
-    `fileExtension` option."""
+    """`pathGlobFilter` selects Parquet files with a custom suffix."""
     directory = tmp_path / "parquet_custom_extension"
     directory.mkdir()
     file_path = directory / "data.hive"
     sample_pandas_df.to_parquet(str(file_path))
-    # TODO: add a file with another extension and the file should be ignored
-    #   when the filtering logic is implemented properly
+    sample_pandas_df.to_parquet(str(directory / "ignored.parquet"))
 
     expected_count = len(sample_pandas_df)
     expected_rows = sorted(sample_pandas_df.to_dict(orient="records"), key=safe_sort_key)
@@ -222,32 +219,17 @@ def test_parquet_read_with_custom_extension(spark, sample_pandas_df, tmp_path):
     def actual_rows(df):
         return sorted(df.toPandas().to_dict(orient="records"), key=safe_sort_key)
 
-    # Option key `extension`, directory path.
-    read_df = spark.read.option("extension", ".hive").parquet(str(directory))
+    read_df = spark.read.option("pathGlobFilter", "*.hive").parquet(str(directory))
     assert read_df.count() == expected_count
     assert actual_rows(read_df) == expected_rows
 
-    # Camel-case alias `fileExtension`, single-file path.
-    read_df = spark.read.option("fileExtension", ".hive").parquet(str(file_path))
-    assert read_df.count() == expected_count
-    assert actual_rows(read_df) == expected_rows
-
-    # Empty string disables extension filtering entirely.
-    read_df = spark.read.option("extension", "").parquet(str(directory))
-    assert read_df.count() == expected_count
-    assert actual_rows(read_df) == expected_rows
-
-    # SQL CREATE TABLE with OPTIONS (fileExtension '.hive').
-    # Use a separate directory so DROP TABLE side effects don't affect other cases.
-    sql_directory = tmp_path / "parquet_custom_extension_sql"
-    sql_directory.mkdir()
-    sample_pandas_df.to_parquet(str(sql_directory / "data.hive"))
+    # SQL CREATE TABLE with OPTIONS (pathGlobFilter '*.hive').
     table_name = "parquet_custom_extension_table"
     try:
         spark.sql(
             f"CREATE TABLE {table_name} USING parquet "
-            f"OPTIONS (fileExtension '.hive') "
-            f"LOCATION '{escape_sql_string_literal(str(sql_directory))}'"
+            f"OPTIONS (pathGlobFilter '*.hive') "
+            f"LOCATION '{escape_sql_string_literal(str(directory))}'"
         )
         read_df = spark.sql(f"SELECT * FROM {table_name}")  # noqa: S608
         assert read_df.count() == expected_count


### PR DESCRIPTION
The `extension` option was introduced in #1786 for Parquet data source. We now support `pathGlobFilter` for all data sources in #2284.