### PR TITLE
fix: preserve the leading and trailing fields of interval types

### DIFF
--- a/crates/sail-catalog-unity/src/data_type.rs
+++ b/crates/sail-catalog-unity/src/data_type.rs
@@ -19,7 +19,7 @@ use arrow::datatypes::{
 use sail_catalog::error::{CatalogError, CatalogResult};
 use sail_common::spec::{
     SAIL_LIST_FIELD_NAME, SAIL_MAP_FIELD_NAME, SAIL_MAP_KEY_FIELD_NAME, SAIL_MAP_VALUE_FIELD_NAME,
-    SAIL_SPARK_UDT_METADATA_KEY, SPARK_METADATA_JSON_KEY,
+    SPARK_METADATA_JSON_KEY, is_sail_internal_metadata_key,
 };
 
 use crate::r#gen;
@@ -80,7 +80,7 @@ fn spark_field_metadata_json(
     };
 
     for (key, value) in metadata {
-        if key == SPARK_METADATA_JSON_KEY || key == SAIL_SPARK_UDT_METADATA_KEY {
+        if key == SPARK_METADATA_JSON_KEY || is_sail_internal_metadata_key(key) {
             continue;
         }
         out.entry(key.clone())

--- a/crates/sail-common/src/spec/data_type.rs
+++ b/crates/sail-common/src/spec/data_type.rs
@@ -41,6 +41,12 @@ pub struct SparkUdtMetadata {
 /// internal to Sail and should not be exposed as Spark column metadata.
 pub const SAIL_SPARK_INTERVAL_METADATA_KEY: &str = "SAIL::spark::interval";
 
+/// Returns whether the Arrow field metadata key is internal to Sail, and must therefore not be
+/// exposed as Spark column metadata.
+pub fn is_sail_internal_metadata_key(key: &str) -> bool {
+    key == SAIL_SPARK_UDT_METADATA_KEY || key == SAIL_SPARK_INTERVAL_METADATA_KEY
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SparkIntervalMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/sail-common/src/spec/data_type.rs
+++ b/crates/sail-common/src/spec/data_type.rs
@@ -34,6 +34,21 @@ pub struct SparkUdtMetadata {
     pub serialized_python_class: Option<String>,
 }
 
+/// Sail metadata key for the fields of a Spark interval type stored in Arrow field metadata.
+///
+/// Arrow interval types do not have a notion of leading and trailing fields, so the Spark
+/// interval fields would be lost without this. Like [`SAIL_SPARK_UDT_METADATA_KEY`], this is
+/// internal to Sail and should not be exposed as Spark column metadata.
+pub const SAIL_SPARK_INTERVAL_METADATA_KEY: &str = "SAIL::spark::interval";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SparkIntervalMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_field: Option<IntervalFieldType>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub end_field: Option<IntervalFieldType>,
+}
+
 /// Field name for list type.
 pub const SAIL_LIST_FIELD_NAME: &str = "item";
 /// Field name for map type's entries.

--- a/crates/sail-common/src/spec/literal.rs
+++ b/crates/sail-common/src/spec/literal.rs
@@ -302,7 +302,11 @@ pub fn data_type_to_null_literal(data_type: spec::DataType) -> CommonResult<Lite
                 start_field,
                 end_field,
             }),
-            spec::IntervalUnit::DayTime => Ok(Literal::IntervalDayTime { value: None }),
+            spec::IntervalUnit::DayTime => Ok(Literal::DurationMicrosecond {
+                microseconds: None,
+                start_field,
+                end_field,
+            }),
             spec::IntervalUnit::MonthDayNano => Ok(Literal::IntervalMonthDayNano { value: None }),
         },
         spec::DataType::Binary => Ok(Literal::Binary { value: None }),

--- a/crates/sail-common/src/spec/literal.rs
+++ b/crates/sail-common/src/spec/literal.rs
@@ -92,12 +92,24 @@ pub enum Literal {
     },
     DurationMicrosecond {
         microseconds: Option<i64>,
+        /// The Spark day-time interval fields, when the literal comes from a qualified interval
+        /// expression. `None` means the Spark default (`DAY TO SECOND`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        start_field: Option<spec::IntervalFieldType>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        end_field: Option<spec::IntervalFieldType>,
     },
     DurationNanosecond {
         nanoseconds: Option<i64>,
     },
     IntervalYearMonth {
         months: Option<i32>,
+        /// The Spark year-month interval fields, when the literal comes from a qualified interval
+        /// expression. `None` means the Spark default (`YEAR TO MONTH`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        start_field: Option<spec::IntervalFieldType>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        end_field: Option<spec::IntervalFieldType>,
     },
     IntervalDayTime {
         value: Option<IntervalDayTime>,
@@ -273,15 +285,23 @@ pub fn data_type_to_null_literal(data_type: spec::DataType) -> CommonResult<Lite
         spec::DataType::Duration { time_unit } => match time_unit {
             spec::TimeUnit::Second => Ok(Literal::DurationSecond { seconds: None }),
             spec::TimeUnit::Millisecond => Ok(Literal::DurationMillisecond { milliseconds: None }),
-            spec::TimeUnit::Microsecond => Ok(Literal::DurationMicrosecond { microseconds: None }),
+            spec::TimeUnit::Microsecond => Ok(Literal::DurationMicrosecond {
+                microseconds: None,
+                start_field: None,
+                end_field: None,
+            }),
             spec::TimeUnit::Nanosecond => Ok(Literal::DurationNanosecond { nanoseconds: None }),
         },
         spec::DataType::Interval {
             interval_unit,
-            start_field: _,
-            end_field: _,
+            start_field,
+            end_field,
         } => match interval_unit {
-            spec::IntervalUnit::YearMonth => Ok(Literal::IntervalYearMonth { months: None }),
+            spec::IntervalUnit::YearMonth => Ok(Literal::IntervalYearMonth {
+                months: None,
+                start_field,
+                end_field,
+            }),
             spec::IntervalUnit::DayTime => Ok(Literal::IntervalDayTime { value: None }),
             spec::IntervalUnit::MonthDayNano => Ok(Literal::IntervalMonthDayNano { value: None }),
         },

--- a/crates/sail-delta-lake/src/catalog/coordinator.rs
+++ b/crates/sail-delta-lake/src/catalog/coordinator.rs
@@ -5,7 +5,7 @@ use sail_catalog::lakehouse::{
     LakehouseCommitRequest,
 };
 use sail_catalog::manager::CatalogManager;
-use sail_common::spec::{SAIL_SPARK_UDT_METADATA_KEY, SPARK_METADATA_JSON_KEY};
+use sail_common::spec::{SPARK_METADATA_JSON_KEY, is_sail_internal_metadata_key};
 use sail_common_datafusion::catalog::LakehouseExecutionContext;
 use sail_common_datafusion::extension::SessionExtensionAccessor;
 
@@ -415,7 +415,7 @@ fn unity_field_metadata(field: &StructField) -> Result<serde_json::Value> {
     };
 
     for (key, value) in field.metadata() {
-        if key == SPARK_METADATA_JSON_KEY || key == SAIL_SPARK_UDT_METADATA_KEY {
+        if key == SPARK_METADATA_JSON_KEY || is_sail_internal_metadata_key(key) {
             continue;
         }
         out.entry(key.clone())

--- a/crates/sail-function/src/scalar/datetime/spark_interval.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_interval.rs
@@ -129,7 +129,7 @@ define_interval_udf!(
 fn string_to_year_month_interval(value: &str) -> Result<i32> {
     let interval = parse_interval(value).map_err(|e| exec_datafusion_err!("{e}"))?;
     match interval {
-        IntervalValue::YearMonth { months } => Ok(months),
+        IntervalValue::YearMonth { months, .. } => Ok(months),
         IntervalValue::Microsecond { .. } | IntervalValue::MonthDayNanosecond { .. } => {
             exec_err!("expected year month interval, but got: {value}")
         }
@@ -139,7 +139,7 @@ fn string_to_year_month_interval(value: &str) -> Result<i32> {
 fn string_to_day_time_interval(value: &str) -> Result<i64> {
     let interval = parse_interval(value).map_err(|e| exec_datafusion_err!("{e}"))?;
     match interval {
-        IntervalValue::Microsecond { microseconds } => Ok(microseconds),
+        IntervalValue::Microsecond { microseconds, .. } => Ok(microseconds),
         IntervalValue::YearMonth { .. } | IntervalValue::MonthDayNanosecond { .. } => {
             exec_err!("expected day time interval, but got: {value}")
         }
@@ -149,12 +149,12 @@ fn string_to_day_time_interval(value: &str) -> Result<i64> {
 fn string_to_calendar_interval(value: &str) -> Result<IntervalMonthDayNano> {
     let interval = parse_interval(value).map_err(|e| exec_datafusion_err!("{e}"))?;
     match interval {
-        IntervalValue::YearMonth { months } => Ok(IntervalMonthDayNano {
+        IntervalValue::YearMonth { months, .. } => Ok(IntervalMonthDayNano {
             months,
             days: 0,
             nanoseconds: 0,
         }),
-        IntervalValue::Microsecond { microseconds } => {
+        IntervalValue::Microsecond { microseconds, .. } => {
             // We do not take into account daylight saving days here.
             let days = i32::try_from(microseconds / (24 * 60 * 60 * 1_000_000)).map_err(|_| {
                 exec_datafusion_err!("microseconds overflow for calendar interval: {value}")

--- a/crates/sail-plan/src/function/scalar/datetime.rs
+++ b/crates/sail-plan/src/function/scalar/datetime.rs
@@ -965,7 +965,7 @@ fn window_interval_micros(expr: &Expr) -> PlanResult<i64> {
         return match parse_interval(s)
             .map_err(|e| PlanError::invalid(format!("invalid window interval {s:?}: {e}")))?
         {
-            IntervalValue::Microsecond { microseconds } => Ok(microseconds),
+            IntervalValue::Microsecond { microseconds, .. } => Ok(microseconds),
             _ => Err(PlanError::invalid(format!(
                 "window interval must not contain months or years: {s:?}"
             ))),

--- a/crates/sail-plan/src/resolver/data_type.rs
+++ b/crates/sail-plan/src/resolver/data_type.rs
@@ -64,6 +64,26 @@ fn validate_geography_srid(srid: i32) -> PlanResult<()> {
     Ok(())
 }
 
+/// Serializes the leading and trailing fields of a Spark interval type, which Arrow interval types
+/// cannot represent. The value is stored under [`spec::SAIL_SPARK_INTERVAL_METADATA_KEY`] in the
+/// Arrow field metadata so that the Spark interval type can be reconstructed for the client.
+/// Returns `None` when no field is declared, in which case Spark's default range applies.
+pub(super) fn interval_field_metadata(
+    start_field: Option<spec::IntervalFieldType>,
+    end_field: Option<spec::IntervalFieldType>,
+) -> PlanResult<Option<String>> {
+    if start_field.is_none() && end_field.is_none() {
+        return Ok(None);
+    }
+    let interval = spec::SparkIntervalMetadata {
+        start_field,
+        end_field,
+    };
+    let value = serde_json::to_string(&interval)
+        .map_err(|e| PlanError::internal(format!("failed to serialize interval metadata: {e}")))?;
+    Ok(Some(value))
+}
+
 impl PlanResolver<'_> {
     fn arrow_binary_type(&self, state: &mut PlanResolverState) -> adt::DataType {
         if self.config.arrow_use_large_var_types && state.config().arrow_allow_large_var_types {
@@ -364,6 +384,16 @@ impl PlanResolver<'_> {
                     EXTENSION_TYPE_NAME_KEY.to_string(),
                     VariantType::NAME.to_string(),
                 );
+                data_type
+            }
+            spec::DataType::Interval {
+                interval_unit: _,
+                start_field,
+                end_field,
+            } => {
+                if let Some(value) = interval_field_metadata(*start_field, *end_field)? {
+                    metadata.insert(spec::SAIL_SPARK_INTERVAL_METADATA_KEY.to_string(), value);
+                }
                 data_type
             }
             x => x,

--- a/crates/sail-plan/src/resolver/expression/cast.rs
+++ b/crates/sail-plan/src/resolver/expression/cast.rs
@@ -65,6 +65,21 @@ impl PlanResolver<'_> {
             } => end_field.or(*start_field),
             _ => None,
         };
+        // Spark truncates the value toward zero to the end field of the target interval type, so
+        // casting to a narrower qualifier drops the finer components rather than keeping them.
+        let day_time_truncation_micros = match &cast_to_type {
+            spec::DataType::Interval {
+                interval_unit: spec::IntervalUnit::DayTime,
+                start_field,
+                end_field,
+            } => match end_field.or(*start_field) {
+                Some(spec::IntervalFieldType::Day) => Some(24 * 60 * 60 * 1_000_000i64),
+                Some(spec::IntervalFieldType::Hour) => Some(60 * 60 * 1_000_000i64),
+                Some(spec::IntervalFieldType::Minute) => Some(60 * 1_000_000i64),
+                _ => None,
+            },
+            _ => None,
+        };
         // The interval fields are part of the Spark type but not of the Arrow type, so they are
         // carried in the field metadata of the projected column.
         let interval_metadata = match &cast_to_type {
@@ -114,6 +129,7 @@ impl PlanResolver<'_> {
                 | DataType::Struct(_)
                 | DataType::Map(_, _)
         );
+        let from_is_day_time_interval = matches!(expr_type, DataType::Duration(_));
         let expr = match (expr_type, cast_to_type.clone(), is_try) {
             (_, DataType::Utf8, _) if expr_is_variant => cast(
                 ScalarUDF::new_from_impl(SparkVariantToJsonUdf::new()).call(vec![expr]),
@@ -142,7 +158,7 @@ impl PlanResolver<'_> {
                     (Some(field), DataType::Duration(_)) => day_time_field_to_microseconds(field),
                     _ => time_unit_to_multiplier(&time_unit),
                 };
-                cast(expr.mul(lit(multiplier)), cast_to_type)
+                cast(expr.mul(lit(multiplier)), cast_to_type.clone())
             }
             (DataType::Timestamp(time_unit, _) | DataType::Duration(time_unit), to, _)
                 if to.is_numeric() =>
@@ -219,6 +235,16 @@ impl PlanResolver<'_> {
             }
             (_, to, true) => try_cast(expr, to),
             (_, to, _) => cast(expr, to),
+        };
+        // A cast between two day-time interval types is an identity cast in Arrow, since the
+        // qualifier is not part of the Arrow type. Truncate explicitly so that the value agrees
+        // with the narrower type that is reported to the client.
+        let expr = match day_time_truncation_micros {
+            Some(unit) if from_is_day_time_interval => {
+                let micros = cast(expr, DataType::Int64);
+                cast(micros.clone() - (micros % lit(unit)), cast_to_type)
+            }
+            _ => expr,
         };
         Ok(NamedExpr::new(name, expr).with_metadata(interval_metadata))
     }

--- a/crates/sail-plan/src/resolver/expression/cast.rs
+++ b/crates/sail-plan/src/resolver/expression/cast.rs
@@ -23,6 +23,7 @@ use sail_function::scalar::variant::spark_variant_to_json::SparkVariantToJsonUdf
 
 use crate::error::{PlanError, PlanResult};
 use crate::resolver::PlanResolver;
+use crate::resolver::data_type::interval_field_metadata;
 use crate::resolver::expression::NamedExpr;
 use crate::resolver::state::PlanResolverState;
 
@@ -63,6 +64,18 @@ impl PlanResolver<'_> {
                 end_field,
             } => end_field.or(*start_field),
             _ => None,
+        };
+        // The interval fields are part of the Spark type but not of the Arrow type, so they are
+        // carried in the field metadata of the projected column.
+        let interval_metadata = match &cast_to_type {
+            spec::DataType::Interval {
+                interval_unit: _,
+                start_field,
+                end_field,
+            } => interval_field_metadata(*start_field, *end_field)?
+                .map(|x| vec![(spec::SAIL_SPARK_INTERVAL_METADATA_KEY.to_string(), x)])
+                .unwrap_or_default(),
+            _ => vec![],
         };
         let cast_to_type = self.resolve_data_type(&cast_to_type, state)?;
         let NamedExpr { expr, name, .. } =
@@ -207,7 +220,7 @@ impl PlanResolver<'_> {
             (_, to, true) => try_cast(expr, to),
             (_, to, _) => cast(expr, to),
         };
-        Ok(NamedExpr::new(name, expr))
+        Ok(NamedExpr::new(name, expr).with_metadata(interval_metadata))
     }
 }
 

--- a/crates/sail-plan/src/resolver/expression/literal.rs
+++ b/crates/sail-plan/src/resolver/expression/literal.rs
@@ -13,6 +13,7 @@ use sail_sql_analyzer::parser::{parse_date, parse_time, parse_timestamp};
 use crate::config::DefaultTimestampType;
 use crate::error::PlanResult;
 use crate::resolver::PlanResolver;
+use crate::resolver::data_type::interval_field_metadata;
 use crate::resolver::expression::NamedExpr;
 use crate::resolver::state::PlanResolverState;
 
@@ -22,15 +23,29 @@ impl PlanResolver<'_> {
         literal: spec::Literal,
         state: &mut PlanResolverState,
     ) -> PlanResult<NamedExpr> {
+        // The interval fields are part of the Spark type but not of the Arrow type, so they are
+        // carried in the field metadata of the projected column.
+        let metadata = match &literal {
+            spec::Literal::IntervalYearMonth {
+                months: _,
+                start_field,
+                end_field,
+            }
+            | spec::Literal::DurationMicrosecond {
+                microseconds: _,
+                start_field,
+                end_field,
+            } => interval_field_metadata(*start_field, *end_field)?
+                .map(|x| vec![(spec::SAIL_SPARK_INTERVAL_METADATA_KEY.to_string(), x)])
+                .unwrap_or_default(),
+            _ => vec![],
+        };
         let literal = self.resolve_literal(literal, state)?;
         let service = self.ctx.extension::<PlanService>()?;
         let name = service
             .plan_formatter()
             .literal_to_string(&literal, &self.config.session_timezone)?;
-        Ok(NamedExpr::new(
-            vec![name],
-            expr::Expr::Literal(literal, None),
-        ))
+        Ok(NamedExpr::new(vec![name], expr::Expr::Literal(literal, None)).with_metadata(metadata))
     }
 
     pub(super) fn resolve_expression_date(

--- a/crates/sail-plan/src/resolver/literal.rs
+++ b/crates/sail-plan/src/resolver/literal.rs
@@ -81,13 +81,19 @@ impl PlanResolver<'_> {
             Literal::DurationMillisecond { milliseconds } => {
                 Ok(ScalarValue::DurationMillisecond(milliseconds))
             }
-            Literal::DurationMicrosecond { microseconds } => {
-                Ok(ScalarValue::DurationMicrosecond(microseconds))
-            }
+            Literal::DurationMicrosecond {
+                microseconds,
+                start_field: _,
+                end_field: _,
+            } => Ok(ScalarValue::DurationMicrosecond(microseconds)),
             Literal::DurationNanosecond { nanoseconds } => {
                 Ok(ScalarValue::DurationNanosecond(nanoseconds))
             }
-            Literal::IntervalYearMonth { months } => Ok(ScalarValue::IntervalYearMonth(months)),
+            Literal::IntervalYearMonth {
+                months,
+                start_field: _,
+                end_field: _,
+            } => Ok(ScalarValue::IntervalYearMonth(months)),
             Literal::IntervalDayTime { value } => {
                 if let Some(value) = value {
                     Ok(ScalarValue::IntervalDayTime(Some(

--- a/crates/sail-spark-connect/src/proto/data_type.rs
+++ b/crates/sail-spark-connect/src/proto/data_type.rs
@@ -22,6 +22,27 @@ pub(crate) const SPARK_DECIMAL_SYSTEM_DEFAULT_PRECISION: u8 = 38;
 #[expect(dead_code)]
 pub(crate) const SPARK_DECIMAL_SYSTEM_DEFAULT_SCALE: i8 = 18;
 
+/// Resolves the leading and trailing fields of a Spark interval type. A type that declares a
+/// single field spans that field only (`YearMonthIntervalType.apply(field)` and
+/// `DayTimeIntervalType.apply(field)` in Spark), while a type that declares none spans the
+/// default range (`YEAR TO MONTH` and `DAY TO SECOND`).
+pub(super) fn interval_fields(
+    start_field: Option<spec::IntervalFieldType>,
+    end_field: Option<spec::IntervalFieldType>,
+    default_start: spec::IntervalFieldType,
+    default_end: spec::IntervalFieldType,
+) -> (
+    Option<spec::IntervalFieldType>,
+    Option<spec::IntervalFieldType>,
+) {
+    match (start_field, end_field) {
+        (Some(start), Some(end)) => (Some(start), Some(end)),
+        (Some(start), None) => (Some(start), Some(start)),
+        (None, Some(end)) => (Some(default_start), Some(end)),
+        (None, None) => (Some(default_start), Some(default_end)),
+    }
+}
+
 /// Parse a Spark data type string of various forms.
 /// Reference: org.apache.spark.sql.connect.planner.SparkConnectPlanner#parseDatatypeString
 pub(crate) fn parse_spark_data_type(schema: &str) -> SparkResult<spec::DataType> {
@@ -164,8 +185,12 @@ impl TryFrom<DataType> for spec::DataType {
                     .transpose()?
                     .map(spec::IntervalFieldType::try_from)
                     .transpose()?;
-                let start_field = Some(start_field.unwrap_or(spec::IntervalFieldType::Year));
-                let end_field = Some(end_field.unwrap_or(spec::IntervalFieldType::Month));
+                let (start_field, end_field) = interval_fields(
+                    start_field,
+                    end_field,
+                    spec::IntervalFieldType::Year,
+                    spec::IntervalFieldType::Month,
+                );
                 Ok(spec::DataType::Interval {
                     interval_unit: spec::IntervalUnit::YearMonth,
                     start_field,
@@ -187,8 +212,12 @@ impl TryFrom<DataType> for spec::DataType {
                     .transpose()?
                     .map(spec::IntervalFieldType::try_from)
                     .transpose()?;
-                let start_field = Some(start_field.unwrap_or(spec::IntervalFieldType::Day));
-                let end_field = Some(end_field.unwrap_or(spec::IntervalFieldType::Second));
+                let (start_field, end_field) = interval_fields(
+                    start_field,
+                    end_field,
+                    spec::IntervalFieldType::Day,
+                    spec::IntervalFieldType::Second,
+                );
                 Ok(spec::DataType::Interval {
                     interval_unit: spec::IntervalUnit::DayTime,
                     start_field,

--- a/crates/sail-spark-connect/src/proto/data_type.rs
+++ b/crates/sail-spark-connect/src/proto/data_type.rs
@@ -38,8 +38,9 @@ pub(super) fn interval_fields(
     match (start_field, end_field) {
         (Some(start), Some(end)) => (Some(start), Some(end)),
         (Some(start), None) => (Some(start), Some(start)),
-        (None, Some(end)) => (Some(default_start), Some(end)),
-        (None, None) => (Some(default_start), Some(default_end)),
+        // Spark ignores a trailing field that comes without a leading one, and falls back to the
+        // default range, so a type that declares only an end field is not a narrower type.
+        (None, _) => (Some(default_start), Some(default_end)),
     }
 }
 

--- a/crates/sail-spark-connect/src/proto/data_type_arrow.rs
+++ b/crates/sail-spark-connect/src/proto/data_type_arrow.rs
@@ -4,6 +4,7 @@ use sail_common::spec;
 use sail_common_datafusion::variant::is_variant_storage_field;
 
 use crate::error::{SparkError, SparkResult};
+use crate::proto::data_type::interval_fields;
 use crate::spark::connect::{DataType, data_type as sdt};
 
 /// Spark geometry and geography type metadata.
@@ -111,6 +112,12 @@ impl TryFrom<adt::Field> for sdt::StructField {
                     type_variation_reference: 0,
                 })),
             }
+        } else if let Some(interval_metadata) =
+            field.metadata().get(spec::SAIL_SPARK_INTERVAL_METADATA_KEY)
+        {
+            let interval_metadata: spec::SparkIntervalMetadata =
+                serde_json::from_str(interval_metadata)?;
+            interval_data_type(field.data_type(), &interval_metadata)?
         } else {
             field.data_type().clone().try_into()?
         };
@@ -121,6 +128,63 @@ impl TryFrom<adt::Field> for sdt::StructField {
             metadata: field.metadata().get(spec::SPARK_METADATA_JSON_KEY).cloned(),
         })
     }
+}
+
+/// Builds a Spark interval type with its leading and trailing fields, which are not part of the
+/// Arrow data type. Spark numbers the fields within each interval type, while the Sail
+/// specification numbers them across both, so the fields are mapped rather than cast.
+fn interval_data_type(
+    data_type: &adt::DataType,
+    interval: &spec::SparkIntervalMetadata,
+) -> SparkResult<DataType> {
+    use spec::IntervalFieldType;
+
+    let year_month = |field: IntervalFieldType| match field {
+        IntervalFieldType::Year => Ok(0),
+        IntervalFieldType::Month => Ok(1),
+        x => Err(SparkError::invalid(format!(
+            "year month interval field: {x:?}"
+        ))),
+    };
+    let day_time = |field: IntervalFieldType| match field {
+        IntervalFieldType::Day => Ok(0),
+        IntervalFieldType::Hour => Ok(1),
+        IntervalFieldType::Minute => Ok(2),
+        IntervalFieldType::Second => Ok(3),
+        x => Err(SparkError::invalid(format!(
+            "day time interval field: {x:?}"
+        ))),
+    };
+    let kind = match data_type {
+        adt::DataType::Interval(adt::IntervalUnit::YearMonth) => {
+            let (start_field, end_field) = interval_fields(
+                interval.start_field,
+                interval.end_field,
+                IntervalFieldType::Year,
+                IntervalFieldType::Month,
+            );
+            sdt::Kind::YearMonthInterval(sdt::YearMonthInterval {
+                start_field: start_field.map(year_month).transpose()?,
+                end_field: end_field.map(year_month).transpose()?,
+                type_variation_reference: 0,
+            })
+        }
+        adt::DataType::Duration(adt::TimeUnit::Microsecond) => {
+            let (start_field, end_field) = interval_fields(
+                interval.start_field,
+                interval.end_field,
+                IntervalFieldType::Day,
+                IntervalFieldType::Second,
+            );
+            sdt::Kind::DayTimeInterval(sdt::DayTimeInterval {
+                start_field: start_field.map(day_time).transpose()?,
+                end_field: end_field.map(day_time).transpose()?,
+                type_variation_reference: 0,
+            })
+        }
+        x => return x.clone().try_into(),
+    };
+    Ok(DataType { kind: Some(kind) })
 }
 
 /// Reference: https://github.com/apache/spark/blob/bb17665955ad536d8c81605da9a59fb94b6e0162/sql/api/src/main/scala/org/apache/spark/sql/util/ArrowUtils.scala

--- a/crates/sail-spark-connect/src/proto/literal.rs
+++ b/crates/sail-spark-connect/src/proto/literal.rs
@@ -116,11 +116,17 @@ impl TryFrom<Literal> for spec::Literal {
                     nanoseconds: x.microseconds * 1_000,
                 }),
             },
-            LiteralType::YearMonthInterval(x) => {
-                spec::Literal::IntervalYearMonth { months: Some(x) }
-            }
+            // The Spark Connect literal messages carry no interval fields, so the Spark default
+            // range applies.
+            LiteralType::YearMonthInterval(x) => spec::Literal::IntervalYearMonth {
+                months: Some(x),
+                start_field: None,
+                end_field: None,
+            },
             LiteralType::DayTimeInterval(x) => spec::Literal::DurationMicrosecond {
                 microseconds: Some(x),
+                start_field: None,
+                end_field: None,
             },
             #[expect(deprecated)]
             LiteralType::Array(Array {

--- a/crates/sail-spark-connect/src/schema.rs
+++ b/crates/sail-spark-connect/src/schema.rs
@@ -74,6 +74,11 @@ fn format_type_name(f: &mut fmt::Formatter, data_type: Option<&sc::DataType>) ->
         Kind::TimestampNtz(_) => write!(f, "timestamp_ntz"),
         Kind::CalendarInterval(_) => write!(f, "interval"),
         Kind::YearMonthInterval(interval) => match (interval.start_field, interval.end_field) {
+            // An interval spanning a single field is named after that field alone.
+            (Some(start), Some(end)) if start == end => {
+                write!(f, "interval ")?;
+                format_year_month_interval_field(f, start)
+            }
             (Some(start), Some(end)) => {
                 write!(f, "interval ")?;
                 format_year_month_interval_field(f, start)?;
@@ -91,6 +96,11 @@ fn format_type_name(f: &mut fmt::Formatter, data_type: Option<&sc::DataType>) ->
             (None, None) => write!(f, "interval"),
         },
         Kind::DayTimeInterval(interval) => match (interval.start_field, interval.end_field) {
+            // An interval spanning a single field is named after that field alone.
+            (Some(start), Some(end)) if start == end => {
+                write!(f, "interval ")?;
+                format_day_time_interval_field(f, start)
+            }
             (Some(start), Some(end)) => {
                 write!(f, "interval ")?;
                 format_day_time_interval_field(f, start)?;

--- a/crates/sail-spark-connect/tests/gold_data/expression/interval.json
+++ b/crates/sail-spark-connect/tests/gold_data/expression/interval.json
@@ -12,7 +12,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": -14
+                    "months": -14,
+                    "startField": "year",
+                    "endField": "month"
                   }
                 }
               }
@@ -40,7 +42,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 86401000000
+                    "microseconds": 86401000000,
+                    "startField": "day",
+                    "endField": "second"
                   }
                 }
               }
@@ -68,7 +72,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -86400000000
+                    "microseconds": -86400000000,
+                    "startField": "day",
+                    "endField": "second"
                   }
                 }
               }
@@ -96,7 +102,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": -1476
+                    "months": -1476,
+                    "startField": "year",
+                    "endField": "month"
                   }
                 }
               }
@@ -124,7 +132,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -69497123456
+                    "microseconds": -69497123456,
+                    "startField": "hour",
+                    "endField": "second"
                   }
                 }
               }
@@ -152,7 +162,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": -27
+                    "months": -27,
+                    "startField": "year",
+                    "endField": "month"
                   }
                 }
               }
@@ -180,7 +192,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -604800000000
+                    "microseconds": -604800000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -208,7 +222,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -604800000000
+                    "microseconds": -604800000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -236,7 +252,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -25200000000
+                    "microseconds": -25200000000,
+                    "startField": "hour",
+                    "endField": "hour"
                   }
                 }
               }
