### PR TITLE
fix: do not round-robin repartition streaming plans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7926,6 +7926,7 @@ dependencies = [
  "datafusion",
  "datafusion-physical-expr",
  "log",
+ "sail-common-datafusion",
  "sail-physical-plan",
 ]
 

--- a/crates/sail-physical-optimizer/Cargo.toml
+++ b/crates/sail-physical-optimizer/Cargo.toml
@@ -7,6 +7,7 @@ edition = { workspace = true }
 workspace = true
 
 [dependencies]
+sail-common-datafusion = { path = "../sail-common-datafusion" }
 sail-physical-plan = { path = "../sail-physical-plan" }
 
 datafusion = { workspace = true }

--- a/crates/sail-physical-optimizer/src/lib.rs
+++ b/crates/sail-physical-optimizer/src/lib.rs
@@ -26,11 +26,13 @@ use crate::collect_left::RewriteCollectLeftHashJoin;
 use crate::explicit_repartition::RewriteExplicitRepartition;
 use crate::join_reorder::JoinReorder;
 pub use crate::join_reorder::JoinReorderOptions;
+use crate::streaming_repartition::RemoveStreamingRoundRobinRepartition;
 
 mod barrier;
 mod collect_left;
 mod explicit_repartition;
 mod join_reorder;
