### PR TITLE
test: use local path for Delta mergeSchema write

### DIFF
--- a/python/pysail/testing/spark/steps/delta.py
+++ b/python/pysail/testing/spark/steps/delta.py
@@ -302,7 +302,7 @@ def append_query_to_delta_table_with_merge_schema(
     spark.sql(docstring).write.format("delta").mode("append").option(
         "mergeSchema",
         "true",
-    ).save(location.path.absolute().as_uri())
+    ).save(str(location.path.absolute()))
 
 
 def _delta_log_compute(which: str, variables: dict, delta_log_cache: dict[str, dict]) -> dict:


### PR DESCRIPTION
The temporary Delta directory already exists when the mergeSchema step runs. Passing it as a file URI makes local URL normalization probe the directory as a file, which Windows rejects with AccessDenied. Pass the absolute filesystem path so it can be identified as a directory without that probe. 