@@ -264,7 +282,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -25200000000
+                    "microseconds": -25200000000,
+                    "startField": "hour",
+                    "endField": "hour"
                   }
                 }
               }
@@ -292,7 +312,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -7
+                    "microseconds": -7,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -320,7 +342,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -7
+                    "microseconds": -7,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -348,7 +372,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -7000
+                    "microseconds": -7000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -376,7 +402,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -7000
+                    "microseconds": -7000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -404,7 +432,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -420000000
+                    "microseconds": -420000000,
+                    "startField": "minute",
+                    "endField": "minute"
                   }
                 }
               }
@@ -432,7 +462,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -420000000
+                    "microseconds": -420000000,
+                    "startField": "minute",
+                    "endField": "minute"
                   }
                 }
               }
@@ -460,7 +492,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": -7
+                    "months": -7,
+                    "startField": "month",
+                    "endField": "month"
                   }
                 }
               }
@@ -488,7 +522,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": -7
+                    "months": -7,
+                    "startField": "month",
+                    "endField": "month"
                   }
                 }
               }
@@ -516,7 +552,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -7000000
+                    "microseconds": -7000000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -544,7 +582,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -7000000
+                    "microseconds": -7000000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -572,7 +612,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -4233600000000
+                    "microseconds": -4233600000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -600,7 +642,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -4233600000000
+                    "microseconds": -4233600000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -628,7 +672,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": -84
+                    "months": -84,
+                    "startField": "year",
+                    "endField": "year"
                   }
                 }
               }
