### PR TITLE
fix: validate explicit Parquet read schemas

### DIFF
--- a/crates/sail-data-source/src/formats/parquet/read.rs
+++ b/crates/sail-data-source/src/formats/parquet/read.rs
@@ -226,8 +226,7 @@ fn validate_parquet_field(path: &str, requested: &Field, physical: &Field) -> Re
         }
         (physical_type, requested_type) => plan_err!(
             "[FAILED_READ_FILE.PARQUET_COLUMN_DATA_TYPE_MISMATCH] Data type mismatches when reading \
-             Parquet column `{path}`. Expected Spark type {requested_type}, actual Parquet type \
-             {physical_type}."
+             Parquet column `{path}`. Expected {requested_type}, actual Parquet type {physical_type}."
         ),
     }
 }

--- a/crates/sail-data-source/src/formats/parquet/read.rs
+++ b/crates/sail-data-source/src/formats/parquet/read.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use datafusion::arrow::datatypes::{Fields, Schema, SchemaRef, TimeUnit};
+use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema, SchemaRef, TimeUnit};
 use datafusion::catalog::Session;
 use datafusion::datasource::physical_plan::ParquetSource;
 use datafusion::datasource::physical_plan::parquet::CachedParquetFileReaderFactory;
@@ -9,7 +9,7 @@ use datafusion::datasource::physical_plan::parquet::metadata::{
 };
 use datafusion_common::config::TableParquetOptions;
 use datafusion_common::parsers::CompressionTypeVariant;
-use datafusion_common::{DataFusionError, Result};
+use datafusion_common::{DataFusionError, Result, plan_err};
 use datafusion_datasource::file_scan_config::{FileScanConfig, FileScanConfigBuilder};
 use futures::{StreamExt, TryStreamExt};
 use object_store::{ObjectMeta, ObjectStore};
@@ -167,9 +167,155 @@ impl ReadFormat for ParquetReadFormat {
         Ok(config)
     }
 
+    fn requires_explicit_schema_validation(&self) -> bool {
+        true
+    }
+
+    fn validate_explicit_schema(&self, schema: &Schema, physical: &Schema) -> Result<()> {
+        validate_parquet_schema(schema, physical)
+    }
+
     fn path_glob_filter(&self) -> Option<&str> {
         self.options.path_glob_filter.as_deref()
     }
