### PR TITLE
fix: order barrier preconditions before driver commands

### DIFF
--- a/crates/sail-execution/src/driver/job_scheduler/core.rs
+++ b/crates/sail-execution/src/driver/job_scheduler/core.rs
@@ -739,7 +739,7 @@ fn build_task_input_keys(
         }
         // Enumerate channels in the outer loop and partitions in the inner loop.
         // This is the whole point of shuffle!
-        InputMode::Shuffle => {
+        InputMode::Shuffle | InputMode::Barrier => {
             let mut groups = Vec::with_capacity(input_channels);
             for channel in 0..input_channels {
                 let mut group = Vec::with_capacity(input_partitions);

--- a/crates/sail-execution/src/driver/job_scheduler/mod.rs
+++ b/crates/sail-execution/src/driver/job_scheduler/mod.rs
@@ -13,6 +13,8 @@ use indexmap::IndexMap;
 pub use options::JobSchedulerOptions;
 use sail_common_datafusion::error::CommonErrorCause;
 pub use state::TaskState;
+#[cfg(test)]
+pub(crate) use topology::JobTopology;
 
 use crate::driver::job_scheduler::state::JobDescriptor;
 use crate::driver::output::JobOutputHandle;

--- a/crates/sail-execution/src/driver/job_scheduler/topology.rs
+++ b/crates/sail-execution/src/driver/job_scheduler/topology.rs
@@ -47,7 +47,9 @@ impl JobTopology {
         for (s, stage) in graph.stages().iter().enumerate() {
             for input in &stage.inputs {
                 stages[input.stage].consumers.push(s);
-                if matches!(&graph.stages()[input.stage].mode, OutputMode::Pipelined) {
+                if matches!(&graph.stages()[input.stage].mode, OutputMode::Pipelined)
+                    && !matches!(input.mode, InputMode::Barrier)
+                {
                     pipelined_adjacency[s].push(input.stage);
                     pipelined_adjacency[input.stage].push(s);
                 }

--- a/crates/sail-execution/src/job_graph/mod.rs
+++ b/crates/sail-execution/src/job_graph/mod.rs
@@ -48,7 +48,10 @@ impl JobGraph {
                     .iter()
                     .filter(|input| input.stage == stage)
                     .map(|input| match input.mode {
-                        InputMode::Forward | InputMode::Shuffle | InputMode::Rescale => 1,
+                        InputMode::Forward
+                        | InputMode::Shuffle
+                        | InputMode::Barrier
+                        | InputMode::Rescale => 1,
                         InputMode::Merge | InputMode::Broadcast => {
                             x.plan.output_partitioning().partition_count()
                         }
@@ -147,6 +150,9 @@ pub enum InputMode {
     /// For each partition in the current stage, execute the same partition to fetch the input
     /// which reads data from the corresponding channel of all partitions in the input stage.
     Shuffle,
+    /// Read the input like a shuffle, but do not schedule the current stage until every input
+    /// partition has succeeded.
+    Barrier,
     /// For each partition in the current stage, execute a single partition to fetch the input
     /// which reads all channels from all partitions in the input stage.
     Broadcast,
@@ -162,6 +168,7 @@ impl fmt::Display for InputMode {
             InputMode::Forward => write!(f, "Forward"),
             InputMode::Merge => write!(f, "Merge"),
             InputMode::Shuffle => write!(f, "Shuffle"),
+            InputMode::Barrier => write!(f, "Barrier"),
             InputMode::Broadcast => write!(f, "Broadcast"),
             InputMode::Rescale => write!(f, "Rescale"),
         }

--- a/crates/sail-execution/src/job_graph/planner.rs
+++ b/crates/sail-execution/src/job_graph/planner.rs
@@ -8,6 +8,7 @@ use datafusion::physical_expr::{Partitioning, PhysicalExpr};
 use datafusion::physical_plan::aggregates::AggregateExec;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::coop::CooperativeExec;
+use datafusion::physical_plan::empty::EmptyExec;
 use datafusion::physical_plan::filter::FilterExec;
 use datafusion::physical_plan::joins::{
     CrossJoinExec, HashJoinExec, NestedLoopJoinExec, PartitionMode, PiecewiseMergeJoinExec,
@@ -569,14 +570,10 @@ fn build_barrier_job_graph(
                 scalar_context,
             )
         })
-        .collect::<ExecutionResult<Vec<_>>>()?;
-    let preconditions_have_pending_scalar_subquery_expr = preconditions
-        .iter()
-        .any(|precondition| precondition.has_pending_scalar_subquery_expr);
-    let preconditions = preconditions
+        .collect::<ExecutionResult<Vec<_>>>()?
         .into_iter()
-        .map(|precondition| precondition.plan)
-        .collect::<Vec<_>>();
+        .map(|precondition| create_barrier_input(precondition, graph, scalar_context))
+        .collect::<ExecutionResult<Vec<_>>>()?;
     let plan_is_driver_stage = is_driver_stage_plan(barrier.plan());
     let plan = if plan_is_driver_stage {
         plan_job_graph_stages(
@@ -595,8 +592,7 @@ fn build_barrier_job_graph(
             scalar_context,
         )?
     };
-    let barrier_has_pending_scalar_subquery_expr =
-        preconditions_have_pending_scalar_subquery_expr || plan.has_pending_scalar_subquery_expr;
+    let barrier_has_pending_scalar_subquery_expr = plan.has_pending_scalar_subquery_expr;
     let barrier = Arc::new(BarrierExec::new(preconditions, plan.plan)) as Arc<dyn ExecutionPlan>;
     let barrier = PlannedSubtree::new(barrier, barrier_has_pending_scalar_subquery_expr);
     if plan_is_driver_stage {
@@ -606,6 +602,29 @@ fn build_barrier_job_graph(
     } else {
         Ok(barrier)
     }
+}
+
+fn create_barrier_input(
+    precondition: PlannedSubtree,
+    graph: &mut JobGraph,
+    scalar_context: Option<ScalarSubqueryContext<'_>>,
+) -> ExecutionResult<Arc<dyn ExecutionPlan>> {
+    let precondition = wrap_pending_scalar_subqueries(precondition, scalar_context);
+    let partitions = precondition.output_partitioning().partition_count();
+    let empty = Arc::new(EmptyExec::new(precondition.schema()).with_partitions(partitions))
+        as Arc<dyn ExecutionPlan>;
+    let guard = Arc::new(BarrierExec::new(vec![precondition], empty));
+    let stage = push_stage(
+        guard,
+        graph,
+        OutputDistribution::RoundRobin {
+            channels: partitions,
+        },
+        TaskPlacement::Worker,
+        OutputMode::Pipelined,
+    )?;
+    let properties = graph.stages[stage].plan.properties().clone();
+    Ok(stage_input_exec(stage, InputMode::Barrier, properties))
 }
 
 fn is_driver_stage_plan(plan: &Arc<dyn ExecutionPlan>) -> bool {
@@ -985,6 +1004,7 @@ mod tests {
     use sail_physical_plan::repartition::ExplicitRepartitionExec;
 
     use super::{JobGraph, JobGraphOptions};
+    use crate::driver::job_scheduler::JobTopology;
     use crate::error::ExecutionResult;
     use crate::job_graph::{InputMode, OutputDistribution, OutputMode, StageInput, TaskPlacement};
     use crate::plan::StageInputExec;
@@ -1150,10 +1170,25 @@ mod tests {
         let command = Arc::new(CooperativeExec::new(command));
         let graph = job_graph(Arc::new(BarrierExec::new(vec![precondition], command))).unwrap();
 
-        assert_eq!(graph.stages().len(), 3);
-        assert_eq!(graph.stages()[1].placement, TaskPlacement::Driver);
+        assert_eq!(graph.stages().len(), 4);
+        assert_eq!(graph.stages()[1].placement, TaskPlacement::Worker);
         #[expect(clippy::expect_used)]
-        let barrier = graph.stages()[1]
+        let guard = graph.stages()[1]
+            .plan
+            .downcast_ref::<BarrierExec>()
+            .expect("precondition stage should contain BarrierExec");
+        assert!(guard.plan().is::<EmptyExec>());
+        assert!(matches!(
+            graph.stages()[1].inputs.as_slice(),
+            [StageInput {
+                stage: 0,
+                mode: InputMode::Shuffle,
+            }]
+        ));
+
+        assert_eq!(graph.stages()[2].placement, TaskPlacement::Driver);
+        #[expect(clippy::expect_used)]
+        let barrier = graph.stages()[2]
             .plan
             .downcast_ref::<BarrierExec>()
             .expect("driver stage should contain BarrierExec");
@@ -1164,19 +1199,39 @@ mod tests {
             .expect("barrier actual plan should preserve CooperativeExec");
         assert!(cooperative.input().is::<CatalogCommandExec>());
         assert!(matches!(
-            graph.stages()[1].inputs.as_slice(),
-            [StageInput {
-                stage: 0,
-                mode: InputMode::Shuffle,
-            }]
-        ));
-        assert!(matches!(
             graph.stages()[2].inputs.as_slice(),
             [StageInput {
                 stage: 1,
+                mode: InputMode::Barrier,
+            }]
+        ));
+        assert!(matches!(
+            graph.stages()[3].inputs.as_slice(),
+            [StageInput {
+                stage: 2,
                 mode: InputMode::Forward,
             }]
         ));
+
+        let topology = JobTopology::try_new(&graph).unwrap();
+        #[expect(clippy::expect_used)]
+        let command_region = topology
+            .regions
+            .iter()
+            .position(|region| region.tasks.iter().any(|task| task.stage == 2))
+            .expect("command stage should belong to a task region");
+        #[expect(clippy::expect_used)]
+        let guard_region = topology
+            .regions
+            .iter()
+            .position(|region| region.tasks.iter().any(|task| task.stage == 1))
+            .expect("precondition guard should belong to a task region");
+        assert_ne!(command_region, guard_region);
+        assert!(
+            topology.regions[command_region]
+                .dependencies
+                .contains(&guard_region)
+        );
     }
 
     #[test]

--- a/crates/sail-physical-plan/src/barrier.rs
+++ b/crates/sail-physical-plan/src/barrier.rs
@@ -23,10 +23,8 @@ use futures::{StreamExt, TryStreamExt};
 /// until all partitions of the preconditions are completed, even if we only call `execute()` for
 /// one partition of the precondition.
 ///
-/// **Distributed execution note**: In distributed processing, `BarrierExec` does not prevent
-/// tasks in dependent stages from being _scheduled_. The barrier is only meaningful within a
-/// single stage: the write node and `BarrierExec` belong to the same stage, so the actual write
-/// only starts after preconditions for the corresponding partition have been exhausted.
+/// **Distributed execution note**: Sail's job graph planner drains preconditions in prerequisite
+/// task regions before scheduling the stage that contains the actual plan.
 #[derive(Debug, Clone)]
 pub struct BarrierExec {
     preconditions: Vec<Arc<dyn ExecutionPlan>>,

--- a/python/pysail/testing/spark/steps/delta.py
+++ b/python/pysail/testing/spark/steps/delta.py
@@ -360,7 +360,7 @@ def _parse_i64_list(raw: str) -> list[int]:
 @then(
     parsers.re(
         r"delta log (?P<which>latest commit info|first commit protocol and metadata|latest effective protocol and metadata) "
-        r"(?P<mode>matches snapshot(?: for paths)?|contains)"
+        r"(?P<mode>matches snapshot(?: for paths)?|contains|does not contain paths)"
     )
 )
 def delta_log_assert(
@@ -371,8 +371,24 @@ def delta_log_assert(
     snapshot: SnapshotAssertion,
     datatable=None,
 ):
-    """Delta log assertions: snapshot whole/subset, or assert specific paths."""
+    """Delta log assertions: snapshot whole/subset, or assert present/absent paths."""
     obj = _delta_log_compute(which, variables, delta_log_cache)
+
+    if mode == "does not contain paths":
+        assert datatable is not None, "expected a datatable: | path |"
+        header, *rows = datatable
+        assert header == ["path"], "expected datatable with single header column: path"
+        for row in rows:
+            if not row or not row[0].strip():
+                continue
+            path = row[0]
+            try:
+                actual = _get_by_path(obj, path)
+            except KeyError:
+                continue
+            message = f"path {path!r} unexpectedly exists with value {actual!r}"
+            raise AssertionError(message)
+        return
 
     if mode == "contains":
         assert datatable is not None, "expected a datatable: | path | value |"

--- a/python/pysail/tests/spark/delta/features/check_constraints.feature
+++ b/python/pysail/tests/spark/delta/features/check_constraints.feature
@@ -87,6 +87,9 @@ Feature: Delta Lake CHECK Constraints
         ALTER TABLE delta_check_constraints_test
         ADD CONSTRAINT positive_id CHECK (id > 0)
         """
+      Then delta log latest effective protocol and metadata does not contain paths
+        | path                                                    |
+        | metaData.configuration['delta.constraints.positive_id'] |
       When query
         """
         SELECT id, value FROM delta_check_constraints_test


### PR DESCRIPTION
Barrier preconditions and their side-effecting driver command were placed in the same retryable pipelined task region. When Delta constraint validation failed, cancellation could race ALTER TABLE and let the constraint commit; a retry then surfaced constraint already exists instead of the validation error.

Materialize preconditions into guard stages and connect commands with non-pipelined Barrier inputs so a command is not scheduled until every guard succeeds. Assert that a rejected ADD CONSTRAINT leaves no Delta metadata behind to prevent this regression.