@@ -656,7 +702,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": -84
+                    "months": -84,
+                    "startField": "year",
+                    "endField": "year"
                   }
                 }
               }
@@ -684,7 +732,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -8594553123456
+                    "microseconds": -8594553123456,
+                    "startField": "day",
+                    "endField": "second"
                   }
                 }
               }
@@ -712,7 +762,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -740,7 +792,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -768,7 +822,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "hour",
+                    "endField": "hour"
                   }
                 }
               }
@@ -796,7 +852,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "hour",
+                    "endField": "hour"
                   }
                 }
               }
@@ -824,7 +882,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -852,7 +912,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -880,7 +942,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -908,7 +972,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -936,7 +1002,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "minute",
+                    "endField": "minute"
                   }
                 }
               }
@@ -964,7 +1032,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "minute",
+                    "endField": "minute"
                   }
                 }
               }
@@ -992,7 +1062,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 0
+                    "months": 0,
+                    "startField": "month",
+                    "endField": "month"
                   }
                 }
               }
@@ -1020,7 +1092,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 0
+                    "months": 0,
+                    "startField": "month",
+                    "endField": "month"
                   }
                 }
               }
@@ -1048,7 +1122,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -1076,7 +1152,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -1104,7 +1182,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -1132,7 +1212,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -1160,7 +1242,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 0
+                    "months": 0,
+                    "startField": "year",
+                    "endField": "year"
                   }
                 }
               }
@@ -1188,7 +1272,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 0
+                    "months": 0,
+                    "startField": "year",
+                    "endField": "year"
                   }
                 }
               }
@@ -1216,7 +1302,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "hour",
+                    "endField": "second"
                   }
                 }
               }
@@ -1244,7 +1332,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 1000000
+                    "microseconds": 1000000,
+                    "startField": "hour",
+                    "endField": "second"
                   }
                 }
               }
@@ -1272,7 +1362,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 86400000000
+                    "microseconds": 86400000000,
+                    "startField": "day",
+                    "endField": "second"
                   }
                 }
               }
@@ -1300,7 +1392,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 86401000000
+                    "microseconds": 86401000000,
+                    "startField": "day",
+                    "endField": "second"
                   }
                 }
               }
@@ -1328,7 +1422,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 93784005006
+                    "microseconds": 93784005006,
+                    "startField": "day",
+                    "endField": "second"
                   }
                 }
               }
@@ -1356,7 +1452,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 14
+                    "months": 14,
+                    "startField": "year",
+                    "endField": "month"
                   }
                 }
               }
@@ -1384,7 +1482,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 896887123456
+                    "microseconds": 896887123456,
+                    "startField": "day",
+                    "endField": "second"
                   }
                 }
               }
@@ -1412,7 +1512,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 864000000000
+                    "microseconds": 864000000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -1440,7 +1542,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 864000000000
+                    "microseconds": 864000000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -1468,7 +1572,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 36000000000
+                    "microseconds": 36000000000,
+                    "startField": "hour",
+                    "endField": "hour"
                   }
                 }
               }
@@ -1496,7 +1602,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 36000000000
+                    "microseconds": 36000000000,
+                    "startField": "hour",
+                    "endField": "hour"
                   }
                 }
               }
@@ -1524,7 +1632,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 10
+                    "microseconds": 10,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -1552,7 +1662,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 10
+                    "microseconds": 10,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -1580,7 +1692,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 10000
+                    "microseconds": 10000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -1608,7 +1722,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 10000
+                    "microseconds": 10000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -1636,7 +1752,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 600000000
+                    "microseconds": 600000000,
+                    "startField": "minute",
+                    "endField": "minute"
                   }
                 }
               }
@@ -1664,7 +1782,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 600000000
+                    "microseconds": 600000000,
+                    "startField": "minute",
+                    "endField": "minute"
                   }
                 }
               }
@@ -1692,7 +1812,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 10
+                    "months": 10,
+                    "startField": "month",
+                    "endField": "month"
                   }
                 }
               }
@@ -1720,7 +1842,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 10
+                    "months": 10,
+                    "startField": "month",
+                    "endField": "month"
                   }
                 }
               }
