### PR TITLE
fix: require cascade for non-empty memory databases

### DIFF
--- a/crates/sail-catalog-memory/src/provider.rs
+++ b/crates/sail-catalog-memory/src/provider.rs
@@ -149,19 +149,29 @@ impl CatalogProvider for MemoryCatalogProvider {
     ) -> CatalogResult<()> {
         let DropDatabaseOptions {
             if_exists,
-            cascade: _,
+            cascade,
         } = options;
-        if self.databases.remove(database).is_none() {
-            if if_exists {
+        match self.databases.entry(database.clone()) {
+            Entry::Occupied(entry) => {
+                if !cascade && (!entry.get().tables.is_empty() || !entry.get().views.is_empty()) {
+                    return Err(CatalogError::InvalidArgument(format!(
+                        "Cannot drop non-empty database '{}', use CASCADE",
+                        quote_namespace_if_needed(database),
+                    )));
+                }
+                let _ = entry.remove_entry();
                 Ok(())
-            } else {
-                Err(CatalogError::NotFound(
-                    CatalogObject::Database,
-                    quote_namespace_if_needed(database),
-                ))
             }
-        } else {
-            Ok(())
+            Entry::Vacant(_) => {
+                if if_exists {
+                    Ok(())
+                } else {
+                    Err(CatalogError::NotFound(
+                        CatalogObject::Database,
+                        quote_namespace_if_needed(database),
+                    ))
+                }
+            }
         }
     }
 

--- a/python/pysail/tests/spark/catalog/features/memory_database_drop.feature
+++ b/python/pysail/tests/spark/catalog/features/memory_database_drop.feature
@@ -1,0 +1,96 @@
+Feature: Memory catalog database drop semantics
+
+  Scenario: Drop non-empty memory database without CASCADE rejects and keeps objects
+    Given final statement
+      """
+      DROP DATABASE IF EXISTS no_cascade_memory_db CASCADE
+      """
+    Given statement
+      """
+      CREATE DATABASE no_cascade_memory_db
+      """
+    Given statement
+      """
+      CREATE TABLE no_cascade_memory_db.tbl (id INT)
+      """
+    Given statement
+      """
+      INSERT INTO no_cascade_memory_db.tbl VALUES (1), (2)
+      """
+    Given statement
+      """
+      CREATE VIEW no_cascade_memory_db.vw AS SELECT * FROM no_cascade_memory_db.tbl
+      """
+    Given statement with error .*
+      """
+      DROP DATABASE no_cascade_memory_db
+      """
+    When query
+      """
+      SHOW TABLES IN no_cascade_memory_db LIKE '*'
+      """
+    Then query result
+      | database                 | tableName | isTemporary |
+      | no_cascade_memory_db     | tbl       | false       |
+      | no_cascade_memory_db     | vw        | false       |
+    When query
+      """
+      SELECT * FROM no_cascade_memory_db.vw ORDER BY id
+      """
+    Then query result ordered
+      | id |
+      | 1  |
+      | 2  |
+
+    When query
+      """
+      SELECT * FROM no_cascade_memory_db.tbl ORDER BY id
+      """
+    Then query result ordered
+      | id |
+      | 1  |
+      | 2  |
+
+  Scenario: Drop non-empty memory database with CASCADE removes it and contained objects
+    Given final statement
+      """
+      DROP DATABASE IF EXISTS cascade_memory_db CASCADE
+      """
+    Given statement
+      """
+      CREATE DATABASE cascade_memory_db
+      """
+    Given statement
+      """
+      CREATE TABLE cascade_memory_db.tbl (id INT)
+      """
+    Given statement
+      """
+      INSERT INTO cascade_memory_db.tbl VALUES (1), (2)
+      """
+    Given statement
+      """
+      CREATE VIEW cascade_memory_db.vw AS SELECT * FROM cascade_memory_db.tbl
+      """
+    Given statement
+      """
+      DROP DATABASE cascade_memory_db CASCADE
+      """
+    When query
+      """
+      SHOW DATABASES LIKE 'cascade_memory_db'
+      """
+    Then query result
+      | name | catalog | description | locationUri |
+
+    When query
+      """
+      SELECT * FROM cascade_memory_db.tbl
+      """
+    Then query error .*
+
+    When query
+      """
+      SELECT * FROM cascade_memory_db.vw
+      """
+    Then query error .*


### PR DESCRIPTION
## Summary

- reject non-CASCADE drops of non-empty in-memory databases
- make the precondition check and removal atomic, so a concurrent table or view create cannot be erased after the check
- add regression coverage for tables and views surviving the rejected drop and CASCADE removal succeeding

## Tests

- `cargo fmt --check`
- `cargo test -p sail-catalog-memory`
- `cargo clippy -p sail-catalog-memory --all-targets --all-features -- -D warnings`