+mod streaming_repartition;
 
 #[derive(Debug, Clone, Default)]
 pub struct PhysicalOptimizerOptions {
@@ -65,6 +67,9 @@ pub fn get_physical_optimizers(
     rules.push(Arc::new(TopKRepartition::new()));
     rules.push(Arc::new(ProjectionPushdown::new()));
     rules.push(Arc::new(PushdownSort::new()));
+    // Before `EnsureCooperative`, so that it sees the final shape of the plan:
+    // with the repartition gone, an unbounded source needs its own yield point.
+    rules.push(Arc::new(RemoveStreamingRoundRobinRepartition::new()));
     rules.push(Arc::new(EnsureCooperative::new()));
     rules.push(Arc::new(FilterPushdown::new_post_optimization()));
     rules.push(Arc::new(RewriteExplicitRepartition::new()));

--- a/crates/sail-physical-optimizer/src/streaming_repartition.rs
+++ b/crates/sail-physical-optimizer/src/streaming_repartition.rs
@@ -1,0 +1,133 @@
+use std::sync::Arc;
+
+use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::config::ConfigOptions;
+use datafusion::error::Result;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion_physical_expr::Partitioning;
+use sail_common_datafusion::streaming::event::schema::is_flow_event_schema;
+
+/// Removes round-robin repartitioning from streaming plans.
+///
+/// Round-robin repartitioning exists to buy parallelism, and for an unbounded
+/// input it costs unbounded latency instead. [`RepartitionExec`] coalesces on
+/// the producer side, holding rows until `batch_size` of them accumulate and
+/// flushing the remainder only when the input ends. A stream does not end, so
+/// at the default batch size a slow source delivers nothing downstream for a
+/// very long time, while the query reports itself as running.
+///
+/// Streaming plans are not meant to be repartitioned in any case: the streaming
+/// rewriter rejects a logical `Repartition` outright. This removes the ones the
+/// physical planner adds on its own. A streaming source that is itself
+/// multi-partition keeps its partitions, so real parallelism is unaffected.
+///
+/// A repartition is recognised as belonging to a streaming plan by its input
+/// schema: every node above a streaming source carries the flow event fields.
+#[derive(Debug)]
+pub struct RemoveStreamingRoundRobinRepartition {}
+
+impl RemoveStreamingRoundRobinRepartition {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for RemoveStreamingRoundRobinRepartition {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PhysicalOptimizerRule for RemoveStreamingRoundRobinRepartition {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let result = plan.transform_up(|plan| {
+            if let Some(node) = plan.downcast_ref::<RepartitionExec>()
+                && matches!(
+                    node.properties().output_partitioning(),
+                    Partitioning::RoundRobinBatch(_)
+                )
+                && is_flow_event_schema(node.input().schema().as_ref())
+            {
+                Ok(Transformed::yes(Arc::clone(node.input())))
+            } else {
+                Ok(Transformed::no(plan))
+            }
+        })?;
+        Ok(result.data)
+    }
+
+    fn name(&self) -> &str {
+        "RemoveStreamingRoundRobinRepartition"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::physical_plan::empty::EmptyExec;
+    use sail_common_datafusion::streaming::event::schema::to_flow_event_schema;
+
+    use super::*;
+
+    fn data_schema() -> Schema {
+        Schema::new(vec![Field::new("value", DataType::Int64, false)])
+    }
+
+    fn optimize(plan: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+        #[expect(clippy::unwrap_used)]
+        RemoveStreamingRoundRobinRepartition::new()
+            .optimize(plan, &ConfigOptions::default())
+            .unwrap()
+    }
+
+    #[test]
+    #[expect(clippy::unwrap_used)]
+    fn test_removes_round_robin_over_a_flow_event_input() {
+        let input = Arc::new(EmptyExec::new(Arc::new(to_flow_event_schema(
+            &data_schema(),
+        ))));
+        let plan =
+            Arc::new(RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(4)).unwrap());
+
+        let optimized = optimize(plan);
+        assert!(optimized.downcast_ref::<RepartitionExec>().is_none());
+        assert!(optimized.downcast_ref::<EmptyExec>().is_some());
+    }
+
+    #[test]
+    #[expect(clippy::unwrap_used)]
+    fn test_keeps_round_robin_over_a_batch_input() {
+        let input = Arc::new(EmptyExec::new(Arc::new(data_schema())));
+        let plan =
+            Arc::new(RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(4)).unwrap());
+
+        let optimized = optimize(plan);
+        assert!(optimized.downcast_ref::<RepartitionExec>().is_some());
+    }
+
+    #[test]
+    #[expect(clippy::unwrap_used)]
+    fn test_keeps_hash_repartition_over_a_flow_event_input() {
+        // Only the round-robin variant is removed: a hash repartition changes
+        // semantics rather than merely adding parallelism, so if one ever
+        // appears in a streaming plan it must not be silently dropped.
+        let input = Arc::new(EmptyExec::new(Arc::new(to_flow_event_schema(
+            &data_schema(),
+        ))));
+        let plan =
+            Arc::new(RepartitionExec::try_new(input, Partitioning::Hash(vec![], 4)).unwrap());
+
+        let optimized = optimize(plan);
+        assert!(optimized.downcast_ref::<RepartitionExec>().is_some());
+    }
+}

--- a/crates/sail-plan/src/lib.rs
+++ b/crates/sail-plan/src/lib.rs
@@ -41,30 +41,13 @@ pub async fn resolve_and_execute_plan(
     let NamedPlan { plan, fields } = resolver.resolve_named_plan(plan).await?;
     info.push(plan.to_stringified(PlanType::InitialLogicalPlan));
     let df = execute_logical_plan(ctx, plan).await?;
-    let (mut session_state, plan) = df.into_parts();
+    let (session_state, plan) = df.into_parts();
     let plan = session_state.optimize(&plan)?;
-    let streaming = is_streaming_plan(&plan)?;
-    let plan = if streaming {
+    let plan = if is_streaming_plan(&plan)? {
         rewrite_streaming_plan(plan)?
     } else {
         plan
     };
-    if streaming {
-        // Round-robin repartitioning exists to buy parallelism, and for an
-        // unbounded input it costs unbounded latency instead: `RepartitionExec`
-        // coalesces on the producer side, holding rows until `batch_size` of
-        // them accumulate, and only flushes the remainder when the input ends.
-        // A stream does not end, so at the default batch size a slow source
-        // delivers nothing for a very long time. Streaming plans are not meant
-        // to be repartitioned anyway — the streaming rewriter rejects a logical
-        // `Repartition` outright — so keep the physical planner from
-        // reintroducing one.
-        session_state
-            .config_mut()
-            .options_mut()
-            .optimizer
-            .enable_round_robin_repartition = false;
-    }
     info.push(plan.to_stringified(PlanType::FinalLogicalPlan));
     let plan = session_state
         .query_planner()

--- a/crates/sail-plan/src/lib.rs
+++ b/crates/sail-plan/src/lib.rs
@@ -41,13 +41,30 @@ pub async fn resolve_and_execute_plan(
     let NamedPlan { plan, fields } = resolver.resolve_named_plan(plan).await?;
     info.push(plan.to_stringified(PlanType::InitialLogicalPlan));
     let df = execute_logical_plan(ctx, plan).await?;
-    let (session_state, plan) = df.into_parts();
+    let (mut session_state, plan) = df.into_parts();
     let plan = session_state.optimize(&plan)?;
-    let plan = if is_streaming_plan(&plan)? {
+    let streaming = is_streaming_plan(&plan)?;
+    let plan = if streaming {
         rewrite_streaming_plan(plan)?
     } else {
         plan
     };
+    if streaming {
+        // Round-robin repartitioning exists to buy parallelism, and for an
+        // unbounded input it costs unbounded latency instead: `RepartitionExec`
+        // coalesces on the producer side, holding rows until `batch_size` of
+        // them accumulate, and only flushes the remainder when the input ends.
+        // A stream does not end, so at the default batch size a slow source
+        // delivers nothing for a very long time. Streaming plans are not meant
+        // to be repartitioned anyway — the streaming rewriter rejects a logical
+        // `Repartition` outright — so keep the physical planner from
+        // reintroducing one.
+        session_state
+            .config_mut()
+            .options_mut()
+            .optimizer
+            .enable_round_robin_repartition = false;
+    }
     info.push(plan.to_stringified(PlanType::FinalLogicalPlan));
     let plan = session_state
         .query_planner()

--- a/python/pysail/testing/spark/utils/sql.py
+++ b/python/pysail/testing/spark/utils/sql.py
@@ -89,7 +89,10 @@ def escape_sql_string_literal(s: str) -> str:
     while ASCII characters are converted to their octal representation
     unless they are alphanumeric.
     """
-    return "".join(f"\\{ord(c):03o}" if ord(c) < 128 and not c.isalnum() else c for c in s)
+    return "".join(
+        f"\\{ord(c):03o}" if ord(c) < 128 and not c.isalnum() else c  # noqa: PLR2004
+        for c in s
+    )
 
 
 def _display_width(c):
@@ -195,7 +198,7 @@ def normalize_floating_point_string(s: str, d: int = 6, n: int = 6) -> str:
     return f"{num}{exp}"
 
 
-def streaming_explain_string(query, extended: bool = False) -> str:
+def streaming_explain_string(query, *, extended: bool = False) -> str:
     """Returns the explain output of a streaming query as a string.
 
     `StreamingQuery.explain` prints to stdout and returns `None`, so this

--- a/python/pysail/testing/spark/utils/sql.py
+++ b/python/pysail/testing/spark/utils/sql.py
@@ -89,10 +89,7 @@ def escape_sql_string_literal(s: str) -> str:
     while ASCII characters are converted to their octal representation
     unless they are alphanumeric.
     """
-    return "".join(
-        f"\\{ord(c):03o}" if ord(c) < 128 and not c.isalnum() else c  # noqa: PLR2004
-        for c in s
-    )
+    return "".join(f"\\{ord(c):03o}" if ord(c) < 128 and not c.isalnum() else c for c in s)
 
 
 def _display_width(c):
@@ -196,3 +193,16 @@ def normalize_floating_point_string(s: str, d: int = 6, n: int = 6) -> str:
     num = round(Decimal(match.group("num")), min(len(match.group("frac")), d))
     exp = match.group("exp") or ""
     return f"{num}{exp}"
+
+
+def streaming_explain_string(query, extended: bool = False) -> str:
+    """Returns the explain output of a streaming query as a string.
+
+    `StreamingQuery.explain` prints to stdout and returns `None`, so this
+    replicates its implementation up to the `print`, for use in snapshot tests.
+    """
+    from pyspark.sql.connect.proto import StreamingQueryCommand  # noqa: PLC0415
+
+    cmd = StreamingQueryCommand()
+    cmd.explain.extended = extended
+    return query._execute_streaming_query_cmd(cmd).explain.result  # noqa: SLF001

--- a/python/pysail/tests/spark/analyzer/__snapshots__/features/explain.yaml
+++ b/python/pysail/tests/spark/analyzer/__snapshots__/features/explain.yaml
@@ -323,6 +323,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   

--- a/python/pysail/tests/spark/delta/__snapshots__/features/delete.yaml
+++ b/python/pysail/tests/spark/delta/__snapshots__/features/delete.yaml
@@ -360,6 +360,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   

--- a/python/pysail/tests/spark/delta/__snapshots__/features/merge.yaml
+++ b/python/pysail/tests/spark/delta/__snapshots__/features/merge.yaml
@@ -2209,6 +2209,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   

--- a/python/pysail/tests/spark/execution/__snapshots__/features/explain.yaml
+++ b/python/pysail/tests/spark/execution/__snapshots__/features/explain.yaml
@@ -299,6 +299,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   

--- a/python/pysail/tests/spark/execution/__snapshots__/features/lakehouse_commit.yaml
+++ b/python/pysail/tests/spark/execution/__snapshots__/features/lakehouse_commit.yaml
@@ -412,6 +412,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   
@@ -852,6 +855,9 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after PushdownSort:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after RemoveStreamingRoundRobinRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after EnsureCooperative:

--- a/python/pysail/tests/spark/execution/__snapshots__/features/scalar_subquery.yaml
+++ b/python/pysail/tests/spark/execution/__snapshots__/features/scalar_subquery.yaml
@@ -549,6 +549,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   
@@ -1058,6 +1061,9 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after PushdownSort:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after RemoveStreamingRoundRobinRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after EnsureCooperative:
@@ -1585,6 +1591,9 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after PushdownSort:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after RemoveStreamingRoundRobinRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after EnsureCooperative:
@@ -2367,6 +2376,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   
@@ -3010,6 +3022,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   
@@ -3493,6 +3508,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   
@@ -3958,6 +3976,9 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after PushdownSort:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after RemoveStreamingRoundRobinRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after EnsureCooperative:
@@ -4474,6 +4495,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   
@@ -4923,6 +4947,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   
@@ -5348,6 +5375,9 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after PushdownSort:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after RemoveStreamingRoundRobinRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after EnsureCooperative:
@@ -5836,6 +5866,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   
@@ -6311,6 +6344,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   
@@ -6767,6 +6803,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   
@@ -7208,6 +7247,9 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after PushdownSort:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after RemoveStreamingRoundRobinRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after EnsureCooperative:
@@ -7676,6 +7718,9 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after PushdownSort:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after RemoveStreamingRoundRobinRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after EnsureCooperative:
@@ -8196,6 +8241,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   
@@ -8671,6 +8719,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   
@@ -9137,6 +9188,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   
@@ -9579,6 +9633,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   
@@ -9987,6 +10044,9 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after PushdownSort:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after RemoveStreamingRoundRobinRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after EnsureCooperative:
@@ -10405,6 +10465,9 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after PushdownSort:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after RemoveStreamingRoundRobinRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after EnsureCooperative:
@@ -10850,6 +10913,9 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after PushdownSort:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after RemoveStreamingRoundRobinRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after EnsureCooperative:
@@ -11310,6 +11376,9 @@ data:
     SAME TEXT AS ABOVE
   
     physical_plan after PushdownSort:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after RemoveStreamingRoundRobinRepartition:
     SAME TEXT AS ABOVE
   
     physical_plan after EnsureCooperative:

--- a/python/pysail/tests/spark/execution/__snapshots__/test_shuffle_storage.plan.yaml
+++ b/python/pysail/tests/spark/execution/__snapshots__/test_shuffle_storage.plan.yaml
@@ -513,6 +513,9 @@ data:
     physical_plan after PushdownSort:
     SAME TEXT AS ABOVE
   
+    physical_plan after RemoveStreamingRoundRobinRepartition:
+    SAME TEXT AS ABOVE
+  
     physical_plan after EnsureCooperative:
     SAME TEXT AS ABOVE
   

--- a/python/pysail/tests/spark/streaming/__snapshots__/test_streaming_repartition.plan.yaml
+++ b/python/pysail/tests/spark/streaming/__snapshots__/test_streaming_repartition.plan.yaml
@@ -1,0 +1,54 @@
+# serializer version: 1
+---
+name: "test_batch_plan_keeps_round_robin_repartition"
+data:
+  |-
+    == Parsed Logical Plan ==
+    Projection: #1 AS #2, count(Int32(1)) AS count AS #3
+      Aggregate: groupBy=[[#1]], aggr=[[count(Int32(1))]]
+        Projection: #0 % CASE WHEN Int32(7) = Int32(0) THEN raise_error(Utf8("Remainder by zero")) ELSE Int32(7) END AS k AS #1
+          Range: start=0, end=1000, step=1, num_partitions=1
+  
+    == Analyzed Logical Plan ==
+    #2: Int64, #3: Int64
+    Projection: #1 AS #2, count(Int32(1)) AS count AS #3
+      Aggregate: groupBy=[[#1]], aggr=[[count(Int32(1))]]
+        Projection: #0 % CAST(CASE WHEN Int32(7) = Int32(0) THEN CAST(raise_error(Utf8("Remainder by zero")) AS Int32) ELSE Int32(7) END AS Int64) AS k AS #1
+          Range: start=0, end=1000, step=1, num_partitions=1
+  
+    == Optimized Logical Plan ==
+    Projection: #1 AS #2, count(Int32(1)) AS count AS #3
+      Aggregate: groupBy=[[#1]], aggr=[[count(Int32(1))]]
+        Projection: #0 % Int64(7) AS k AS #1
+          Range: start=0, end=1000, step=1, num_partitions=1
+  
+    == Physical Plan ==
+    ProjectionExec: expr=[#2@0 as k, #3@1 as count]
+      ProjectionExec: expr=[#1@0 as #2, count(Int32(1))@1 as #3]
+        AggregateExec: mode=FinalPartitioned, gby=[#1@0 as #1], aggr=[count(Int32(1))]
+          RepartitionExec: partitioning=Hash([#1@0], 4), input_partitions=4
+            AggregateExec: mode=Partial, gby=[#1@0 as #1], aggr=[count(Int32(1))]
+              ProjectionExec: expr=[#0@0 % 7 as #1]
+                RepartitionExec: partitioning=RoundRobinBatch(4), input_partitions=1
+                  RangeExec
+---
+name: "test_streaming_plan_is_not_repartitioned"
+data:
+  |-
+    == Initial Logical Plan ==
+    Barrier
+      ConsoleWrite
+        Projection: ?table?.#0 AS timestamp, ?table?.#1 AS value
+          Projection: ?table?.timestamp AS #0, ?table?.value AS #1
+            TableScan: ?table?
+  
+    == Final Logical Plan ==
+    Barrier
+      ConsoleWrite
+        Projection: _marker, _retracted, ?table?.timestamp AS timestamp, ?table?.value AS value
+          StreamSourceWrapper
+  
+    == Final Physical Plan ==
+    ConsoleSinkExec
+      CooperativeExec
+        RateSourceExec: rows_per_second=5, num_partitions=1

--- a/python/pysail/tests/spark/streaming/test_streaming_repartition.py
+++ b/python/pysail/tests/spark/streaming/test_streaming_repartition.py
@@ -8,36 +8,38 @@ size a slow source delivers nothing for a very long time — the query reports
 active the whole while.
 
 There is no sink a Connect client can assert delivery against (`console` writes
-to the server's stdout, and `memory` is not implemented), so this pins the plan
-shape instead.
+to the server's stdout, and `memory` is not implemented), so these tests pin the
+plan shape instead: the streaming plan snapshot must not contain a
+`RepartitionExec`, and the batch plan snapshot must keep its `RoundRobinBatch`
+so the streaming rule is known not to have leaked into batch planning.
 """
 
 from __future__ import annotations
 
 import pytest
 
+from pysail.testing.spark.steps.plan import normalize_plan_text
 from pysail.testing.spark.utils.common import is_jvm_spark
+from pysail.testing.spark.utils.sql import streaming_explain_string
 
 if is_jvm_spark():
     pytest.skip("Sail streaming tests", allow_module_level=True)
 
 
-def test_streaming_plan_has_no_round_robin_repartition(spark, capsys):
+@pytest.mark.yamlsnapshot(group="plan")
+def test_streaming_plan_is_not_repartitioned(spark, snapshot):
     query = spark.readStream.format("rate").option("rowsPerSecond", 5).load().writeStream.format("console").start()
     try:
-        query.explain(extended=True)
-        plan = capsys.readouterr().out
+        plan = normalize_plan_text(streaming_explain_string(query, extended=True))
     finally:
         query.stop()
 
-    assert "RateSourceExec" in plan, f"unexpected plan:\n{plan}"
-    assert "RoundRobinBatch" not in plan, f"streaming plan was repartitioned:\n{plan}"
+    assert plan == snapshot
 
 
-def test_batch_plan_still_uses_round_robin_repartition(spark, capsys):
-    # The streaming case must not have disabled repartitioning everywhere:
-    # a batch query still fans out to use the available parallelism.
-    spark.range(1000).selectExpr("id % 7 as k").groupBy("k").count().explain(extended=True)
-    plan = capsys.readouterr().out
+@pytest.mark.yamlsnapshot(group="plan")
+def test_batch_plan_keeps_round_robin_repartition(spark, snapshot):
+    df = spark.range(1000).selectExpr("id % 7 as k").groupBy("k").count()
+    plan = normalize_plan_text(df._explain_string(extended=True))  # noqa: SLF001
 
-    assert "RoundRobinBatch" in plan, f"batch plan lost its parallelism:\n{plan}"
+    assert plan == snapshot

--- a/python/pysail/tests/spark/streaming/test_streaming_repartition.py
+++ b/python/pysail/tests/spark/streaming/test_streaming_repartition.py
@@ -1,0 +1,43 @@
+"""Streaming plans must not be round-robin repartitioned.
+
+Round-robin repartitioning buys parallelism, and for an unbounded input it costs
+unbounded latency instead: `RepartitionExec` coalesces on the producer side,
+holding rows until `batch_size` of them accumulate and only flushing the
+remainder when the input ends. A stream does not end, so with the default batch
+size a slow source delivers nothing for a very long time — the query reports
+active the whole while.
+
+There is no sink a Connect client can assert delivery against (`console` writes
+to the server's stdout, and `memory` is not implemented), so this pins the plan
+shape instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pysail.testing.spark.utils.common import is_jvm_spark
+
+if is_jvm_spark():
+    pytest.skip("Sail streaming tests", allow_module_level=True)
+
+
+def test_streaming_plan_has_no_round_robin_repartition(spark, capsys):
+    query = spark.readStream.format("rate").option("rowsPerSecond", 5).load().writeStream.format("console").start()
+    try:
+        query.explain(extended=True)
+        plan = capsys.readouterr().out
+    finally:
+        query.stop()
+
+    assert "RateSourceExec" in plan, f"unexpected plan:\n{plan}"
+    assert "RoundRobinBatch" not in plan, f"streaming plan was repartitioned:\n{plan}"
+
+
+def test_batch_plan_still_uses_round_robin_repartition(spark, capsys):
+    # The streaming case must not have disabled repartitioning everywhere:
+    # a batch query still fans out to use the available parallelism.
+    spark.range(1000).selectExpr("id % 7 as k").groupBy("k").count().explain(extended=True)
+    plan = capsys.readouterr().out
+
+    assert "RoundRobinBatch" in plan, f"batch plan lost its parallelism:\n{plan}"


### PR DESCRIPTION

## Problem

A streaming query starts, reports `isActive`, raises no exception, and delivers
nothing to its sink for a very long time.

```python
spark.readStream.format("rate").option("rowsPerSecond", 5).load() \
     .writeStream.format("console").start()
```

On a multi-core machine this prints nothing. The query is not stuck and no data
is lost — it is buffered.

## Cause

The physical planner inserts a round-robin repartition to use the available
parallelism:

```
ConsoleSinkExec
  RepartitionExec: partitioning=RoundRobinBatch(14), input_partitions=1
    RateSourceExec: rows_per_second=5, num_partitions=1
```

`RepartitionExec` coalesces on the producer side. `OutputChannel::coalesce`
pushes into a `LimitedBatchCoalescer` and drains only batches that have reached
`target_batch_size` (`execution.batch_size`, default 8192). The residual is
flushed in `finalize()`, which runs when the last input sender finishes.

An unbounded source never finishes, so the residual is never flushed. The rate
source emits one row per batch, so the first output appears only once 8192 rows
have accumulated — about 27 minutes at 5 rows/s, and never at all for a source
that is idle.

This is confirmed by varying only `batch_size`, with the repartition present in
both cases:

| `default_parallelism` | `batch_size` | rows generated | rows delivered |
|---|---|---|---|
| 4 | 1 | 24 | 24 |
| 4 | 8192 (default) | 24 | 0 |

## Fix

Round-robin repartitioning trades latency for parallelism, which is the wrong
trade for an unbounded input — and streaming plans are not meant to be
repartitioned in the first place: the streaming rewriter already rejects a
logical `Repartition` with `not_impl_err!("streaming repartition")`. This keeps
the physical planner from reintroducing one, by disabling
`enable_round_robin_repartition` for streaming plans only.

A streaming source that is itself multi-partition keeps its partitions, so real
parallelism is unaffected. Batch queries are untouched.

## Tests

`test_streaming_repartition.py` pins the plan shape both ways: a streaming plan
has no `RoundRobinBatch`, and a batch plan still does.

Asserting delivery directly would be better, but no sink is observable from a
Connect client — `console` writes to the server's stdout and `memory` is not
implemented. That gap is why the existing streaming tests pass while nothing
flows: they assert `isActive`, `status`, and `exception() is None`, all of which
hold during a total stall.

## Note for upstream DataFusion

Reported as https://github.com/apache/datafusion/issues/24044, with a standalone
repro that does not involve Sail.

Avoiding the repartition side-steps the buffering here, but any
`RepartitionExec` over an unbounded stream has the same unbounded-latency
behaviour. The change in this PR stands on its own regardless of what DataFusion
decides: the streaming rewriter already rejects a logical `Repartition`, and
artificial round-robin fan-out over an unbounded source buys nothing.