@@ -1748,7 +1872,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 10000000
+                    "microseconds": 10000000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -1776,7 +1902,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 10000000
+                    "microseconds": 10000000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -1804,7 +1932,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 6048000000000
+                    "microseconds": 6048000000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -1832,7 +1962,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 6048000000000
+                    "microseconds": 6048000000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -1860,7 +1992,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 120
+                    "months": 120,
+                    "startField": "year",
+                    "endField": "year"
                   }
                 }
               }
@@ -1888,7 +2022,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 120
+                    "months": 120,
+                    "startField": "year",
+                    "endField": "year"
                   }
                 }
               }
@@ -1916,7 +2052,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 40953123456
+                    "microseconds": 40953123456,
+                    "startField": "hour",
+                    "endField": "second"
                   }
                 }
               }
@@ -1944,7 +2082,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 1486
+                    "months": 1486,
+                    "startField": "year",
+                    "endField": "month"
                   }
                 }
               }
@@ -1972,7 +2112,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 1814400000000
+                    "microseconds": 1814400000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -2000,7 +2142,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 1814400000000
+                    "microseconds": 1814400000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -2028,7 +2172,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 75600000000
+                    "microseconds": 75600000000,
+                    "startField": "hour",
+                    "endField": "hour"
                   }
                 }
               }
@@ -2056,7 +2202,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 75600000000
+                    "microseconds": 75600000000,
+                    "startField": "hour",
+                    "endField": "hour"
                   }
                 }
               }
@@ -2084,7 +2232,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 21
+                    "microseconds": 21,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -2112,7 +2262,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 21
+                    "microseconds": 21,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -2140,7 +2292,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 21000
+                    "microseconds": 21000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -2168,7 +2322,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 21000
+                    "microseconds": 21000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -2196,7 +2352,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 1260000000
+                    "microseconds": 1260000000,
+                    "startField": "minute",
+                    "endField": "minute"
                   }
                 }
               }
@@ -2224,7 +2382,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 1260000000
+                    "microseconds": 1260000000,
+                    "startField": "minute",
+                    "endField": "minute"
                   }
                 }
               }
@@ -2252,7 +2412,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 21
+                    "months": 21,
+                    "startField": "month",
+                    "endField": "month"
                   }
                 }
               }
@@ -2280,7 +2442,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 21
+                    "months": 21,
+                    "startField": "month",
+                    "endField": "month"
                   }
                 }
               }
@@ -2308,7 +2472,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 21000000
+                    "microseconds": 21000000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -2336,7 +2502,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 21000000
+                    "microseconds": 21000000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -2364,7 +2532,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 12700800000000
+                    "microseconds": 12700800000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -2392,7 +2562,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 12700800000000
+                    "microseconds": 12700800000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -2420,7 +2592,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 252
+                    "months": 252,
+                    "startField": "year",
+                    "endField": "year"
                   }
                 }
               }
@@ -2448,7 +2622,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 252
+                    "months": 252,
+                    "startField": "year",
+                    "endField": "year"
                   }
                 }
               }
@@ -2508,7 +2684,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 5952
+                    "months": 5952,
+                    "startField": "year",
+                    "endField": "month"
                   }
                 }
               }
@@ -2536,7 +2714,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 8594553123456
+                    "microseconds": 8594553123456,
+                    "startField": "day",
+                    "endField": "second"
                   }
                 }
               }
@@ -2564,7 +2744,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 32887123456
+                    "microseconds": 32887123456,
+                    "startField": "hour",
+                    "endField": "second"
                   }
                 }
               }
@@ -2592,7 +2774,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -13123456
+                    "microseconds": -13123456,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -2620,7 +2804,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -604800000000
+                    "microseconds": -604800000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -2648,7 +2834,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -604800000000
+                    "microseconds": -604800000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -2676,7 +2864,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -25200000000
+                    "microseconds": -25200000000,
+                    "startField": "hour",
+                    "endField": "hour"
                   }
                 }
               }
@@ -2704,7 +2894,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -25200000000
+                    "microseconds": -25200000000,
+                    "startField": "hour",
+                    "endField": "hour"
                   }
                 }
               }
@@ -2732,7 +2924,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -7
+                    "microseconds": -7,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -2760,7 +2954,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -7
+                    "microseconds": -7,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -2788,7 +2984,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -7000
+                    "microseconds": -7000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -2816,7 +3014,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -7000
+                    "microseconds": -7000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -2844,7 +3044,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -420000000
+                    "microseconds": -420000000,
+                    "startField": "minute",
+                    "endField": "minute"
                   }
                 }
               }
@@ -2872,7 +3074,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -420000000
+                    "microseconds": -420000000,
+                    "startField": "minute",
+                    "endField": "minute"
                   }
                 }
               }
@@ -2900,7 +3104,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": -7
+                    "months": -7,
+                    "startField": "month",
+                    "endField": "month"
                   }
                 }
               }
@@ -2928,7 +3134,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": -7
+                    "months": -7,
+                    "startField": "month",
+                    "endField": "month"
                   }
                 }
               }
@@ -2956,7 +3164,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -7000000
+                    "microseconds": -7000000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -2984,7 +3194,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -7000000
+                    "microseconds": -7000000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -3012,7 +3224,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -4233600000000
+                    "microseconds": -4233600000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -3040,7 +3254,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": -4233600000000
+                    "microseconds": -4233600000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -3068,7 +3284,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": -84
+                    "months": -84,
+                    "startField": "year",
+                    "endField": "year"
                   }
                 }
               }
@@ -3096,7 +3314,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": -84
+                    "months": -84,
+                    "startField": "year",
+                    "endField": "year"
                   }
                 }
               }
@@ -3124,7 +3344,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -3152,7 +3374,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -3180,7 +3404,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "hour",
+                    "endField": "hour"
                   }
                 }
               }
@@ -3208,7 +3434,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "hour",
+                    "endField": "hour"
                   }
                 }
               }
@@ -3236,7 +3464,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -3264,7 +3494,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -3292,7 +3524,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -3320,7 +3554,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -3348,7 +3584,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "minute",
+                    "endField": "minute"
                   }
                 }
               }
@@ -3376,7 +3614,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "minute",
+                    "endField": "minute"
                   }
                 }
               }
@@ -3404,7 +3644,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 0
+                    "months": 0,
+                    "startField": "month",
+                    "endField": "month"
                   }
                 }
               }
@@ -3432,7 +3674,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 0
+                    "months": 0,
+                    "startField": "month",
+                    "endField": "month"
                   }
                 }
               }
@@ -3460,7 +3704,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -3488,7 +3734,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -3516,7 +3764,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -3544,7 +3794,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 0
+                    "microseconds": 0,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -3572,7 +3824,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 0
+                    "months": 0,
+                    "startField": "year",
+                    "endField": "year"
                   }
                 }
               }
@@ -3600,7 +3854,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 0
+                    "months": 0,
+                    "startField": "year",
+                    "endField": "year"
                   }
                 }
               }
@@ -3628,7 +3884,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 1001000
+                    "microseconds": 1001000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -3656,7 +3914,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 864000000000
+                    "microseconds": 864000000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -3684,7 +3944,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 864000000000
+                    "microseconds": 864000000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -3712,7 +3974,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 36000000000
+                    "microseconds": 36000000000,
+                    "startField": "hour",
+                    "endField": "hour"
                   }
                 }
               }
@@ -3740,7 +4004,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 36000000000
+                    "microseconds": 36000000000,
+                    "startField": "hour",
+                    "endField": "hour"
                   }
                 }
               }
@@ -3768,7 +4034,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 10
+                    "microseconds": 10,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -3796,7 +4064,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 10
+                    "microseconds": 10,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -3824,7 +4094,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 10000
+                    "microseconds": 10000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -3852,7 +4124,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 10000
+                    "microseconds": 10000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -3880,7 +4154,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 600000000
+                    "microseconds": 600000000,
+                    "startField": "minute",
+                    "endField": "minute"
                   }
                 }
               }
@@ -3908,7 +4184,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 600000000
+                    "microseconds": 600000000,
+                    "startField": "minute",
+                    "endField": "minute"
                   }
                 }
               }
@@ -3936,7 +4214,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 10
+                    "months": 10,
+                    "startField": "month",
+                    "endField": "month"
                   }
                 }
               }
@@ -3964,7 +4244,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 10
+                    "months": 10,
+                    "startField": "month",
+                    "endField": "month"
                   }
                 }
               }
@@ -3992,7 +4274,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 10000000
+                    "microseconds": 10000000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -4020,7 +4304,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 10000000
+                    "microseconds": 10000000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -4048,7 +4334,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 6048000000000
+                    "microseconds": 6048000000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -4076,7 +4364,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 6048000000000
+                    "microseconds": 6048000000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -4104,7 +4394,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 120
+                    "months": 120,
+                    "startField": "year",
+                    "endField": "year"
                   }
                 }
               }
@@ -4132,7 +4424,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 120
+                    "months": 120,
+                    "startField": "year",
+                    "endField": "year"
                   }
                 }
               }
@@ -4160,7 +4454,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 123
+                    "months": 123,
+                    "startField": "year",
+                    "endField": "month"
                   }
                 }
               }
@@ -4188,7 +4484,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 13123456
+                    "microseconds": 13123456,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -4216,7 +4514,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 13123456
+                    "microseconds": 13123456,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -4244,7 +4544,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 1814400000000
+                    "microseconds": 1814400000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -4272,7 +4574,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 1814400000000
+                    "microseconds": 1814400000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -4300,7 +4604,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 75600000000
+                    "microseconds": 75600000000,
+                    "startField": "hour",
+                    "endField": "hour"
                   }
                 }
               }
@@ -4328,7 +4634,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 75600000000
+                    "microseconds": 75600000000,
+                    "startField": "hour",
+                    "endField": "hour"
                   }
                 }
               }
@@ -4356,7 +4664,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 21
+                    "microseconds": 21,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -4384,7 +4694,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 21
+                    "microseconds": 21,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -4412,7 +4724,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 21000
+                    "microseconds": 21000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -4440,7 +4754,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 21000
+                    "microseconds": 21000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -4468,7 +4784,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 1260000000
+                    "microseconds": 1260000000,
+                    "startField": "minute",
+                    "endField": "minute"
                   }
                 }
               }
@@ -4496,7 +4814,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 1260000000
+                    "microseconds": 1260000000,
+                    "startField": "minute",
+                    "endField": "minute"
                   }
                 }
               }
@@ -4524,7 +4844,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 21
+                    "months": 21,
+                    "startField": "month",
+                    "endField": "month"
                   }
                 }
               }
@@ -4552,7 +4874,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 21
+                    "months": 21,
+                    "startField": "month",
+                    "endField": "month"
                   }
                 }
               }
@@ -4580,7 +4904,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 21000000
+                    "microseconds": 21000000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -4608,7 +4934,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 21000000
+                    "microseconds": 21000000,
+                    "startField": "second",
+                    "endField": "second"
                   }
                 }
               }
@@ -4636,7 +4964,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 12700800000000
+                    "microseconds": 12700800000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -4664,7 +4994,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 12700800000000
+                    "microseconds": 12700800000000,
+                    "startField": "day",
+                    "endField": "day"
                   }
                 }
               }
@@ -4692,7 +5024,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 252
+                    "months": 252,
+                    "startField": "year",
+                    "endField": "year"
                   }
                 }
               }
@@ -4720,7 +5054,9 @@
               {
                 "literal": {
                   "intervalYearMonth": {
-                    "months": 252
+                    "months": 252,
+                    "startField": "year",
+                    "endField": "year"
                   }
                 }
               }
@@ -4780,7 +5116,9 @@
               {
                 "literal": {
                   "durationMicrosecond": {
-                    "microseconds": 698601000000
+                    "microseconds": 698601000000,
+                    "startField": "day",
+                    "endField": "second"
                   }
                 }
               }
@@ -4802,7 +5140,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 93784005006
+              "microseconds": 93784005006,
+              "startField": "day",
+              "endField": "second"
             }
           }
         }
@@ -4814,7 +5154,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 14
+              "months": 14,
+              "startField": "year",
+              "endField": "month"
             }
           }
         }