+}
+
+fn validate_parquet_schema(schema: &Schema, physical: &Schema) -> Result<()> {
+    for field in schema.fields() {
+        if let Ok(physical_field) = physical.field_with_name(field.name()) {
+            validate_parquet_field(field.name(), field, physical_field)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_parquet_field(path: &str, requested: &Field, physical: &Field) -> Result<()> {
+    match (physical.data_type(), requested.data_type()) {
+        (DataType::Struct(physical_fields), DataType::Struct(requested_fields)) => {
+            for requested_field in requested_fields {
+                if let Some(physical_field) = physical_fields
+                    .iter()
+                    .find(|field| field.name() == requested_field.name())
+                {
+                    validate_parquet_field(
+                        &format!("{path}.{}", requested_field.name()),
+                        requested_field,
+                        physical_field,
+                    )?;
+                }
+            }
+            Ok(())
+        }
+        (DataType::List(physical_element), DataType::List(requested_element))
+        | (DataType::LargeList(physical_element), DataType::LargeList(requested_element)) => {
+            validate_parquet_field(&format!("{path}[]"), requested_element, physical_element)
+        }
+        (
+            DataType::FixedSizeList(physical_element, physical_length),
+            DataType::FixedSizeList(requested_element, requested_length),
+        ) if physical_length == requested_length => {
+            validate_parquet_field(&format!("{path}[]"), requested_element, physical_element)
+        }
+        (DataType::Map(physical_entries, _), DataType::Map(requested_entries, _)) => {
+            validate_parquet_field(path, requested_entries, physical_entries)
+        }
+        (physical_type, requested_type)
+            if parquet_primitive_type_compatible(physical_type, requested_type) =>
+        {
+            Ok(())
+        }
+        (physical_type, requested_type) => plan_err!(
+            "[FAILED_READ_FILE.PARQUET_COLUMN_DATA_TYPE_MISMATCH] Data type mismatches when reading \
+             Parquet column `{path}`. Expected Spark type {requested_type}, actual Parquet type \
+             {physical_type}."
+        ),
+    }
+}
+
+fn parquet_primitive_type_compatible(physical: &DataType, requested: &DataType) -> bool {
+    if physical == requested {
+        return true;
+    }
+
+    match (physical, requested) {
+        // Spark's Parquet readers support these lossless numeric widenings.
+        (DataType::Int32, DataType::Int64 | DataType::Float64)
+        | (DataType::Float32, DataType::Float64)
+        | (DataType::UInt8, DataType::Int16)
+        | (DataType::UInt16, DataType::Int32)
+        | (DataType::UInt32, DataType::Int64) => true,
+        (DataType::UInt64, DataType::Decimal128(20, 0)) => true,
+        (
+            DataType::Int8 | DataType::Int16 | DataType::Int32,
+            DataType::Decimal128(precision, scale),
+        ) => decimal_integer_digits(*precision, *scale) >= 10,
+        (DataType::Int64, DataType::Decimal128(precision, scale)) => {
+            decimal_integer_digits(*precision, *scale) >= 20
+        }
+        (
+            DataType::Decimal128(physical_precision, physical_scale),
+            DataType::Decimal128(requested_precision, requested_scale),
+        )
+        | (
+            DataType::Decimal256(physical_precision, physical_scale),
+            DataType::Decimal256(requested_precision, requested_scale),
+        ) => decimal_type_compatible(
+            *physical_precision,
+            *physical_scale,
+            *requested_precision,
+            *requested_scale,
+        ),
+        (
+            DataType::Decimal128(physical_precision, physical_scale),
+            DataType::Decimal256(requested_precision, requested_scale),
+        ) => decimal_type_compatible(
+            *physical_precision,
+            *physical_scale,
+            *requested_precision,
+            *requested_scale,
+        ),
+        // Parquet timestamps may differ in storage precision, but Spark keeps the
+        // local-time-zone and no-time-zone families distinct.
+        (DataType::Timestamp(_, physical_timezone), DataType::Timestamp(_, requested_timezone)) => {
+            physical_timezone.is_some() == requested_timezone.is_some()
+        }
+        (DataType::Date32, DataType::Timestamp(_, None)) => true,
+        (physical, requested) if is_string_type(physical) && is_string_type(requested) => true,
+        (physical, requested) if is_binary_type(physical) && is_binary_type(requested) => true,
+        _ => false,
+    }
+}
+
+fn decimal_integer_digits(precision: u8, scale: i8) -> i16 {
+    i16::from(precision) - i16::from(scale)
+}
+
+fn decimal_type_compatible(
+    physical_precision: u8,
+    physical_scale: i8,
+    requested_precision: u8,
+    requested_scale: i8,
+) -> bool {
+    let scale_increase = i16::from(requested_scale) - i16::from(physical_scale);
+    let precision_increase = i16::from(requested_precision) - i16::from(physical_precision);
+    scale_increase >= 0 && precision_increase >= scale_increase
+}
+
+fn is_string_type(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View
+    )
+}
+
+fn is_binary_type(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Binary
+            | DataType::LargeBinary
+            | DataType::BinaryView
+            | DataType::FixedSizeBinary(_)
+    )
 }
 
 /// Clears all metadata (Schema level and field level) for a schema.

--- a/crates/sail-data-source/src/listing/source.rs
+++ b/crates/sail-data-source/src/listing/source.rs
@@ -84,6 +84,16 @@ pub trait ReadFormat: Debug + Send + Sync + 'static {
     /// Build a scan configuration for listing reads.
     async fn scan(&self, ctx: &dyn Session, input: ListingScanInput) -> Result<FileScanConfig>;
 
+    /// Whether validating an explicit schema requires the physical file schema.
+    fn requires_explicit_schema_validation(&self) -> bool {
+        false
+    }
+
+    /// Validate a user-provided file schema against the physical file schema.
+    fn validate_explicit_schema(&self, _schema: &Schema, _physical: &Schema) -> Result<()> {
+        Ok(())
+    }
+
     /// File-name glob restricting which listed files compose the dataset.
     fn path_glob_filter(&self) -> Option<&str> {
         None
@@ -174,23 +184,31 @@ impl<T: FormatFactory> TableFormat for ListingTableFormat<T> {
 
         let (schema, partition_fields) = match schema {
             Some(schema) if !schema.fields().is_empty() => {
+                let physical = if read_format.requires_explicit_schema_validation() {
+                    Some(
+                        read_format
+                            .infer_schema(ctx, &sampled_files, compression)
+                            .await?,
+                    )
+                } else if read_case_sensitive {
+                    None
+                } else {
+                    read_format
+                        .infer_schema(ctx, &sampled_files, compression)
+                        .await
+                        .ok()
+                };
                 // Spark matches a user-specified schema against the physical file
                 // columns case-insensitively by default (`spark.sql.caseSensitive=false`).
                 // Reconcile the user column names to the physical names up front so that both
                 // the file stats and reader (which resolve columns by exact name) find the data.
                 let schema = if read_case_sensitive {
                     schema
+                } else if let Some(physical) = &physical {
+                    reconcile_schema_names_case_insensitive(schema, physical)?
                 } else {
-                    match read_format
-                        .infer_schema(ctx, &sampled_files, compression)
-                        .await
-                    {
-                        Ok(physical) => reconcile_schema_names_case_insensitive(schema, &physical)?,
-                        _ => {
-                            // Keeps the user schema if physical schema inference is unavailable.
-                            schema
-                        }
-                    }
+                    // Keeps the user schema if physical schema inference is unavailable.
+                    schema
                 };
                 // When the partition columns are not specified, auto-discover
                 // them from `key=value` segments in the listing paths.
@@ -212,6 +230,9 @@ impl<T: FormatFactory> TableFormat for ListingTableFormat<T> {
                 };
                 let (partition_fields, schema) =
                     get_partition_columns_and_file_schema(&schema, partition_by)?;
+                if let Some(physical) = physical {
+                    read_format.validate_explicit_schema(&schema, &physical)?;
+                }
                 (Arc::new(schema), partition_fields)
             }
             _ => {

--- a/python/pysail/tests/spark/datasource/test_parquet.py
+++ b/python/pysail/tests/spark/datasource/test_parquet.py
@@ -131,6 +131,42 @@ def test_parquet_read_options(spark, sample_df, tmp_path):
     assert sorted(sample_df.collect(), key=safe_sort_key) == sorted(read_df.collect(), key=safe_sort_key)
 
 
+@pytest.mark.parametrize(
+    ("physical_schema", "requested_schema", "value"),
+    [
+        ("value DOUBLE", "value INT", 1.5),
+        ("value INT", "value BOOLEAN", 1),
+        ("value STRUCT<nested: DOUBLE>", "value STRUCT<nested: INT>", Row(nested=1.5)),
+        ("value ARRAY<DOUBLE>", "value ARRAY<INT>", [1.5]),
+        ("value MAP<STRING, DOUBLE>", "value MAP<STRING, INT>", {"key": 1.5}),
+    ],
+)
+def test_parquet_explicit_schema_rejects_incompatible_types(spark, tmp_path, physical_schema, requested_schema, value):
+    path = str(tmp_path / "incompatible_explicit_schema")
+    spark.createDataFrame([(value,)], physical_schema).write.parquet(path)
+
+    with pytest.raises(Exception, match="PARQUET_COLUMN_DATA_TYPE_MISMATCH"):
+        spark.read.schema(requested_schema).parquet(path).collect()
+
+
+def test_parquet_explicit_schema_allows_supported_widening(spark, tmp_path):
+    path = str(tmp_path / "supported_explicit_schema_widening")
+    spark.createDataFrame([(1, 1.5), (None, None)], "id INT, value FLOAT").write.parquet(path)
+
+    rows = spark.read.schema("id BIGINT, value DOUBLE").parquet(path).orderBy("id").collect()
+
+    assert rows == [Row(id=None, value=None), Row(id=1, value=1.5)]
+
+
+def test_parquet_explicit_schema_allows_missing_fields(spark, tmp_path):
+    path = str(tmp_path / "missing_explicit_schema_field")
+    spark.createDataFrame([(1,)], "id INT").write.parquet(path)
+
+    rows = spark.read.schema("id INT, missing STRING").parquet(path).collect()
+
+    assert rows == [Row(id=1, missing=None)]
+
+
 def test_parquet_write_with_bloom_filter(spark, tmpdir):
     def size(p):
         return get_data_directory_size(p, extension=".parquet")


### PR DESCRIPTION
## Summary

- validate explicit Parquet schemas against physical file schemas
- reject incompatible type conversions with a Spark-style error
- support compatible widening and recursively validate nested types
- preserve missing fields, partition columns, and case-insensitive matching
- add Sail-only read/write round-trip tests without JVM Spark

Closes #2298

## Testing

- `cargo test -p sail-data-source --lib`
- `cargo clippy -p sail-data-source --all-targets -- -D warnings`
- `hatch run python -m pytest python/pysail/tests/spark/datasource/test_parquet.py -q`