### PR TITLE
feat: adjust checkpoint and shuffle storage paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7367,7 +7367,6 @@ dependencies = [
  "sail-common-datafusion",
  "sail-object-store",
  "thiserror 2.0.19",
- "uuid",
 ]
 
 [[package]]

--- a/crates/sail-cache/Cargo.toml
+++ b/crates/sail-cache/Cargo.toml
@@ -18,4 +18,3 @@ datafusion-common = { workspace = true }
 chrono = { workspace = true }
 log = { workspace = true }
 moka = { workspace = true }
-uuid = { workspace = true }

--- a/crates/sail-cache/src/remote_checkpoint.rs
+++ b/crates/sail-cache/src/remote_checkpoint.rs
@@ -13,7 +13,6 @@ use sail_common_datafusion::extension::SessionExtension;
 use sail_object_store::{
     ResolvedObjectStorePath, delete_object_store_prefix_objects, resolve_object_store_path,
 };
-use uuid::Uuid;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RemoteCheckpointFile {
@@ -45,16 +44,16 @@ pub struct RemoteCheckpointDescriptor {
 #[derive(Debug)]
 pub struct RemoteCheckpointRegistry {
     path: Option<String>,
-    session_namespace: String,
+    session_id: String,
     closed: AtomicBool,
     relations: RwLock<HashMap<String, Arc<RemoteCheckpointDescriptor>>>,
 }
 
 impl RemoteCheckpointRegistry {
-    pub fn new(path: Option<String>) -> Self {
+    pub fn new(path: Option<String>, session_id: String) -> Self {
         Self {
             path,
-            session_namespace: Uuid::new_v4().to_string(),
+            session_id,
             closed: AtomicBool::new(false),
             relations: RwLock::new(HashMap::new()),
         }
@@ -152,7 +151,7 @@ impl RemoteCheckpointRegistry {
     }
 
     fn session_prefix(&self, root: &Path) -> Path {
-        root.clone().join(self.session_namespace.as_str())
+        root.clone().join(self.session_id.as_str())
     }
 
     fn clear(&self) -> Result<()> {
@@ -161,12 +160,6 @@ impl RemoteCheckpointRegistry {
         })?;
         relations.clear();
         Ok(())
-    }
-}
-
-impl Default for RemoteCheckpointRegistry {
-    fn default() -> Self {
-        Self::new(None)
     }
 }
 
@@ -199,7 +192,7 @@ mod tests {
 
     #[test]
     fn registry_owns_only_ready_descriptors() -> Result<()> {
-        let registry = RemoteCheckpointRegistry::default();
+        let registry = RemoteCheckpointRegistry::new(None, "session".to_string());
         registry.insert(descriptor("relation"))?;
         assert_eq!(
             registry
@@ -219,5 +212,14 @@ mod tests {
         registry.clear()?;
         assert!(registry.get("relation")?.is_none());
         Ok(())
+    }
+
+    #[test]
+    fn registry_uses_the_provided_session_id_for_storage_paths() {
+        let registry = RemoteCheckpointRegistry::new(None, "session-1".to_string());
+        assert_eq!(
+            registry.session_prefix(&Path::from("checkpoint")),
+            Path::from("checkpoint/session-1")
+        );
     }
 }

--- a/crates/sail-common/src/config/application.rs
+++ b/crates/sail-common/src/config/application.rs
@@ -186,6 +186,8 @@ pub struct TemporaryFilesConfig {
 #[serde(deny_unknown_fields)]
 pub struct ClusterConfig {
     pub enable_tls: bool,
+    #[serde(skip_serializing)]
+    pub session_id: String,
     pub driver_listen_host: String,
     pub driver_listen_port: u16,
     pub driver_external_host: String,
@@ -308,7 +310,11 @@ pub enum ShuffleBackend {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct StorageShuffleBackend {
-    pub path: String,
+    #[serde(
+        serialize_with = "serialize_non_empty_string",
+        deserialize_with = "deserialize_non_empty_string"
+    )]
+    pub path: Option<String>,
     pub max_file_size: usize,
     pub compression: ShuffleCompression,
 }
@@ -353,7 +359,7 @@ mod shuffle_backend {
                 super::ShuffleBackend::Streaming => ShuffleBackend {
                     r#type: Type::Streaming,
                     storage: super::StorageShuffleBackend {
-                        path: String::new(),
+                        path: None,
                         max_file_size: 0,
                         compression: super::ShuffleCompression::None,
                     },
@@ -767,6 +773,7 @@ macro_rules! define_cluster_config_env {
 impl ClusterConfigEnv {
     define_cluster_config_env! {
         ENABLE_TLS,
+        SESSION_ID,
         DRIVER_EXTERNAL_HOST,
         DRIVER_EXTERNAL_PORT,
         DRIVER_ID,

--- a/crates/sail-common/src/config/application.yaml
+++ b/crates/sail-common/src/config/application.yaml
@@ -71,6 +71,12 @@
   description: Whether to enable TLS for cluster communication.
   experimental: true
 
+- key: cluster.session_id
+  type: string
+  default: ""
+  description:
+  hidden: true
+
 - key: cluster.driver_listen_host
   type: string
   default: "127.0.0.1"
@@ -262,7 +268,7 @@
 
 - key: cluster.shuffle_backend.storage.path
   type: string
-  default: "file:///tmp/sail/shuffle"
+  default: ""
   description: |
     The object storage base URL for storage-backed shuffle data.
     This is only used when `cluster.shuffle_backend.type` is `storage`.

--- a/crates/sail-common/src/config/application.yaml
+++ b/crates/sail-common/src/config/application.yaml
@@ -271,7 +271,7 @@
   default: ""
   description: |
     The object storage base URL for storage-backed shuffle data.
-    This is only used when `cluster.shuffle_backend.type` is `storage`.
+    This is required when `cluster.shuffle_backend.type` is `storage`.
   experimental: true
 
 - key: cluster.shuffle_backend.storage.max_file_size

--- a/crates/sail-execution/src/driver/options.rs
+++ b/crates/sail-execution/src/driver/options.rs
@@ -12,6 +12,7 @@ use crate::worker_manager::WorkerManager;
 #[readonly::make]
 pub struct DriverOptions {
     pub enable_tls: bool,
+    pub session_id: String,
     pub driver_id: DriverId,
     pub driver_server_port: u16,
     pub driver_external_host: String,
@@ -41,11 +42,13 @@ impl DriverOptions {
     pub fn new(
         config: &AppConfig,
         runtime: RuntimeHandle,
+        session_id: String,
         driver_id: DriverId,
         driver_server_port: u16,
     ) -> Self {
         Self {
             enable_tls: config.cluster.enable_tls,
+            session_id,
             driver_id,
             driver_server_port,
             driver_external_host: config.cluster.driver_external_host.clone(),

--- a/crates/sail-execution/src/driver/worker_pool/core.rs
+++ b/crates/sail-execution/src/driver/worker_pool/core.rs
@@ -68,6 +68,7 @@ impl WorkerPool {
         let _guard = span.set_local_parent();
         let options = WorkerLaunchOptions {
             enable_tls: self.options.enable_tls,
+            session_id: self.options.session_id.clone(),
             driver_id: self.options.driver_id,
             driver_external_host: self.options.driver_external_host.to_string(),
             driver_external_port: if self.options.driver_external_port > 0 {

--- a/crates/sail-execution/src/driver/worker_pool/options.rs
+++ b/crates/sail-execution/src/driver/worker_pool/options.rs
@@ -10,6 +10,7 @@ use crate::shuffle::ShuffleBackendKind;
 #[readonly::make]
 pub struct WorkerPoolOptions {
     pub enable_tls: bool,
+    pub session_id: String,
     pub driver_id: DriverId,
     pub driver_server_port: u16,
     pub driver_external_host: String,
@@ -28,6 +29,7 @@ impl From<&DriverOptions> for WorkerPoolOptions {
     fn from(options: &DriverOptions) -> Self {
         Self {
             enable_tls: options.enable_tls,
+            session_id: options.session_id.clone(),
             driver_id: options.driver_id,
             driver_server_port: options.driver_server_port,
             driver_external_host: options.driver_external_host.clone(),

--- a/crates/sail-execution/src/shuffle.rs
+++ b/crates/sail-execution/src/shuffle.rs
@@ -2,7 +2,7 @@
 pub enum ShuffleBackendKind {
     Streaming,
     Storage {
-        path: String,
+        path: Option<String>,
         max_file_size: usize,
         compression: ShuffleCompression,
     },

--- a/crates/sail-execution/src/stream_manager/core.rs
+++ b/crates/sail-execution/src/stream_manager/core.rs
@@ -32,6 +32,7 @@ impl StreamManager {
                 compression,
             } => Some(Arc::new(RemoteStreamManager::new(
                 path.clone(),
+                options.session_id.clone(),
                 *max_file_size,
                 *compression,
             ))),

--- a/crates/sail-execution/src/stream_manager/options.rs
+++ b/crates/sail-execution/src/stream_manager/options.rs
@@ -6,6 +6,7 @@ use crate::worker::WorkerOptions;
 
 #[readonly::make]
 pub struct StreamManagerOptions {
+    pub session_id: String,
     pub task_stream_buffer: usize,
     pub task_stream_creation_timeout: Duration,
     pub shuffle_backend: ShuffleBackendKind,
@@ -14,6 +15,7 @@ pub struct StreamManagerOptions {
 impl From<&DriverOptions> for StreamManagerOptions {
     fn from(options: &DriverOptions) -> Self {
         Self {
+            session_id: options.session_id.clone(),
             task_stream_buffer: options.task_stream_buffer,
             task_stream_creation_timeout: options.task_stream_creation_timeout,
             shuffle_backend: options.shuffle_backend.clone(),
@@ -24,6 +26,7 @@ impl From<&DriverOptions> for StreamManagerOptions {
 impl From<&WorkerOptions> for StreamManagerOptions {
     fn from(options: &WorkerOptions) -> Self {
         Self {
+            session_id: options.session_id.clone(),
             task_stream_buffer: options.task_stream_buffer,
             task_stream_creation_timeout: options.task_stream_creation_timeout,
             shuffle_backend: options.shuffle_backend.clone(),

--- a/crates/sail-execution/src/stream_manager/remote.rs
+++ b/crates/sail-execution/src/stream_manager/remote.rs
@@ -25,19 +25,22 @@ use crate::stream::writer::{TaskStreamSink, TaskStreamSinkState};
 /// directory, allowing retries to be selected by the task scheduler without overwriting an
 /// earlier attempt.
 pub(super) struct RemoteStreamManager {
-    storage_path: String,
+    path: Option<String>,
+    session_id: String,
     max_file_size: usize,
     compression: ShuffleCompression,
 }
 
 impl RemoteStreamManager {
     pub(super) fn new(
-        storage_path: String,
+        path: Option<String>,
+        session_id: String,
         max_file_size: usize,
         compression: ShuffleCompression,
     ) -> Self {
         Self {
-            storage_path,
+            path,
+            session_id,
             max_file_size,
             compression,
         }
@@ -150,14 +153,10 @@ impl RemoteStreamManager {
         };
         let locations = store
             .list(Some(&prefix))
-            .map_err(|e| DataFusionError::External(Box::new(e)))
-            .try_collect::<Vec<_>>()
-            .await
-            .map_err(|e| DataFusionError::External(Box::new(e)))?
-            .into_iter()
-            .map(|meta| Ok(meta.location));
+            .map_ok(|meta| meta.location)
+            .boxed();
         store
-            .delete_stream(Box::pin(futures::stream::iter(locations)))
+            .delete_stream(locations)
             .try_collect::<Vec<_>>()
             .await
             .map_err(|e| DataFusionError::External(Box::new(e)))?;
@@ -169,13 +168,15 @@ impl RemoteStreamManager {
         key: &TaskStreamKey,
         context: &TaskContext,
     ) -> ExecutionResult<(Arc<dyn ObjectStore>, Path)> {
-        let url = Url::parse(&self.storage_path)
-            .map_err(|e| ExecutionError::InvalidArgument(e.to_string()))?;
+        let path = self.path.as_deref().ok_or_else(|| {
+            ExecutionError::InvalidArgument("missing shuffle storage path".to_string())
+        })?;
+        let url = Url::parse(path).map_err(|e| ExecutionError::InvalidArgument(e.to_string()))?;
         let store = context
             .runtime_env()
             .object_store_registry
             .get_store(&url)?;
-        Ok((store, stream_prefix(&url, key)?))
+        Ok((store, stream_prefix(&url, key, &self.session_id)?))
     }
 
     fn store_and_cleanup_prefix(
@@ -184,16 +185,18 @@ impl RemoteStreamManager {
         stage: Option<usize>,
         context: &TaskContext,
     ) -> ExecutionResult<Option<(Arc<dyn ObjectStore>, Path)>> {
-        if self.storage_path.is_empty() {
+        let Some(path) = self.path.as_deref() else {
             return Ok(None);
-        }
-        let url = Url::parse(&self.storage_path)
-            .map_err(|e| ExecutionError::InvalidArgument(e.to_string()))?;
+        };
+        let url = Url::parse(path).map_err(|e| ExecutionError::InvalidArgument(e.to_string()))?;
         let store = context
             .runtime_env()
             .object_store_registry
             .get_store(&url)?;
-        Ok(Some((store, shuffle_prefix(&url, job_id, stage)?)))
+        Ok(Some((
+            store,
+            shuffle_prefix(&url, &self.session_id, job_id, stage)?,
+        )))
     }
 }
 
@@ -307,16 +310,24 @@ impl TaskStreamSink for RemoteStreamSink {
     }
 }
 
-fn stream_prefix(url: &Url, key: &TaskStreamKey) -> ExecutionResult<Path> {
-    Ok(shuffle_prefix(url, key.job_id, Some(key.stage))?
-        .join(format!("partition-{}", key.partition))
-        .join(format!("attempt-{}", key.attempt))
-        .join(format!("channel-{}", key.channel)))
+fn stream_prefix(url: &Url, key: &TaskStreamKey, session_id: &str) -> ExecutionResult<Path> {
+    Ok(
+        shuffle_prefix(url, session_id, key.job_id, Some(key.stage))?
+            .join(format!("partition-{}", key.partition))
+            .join(format!("attempt-{}", key.attempt))
+            .join(format!("channel-{}", key.channel)),
+    )
 }
 
-fn shuffle_prefix(url: &Url, job_id: JobId, stage: Option<usize>) -> ExecutionResult<Path> {
+fn shuffle_prefix(
+    url: &Url,
+    session_id: &str,
+    job_id: JobId,
+    stage: Option<usize>,
+) -> ExecutionResult<Path> {
     let mut prefix = Path::from_url_path(url.path())
         .map_err(|e| ExecutionError::InvalidArgument(e.to_string()))?
+        .join(session_id)
         .join(format!("job-{job_id}"));
     if let Some(stage) = stage {
         prefix = prefix.join(format!("stage-{stage}"));
@@ -333,8 +344,8 @@ mod tests {
     fn shuffle_prefix_decodes_url_path() {
         let url = Url::parse("file:///tmp/sail%20shuffle").unwrap();
         assert_eq!(
-            shuffle_prefix(&url, JobId::from(1), Some(2)).unwrap(),
-            Path::from("tmp/sail shuffle/job-1/stage-2")
+            shuffle_prefix(&url, "session-1", JobId::from(1), Some(2)).unwrap(),
+            Path::from("tmp/sail shuffle/session-1/job-1/stage-2")
         );
     }
 
@@ -348,10 +359,30 @@ mod tests {
             attempt: 4,
             channel: 5,
         };
-        let prefix = stream_prefix(&url, &key).unwrap();
+        let prefix = stream_prefix(&url, &key, "session-1").unwrap();
         assert_eq!(
             prefix,
-            Path::from("shuffle/job-1/stage-2/partition-3/attempt-4/channel-5")
+            Path::from("shuffle/session-1/job-1/stage-2/partition-3/attempt-4/channel-5")
+        );
+    }
+
+    #[test]
+    fn missing_storage_path_is_invalid() {
+        let manager =
+            RemoteStreamManager::new(None, "session-1".to_string(), 1, ShuffleCompression::None);
+        let key = TaskStreamKey {
+            job_id: JobId::from(1),
+            stage: 2,
+            partition: 3,
+            attempt: 4,
+            channel: 5,
+        };
+        let error = manager
+            .store_and_prefix(&key, &TaskContext::default())
+            .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "invalid argument: missing shuffle storage path"
         );
     }
 }

--- a/crates/sail-execution/src/worker/options.rs
+++ b/crates/sail-execution/src/worker/options.rs
@@ -12,6 +12,7 @@ use crate::worker_manager::WorkerLaunchOptions;
 #[readonly::make]
 pub struct WorkerOptions {
     pub enable_tls: bool,
+    pub session_id: String,
     pub driver_id: DriverId,
     pub driver_host: String,
     pub driver_port: u16,
@@ -33,6 +34,7 @@ impl WorkerOptions {
     pub fn new(config: &AppConfig, runtime: RuntimeHandle, session: SessionContext) -> Self {
         Self {
             enable_tls: config.cluster.enable_tls,
+            session_id: config.cluster.session_id.clone(),
             driver_id: config.cluster.driver_id.into(),
             driver_host: config.cluster.driver_external_host.clone(),
             driver_port: if config.cluster.driver_external_port > 0 {
@@ -67,6 +69,7 @@ impl WorkerOptions {
     ) -> Self {
         WorkerOptions {
             enable_tls: options.enable_tls,
+            session_id: options.session_id,
             driver_id: options.driver_id,
             driver_host: options.driver_external_host,
             driver_port: options.driver_external_port,

--- a/crates/sail-execution/src/worker_manager/kubernetes.rs
+++ b/crates/sail-execution/src/worker_manager/kubernetes.rs
@@ -115,6 +115,7 @@ impl KubernetesWorkerManager {
         let WorkerLaunchOptions {
             enable_tls,
             driver_id,
+            session_id,
             driver_external_host,
             driver_external_port,
             worker_heartbeat_interval,
@@ -178,6 +179,11 @@ impl KubernetesWorkerManager {
                 value_from: None,
             },
             EnvVar {
+                name: ClusterConfigEnv::SESSION_ID.to_string(),
+                value: Some(session_id),
+                value_from: None,
+            },
+            EnvVar {
                 name: ClusterConfigEnv::WORKER_ID.to_string(),
                 value: Some(u64::from(id).to_string()),
                 value_from: None,
@@ -236,12 +242,14 @@ impl KubernetesWorkerManager {
             compression,
         } = shuffle_backend
         {
-            env.extend([
-                EnvVar {
+            if let Some(path) = path {
+                env.push(EnvVar {
                     name: ClusterConfigEnv::SHUFFLE_BACKEND__STORAGE__PATH.to_string(),
                     value: Some(path),
                     value_from: None,
-                },
+                });
+            }
+            env.extend([
                 EnvVar {
                     name: ClusterConfigEnv::SHUFFLE_BACKEND__STORAGE__MAX_FILE_SIZE.to_string(),
                     value: Some(max_file_size.to_string()),

--- a/crates/sail-execution/src/worker_manager/options.rs
+++ b/crates/sail-execution/src/worker_manager/options.rs
@@ -8,6 +8,7 @@ use crate::shuffle::ShuffleBackendKind;
 #[derive(Debug, Clone)]
 pub struct WorkerLaunchOptions {
     pub enable_tls: bool,
+    pub session_id: String,
     pub driver_id: DriverId,
     pub driver_external_host: String,
     pub driver_external_port: u16,

--- a/crates/sail-physical-plan/src/remote_checkpoint.rs
+++ b/crates/sail-physical-plan/src/remote_checkpoint.rs
@@ -933,9 +933,10 @@ mod tests {
             &RecordBatchOptions::new().with_row_count(Some(3)),
         )?;
         let input = MemorySourceConfig::try_new_exec(&[vec![batch]], Arc::clone(&schema), None)?;
-        let registry = Arc::new(RemoteCheckpointRegistry::new(Some(
-            "memory:///checkpoint".to_string(),
-        )));
+        let registry = Arc::new(RemoteCheckpointRegistry::new(
+            Some("memory:///checkpoint".to_string()),
+            "session".to_string(),
+        ));
         let config = SessionConfig::new().with_extension(Arc::clone(&registry));
         let context = SessionContext::new_with_config(config);
         let object_store_url = ObjectStoreUrl::parse("memory://")?;
@@ -990,9 +991,10 @@ mod tests {
             Arc::clone(&logical_schema),
             None,
         )?;
-        let registry = Arc::new(RemoteCheckpointRegistry::new(Some(
-            "memory:///checkpoint".to_string(),
-        )));
+        let registry = Arc::new(RemoteCheckpointRegistry::new(
+            Some("memory:///checkpoint".to_string()),
+            "session".to_string(),
+        ));
         let config = SessionConfig::new().with_extension(Arc::clone(&registry));
         let context = SessionContext::new_with_config(config);
         let object_store_url = ObjectStoreUrl::parse("memory://")?;

--- a/crates/sail-session/src/planner.rs
+++ b/crates/sail-session/src/planner.rs
@@ -660,9 +660,10 @@ mod tests {
     #[tokio::test]
     async fn checkpoint_command_optimizer_coalesces_writer_before_commit()
     -> datafusion_common::Result<()> {
-        let registry = Arc::new(RemoteCheckpointRegistry::new(Some(
-            "memory:///checkpoint".to_string(),
-        )));
+        let registry = Arc::new(RemoteCheckpointRegistry::new(
+            Some("memory:///checkpoint".to_string()),
+            "session".to_string(),
+        ));
         let config = SessionConfig::new().with_extension(registry);
         let runtime_env = Arc::new(RuntimeEnv::default());
         let object_store_url =
@@ -706,9 +707,10 @@ mod tests {
     #[tokio::test]
     async fn zero_column_checkpoint_scan_preserves_partition_rows() -> datafusion_common::Result<()>
     {
-        let registry = Arc::new(RemoteCheckpointRegistry::new(Some(
-            "memory:///checkpoint".to_string(),
-        )));
+        let registry = Arc::new(RemoteCheckpointRegistry::new(
+            Some("memory:///checkpoint".to_string()),
+            "session".to_string(),
+        ));
         registry.insert(sail_cache::remote_checkpoint::RemoteCheckpointDescriptor {
             relation_id: "zero-columns".to_string(),
             object_store_url: datafusion::execution::object_store::ObjectStoreUrl::parse(
@@ -767,9 +769,10 @@ mod tests {
         let logical_schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int64, false)]));
         let storage_schema = checkpoint_storage_schema(&logical_schema);
         let storage_key = Arc::new(Column::new("_c0", 0)) as Arc<dyn PhysicalExpr>;
-        let registry = Arc::new(RemoteCheckpointRegistry::new(Some(
-            "memory:///checkpoint".to_string(),
-        )));
+        let registry = Arc::new(RemoteCheckpointRegistry::new(
+            Some("memory:///checkpoint".to_string()),
+            "session".to_string(),
+        ));
         registry.insert(sail_cache::remote_checkpoint::RemoteCheckpointDescriptor {
             relation_id: "relation".to_string(),
             object_store_url: datafusion::execution::object_store::ObjectStoreUrl::parse(

--- a/crates/sail-session/src/session_factory/job_runner.rs
+++ b/crates/sail-session/src/session_factory/job_runner.rs
@@ -42,6 +42,7 @@ impl SessionJobRunner {
 }
 
 pub struct SessionJobRunnerInfo {
+    pub session_id: String,
     pub driver_id: DriverId,
     pub driver_server_port: Option<u16>,
     pub history_reporter: Box<dyn JobRunnerHistoryReporter>,
@@ -78,7 +79,13 @@ impl ServerSessionJobRunnerFactory {
         let Some(port) = info.driver_server_port else {
             return internal_err!("driver gateway is not available");
         };
-        let options = DriverOptions::new(&self.config, self.runtime.clone(), info.driver_id, port);
+        let options = DriverOptions::new(
+            &self.config,
+            self.runtime.clone(),
+            info.session_id,
+            info.driver_id,
+            port,
+        );
         let components = DriverComponents {
             worker_manager,
             history_reporter: info.history_reporter,

--- a/crates/sail-session/src/session_factory/server.rs
+++ b/crates/sail-session/src/session_factory/server.rs
@@ -119,6 +119,7 @@ impl ServerSessionFactory {
             .with_extension(Arc::new(JobService::new(job_runner)))
             .with_extension(Arc::new(RemoteCheckpointRegistry::new(
                 self.config.execution.checkpoint.path.clone(),
+                info.session_id.clone(),
             )))
             .with_extension(Arc::new(RepartitionBufferConfig::new(
                 self.config.cluster.task_stream_buffer,

--- a/crates/sail-session/src/session_manager/actor/handler.rs
+++ b/crates/sail-session/src/session_manager/actor/handler.rs
@@ -89,6 +89,7 @@ impl SessionManagerActor {
                 }
             };
             let runner = self.job_runner_factory.create(SessionJobRunnerInfo {
+                session_id: session_id.clone(),
                 driver_id,
                 driver_server_port: self.driver_gateway.as_ref().map(|x| x.port()),
                 history_reporter: Box::new(SessionJobRunnerHistoryReporter {

--- a/crates/sail-session/src/session_manager/actor/handler.rs
+++ b/crates/sail-session/src/session_manager/actor/handler.rs
@@ -73,6 +73,10 @@ impl SessionManagerActor {
                 )))
             }
         } else {
+            // TODO: The session ID is used in various storage paths, so it is assumed to be unique
+            //   across all session managers, and it should contain only valid characters for a
+            //   path segment. Right now the session ID is generated as a UUID by the Spark client,
+            //   so this is true in practice, but we may still want some validation here.
             let session_id = session_id.clone();
             info!("creating session {session_id}");
             let span = Span::root(

--- a/python/pysail/testing/spark/steps/plan.py
+++ b/python/pysail/testing/spark/steps/plan.py
@@ -149,6 +149,13 @@ def normalize_plan_text(plan_text: str) -> str:
         end = block.rfind("]")
         if start == -1 or end == -1 or end <= start:
             return block
+
+        # Checkpoint scans retain the input's physical partition layout. For iterative queries,
+        # repartitioning can leave different partitions empty across runs, so individual checkpoint
+        # files are execution details rather than stable plan properties.
+        if "__checkpoint_testing__/" in block:
+            return block[:start] + "<checkpoint files>" + block[end + 1 :]
+
         groups_list = block[start : end + 1]
 
         # Parse top-level groups inside the outer list.

--- a/python/pysail/tests/spark/dataframe/__snapshots__/test_checkpoint.plan.yaml
+++ b/python/pysail/tests/spark/dataframe/__snapshots__/test_checkpoint.plan.yaml
@@ -8,14 +8,14 @@ data:
       ProjectionExec: expr=[#1@0 as #2, count(Int32(1))@1 as #3]
         AggregateExec: mode=SinglePartitioned, gby=[#1@0 as #1], aggr=[count(Int32(1))], ordering_mode=Sorted
           ProjectionExec: expr=[#1@1 as #1]
-            DataSourceExec: file_groups={4 groups: [[<tmp>/__checkpoint_testing__/<session>/<relation>/part-00000-<uuid>.parquet], [<tmp>/__checkpoint_testing__/<session>/<relation>/part-00001-<uuid>.parquet], [<tmp>/__checkpoint_testing__/<session>/<relation>/part-00003-<uuid>.parquet], []]}, projection=[_c0@0 as #0, _c1@1 as #1], file_type=parquet
+            DataSourceExec: file_groups={4 groups: <checkpoint files>}, projection=[_c0@0 as #0, _c1@1 as #1], file_type=parquet
 ---
 name: "test_checkpoint_preserves_partitioning_and_ordering[checkpoint].1"
 data:
   |-
     == Physical Plan ==
     ProjectionExec: expr=[#0@0 as id, #1@1 as key]
-      DataSourceExec: file_groups={4 groups: [[<tmp>/__checkpoint_testing__/<session>/<relation>/part-00000-<uuid>.parquet], [<tmp>/__checkpoint_testing__/<session>/<relation>/part-00001-<uuid>.parquet], [<tmp>/__checkpoint_testing__/<session>/<relation>/part-00003-<uuid>.parquet], []]}, projection=[_c0@0 as #0, _c1@1 as #1], file_type=parquet
+      DataSourceExec: file_groups={4 groups: <checkpoint files>}, projection=[_c0@0 as #0, _c1@1 as #1], file_type=parquet
 ---
 name: "test_checkpoint_preserves_partitioning_and_ordering[local-checkpoint]"
 data:
@@ -25,14 +25,14 @@ data:
       ProjectionExec: expr=[#1@0 as #2, count(Int32(1))@1 as #3]
         AggregateExec: mode=SinglePartitioned, gby=[#1@0 as #1], aggr=[count(Int32(1))], ordering_mode=Sorted
           ProjectionExec: expr=[#1@1 as #1]
-            DataSourceExec: file_groups={4 groups: [[<tmp>/__checkpoint_testing__/<session>/<relation>/part-00000-<uuid>.parquet], [<tmp>/__checkpoint_testing__/<session>/<relation>/part-00001-<uuid>.parquet], [<tmp>/__checkpoint_testing__/<session>/<relation>/part-00003-<uuid>.parquet], []]}, projection=[_c0@0 as #0, _c1@1 as #1], file_type=parquet
+            DataSourceExec: file_groups={4 groups: <checkpoint files>}, projection=[_c0@0 as #0, _c1@1 as #1], file_type=parquet
 ---
 name: "test_checkpoint_preserves_partitioning_and_ordering[local-checkpoint].1"
 data:
   |-
     == Physical Plan ==
     ProjectionExec: expr=[#0@0 as id, #1@1 as key]
-      DataSourceExec: file_groups={4 groups: [[<tmp>/__checkpoint_testing__/<session>/<relation>/part-00000-<uuid>.parquet], [<tmp>/__checkpoint_testing__/<session>/<relation>/part-00001-<uuid>.parquet], [<tmp>/__checkpoint_testing__/<session>/<relation>/part-00003-<uuid>.parquet], []]}, projection=[_c0@0 as #0, _c1@1 as #1], file_type=parquet
+      DataSourceExec: file_groups={4 groups: <checkpoint files>}, projection=[_c0@0 as #0, _c1@1 as #1], file_type=parquet
 ---
 name: "test_checkpoint_supports_iterative_weakly_connected_components"
 data:
@@ -42,7 +42,7 @@ data:
       ProjectionExec: expr=[#0@0 as #24, least(#1@1, CASE WHEN #20@2 IS NOT NULL THEN #20@2 ELSE #1@1 END) as #25]
         HashJoinExec: mode=CollectLeft, join_type=Left, on=[(#0@0, #19@0)], projection=[#0@0, #1@1, #20@3]
           CoalescePartitionsExec
-            DataSourceExec: file_groups={4 groups: [[<tmp>/__checkpoint_testing__/<session>/<relation>/part-00000-<uuid>.parquet], [<tmp>/__checkpoint_testing__/<session>/<relation>/part-00001-<uuid>.parquet], [<tmp>/__checkpoint_testing__/<session>/<relation>/part-00003-<uuid>.parquet], []]}, projection=[_c0@0 as #0, _c1@1 as #1], file_type=parquet
+            DataSourceExec: file_groups={4 groups: <checkpoint files>}, projection=[_c0@0 as #0, _c1@1 as #1], file_type=parquet
           ProjectionExec: expr=[#4@0 as #19, min(#13)@1 as #20]
             AggregateExec: mode=FinalPartitioned, gby=[#4@0 as #4], aggr=[min(#13)]
               RepartitionExec: partitioning=Hash([#4@0], 4), input_partitions=4
@@ -51,7 +51,7 @@ data:
                     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(#12@0, #5@1)], projection=[#4@2, #13@1]
                       CoalescePartitionsExec
                         ProjectionExec: expr=[#10@0 as #12, #11@1 as #13]
-                          DataSourceExec: file_groups={4 groups: [[<tmp>/__checkpoint_testing__/<session>/<relation>/part-00000-<uuid>.parquet], [<tmp>/__checkpoint_testing__/<session>/<relation>/part-00001-<uuid>.parquet], [<tmp>/__checkpoint_testing__/<session>/<relation>/part-00003-<uuid>.parquet], []]}, projection=[_c0@0 as #10, _c1@1 as #11], file_type=parquet
+                          DataSourceExec: file_groups={4 groups: <checkpoint files>}, projection=[_c0@0 as #10, _c1@1 as #11], file_type=parquet
                       UnionExec
                         ProjectionExec: expr=[a@0 as #4, b@1 as #5]
                           DataSourceExec: partitions=1, partition_sizes=[1]


### PR DESCRIPTION
1. Use session ID in both checkpoint and shuffle storage paths.
2. Remove the default value for shuffle storage path in application config.