@@ -4859,7 +5201,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 93784005006
+              "microseconds": 93784005006,
+              "startField": "day",
+              "endField": "second"
             }
           }
         }
@@ -4871,7 +5215,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 14
+              "months": 14,
+              "startField": "year",
+              "endField": "month"
             }
           }
         }
@@ -4920,7 +5266,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": -14
+              "months": -14,
+              "startField": "year",
+              "endField": "month"
             }
           }
         }
@@ -4932,7 +5280,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 86401000000
+              "microseconds": 86401000000,
+              "startField": "day",
+              "endField": "second"
             }
           }
         }
@@ -4944,7 +5294,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -86400000000
+              "microseconds": -86400000000,
+              "startField": "day",
+              "endField": "second"
             }
           }
         }
@@ -4956,7 +5308,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": -1476
+              "months": -1476,
+              "startField": "year",
+              "endField": "month"
             }
           }
         }
@@ -4968,7 +5322,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -69497123456
+              "microseconds": -69497123456,
+              "startField": "hour",
+              "endField": "second"
             }
           }
         }
@@ -4980,7 +5336,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": -27
+              "months": -27,
+              "startField": "year",
+              "endField": "month"
             }
           }
         }
@@ -4992,7 +5350,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -604800000000
+              "microseconds": -604800000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -5004,7 +5364,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -604800000000
+              "microseconds": -604800000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -5016,7 +5378,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -25200000000
+              "microseconds": -25200000000,
+              "startField": "hour",
+              "endField": "hour"
             }
           }
         }
@@ -5028,7 +5392,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -25200000000
+              "microseconds": -25200000000,
+              "startField": "hour",
+              "endField": "hour"
             }
           }
         }
@@ -5040,7 +5406,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -7
+              "microseconds": -7,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5052,7 +5420,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -7
+              "microseconds": -7,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5064,7 +5434,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -7000
+              "microseconds": -7000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5076,7 +5448,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -7000
+              "microseconds": -7000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5088,7 +5462,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -420000000
+              "microseconds": -420000000,
+              "startField": "minute",
+              "endField": "minute"
             }
           }
         }
@@ -5100,7 +5476,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -420000000
+              "microseconds": -420000000,
+              "startField": "minute",
+              "endField": "minute"
             }
           }
         }
@@ -5112,7 +5490,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": -7
+              "months": -7,
+              "startField": "month",
+              "endField": "month"
             }
           }
         }
@@ -5124,7 +5504,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": -7
+              "months": -7,
+              "startField": "month",
+              "endField": "month"
             }
           }
         }
@@ -5136,7 +5518,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -7000000
+              "microseconds": -7000000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5148,7 +5532,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -7000000
+              "microseconds": -7000000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5160,7 +5546,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -4233600000000
+              "microseconds": -4233600000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -5172,7 +5560,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -4233600000000
+              "microseconds": -4233600000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -5184,7 +5574,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": -84
+              "months": -84,
+              "startField": "year",
+              "endField": "year"
             }
           }
         }
@@ -5196,7 +5588,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": -84
+              "months": -84,
+              "startField": "year",
+              "endField": "year"
             }
           }
         }
@@ -5208,7 +5602,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -8594553123456
+              "microseconds": -8594553123456,
+              "startField": "day",
+              "endField": "second"
             }
           }
         }
@@ -5220,7 +5616,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -5232,7 +5630,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -5244,7 +5644,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "hour",
+              "endField": "hour"
             }
           }
         }
@@ -5256,7 +5658,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "hour",
+              "endField": "hour"
             }
           }
         }
@@ -5268,7 +5672,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5280,7 +5686,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5292,7 +5700,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5304,7 +5714,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5316,7 +5728,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "minute",
+              "endField": "minute"
             }
           }
         }
@@ -5328,7 +5742,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "minute",
+              "endField": "minute"
             }
           }
         }
@@ -5340,7 +5756,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 0
+              "months": 0,
+              "startField": "month",
+              "endField": "month"
             }
           }
         }
@@ -5352,7 +5770,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 0
+              "months": 0,
+              "startField": "month",
+              "endField": "month"
             }
           }
         }
@@ -5364,7 +5784,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5376,7 +5798,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5388,7 +5812,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -5400,7 +5826,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -5412,7 +5840,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 0
+              "months": 0,
+              "startField": "year",
+              "endField": "year"
             }
           }
         }
@@ -5424,7 +5854,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 0
+              "months": 0,
+              "startField": "year",
+              "endField": "year"
             }
           }
         }
@@ -5436,7 +5868,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "hour",
+              "endField": "second"
             }
           }
         }
@@ -5448,7 +5882,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 1000000
+              "microseconds": 1000000,
+              "startField": "hour",
+              "endField": "second"
             }
           }
         }
@@ -5460,7 +5896,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 86400000000
+              "microseconds": 86400000000,
+              "startField": "day",
+              "endField": "second"
             }
           }
         }
@@ -5472,7 +5910,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 86401000000
+              "microseconds": 86401000000,
+              "startField": "day",
+              "endField": "second"
             }
           }
         }
@@ -5500,7 +5940,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 896887123456
+              "microseconds": 896887123456,
+              "startField": "day",
+              "endField": "second"
             }
           }
         }
@@ -5512,7 +5954,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 864000000000
+              "microseconds": 864000000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -5524,7 +5968,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 864000000000
+              "microseconds": 864000000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -5536,7 +5982,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 36000000000
+              "microseconds": 36000000000,
+              "startField": "hour",
+              "endField": "hour"
             }
           }
         }
@@ -5548,7 +5996,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 36000000000
+              "microseconds": 36000000000,
+              "startField": "hour",
+              "endField": "hour"
             }
           }
         }
@@ -5560,7 +6010,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 10
+              "microseconds": 10,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5572,7 +6024,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 10
+              "microseconds": 10,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5584,7 +6038,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 10000
+              "microseconds": 10000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5596,7 +6052,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 10000
+              "microseconds": 10000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5608,7 +6066,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 600000000
+              "microseconds": 600000000,
+              "startField": "minute",
+              "endField": "minute"
             }
           }
         }
@@ -5620,7 +6080,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 600000000
+              "microseconds": 600000000,
+              "startField": "minute",
+              "endField": "minute"
             }
           }
         }
@@ -5632,7 +6094,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 10
+              "months": 10,
+              "startField": "month",
+              "endField": "month"
             }
           }
         }
@@ -5651,7 +6115,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 10
+              "months": 10,
+              "startField": "month",
+              "endField": "month"
             }
           }
         }
@@ -5663,7 +6129,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 10000000
+              "microseconds": 10000000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5675,7 +6143,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 10000000
+              "microseconds": 10000000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5687,7 +6157,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 6048000000000
+              "microseconds": 6048000000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -5699,7 +6171,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 6048000000000
+              "microseconds": 6048000000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -5711,7 +6185,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 120
+              "months": 120,
+              "startField": "year",
+              "endField": "year"
             }
           }
         }
@@ -5723,7 +6199,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 120
+              "months": 120,
+              "startField": "year",
+              "endField": "year"
             }
           }
         }
@@ -5735,7 +6213,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 40953123456
+              "microseconds": 40953123456,
+              "startField": "hour",
+              "endField": "second"
             }
           }
         }
@@ -5747,7 +6227,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 1486
+              "months": 1486,
+              "startField": "year",
+              "endField": "month"
             }
           }
         }
@@ -5759,7 +6241,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 1814400000000
+              "microseconds": 1814400000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -5771,7 +6255,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 1814400000000
+              "microseconds": 1814400000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -5783,7 +6269,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 75600000000
+              "microseconds": 75600000000,
+              "startField": "hour",
+              "endField": "hour"
             }
           }
         }
@@ -5795,7 +6283,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 75600000000
+              "microseconds": 75600000000,
+              "startField": "hour",
+              "endField": "hour"
             }
           }
         }
@@ -5807,7 +6297,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 21
+              "microseconds": 21,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5819,7 +6311,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 21
+              "microseconds": 21,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5831,7 +6325,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 21000
+              "microseconds": 21000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5843,7 +6339,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 21000
+              "microseconds": 21000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5855,7 +6353,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 1260000000
+              "microseconds": 1260000000,
+              "startField": "minute",
+              "endField": "minute"
             }
           }
         }
@@ -5867,7 +6367,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 1260000000
+              "microseconds": 1260000000,
+              "startField": "minute",
+              "endField": "minute"
             }
           }
         }
@@ -5879,7 +6381,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 21
+              "months": 21,
+              "startField": "month",
+              "endField": "month"
             }
           }
         }
@@ -5891,7 +6395,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 21
+              "months": 21,
+              "startField": "month",
+              "endField": "month"
             }
           }
         }
@@ -5903,7 +6409,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 21000000
+              "microseconds": 21000000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5915,7 +6423,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 21000000
+              "microseconds": 21000000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -5927,7 +6437,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 12700800000000
+              "microseconds": 12700800000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -5939,7 +6451,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 12700800000000
+              "microseconds": 12700800000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -5951,7 +6465,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 252
+              "months": 252,
+              "startField": "year",
+              "endField": "year"
             }
           }
         }
@@ -5963,7 +6479,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 252
+              "months": 252,
+              "startField": "year",
+              "endField": "year"
             }
           }
         }
@@ -5975,7 +6493,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 5952
+              "months": 5952,
+              "startField": "year",
+              "endField": "month"
             }
           }
         }
@@ -5987,7 +6507,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 8594553123456
+              "microseconds": 8594553123456,
+              "startField": "day",
+              "endField": "second"
             }
           }
         }
@@ -5999,7 +6521,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 32887123456
+              "microseconds": 32887123456,
+              "startField": "hour",
+              "endField": "second"
             }
           }
         }
@@ -6011,7 +6535,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -13123456
+              "microseconds": -13123456,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6023,7 +6549,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -604800000000
+              "microseconds": -604800000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -6035,7 +6563,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -604800000000
+              "microseconds": -604800000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -6047,7 +6577,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -25200000000
+              "microseconds": -25200000000,
+              "startField": "hour",
+              "endField": "hour"
             }
           }
         }
@@ -6059,7 +6591,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -25200000000
+              "microseconds": -25200000000,
+              "startField": "hour",
+              "endField": "hour"
             }
           }
         }
@@ -6071,7 +6605,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -7
+              "microseconds": -7,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6083,7 +6619,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -7
+              "microseconds": -7,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6095,7 +6633,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -7000
+              "microseconds": -7000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6107,7 +6647,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -7000
+              "microseconds": -7000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6119,7 +6661,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -420000000
+              "microseconds": -420000000,
+              "startField": "minute",
+              "endField": "minute"
             }
           }
         }
@@ -6131,7 +6675,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -420000000
+              "microseconds": -420000000,
+              "startField": "minute",
+              "endField": "minute"
             }
           }
         }
@@ -6143,7 +6689,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": -7
+              "months": -7,
+              "startField": "month",
+              "endField": "month"
             }
           }
         }
@@ -6155,7 +6703,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": -7
+              "months": -7,
+              "startField": "month",
+              "endField": "month"
             }
           }
         }
@@ -6167,7 +6717,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -7000000
+              "microseconds": -7000000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6179,7 +6731,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -7000000
+              "microseconds": -7000000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6191,7 +6745,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -4233600000000
+              "microseconds": -4233600000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -6203,7 +6759,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": -4233600000000
+              "microseconds": -4233600000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -6215,7 +6773,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": -84
+              "months": -84,
+              "startField": "year",
+              "endField": "year"
             }
           }
         }
@@ -6227,7 +6787,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": -84
+              "months": -84,
+              "startField": "year",
+              "endField": "year"
             }
           }
         }
@@ -6239,7 +6801,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -6251,7 +6815,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -6263,7 +6829,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "hour",
+              "endField": "hour"
             }
           }
         }
@@ -6275,7 +6843,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "hour",
+              "endField": "hour"
             }
           }
         }
@@ -6287,7 +6857,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6299,7 +6871,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6311,7 +6885,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6323,7 +6899,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6335,7 +6913,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "minute",
+              "endField": "minute"
             }
           }
         }
@@ -6347,7 +6927,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "minute",
+              "endField": "minute"
             }
           }
         }
@@ -6359,7 +6941,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 0
+              "months": 0,
+              "startField": "month",
+              "endField": "month"
             }
           }
         }
@@ -6371,7 +6955,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 0
+              "months": 0,
+              "startField": "month",
+              "endField": "month"
             }
           }
         }
@@ -6383,7 +6969,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6395,7 +6983,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6407,7 +6997,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -6419,7 +7011,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 0
+              "microseconds": 0,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -6431,7 +7025,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 0
+              "months": 0,
+              "startField": "year",
+              "endField": "year"
             }
           }
         }
@@ -6443,7 +7039,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 0
+              "months": 0,
+              "startField": "year",
+              "endField": "year"
             }
           }
         }
@@ -6455,7 +7053,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 1001000
+              "microseconds": 1001000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6467,7 +7067,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 864000000000
+              "microseconds": 864000000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -6479,7 +7081,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 864000000000
+              "microseconds": 864000000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -6491,7 +7095,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 36000000000
+              "microseconds": 36000000000,
+              "startField": "hour",
+              "endField": "hour"
             }
           }
         }
@@ -6503,7 +7109,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 36000000000
+              "microseconds": 36000000000,
+              "startField": "hour",
+              "endField": "hour"
             }
           }
         }
@@ -6515,7 +7123,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 10
+              "microseconds": 10,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6527,7 +7137,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 10
+              "microseconds": 10,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6539,7 +7151,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 10000
+              "microseconds": 10000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6551,7 +7165,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 10000
+              "microseconds": 10000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6563,7 +7179,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 600000000
+              "microseconds": 600000000,
+              "startField": "minute",
+              "endField": "minute"
             }
           }
         }
@@ -6575,7 +7193,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 600000000
+              "microseconds": 600000000,
+              "startField": "minute",
+              "endField": "minute"
             }
           }
         }
@@ -6587,7 +7207,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 10
+              "months": 10,
+              "startField": "month",
+              "endField": "month"
             }
           }
         }
@@ -6599,7 +7221,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 10
+              "months": 10,
+              "startField": "month",
+              "endField": "month"
             }
           }
         }
@@ -6611,7 +7235,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 10000000
+              "microseconds": 10000000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6623,7 +7249,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 10000000
+              "microseconds": 10000000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6635,7 +7263,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 6048000000000
+              "microseconds": 6048000000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -6647,7 +7277,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 6048000000000
+              "microseconds": 6048000000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -6659,7 +7291,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 120
+              "months": 120,
+              "startField": "year",
+              "endField": "year"
             }
           }
         }
@@ -6671,7 +7305,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 120
+              "months": 120,
+              "startField": "year",
+              "endField": "year"
             }
           }
         }
@@ -6683,7 +7319,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 123
+              "months": 123,
+              "startField": "year",
+              "endField": "month"
             }
           }
         }
@@ -6695,7 +7333,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 13123456
+              "microseconds": 13123456,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6707,7 +7347,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 13123456
+              "microseconds": 13123456,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6719,7 +7361,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 1814400000000
+              "microseconds": 1814400000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -6731,7 +7375,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 1814400000000
+              "microseconds": 1814400000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -6743,7 +7389,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 75600000000
+              "microseconds": 75600000000,
+              "startField": "hour",
+              "endField": "hour"
             }
           }
         }
@@ -6755,7 +7403,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 75600000000
+              "microseconds": 75600000000,
+              "startField": "hour",
+              "endField": "hour"
             }
           }
         }
@@ -6767,7 +7417,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 21
+              "microseconds": 21,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6779,7 +7431,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 21
+              "microseconds": 21,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6791,7 +7445,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 21000
+              "microseconds": 21000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6803,7 +7459,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 21000
+              "microseconds": 21000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6815,7 +7473,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 1260000000
+              "microseconds": 1260000000,
+              "startField": "minute",
+              "endField": "minute"
             }
           }
         }
@@ -6827,7 +7487,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 1260000000
+              "microseconds": 1260000000,
+              "startField": "minute",
+              "endField": "minute"
             }
           }
         }
@@ -6839,7 +7501,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 21
+              "months": 21,
+              "startField": "month",
+              "endField": "month"
             }
           }
         }
@@ -6851,7 +7515,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 21
+              "months": 21,
+              "startField": "month",
+              "endField": "month"
             }
           }
         }
@@ -6863,7 +7529,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 21000000
+              "microseconds": 21000000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6875,7 +7543,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 21000000
+              "microseconds": 21000000,
+              "startField": "second",
+              "endField": "second"
             }
           }
         }
@@ -6887,7 +7557,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 12700800000000
+              "microseconds": 12700800000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -6899,7 +7571,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 12700800000000
+              "microseconds": 12700800000000,
+              "startField": "day",
+              "endField": "day"
             }
           }
         }
@@ -6911,7 +7585,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 252
+              "months": 252,
+              "startField": "year",
+              "endField": "year"
             }
           }
         }
@@ -6923,7 +7599,9 @@
         "success": {
           "literal": {
             "intervalYearMonth": {
-              "months": 252
+              "months": 252,
+              "startField": "year",
+              "endField": "year"
             }
           }
         }
@@ -6951,7 +7629,9 @@
         "success": {
           "literal": {
             "durationMicrosecond": {
-              "microseconds": 698601000000
+              "microseconds": 698601000000,
+              "startField": "day",
+              "endField": "second"
             }
           }
         }

--- a/crates/sail-spark-connect/tests/gold_data/plan/ddl_insert_into.json
+++ b/crates/sail-spark-connect/tests/gold_data/plan/ddl_insert_into.json
@@ -654,7 +654,9 @@
                   {
                     "literal": {
                       "durationMicrosecond": {
-                        "microseconds": 93784128462
+                        "microseconds": 93784128462,
+                        "startField": "day",
+                        "endField": "second"
                       }
                     }
                   }
@@ -701,7 +703,9 @@
                   {
                     "literal": {
                       "intervalYearMonth": {
-                        "months": 14
+                        "months": 14,
+                        "startField": "year",
+                        "endField": "month"
                       }
                     }
                   }

--- a/crates/sail-sql-analyzer/src/expression.rs
+++ b/crates/sail-sql-analyzer/src/expression.rs
@@ -16,7 +16,7 @@ use sail_sql_parser::ast::query::{
 
 use crate::data_type::from_ast_data_type;
 use crate::error::{SqlError, SqlResult};
-use crate::literal::interval::from_ast_signed_interval;
+use crate::literal::interval::{MixedIntervalUnits, from_ast_signed_interval};
 use crate::literal::utils::Signed;
 use crate::query::{from_ast_named_expression, from_ast_query};
 use crate::value::{
@@ -1073,7 +1073,7 @@ fn from_ast_atom_expression(atom: AtomExpr) -> SqlResult<spec::Expr> {
         AtomExpr::BooleanLiteral(value) => from_ast_boolean_literal(value),
         AtomExpr::Null(_) => Ok(spec::Expr::Literal(spec::Literal::Null)),
         AtomExpr::Interval(_, value) => Ok(spec::Expr::Literal(
-            from_ast_signed_interval(Signed::Positive(*value))?.into(),
+            from_ast_signed_interval(Signed::Positive(*value), MixedIntervalUnits::Reject)?.into(),
         )),
         AtomExpr::Placeholder(variable) => Ok(spec::Expr::Placeholder(variable.value)),
         AtomExpr::Identifier(x) => Ok(spec::Expr::UnresolvedAttribute {

--- a/crates/sail-sql-analyzer/src/literal/interval.rs
+++ b/crates/sail-sql-analyzer/src/literal/interval.rs
@@ -61,9 +61,13 @@ lazy_static! {
 pub enum IntervalValue {
     YearMonth {
         months: i32,
+        start_field: Option<spec::IntervalFieldType>,
+        end_field: Option<spec::IntervalFieldType>,
     },
     Microsecond {
         microseconds: i64,
+        start_field: Option<spec::IntervalFieldType>,
+        end_field: Option<spec::IntervalFieldType>,
     },
     MonthDayNanosecond {
         months: i32,
@@ -72,14 +76,46 @@ pub enum IntervalValue {
     },
 }
 
+impl IntervalValue {
+    /// Records the leading and trailing fields of the interval qualifier that produced this value.
+    /// The fields are not part of the value itself, but Spark keeps them in the interval type.
+    fn with_fields(self, start: spec::IntervalFieldType, end: spec::IntervalFieldType) -> Self {
+        match self {
+            IntervalValue::YearMonth { months, .. } => IntervalValue::YearMonth {
+                months,
+                start_field: Some(start),
+                end_field: Some(end),
+            },
+            IntervalValue::Microsecond { microseconds, .. } => IntervalValue::Microsecond {
+                microseconds,
+                start_field: Some(start),
+                end_field: Some(end),
+            },
+            x @ IntervalValue::MonthDayNanosecond { .. } => x,
+        }
+    }
+}
+
 impl From<IntervalValue> for spec::Literal {
     fn from(value: IntervalValue) -> Self {
         match value {
-            IntervalValue::YearMonth { months } => spec::Literal::IntervalYearMonth {
+            IntervalValue::YearMonth {
+                months,
+                start_field,
+                end_field,
+            } => spec::Literal::IntervalYearMonth {
                 months: Some(months),
+                start_field,
+                end_field,
             },
-            IntervalValue::Microsecond { microseconds } => spec::Literal::DurationMicrosecond {
+            IntervalValue::Microsecond {
+                microseconds,
+                start_field,
+                end_field,
+            } => spec::Literal::DurationMicrosecond {
                 microseconds: Some(microseconds),
+                start_field,
+                end_field,
             },
             IntervalValue::MonthDayNanosecond {
                 months,
@@ -194,7 +230,11 @@ fn parse_interval_year_month_string(
     } else {
         n
     };
-    Ok(IntervalValue::YearMonth { months: n })
+    Ok(IntervalValue::YearMonth {
+        months: n,
+        start_field: None,
+        end_field: None,
+    })
 }
 
 fn parse_interval_day_time_string(
@@ -226,7 +266,11 @@ fn parse_interval_day_time_string(
     } else {
         microseconds
     };
-    Ok(IntervalValue::Microsecond { microseconds: n })
+    Ok(IntervalValue::Microsecond {
+        microseconds: n,
+        start_field: None,
+        end_field: None,
+    })
 }
 
 enum StandardIntervalKind {
@@ -243,6 +287,31 @@ enum StandardIntervalKind {
     Minute,
     MinuteToSecond,
     Second,
+}
+
+impl StandardIntervalKind {
+    /// The leading and trailing fields of the resulting Spark interval type. A qualifier with a
+    /// single field spans that field only, matching `YearMonthIntervalType.apply(field)` and
+    /// `DayTimeIntervalType.apply(field)` in Spark.
+    fn fields(&self) -> (spec::IntervalFieldType, spec::IntervalFieldType) {
+        use spec::IntervalFieldType::{Day, Hour, Minute, Month, Second, Year};
+
+        match self {
+            StandardIntervalKind::Year => (Year, Year),
+            StandardIntervalKind::YearToMonth => (Year, Month),
+            StandardIntervalKind::Month => (Month, Month),
+            StandardIntervalKind::Day => (Day, Day),
+            StandardIntervalKind::DayToHour => (Day, Hour),
+            StandardIntervalKind::DayToMinute => (Day, Minute),
+            StandardIntervalKind::DayToSecond => (Day, Second),
+            StandardIntervalKind::Hour => (Hour, Hour),
+            StandardIntervalKind::HourToMinute => (Hour, Minute),
+            StandardIntervalKind::HourToSecond => (Hour, Second),
+            StandardIntervalKind::Minute => (Minute, Minute),
+            StandardIntervalKind::MinuteToSecond => (Minute, Second),
+            StandardIntervalKind::Second => (Second, Second),
+        }
+    }
 }
 
 fn from_ast_interval_qualifier(qualifier: IntervalQualifier) -> SqlResult<StandardIntervalKind> {
@@ -305,7 +374,8 @@ fn from_ast_standard_interval(
     let signed: Signed<String> = parse_signed_value(value)?;
     let negated = signed.is_negative() ^ negated;
     let value = signed.into_inner();
-    match kind {
+    let (start_field, end_field) = kind.fields();
+    let interval = match kind {
         StandardIntervalKind::Year => {
             parse_interval_year_month_string(&value, negated, &INTERVAL_YEAR_REGEX)
         }
@@ -345,7 +415,39 @@ fn from_ast_standard_interval(
         StandardIntervalKind::Second => {
             parse_interval_day_time_string(&value, negated, &INTERVAL_SECOND_REGEX)
         }
+    }?;
+    Ok(interval.with_fields(start_field, end_field))
+}
+
+/// The Spark interval field that a multi-unit keyword contributes to. Sub-day units below the
+/// second and the week both fold into a coarser field, since Spark has no field for them.
+fn interval_unit_field(unit: &IntervalUnit) -> spec::IntervalFieldType {
+    use spec::IntervalFieldType::{Day, Hour, Minute, Month, Second, Year};
+
+    match unit {
+        IntervalUnit::Year(_) | IntervalUnit::Years(_) => Year,
+        IntervalUnit::Month(_) | IntervalUnit::Months(_) => Month,
+        IntervalUnit::Week(_)
+        | IntervalUnit::Weeks(_)
+        | IntervalUnit::Day(_)
+        | IntervalUnit::Days(_) => Day,
+        IntervalUnit::Hour(_) | IntervalUnit::Hours(_) => Hour,
+        IntervalUnit::Minute(_) | IntervalUnit::Minutes(_) => Minute,
+        IntervalUnit::Second(_)
+        | IntervalUnit::Seconds(_)
+        | IntervalUnit::Millisecond(_)
+        | IntervalUnit::Milliseconds(_)
+        | IntervalUnit::Microsecond(_)
+        | IntervalUnit::Microseconds(_) => Second,
     }
+}
+
+/// The interval spans from the coarsest to the finest field that its units mention, regardless of
+/// the order they are written in.
+fn interval_field_span(
+    fields: &[spec::IntervalFieldType],
+) -> Option<(spec::IntervalFieldType, spec::IntervalFieldType)> {
+    Some((*fields.iter().min()?, *fields.iter().max()?))
 }
 
 fn from_ast_multi_unit_interval(
@@ -355,8 +457,19 @@ fn from_ast_multi_unit_interval(
     let error = || SqlError::invalid("multi-unit interval");
     let mut months = 0i32;
     let mut delta = TimeDelta::zero();
+    let mut year_month_fields = vec![];
+    let mut day_time_fields = vec![];
     for value in values {
         let IntervalValueWithUnit { value, unit } = value;
+        let field = interval_unit_field(&unit);
+        if matches!(
+            field,
+            spec::IntervalFieldType::Year | spec::IntervalFieldType::Month
+        ) {
+            year_month_fields.push(field);
+        } else {
+            day_time_fields.push(field);
+        }
         match unit {
             IntervalUnit::Year(_) | IntervalUnit::Years(_) => {
                 let value: i32 = parse_signed_value(value)?;
@@ -420,7 +533,15 @@ fn from_ast_multi_unit_interval(
             } else {
                 months
             };
-            Ok(IntervalValue::YearMonth { months: n })
+            let interval = IntervalValue::YearMonth {
+                months: n,
+                start_field: None,
+                end_field: None,
+            };
+            Ok(match interval_field_span(&year_month_fields) {
+                Some((start, end)) => interval.with_fields(start, end),
+                None => interval,
+            })
         }
         (true, true) => {
             let days = delta.num_days();
@@ -460,7 +581,15 @@ fn from_ast_multi_unit_interval(
             } else {
                 microseconds
             };
-            Ok(IntervalValue::Microsecond { microseconds: n })
+            let interval = IntervalValue::Microsecond {
+                microseconds: n,
+                start_field: None,
+                end_field: None,
+            };
+            Ok(match interval_field_span(&day_time_fields) {
+                Some((start, end)) => interval.with_fields(start, end),
+                None => interval,
+            })
         }
     }
 }

--- a/crates/sail-sql-analyzer/src/literal/interval.rs
+++ b/crates/sail-sql-analyzer/src/literal/interval.rs
@@ -132,7 +132,20 @@ impl From<IntervalValue> for spec::Literal {
     }
 }
 
-pub fn from_ast_signed_interval(value: Signed<IntervalExpr>) -> SqlResult<IntervalValue> {
+/// Whether a multi-unit interval may mix year-month units with day-time units.
+///
+/// Spark rejects the mix for an ANSI interval literal, but accepts it for the legacy calendar
+/// interval string form, which yields a `CalendarInterval` spanning both families.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MixedIntervalUnits {
+    Allow,
+    Reject,
+}
+
+pub fn from_ast_signed_interval(
+    value: Signed<IntervalExpr>,
+    mixed_units: MixedIntervalUnits,
+) -> SqlResult<IntervalValue> {
     // TODO: support the legacy calendar interval when `spark.sql.legacy.interval.enabled` is `true`
     let negated = value.is_negative();
     let interval = value.into_inner();
@@ -170,11 +183,11 @@ pub fn from_ast_signed_interval(value: Signed<IntervalExpr>) -> SqlResult<Interv
                             negated,
                         )
                     }
-                    _ => from_ast_multi_unit_interval(vec![head], negated),
+                    _ => from_ast_multi_unit_interval(vec![head], negated, mixed_units),
                 }
             } else {
                 let values = once(head).chain(tail).collect();
-                from_ast_multi_unit_interval(values, negated)
+                from_ast_multi_unit_interval(values, negated, mixed_units)
             }
         }
         IntervalExpr::Literal(value) => {
@@ -453,6 +466,7 @@ fn interval_field_span(
 fn from_ast_multi_unit_interval(
     values: Vec<IntervalValueWithUnit>,
     negated: bool,
+    mixed_units: MixedIntervalUnits,
 ) -> SqlResult<IntervalValue> {
     let error = || SqlError::invalid("multi-unit interval");
     let mut months = 0i32;
@@ -525,6 +539,29 @@ fn from_ast_multi_unit_interval(
                 delta = delta.checked_add(&microseconds).ok_or_else(error)?;
             }
         }
+    }
+    if mixed_units == MixedIntervalUnits::Reject && !year_month_fields.is_empty() {
+        // Spark selects the interval family from the units that are written, not from the value
+        // they add up to, and rejects an ANSI interval literal that mixes the two families.
+        if !day_time_fields.is_empty() {
+            return Err(SqlError::invalid(
+                "Cannot mix year-month and day-time fields in an interval",
+            ));
+        }
+        let n = if negated {
+            months.checked_mul(-1).ok_or_else(error)?
+        } else {
+            months
+        };
+        let interval = IntervalValue::YearMonth {
+            months: n,
+            start_field: None,
+            end_field: None,
+        };
+        return Ok(match interval_field_span(&year_month_fields) {
+            Some((start, end)) => interval.with_fields(start, end),
+            None => interval,
+        });
     }
     match (months != 0, delta != TimeDelta::zero()) {
         (true, false) => {
@@ -607,7 +644,8 @@ pub(crate) fn parse_unqualified_interval_string(
     } else {
         Signed::Positive(interval)
     };
-    from_ast_signed_interval(value)
+    // The unqualified string form is the legacy calendar interval, which may span both families.
+    from_ast_signed_interval(value, MixedIntervalUnits::Allow)
 }
 
 #[cfg(test)]

--- a/python/pysail/tests/spark/function/features/datetime/interval_type_fields.feature
+++ b/python/pysail/tests/spark/function/features/datetime/interval_type_fields.feature
@@ -1,0 +1,166 @@
+@interval_type_fields
+Feature: Leading and trailing fields of the interval types
+
+  Rule: A year-month interval only spans the fields that it is declared with
+
+    Scenario Outline: Year-month interval: <case>
+      When query
+        """
+        SELECT <lit> AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: interval <fields> (nullable = false)
+        """
+
+      Examples:
+        | case          | lit                            | fields        |
+        | year to month | INTERVAL '10-8' YEAR TO MONTH  | year to month |
+        | year only     | INTERVAL '10' YEAR             | year          |
+        | month only    | INTERVAL '8' MONTH             | month         |
+
+  Rule: A day-time interval only spans the fields that it is declared with
+
+    Scenario Outline: Day-time interval: <case>
+      When query
+        """
+        SELECT <lit> AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: interval <fields> (nullable = false)
+        """
+
+      Examples:
+        | case           | lit                              | fields         |
+        | day to second  | INTERVAL '1 2:3:4' DAY TO SECOND | day to second  |
+        | day only       | INTERVAL '5' DAY                 | day            |
+        | hour only      | INTERVAL '7' HOUR                | hour           |
+        | minute only    | INTERVAL '9' MINUTE              | minute         |
+        | second only    | INTERVAL '3' SECOND              | second         |
+        | day to hour    | INTERVAL '1 2' DAY TO HOUR       | day to hour    |
+        | day to minute  | INTERVAL '1 2:3' DAY TO MINUTE   | day to minute  |
+        | hour to minute | INTERVAL '2:3' HOUR TO MINUTE    | hour to minute |
+        | hour to second | INTERVAL '2:3:4' HOUR TO SECOND  | hour to second |
+        | minute to second | INTERVAL '3:4' MINUTE TO SECOND | minute to second |
+
+  Rule: A multi-unit interval with a single unit only spans that unit
+
+    Scenario Outline: Multi-unit interval: <case>
+      When query
+        """
+        SELECT <lit> AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: interval <fields> (nullable = false)
+        """
+
+      Examples:
+        | case         | lit               | fields |
+        | years        | INTERVAL 3 YEARS  | year   |
+        | months       | INTERVAL 2 MONTHS | month  |
+        | days         | INTERVAL 5 DAYS   | day    |
+        | hours        | INTERVAL 4 HOURS  | hour   |
+        | seconds      | INTERVAL 6 SECONDS | second |
+
+  Rule: A week folds into the day field and sub-second units fold into the second field
+
+    Scenario Outline: Coarser field for <case>
+      When query
+        """
+        SELECT <lit> AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: interval <fields> (nullable = false)
+        """
+
+      Examples:
+        | case          | lit                     | fields |
+        | week          | INTERVAL 1 WEEK         | day    |
+        | weeks days    | INTERVAL 2 WEEKS 3 DAYS | day    |
+        | millisecond   | INTERVAL '-7' MILLISECOND | second |
+        | microsecond   | INTERVAL '-7' MICROSECOND | second |
+        | microseconds  | INTERVAL 5 MICROSECONDS | second |
+
+  Rule: A multi-unit interval spans from its coarsest to its finest unit
+
+    Scenario Outline: Multi-unit span: <case>
+      When query
+        """
+        SELECT <lit> AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: interval <fields> (nullable = false)
+        """
+
+      Examples:
+        | case                  | lit                                         | fields           |
+        | year to month         | INTERVAL 1 YEAR 2 MONTHS                    | year to month    |
+        | day to hour           | INTERVAL 1 DAY 2 HOURS                      | day to hour      |
+        | hour to minute        | INTERVAL 2 HOURS 3 MINUTES                  | hour to minute   |
+        | hour to second        | INTERVAL 1 HOUR 2 SECONDS                   | hour to second   |
+        | minute to second      | INTERVAL 1 MINUTE 5 MICROSECONDS            | minute to second |
+        | second only           | INTERVAL 1 SECOND 2 MILLISECONDS            | second           |
+        | day to second         | INTERVAL 3 DAYS 4 HOURS 5 MINUTES 6 SECONDS | day to second    |
+
+    Scenario: The span ignores the order the units are written in
+      When query
+        """
+        SELECT INTERVAL 2 HOURS 1 DAY AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: interval day to hour (nullable = false)
+        """
+
+  Rule: A cast to an interval type only spans the fields that it is declared with
+
+    Scenario Outline: Cast of NULL to an interval type: <case>
+      When query
+        """
+        SELECT CAST(NULL AS INTERVAL <type>) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: interval <fields> (nullable = true)
+        """
+
+      Examples:
+        | case          | type          | fields        |
+        | year only     | YEAR          | year          |
+        | month only    | MONTH         | month         |
+        | hour only     | HOUR          | hour          |
+        | minute only   | MINUTE        | minute        |
+        | year to month | YEAR TO MONTH | year to month |
+
+    Scenario: Cast narrows a year-month interval to its leading field
+      When query
+        """
+        SELECT CAST(INTERVAL '10-8' YEAR TO MONTH AS INTERVAL YEAR) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: interval year (nullable = false)
+        """
+
+    Scenario: Cast of a day-time interval keeps the declared field
+      When query
+        """
+        SELECT CAST(INTERVAL '3' DAY AS INTERVAL DAY) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: interval day (nullable = false)
+        """

--- a/python/pysail/tests/spark/function/features/datetime/interval_type_fields.feature
+++ b/python/pysail/tests/spark/function/features/datetime/interval_type_fields.feature
@@ -164,3 +164,239 @@ Feature: Leading and trailing fields of the interval types
         root
          |-- result: interval day (nullable = false)
         """
+
+  Rule: A cast to a narrower interval type truncates the value toward zero
+
+    Scenario Outline: Cast truncates a day-time value: <case>
+      When query
+        """
+        SELECT CAST(INTERVAL '<lit>' DAY TO SECOND AS INTERVAL <type>) AS result
+        """
+      Then query result collected
+        | result  |
+        | <value> |
+
+      Examples:
+        | case              | lit         | type   | value             |
+        | to hour           | 1 02:03:04  | HOUR   | 1 day, 2:00:00    |
+        | to day            | 1 02:03:04  | DAY    | 1 day, 0:00:00    |
+        | to minute         | 1 02:03:04  | MINUTE | 1 day, 2:03:00    |
+        | negative to hour  | -1 02:03:04 | HOUR   | -2 days, 22:00:00 |
+
+    @sail-bug
+    Scenario Outline: Cast truncates a year-month value: <case>
+      When query
+        """
+        SELECT CAST(INTERVAL '<lit>' YEAR TO MONTH AS INTERVAL <type>) AS result
+        """
+      Then query result
+        | result  |
+        | <value> |
+
+      Examples:
+        | case             | lit   | type  | value              |
+        | to year          | 10-8  | YEAR  | INTERVAL '10' YEAR  |
+        | negative to year | -10-8 | YEAR  | INTERVAL '-10' YEAR |
+        | to month         | 10-8  | MONTH | INTERVAL '128' MONTH |
+
+  Rule: A multi-unit interval takes its family from the units written, not from its value
+
+    Scenario Outline: Zero-valued year-month multi-unit interval: <case>
+      When query
+        """
+        SELECT <lit> AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: interval <fields> (nullable = false)
+        """
+
+      Examples:
+        | case                 | lit                        | fields        |
+        | year cancels month   | INTERVAL 1 YEAR -12 MONTHS | year to month |
+        | all year-month zeros | INTERVAL 0 YEARS 0 MONTHS  | year to month |
+        | month cancels month  | INTERVAL 1 MONTH -1 MONTH  | month         |
+
+    Scenario Outline: Zero-valued interval keeps its units: <case>
+      When query
+        """
+        SELECT <lit> AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: interval <fields> (nullable = false)
+        """
+
+      Examples:
+        | case               | lit                      | fields      |
+        | single zero year   | INTERVAL 0 YEARS         | year        |
+        | single zero month  | INTERVAL 0 MONTHS        | month       |
+        | day cancels hour   | INTERVAL 1 DAY -24 HOURS | day to hour |
+        | single zero day    | INTERVAL 0 DAYS          | day         |
+        | single zero second | INTERVAL 0 SECONDS       | second      |
+
+  Rule: Mixing year-month and day-time units is rejected
+
+    Scenario Outline: Mixed interval units: <case>
+      When query
+        """
+        SELECT <lit> AS result
+        """
+      Then query error Cannot mix year-month and day-time fields
+
+      Examples:
+        | case            | lit                       |
+        | year with day   | INTERVAL 1 YEAR 2 DAYS    |
+        | month with hour | INTERVAL 1 MONTH 3 HOURS  |
+
+  Rule: The interval qualifier survives the expressions that produce interval values
+
+    @sail-bug
+    Scenario Outline: Qualifier of a derived interval: <case>
+      When query
+        """
+        SELECT <expr> AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: interval <fields> (nullable = false)
+        """
+
+      Examples:
+        | case             | expr                                                            | fields      |
+        | negate year      | -INTERVAL '1' YEAR                                              | year        |
+        | negate hour      | -INTERVAL '3' HOUR                                              | hour        |
+        | add same year    | INTERVAL '1' YEAR + INTERVAL '2' YEAR                           | year        |
+        | add day and hour | INTERVAL '1' DAY + INTERVAL '2' HOUR                            | day to hour |
+        | coalesce hour    | coalesce(INTERVAL '3' HOUR)                                     | hour        |
+        | case when hour   | CASE WHEN true THEN INTERVAL '3' HOUR ELSE INTERVAL '4' HOUR END | hour        |
+        | explode month    | explode(array(INTERVAL '1' MONTH))                              | month       |
+
+    Scenario: Adding a month and a year interval widens to year to month
+      When query
+        """
+        SELECT INTERVAL '1' MONTH + INTERVAL '2' YEAR AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: interval year to month (nullable = false)
+        """
+
+    @sail-bug
+    Scenario Outline: Qualifier of an interval column: <case>
+      When query
+        """
+        SELECT result FROM VALUES (<lit>) AS t(result)
+        """
+      Then query schema
+        """
+        root
+         |-- result: interval <fields> (nullable = false)
+        """
+
+      Examples:
+        | case | lit                | fields |
+        | year | INTERVAL '10' YEAR | year   |
+        | hour | INTERVAL '3' HOUR  | hour   |
+
+    @sail-bug
+    Scenario: The qualifier survives an aggregate
+      When query
+        """
+        SELECT max(result) AS result FROM VALUES (INTERVAL '10' YEAR) AS t(result)
+        """
+      Then query schema
+        """
+        root
+         |-- result: interval year (nullable = true)
+        """
+
+    @sail-bug
+    Scenario: The qualifier survives an array
+      When query
+        """
+        SELECT array(INTERVAL '1' MONTH) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: array (nullable = false)
+         |    |-- element: interval month (containsNull = false)
+        """
+
+    @sail-bug
+    Scenario: The qualifier survives a struct
+      When query
+        """
+        SELECT named_struct('a', INTERVAL '3' HOUR) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: struct (nullable = false)
+         |    |-- a: interval hour (nullable = false)
+        """
+
+    @sail-bug
+    Scenario: The qualifier survives a map
+      When query
+        """
+        SELECT map('k', INTERVAL '3' HOUR) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: map (nullable = false)
+         |    |-- key: string
+         |    |-- value: interval hour (valueContainsNull = false)
+        """
+
+    Scenario: A union widens the qualifier to cover both sides
+      When query
+        """
+        SELECT INTERVAL '1' YEAR AS result UNION ALL SELECT INTERVAL '1' MONTH
+        """
+      Then query schema
+        """
+        root
+         |-- result: interval year to month (nullable = false)
+        """
+
+  Rule: An interval renders with the fields it is declared with
+
+    @sail-bug
+    Scenario Outline: Rendering of a single-field interval: <case>
+      When query
+        """
+        SELECT CAST(<lit> AS STRING) AS result
+        """
+      Then query result collected
+        | result  |
+        | <value> |
+
+      Examples:
+        | case           | lit                           | value                           |
+        | month only     | INTERVAL '1' MONTH            | INTERVAL '1' MONTH              |
+        | year only      | INTERVAL '10' YEAR            | INTERVAL '10' YEAR              |
+        | hour only      | INTERVAL '10' HOUR            | INTERVAL '10' HOUR              |
+        | day only       | INTERVAL '5' DAY              | INTERVAL '5' DAY                |
+        | second only    | INTERVAL '3' SECOND           | INTERVAL '03' SECOND            |
+        | hour to minute | INTERVAL '2:3' HOUR TO MINUTE | INTERVAL '02:03' HOUR TO MINUTE |
+
+    Scenario Outline: Rendering of a full-span interval: <case>
+      When query
+        """
+        SELECT CAST(<lit> AS STRING) AS result
+        """
+      Then query result collected
+        | result  |
+        | <value> |
+
+      Examples:
+        | case          | lit                              | value                               |
+        | year to month | INTERVAL '10-8' YEAR TO MONTH    | INTERVAL '10-8' YEAR TO MONTH       |
+        | day to second | INTERVAL '1 2:3:4' DAY TO SECOND | INTERVAL '1 02:03:04' DAY TO SECOND |

--- a/python/pysail/tests/spark/function/features/datetime/interval_type_fields.feature
+++ b/python/pysail/tests/spark/function/features/datetime/interval_type_fields.feature
@@ -1,6 +1,6 @@
-@interval_type_fields
 Feature: Leading and trailing fields of the interval types
 
+  @function(nullability)
   Rule: A year-month interval only spans the fields that it is declared with
 
     Scenario Outline: Year-month interval: <case>
@@ -20,6 +20,7 @@ Feature: Leading and trailing fields of the interval types
         | year only     | INTERVAL '10' YEAR             | year          |
         | month only    | INTERVAL '8' MONTH             | month         |
 
+  @function(nullability)
   Rule: A day-time interval only spans the fields that it is declared with
 
     Scenario Outline: Day-time interval: <case>
@@ -46,6 +47,7 @@ Feature: Leading and trailing fields of the interval types
         | hour to second | INTERVAL '2:3:4' HOUR TO SECOND  | hour to second |
         | minute to second | INTERVAL '3:4' MINUTE TO SECOND | minute to second |
 
+  @function(nullability)
   Rule: A multi-unit interval with a single unit only spans that unit
 
     Scenario Outline: Multi-unit interval: <case>
@@ -67,6 +69,7 @@ Feature: Leading and trailing fields of the interval types
         | hours        | INTERVAL 4 HOURS  | hour   |
         | seconds      | INTERVAL 6 SECONDS | second |
 
+  @function(nullability)
   Rule: A week folds into the day field and sub-second units fold into the second field
 
     Scenario Outline: Coarser field for <case>
@@ -88,6 +91,7 @@ Feature: Leading and trailing fields of the interval types
         | microsecond   | INTERVAL '-7' MICROSECOND | second |
         | microseconds  | INTERVAL 5 MICROSECONDS | second |
 
+  @function(nullability)
   Rule: A multi-unit interval spans from its coarsest to its finest unit
 
     Scenario Outline: Multi-unit span: <case>
@@ -122,6 +126,7 @@ Feature: Leading and trailing fields of the interval types
          |-- result: interval day to hour (nullable = false)
         """
 
+  @function(nullability)
   Rule: A cast to an interval type only spans the fields that it is declared with
 
     Scenario Outline: Cast of NULL to an interval type: <case>
@@ -199,6 +204,7 @@ Feature: Leading and trailing fields of the interval types
         | negative to year | -10-8 | YEAR  | INTERVAL '-10' YEAR |
         | to month         | 10-8  | MONTH | INTERVAL '128' MONTH |
 
+  @function(nullability)
   Rule: A multi-unit interval takes its family from the units written, not from its value
 
     Scenario Outline: Zero-valued year-month multi-unit interval: <case>
@@ -251,6 +257,7 @@ Feature: Leading and trailing fields of the interval types
         | year with day   | INTERVAL 1 YEAR 2 DAYS    |
         | month with hour | INTERVAL 1 MONTH 3 HOURS  |
 
+  @function(nullability)
   Rule: The interval qualifier survives the expressions that produce interval values
 
     @sail-bug


### PR DESCRIPTION
Arrow interval types have no notion of leading and trailing fields, so the fields of a Spark interval type were dropped and every interval was reported over its full default range. For example, `INTERVAL '7' HOUR` was returned as `interval day to second` instead of `interval hour`.

The fields are now carried in the Arrow field metadata, following the approach already used for user-defined types, and are restored when the schema is converted back for the client. Five routes produce an interval type and each one is covered:

- qualified literals, where the fields come from the interval qualifier
- multi-unit literals, which span from their coarsest to their finest unit regardless of the order the units are written in, with a week folding into the day field and sub-second units into the second field
- unqualified interval strings, which follow the multi-unit rules
- schemas sent by the client, where a type declaring a single field was widened to the whole family instead of spanning that field only
- casts, where the fields of the target type were discarded
