### PR TITLE
test: improve function test selection

### DIFF
--- a/python/pysail/tests/conftest.py
+++ b/python/pysail/tests/conftest.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 import sys
+from pathlib import Path
 
 
 def pytest_configure(config):
@@ -36,6 +37,18 @@ def pytest_configure(config):
     )
 
     configure_sail_environment()
+
+
+def pytest_collection_modifyitems(items):
+    # Add BDD feature file paths as an extra keyword to support test selection based on feature files.
+    package_root = Path(__file__).resolve().parents[1]
+    for item in items:
+        scenario = getattr(getattr(item, "function", None), "__scenario__", None)
+        feature = getattr(scenario, "feature", None)
+        filename = getattr(feature, "filename", None)
+        if filename:
+            path = Path(filename).resolve().relative_to(package_root)
+            item.extra_keyword_matches.add(path.as_posix())
 
 
 def configure_sail_environment():

--- a/python/pysail/tests/spark/conftest.py
+++ b/python/pysail/tests/spark/conftest.py
@@ -36,7 +36,7 @@ def pytest_configure(config):
     )
     config.addinivalue_line(
         "markers",
-        "spark_null: output-schema/nullability scenarios; run the whole suite with -m spark_null",
+        "function(group): categorize a function BDD scenario",
     )
     # Load all pytest-bdd step modules.
     config.pluginmanager.import_plugin("pysail.testing.spark.steps.files")
@@ -159,7 +159,20 @@ DOCTEST_MARKERS = [
 ]
 
 
+FUNCTION_TAG_PATTERN = re.compile(r"function\((.*)\)")
+FUNCTION_TAG_VALUES = ["nullability", "columnargs", "lambda", "sketch"]
+SPARK_TAG_PATTERN = re.compile(r"spark-(.*)")
+
+
 def pytest_bdd_apply_tag(tag: str, function):
+    if (m := FUNCTION_TAG_PATTERN.fullmatch(tag)) is not None:
+        group = m.group(1)
+        if group not in FUNCTION_TAG_VALUES:
+            msg = f"invalid function tag: {tag}"
+            raise ValueError(msg)
+        pytest.mark.function(group=group)(function)
+        return True
+
     if tag == "sail-only":
         pytest.mark.skipif(is_jvm_spark(), reason="Sail-only feature not supported by JVM Spark")(function)
         return True
@@ -169,13 +182,16 @@ def pytest_bdd_apply_tag(tag: str, function):
         pytest.mark.xfail(not is_jvm_spark(), reason="Known Sail bug", strict=True)(function)
         return True
 
-    if tag.startswith("spark-"):
-        match = re.fullmatch(r"spark-(\d+(?:\.\d+)*)", tag)
-        if match is None:
+    if (m := SPARK_TAG_PATTERN.fullmatch(tag)) is not None:
+        try:
+            s = m.group(1)
+            version = tuple(int(part) for part in s.split("."))
+            if not version:
+                msg = "empty version"
+                raise ValueError(msg)  # noqa: TRY301
+        except ValueError as e:
             msg = f"invalid Spark version tag: {tag}"
-            raise ValueError(msg)
-        s = match.group(1)
-        version = tuple(int(part) for part in s.split("."))
+            raise ValueError(msg) from e
         pytest.mark.skipif(pyspark_version() < version, reason=f"Requires Spark {s}+")(function)
         return True
 

--- a/python/pysail/tests/spark/function/features/aggregate/bitmap_construct_agg.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/bitmap_construct_agg.feature
@@ -1,4 +1,3 @@
-@bitmap_construct_agg
 Feature: bitmap_construct_agg builds a bitmap from bit positions
 
   Rule: bitmap_construct_agg sets bits from bitmap_bit_position

--- a/python/pysail/tests/spark/function/features/aggregate/bitmap_or_agg.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/bitmap_or_agg.feature
@@ -1,4 +1,3 @@
-@bitmap_or_agg
 Feature: bitmap_or_agg returns the bitwise OR of all input bitmaps
 
   Rule: bitmap_or_agg ORs identical bitmaps

--- a/python/pysail/tests/spark/function/features/aggregate/collect_list.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/collect_list.feature
@@ -1,4 +1,3 @@
-@collect_list @collect_set
 Feature: collect_list / collect_set
 
   collect_list gathers all values of a group into an array (order and duplicates preserved);

--- a/python/pysail/tests/spark/function/features/aggregate/count_distinct_star.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/count_distinct_star.feature
@@ -1,4 +1,3 @@
-@count_distinct_star
 Feature: COUNT(DISTINCT *) function
 
   Rule: COUNT(DISTINCT *) counts distinct rows

--- a/python/pysail/tests/spark/function/features/aggregate/count_if.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/count_if.feature
@@ -1,4 +1,3 @@
-@count_if
 Feature: count_if function
 
   Rule: count_if as window function

--- a/python/pysail/tests/spark/function/features/aggregate/first_last.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/first_last.feature
@@ -1,4 +1,3 @@
-@first_last
 Feature: first / last / any_value inherit ordering from an adjacent ORDER BY
 
   # The row STORAGE order in every VALUES list below is deliberately scrambled so

--- a/python/pysail/tests/spark/function/features/aggregate/grouping_id.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/grouping_id.feature
@@ -1,4 +1,3 @@
-@grouping_id
 Feature: grouping_id returns Spark-compatible grouping-set bit masks
 
   Rule: grouping_id over grouping analytics

--- a/python/pysail/tests/spark/function/features/aggregate/input_order.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/input_order.feature
@@ -1,4 +1,3 @@
-@input_order
 Feature: input_order
   Aggregate/window functions observe input row order established by an
   upstream ORDER BY (migrated SQL-expressible subset of test_input_order.txt).

--- a/python/pysail/tests/spark/function/features/aggregate/max_by.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/max_by.feature
@@ -1,4 +1,3 @@
-@max_by
 Feature: max_by function
 
   Rule: max_by with all NULLs in ordering column

--- a/python/pysail/tests/spark/function/features/aggregate/min_by.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/min_by.feature
@@ -1,4 +1,3 @@
-@min_by
 Feature: min_by function
 
   Rule: min_by with all NULLs in ordering column

--- a/python/pysail/tests/spark/function/features/aggregate/mode.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/mode.feature
@@ -1,4 +1,3 @@
-@mode
 Feature: mode
 
   Rule: Result values (migrated from test_mode.txt doctests)

--- a/python/pysail/tests/spark/function/features/aggregate/percentile.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/percentile.feature
@@ -1,4 +1,3 @@
-@percentile
 Feature: percentile() aggregate function computes percentiles
 
   Rule: Basic percentile calculation

--- a/python/pysail/tests/spark/function/features/aggregate/percentile_disc.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/percentile_disc.feature
@@ -1,4 +1,3 @@
-@percentile_disc
 Feature: percentile_disc() returns the discrete percentile for a numeric column
 
   # Regression coverage for `percentile_disc` over numeric inputs (including

--- a/python/pysail/tests/spark/function/features/aggregate/product.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/product.feature
@@ -1,4 +1,3 @@
-@product
 Feature: product returns the multiplicative product of all non-null input values
 
   Rule: product multiplies non-null values

--- a/python/pysail/tests/spark/function/features/aggregate/try_avg.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/try_avg.feature
@@ -1,4 +1,3 @@
-@try_avg
 Feature: try_avg
 
   Rule: Result values (migrated from test_try_avg.txt doctests)

--- a/python/pysail/tests/spark/function/features/aggregate/try_sum.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/try_sum.feature
@@ -1,4 +1,3 @@
-@try_sum
 Feature: try_sum
 
   Rule: Result values (migrated from test_try_sum.txt doctests)

--- a/python/pysail/tests/spark/function/features/array/aggregate.feature
+++ b/python/pysail/tests/spark/function/features/array/aggregate.feature
@@ -1,5 +1,4 @@
-@lambda_hof
-@aggregate
+@function(lambda)
 Feature: aggregate higher-order function
 
   Rule: Array aggregation with lambda functions

--- a/python/pysail/tests/spark/function/features/array/array.feature
+++ b/python/pysail/tests/spark/function/features/array/array.feature
@@ -1,7 +1,6 @@
-@array
 Feature: array output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to array yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/array/array_append.feature
+++ b/python/pysail/tests/spark/function/features/array/array_append.feature
@@ -1,7 +1,6 @@
-@array_append
 Feature: array_append output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/array_coercion.feature
+++ b/python/pysail/tests/spark/function/features/array/array_coercion.feature
@@ -1,4 +1,3 @@
-@array_coercion
 Feature: array() type coercion with mixed element types
 
   Spark's non-ANSI semantics coerce mixed string/numeric arrays to string,

--- a/python/pysail/tests/spark/function/features/array/array_compact.feature
+++ b/python/pysail/tests/spark/function/features/array/array_compact.feature
@@ -1,4 +1,3 @@
-@array_compact
 Feature: array_compact() removes null values from an array
 
   Rule: Basic usage
@@ -86,7 +85,7 @@ Feature: array_compact() removes null values from an array
         | double  | array(1.1, NULL, 2.2, NULL) | [1.1, 2.2]    |
         | boolean | array(true, NULL, false)    | [true, false] |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/array_contains.feature
+++ b/python/pysail/tests/spark/function/features/array/array_contains.feature
@@ -1,7 +1,6 @@
-@array_contains
 Feature: array_contains output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/array_distinct.feature
+++ b/python/pysail/tests/spark/function/features/array/array_distinct.feature
@@ -1,7 +1,6 @@
-@array_distinct
 Feature: array_distinct output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/array_except.feature
+++ b/python/pysail/tests/spark/function/features/array/array_except.feature
@@ -1,7 +1,6 @@
-@array_except
 Feature: array_except output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/array_filter.feature
+++ b/python/pysail/tests/spark/function/features/array/array_filter.feature
@@ -1,4 +1,4 @@
-@lambda_hof
+@function(lambda)
 Feature: array filter with lambda
 
   Rule: Filter array elements using lambda predicates

--- a/python/pysail/tests/spark/function/features/array/array_insert.feature
+++ b/python/pysail/tests/spark/function/features/array/array_insert.feature
@@ -1,4 +1,3 @@
-@array_insert
 Feature: array_insert with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: array_insert with an argument coming from a column
 
   Rule: array_insert — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: array_insert with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: array_insert with an argument coming from a column
         | [1, 2, 3, 4, 5] |
 
     # Sail rejects the column: Sail errors: array_insert: the index 0 is invalid. An index shall be either < 0 or > 0 (the first eleme...
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: array_insert takes argument 2 from a column containing NULL
       When query
         """
@@ -28,7 +27,7 @@ Feature: array_insert with an argument coming from a column
         | [1, 2, 3, 4, 5] |
         | NULL            |
 
-    @column_args
+    @function(columnargs)
     Scenario: array_insert takes argument 2 from a column holding two different values
       When query
         """
@@ -39,7 +38,7 @@ Feature: array_insert with an argument coming from a column
         | [9, 1, 2, 3] |
         | [1, 2, 9, 3] |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/array_intersect.feature
+++ b/python/pysail/tests/spark/function/features/array/array_intersect.feature
@@ -1,4 +1,3 @@
-@array_intersect
 Feature: array_intersect() returns common array elements without duplicates
 
   Rule: Source-of-truth examples
@@ -168,7 +167,7 @@ Feature: array_intersect() returns common array elements without duplicates
         | non-array inputs           | 1, array(1)          |
         | incompatible element types | array(1), array('1') |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: non-null array literals yield a non-nullable array

--- a/python/pysail/tests/spark/function/features/array/array_join.feature
+++ b/python/pysail/tests/spark/function/features/array/array_join.feature
@@ -1,7 +1,6 @@
-@array_join
 Feature: array_join output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/array_max.feature
+++ b/python/pysail/tests/spark/function/features/array/array_max.feature
@@ -1,7 +1,6 @@
-@array_max
 Feature: array_max output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to array_max yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/array/array_min.feature
+++ b/python/pysail/tests/spark/function/features/array/array_min.feature
@@ -1,7 +1,6 @@
-@array_min
 Feature: array_min output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to array_min yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/array/array_min_max.feature
+++ b/python/pysail/tests/spark/function/features/array/array_min_max.feature
@@ -1,4 +1,3 @@
-@array_min
 Feature: array_min and array_max functions
 
   Rule: Basic usage
@@ -222,7 +221,7 @@ Feature: array_min and array_max functions
         | 2  | 5       | 25      |
         | 3  | 100     | 100     |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: array_min of a non-null array literal

--- a/python/pysail/tests/spark/function/features/array/array_position.feature
+++ b/python/pysail/tests/spark/function/features/array/array_position.feature
@@ -1,7 +1,6 @@
-@array_position
 Feature: array_position output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/array_prepend.feature
+++ b/python/pysail/tests/spark/function/features/array/array_prepend.feature
@@ -1,7 +1,6 @@
-@array_prepend
 Feature: array_prepend output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/array_remove.feature
+++ b/python/pysail/tests/spark/function/features/array/array_remove.feature
@@ -1,4 +1,3 @@
-@array_remove
 Feature: array_remove with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: array_remove with an argument coming from a column
 
   Rule: array_remove — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: array_remove with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: array_remove with an argument coming from a column
         | [1, 2, NULL] |
 
     # Sail rejects the column: Sail errors: Invalid argument error: Column '#4' is declared as non-nullable but contains null values
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: array_remove takes argument 2 from a column containing NULL
       When query
         """
@@ -28,7 +27,7 @@ Feature: array_remove with an argument coming from a column
         | [1, 2, NULL] |
         | NULL         |
 
-    @column_args
+    @function(columnargs)
     Scenario: array_remove takes argument 2 from a column holding two different values
       When query
         """
@@ -39,7 +38,7 @@ Feature: array_remove with an argument coming from a column
         | [2, 3] |
         | [1, 2] |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null array literal yields a non-nullable array

--- a/python/pysail/tests/spark/function/features/array/array_repeat.feature
+++ b/python/pysail/tests/spark/function/features/array/array_repeat.feature
@@ -1,7 +1,6 @@
-@array_repeat
 Feature: array_repeat output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/array_sort.feature
+++ b/python/pysail/tests/spark/function/features/array/array_sort.feature
@@ -1,4 +1,3 @@
-@array_sort
 Feature: array_sort higher-order function
 
   Rule: No-comparator form — natural ascending order, NULLs last

--- a/python/pysail/tests/spark/function/features/array/array_union.feature
+++ b/python/pysail/tests/spark/function/features/array/array_union.feature
@@ -1,7 +1,6 @@
-@array_union
 Feature: array_union output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/array_update.feature
+++ b/python/pysail/tests/spark/function/features/array/array_update.feature
@@ -1,4 +1,3 @@
-@array_update
 Feature: array update functions
 
   Rule: array_append

--- a/python/pysail/tests/spark/function/features/array/arrays_overlap.feature
+++ b/python/pysail/tests/spark/function/features/array/arrays_overlap.feature
@@ -1,7 +1,6 @@
-@arrays_overlap
 Feature: arrays_overlap output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/arrays_zip.feature
+++ b/python/pysail/tests/spark/function/features/array/arrays_zip.feature
@@ -1,4 +1,3 @@
-@arrays_zip
 Feature: arrays_zip comprehensive tests
 
   Rule: Basic usage
@@ -320,7 +319,7 @@ Feature: arrays_zip comprehensive tests
         | arrays_zip non-array input errors           | 1, 2                |
         | arrays_zip mixed array and non-array errors | array(1,2), 'hello' |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/exists.feature
+++ b/python/pysail/tests/spark/function/features/array/exists.feature
@@ -1,5 +1,4 @@
-@lambda_hof
-@exists
+@function(lambda)
 Feature: exists higher-order function
 
   Rule: Basic boolean predicate evaluation
@@ -290,7 +289,7 @@ Feature: exists higher-order function
         | on   | true  |
         | off  | false |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/flatten.feature
+++ b/python/pysail/tests/spark/function/features/array/flatten.feature
@@ -1,4 +1,3 @@
-@flatten
 Feature: flatten() flattens nested arrays
 
   Rule: Basic flattening
@@ -45,7 +44,7 @@ Feature: flatten() flattens nested arrays
         | result |
         | NULL   |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/forall.feature
+++ b/python/pysail/tests/spark/function/features/array/forall.feature
@@ -1,5 +1,4 @@
-@lambda_hof
-@forall
+@function(lambda)
 Feature: forall higher-order function
 
   Rule: Basic boolean predicate evaluation
@@ -297,7 +296,7 @@ Feature: forall higher-order function
         | on   | true  |
         | off  | false |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/get.feature
+++ b/python/pysail/tests/spark/function/features/array/get.feature
@@ -1,4 +1,3 @@
-@get
 Feature: get with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: get with an argument coming from a column
 
   Rule: get — the argument is resolved per row, not taken from the first row
 
-    @column_args
+    @function(columnargs)
     Scenario: get with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: get with an argument coming from a column
         | 1      |
 
     # Sail applies the first row's value to every row: Sail returns ['1', '1'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: get takes argument 2 from a column containing NULL
       When query
         """
@@ -28,7 +27,7 @@ Feature: get with an argument coming from a column
         | 1      |
         | NULL   |
 
-    @column_args
+    @function(columnargs)
     Scenario: get takes argument 2 from a column holding two different values
       When query
         """
@@ -39,7 +38,7 @@ Feature: get with an argument coming from a column
         | 10     |
         | 30     |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/sequence.feature
+++ b/python/pysail/tests/spark/function/features/array/sequence.feature
@@ -1,7 +1,6 @@
-@sequence
 Feature: sequence output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/shuffle.feature
+++ b/python/pysail/tests/spark/function/features/array/shuffle.feature
@@ -1,7 +1,6 @@
-@shuffle
 Feature: shuffle output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to shuffle yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/array/slice.feature
+++ b/python/pysail/tests/spark/function/features/array/slice.feature
@@ -1,4 +1,3 @@
-@slice
 Feature: slice with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: slice with an argument coming from a column
 
   Rule: slice — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: slice with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: slice with an argument coming from a column
         | [2, 3] |
 
     # Sail rejects the column: Sail errors: Invalid argument error: Non-nullable field of ListArray "item" cannot contain nulls
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario Outline: slice takes argument <n> from a column containing NULL
       When query
         """
@@ -33,7 +32,7 @@ Feature: slice with an argument coming from a column
         | 2 | c, 2 |
         | 3 | 2, c |
 
-    @column_args
+    @function(columnargs)
     Scenario: slice takes argument 2 from a column holding two different values
       When query
         """
@@ -44,7 +43,7 @@ Feature: slice with an argument coming from a column
         | [1, 2] |
         | [3, 4] |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/sort_array.feature
+++ b/python/pysail/tests/spark/function/features/array/sort_array.feature
@@ -1,7 +1,6 @@
-@sort_array
 Feature: sort_array output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/array/transform.feature
+++ b/python/pysail/tests/spark/function/features/array/transform.feature
@@ -1,5 +1,4 @@
-@lambda_hof
-@transform
+@function(lambda)
 Feature: transform higher-order function
 
   Rule: Basic 1-param transform — integer arithmetic

--- a/python/pysail/tests/spark/function/features/bitwise/bit_count.feature
+++ b/python/pysail/tests/spark/function/features/bitwise/bit_count.feature
@@ -1,7 +1,6 @@
-@bit_count
 Feature: bit_count output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to bit_count yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/bitwise/bit_get.feature
+++ b/python/pysail/tests/spark/function/features/bitwise/bit_get.feature
@@ -1,7 +1,6 @@
-@bit_get
 Feature: bit_get output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to bit_get yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/bitwise/getbit.feature
+++ b/python/pysail/tests/spark/function/features/bitwise/getbit.feature
@@ -1,7 +1,6 @@
-@getbit
 Feature: getbit output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to getbit yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/bitwise/shiftleft.feature
+++ b/python/pysail/tests/spark/function/features/bitwise/shiftleft.feature
@@ -1,7 +1,6 @@
-@shiftleft
 Feature: shiftleft output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to shiftleft yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/bitwise/shiftright.feature
+++ b/python/pysail/tests/spark/function/features/bitwise/shiftright.feature
@@ -1,7 +1,6 @@
-@shiftright
 Feature: shiftright output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to shiftright yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/bitwise/shiftrightunsigned.feature
+++ b/python/pysail/tests/spark/function/features/bitwise/shiftrightunsigned.feature
@@ -1,7 +1,6 @@
-@shiftrightunsigned
 Feature: shiftrightunsigned output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/collection/cardinality.feature
+++ b/python/pysail/tests/spark/function/features/collection/cardinality.feature
@@ -1,7 +1,6 @@
-@cardinality
 Feature: cardinality output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/collection/concat.feature
+++ b/python/pysail/tests/spark/function/features/collection/concat.feature
@@ -1,4 +1,3 @@
-@concat
 Feature: concat function
 
   Rule: Basic concatenation
@@ -300,7 +299,7 @@ Feature: concat function
         | single NULL timestamp column returns NULL                 | ts                 | CAST(NULL AS TIMESTAMP)                | ts  | NULL                       |
         | single TIMESTAMP_NTZ column coerced to string             | ts                 | TIMESTAMP_NTZ '2024-01-15 12:00:00'    | ts  | 2024-01-15 12:00:00        |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: non-null string literals yield a non-nullable string

--- a/python/pysail/tests/spark/function/features/collection/element_at.feature
+++ b/python/pysail/tests/spark/function/features/collection/element_at.feature
@@ -1,7 +1,6 @@
-@element_at
 Feature: element_at output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/collection/reverse.feature
+++ b/python/pysail/tests/spark/function/features/collection/reverse.feature
@@ -1,7 +1,6 @@
-@reverse
 Feature: reverse output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/collection/size.feature
+++ b/python/pysail/tests/spark/function/features/collection/size.feature
@@ -1,7 +1,6 @@
-@size
 Feature: size output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/collection/try_element_at.feature
+++ b/python/pysail/tests/spark/function/features/collection/try_element_at.feature
@@ -1,7 +1,6 @@
-@try_element_at
 Feature: try_element_at output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/conditional/coalesce.feature
+++ b/python/pysail/tests/spark/function/features/conditional/coalesce.feature
@@ -1,4 +1,3 @@
-@coalesce
 Feature: coalesce returns the first non-null argument
 
   Rule: Spark-compatible coercion for mixed string and temporal arguments
@@ -59,7 +58,7 @@ Feature: coalesce returns the first non-null argument
         | result | result_type |
         | NULL   | string      |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null argument yields a non-nullable value

--- a/python/pysail/tests/spark/function/features/conditional/if.feature
+++ b/python/pysail/tests/spark/function/features/conditional/if.feature
@@ -1,7 +1,6 @@
-@if
 Feature: if output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to if yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/conditional/ifnull.feature
+++ b/python/pysail/tests/spark/function/features/conditional/ifnull.feature
@@ -1,7 +1,6 @@
-@ifnull
 Feature: ifnull output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/conditional/nanvl.feature
+++ b/python/pysail/tests/spark/function/features/conditional/nanvl.feature
@@ -1,7 +1,6 @@
-@nanvl
 Feature: nanvl output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to nanvl yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/conditional/nullif.feature
+++ b/python/pysail/tests/spark/function/features/conditional/nullif.feature
@@ -1,7 +1,6 @@
-@nullif
 Feature: nullif output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to nullif yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/conditional/nullifzero.feature
+++ b/python/pysail/tests/spark/function/features/conditional/nullifzero.feature
@@ -1,7 +1,6 @@
-@nullifzero
 Feature: nullifzero output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to nullifzero yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/conditional/nvl.feature
+++ b/python/pysail/tests/spark/function/features/conditional/nvl.feature
@@ -1,7 +1,6 @@
-@nvl
 Feature: nvl output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/conditional/nvl2.feature
+++ b/python/pysail/tests/spark/function/features/conditional/nvl2.feature
@@ -1,7 +1,6 @@
-@nvl2
 Feature: nvl2 output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to nvl2 yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/conditional/when.feature
+++ b/python/pysail/tests/spark/function/features/conditional/when.feature
@@ -1,7 +1,6 @@
-@when
 Feature: when output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/conditional/zeroifnull.feature
+++ b/python/pysail/tests/spark/function/features/conditional/zeroifnull.feature
@@ -1,7 +1,6 @@
-@zeroifnull
 Feature: zeroifnull output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to zeroifnull yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/conversion/cast.feature
+++ b/python/pysail/tests/spark/function/features/conversion/cast.feature
@@ -1,7 +1,6 @@
-@cast
 Feature: cast output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/conversion/cast_date_to_numeric.feature
+++ b/python/pysail/tests/spark/function/features/conversion/cast_date_to_numeric.feature
@@ -1,4 +1,3 @@
-@cast_date_to_numeric
 Feature: CAST date to numeric types returns null
 
   In Spark legacy mode, casting a DATE to any numeric type returns NULL.

--- a/python/pysail/tests/spark/function/features/conversion/cast_nan_inf.feature
+++ b/python/pysail/tests/spark/function/features/conversion/cast_nan_inf.feature
@@ -1,4 +1,3 @@
-@cast_nan_inf
 Feature: CAST and type constructors with NaN and Infinity (issue #630)
 
   Rule: FLOAT type constructor

--- a/python/pysail/tests/spark/function/features/csv/csv_options.feature
+++ b/python/pysail/tests/spark/function/features/csv/csv_options.feature
@@ -1,4 +1,3 @@
-@csv
 Feature: CSV expression functions handle Spark's CSV options
 
   Spark builds `CSVOptions` eagerly, so every option is parsed as soon as the options map is read,

--- a/python/pysail/tests/spark/function/features/csv/from_csv.feature
+++ b/python/pysail/tests/spark/function/features/csv/from_csv.feature
@@ -1,4 +1,3 @@
-@csv @from_csv
 Feature: from_csv column display name matches Spark
 
   Spark renders `from_csv` as a UnaryExpression: only the input column
@@ -80,7 +79,7 @@ Feature: from_csv column display name matches Spark
         | first_value |
         | last_value  |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/csv/schema_of_csv.feature
+++ b/python/pysail/tests/spark/function/features/csv/schema_of_csv.feature
@@ -1,4 +1,3 @@
-@csv @schema_of_csv
 Feature: schema_of_csv infers a CSV schema from a literal row
 
     Scenario Outline: schema_of_csv infers <case>
@@ -25,7 +24,7 @@ Feature: schema_of_csv infers a CSV schema from a literal row
         | schema                        |
         | STRUCT<_c0: INT, _c1: STRING> |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/csv/to_csv.feature
+++ b/python/pysail/tests/spark/function/features/csv/to_csv.feature
@@ -1,4 +1,3 @@
-@csv @to_csv
 Feature: to_csv converts a struct value to a CSV string
 
   Rule: Basic serialization
@@ -190,7 +189,7 @@ Feature: to_csv converts a struct value to a CSV string
         | Floating-point special values use Spark display strings       | 'nan', CAST('NaN' AS DOUBLE), 'pos', CAST('Infinity' AS DOUBLE), 'neg', CAST('-Infinity' AS DOUBLE) | NaN,Infinity,-Infinity |
         | Binary values use Spark hex pretty strings                    | 'b', CAST('abc' AS BINARY)                                                                          | [61 62 63]             |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null struct literal is nullable (to_csv is inherently nullable in Spark)

--- a/python/pysail/tests/spark/function/features/cte.feature
+++ b/python/pysail/tests/spark/function/features/cte.feature
@@ -1,4 +1,3 @@
-@cte
 Feature: CTE (Common Table Expressions) support
 
   Rule: Basic CTE

--- a/python/pysail/tests/spark/function/features/datetime/convert_timezone.feature
+++ b/python/pysail/tests/spark/function/features/datetime/convert_timezone.feature
@@ -1,4 +1,3 @@
-@convert_timezone
 Feature: convert_timezone
 
   Rule: Type coercion
@@ -66,7 +65,7 @@ Feature: convert_timezone
         | '2025-03-09 10:30:00' | 'Europe/Amsterdam'    | 'America/Los_Angeles' | 2025-03-09 01:30:00 |
         | '2025-03-09 11:30:00' | 'Europe/Amsterdam'    | 'America/Los_Angeles' | 2025-03-09 03:30:00 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/curdate.feature
+++ b/python/pysail/tests/spark/function/features/datetime/curdate.feature
@@ -1,7 +1,6 @@
-@curdate
 Feature: curdate output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/current_date.feature
+++ b/python/pysail/tests/spark/function/features/datetime/current_date.feature
@@ -1,7 +1,6 @@
-@current_date
 Feature: current_date output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/current_timezone.feature
+++ b/python/pysail/tests/spark/function/features/datetime/current_timezone.feature
@@ -1,7 +1,6 @@
-@current_timezone
 Feature: current_timezone output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to current_timezone yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/datetime/date_diff.feature
+++ b/python/pysail/tests/spark/function/features/datetime/date_diff.feature
@@ -1,7 +1,6 @@
-@date_diff
 Feature: date_diff output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/date_format.feature
+++ b/python/pysail/tests/spark/function/features/datetime/date_format.feature
@@ -1,4 +1,3 @@
-@date_format
 Feature: date_format with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: date_format with an argument coming from a column
 
   Rule: date_format — the argument is resolved per row, not taken from the first row
 
-    @column_args
+    @function(columnargs)
     Scenario: date_format with the argument as a literal
       When query
         """
@@ -16,7 +15,7 @@ Feature: date_format with an argument coming from a column
         | result |
         | 2016   |
 
-    @column_args
+    @function(columnargs)
     Scenario: date_format takes argument 2 from a column containing NULL
       When query
         """
@@ -27,7 +26,7 @@ Feature: date_format with an argument coming from a column
         | 2016   |
         | NULL   |
 
-    @column_args
+    @function(columnargs)
     Scenario: date_format takes argument 2 from a column holding two different values
       When query
         """
@@ -38,7 +37,7 @@ Feature: date_format with an argument coming from a column
         | 2026   |
         | 02     |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/date_from_unix_date.feature
+++ b/python/pysail/tests/spark/function/features/datetime/date_from_unix_date.feature
@@ -1,7 +1,6 @@
-@date_from_unix_date
 Feature: date_from_unix_date output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to date_from_unix_date yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/datetime/date_part.feature
+++ b/python/pysail/tests/spark/function/features/datetime/date_part.feature
@@ -1,7 +1,6 @@
-@date_part
 Feature: date_part / extract output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/date_trunc.feature
+++ b/python/pysail/tests/spark/function/features/datetime/date_trunc.feature
@@ -1,4 +1,3 @@
-@date_trunc
 Feature: DATE_TRUNC preserves timestamp type
 
   Rule: date_trunc on timestamp preserves type
@@ -89,7 +88,7 @@ Feature: DATE_TRUNC preserves timestamp type
 
   Rule: date_trunc — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: date_trunc with the argument as a literal
       When query
         """
@@ -100,7 +99,7 @@ Feature: DATE_TRUNC preserves timestamp type
         | 2015-03-01 00:00:00 |
 
     # Sail rejects the column: Sail errors: Granularity of `date_trunc` must be non-null scalar Utf8
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario Outline: Date_trunc: <case>
       When query
         """
@@ -116,7 +115,7 @@ Feature: DATE_TRUNC preserves timestamp type
         | date_trunc takes argument 1 from a column holding two different values | 'YEAR' | 'MM'   | 2015-01-01 00:00:00 | 2015-03-01 00:00:00 |
         | date_trunc takes argument 1 from a column                              | 'YEAR' | 'YEAR' | 2015-01-01 00:00:00 | 2015-01-01 00:00:00 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null timestamp literal yields a timestamp

--- a/python/pysail/tests/spark/function/features/datetime/datediff.feature
+++ b/python/pysail/tests/spark/function/features/datetime/datediff.feature
@@ -1,7 +1,6 @@
-@datediff
 Feature: datediff output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/datepart.feature
+++ b/python/pysail/tests/spark/function/features/datetime/datepart.feature
@@ -1,7 +1,6 @@
-@datepart
 Feature: datepart output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to datepart yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/datetime/datetime_edge_cases.feature
+++ b/python/pysail/tests/spark/function/features/datetime/datetime_edge_cases.feature
@@ -1,5 +1,4 @@
 # Moved from features/datetime_edge_cases.feature by the datetime/ layout reorganisation.
-@datetime_edge_cases
 Feature: datetime edge cases
 
   Rule: 2-digit year expansion boundaries

--- a/python/pysail/tests/spark/function/features/datetime/datetime_format.feature
+++ b/python/pysail/tests/spark/function/features/datetime/datetime_format.feature
@@ -1,5 +1,4 @@
 # Moved from features/datetime_format.feature by the datetime/ layout reorganisation.
-@datetime_format
 Feature: datetime format strings
 
   Rule: Java datetime pattern formatting compatibility

--- a/python/pysail/tests/spark/function/features/datetime/datetime_literal.feature
+++ b/python/pysail/tests/spark/function/features/datetime/datetime_literal.feature
@@ -1,5 +1,4 @@
 # Moved from features/datetime_literal.feature by the datetime/ layout reorganisation.
-@datetime_literal
 Feature: Datetime literal syntax from Spark SQL documentation
 
   This feature tests datetime literal syntax as documented in Spark 4.1.2:

--- a/python/pysail/tests/spark/function/features/datetime/datetime_parse.feature
+++ b/python/pysail/tests/spark/function/features/datetime/datetime_parse.feature
@@ -1,5 +1,4 @@
 # Moved from features/datetime_parse.feature by the datetime/ layout reorganisation.
-@datetime_parse
 Feature: datetime parsing with format strings
 
   Rule: Spark datetime pattern validation for parsing

--- a/python/pysail/tests/spark/function/features/datetime/day.feature
+++ b/python/pysail/tests/spark/function/features/datetime/day.feature
@@ -1,7 +1,6 @@
-@day
 Feature: day output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/dayname.feature
+++ b/python/pysail/tests/spark/function/features/datetime/dayname.feature
@@ -1,7 +1,6 @@
-@dayname
 Feature: dayname output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to dayname yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/datetime/dayofmonth.feature
+++ b/python/pysail/tests/spark/function/features/datetime/dayofmonth.feature
@@ -1,7 +1,6 @@
-@dayofmonth
 Feature: dayofmonth output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/dayofyear.feature
+++ b/python/pysail/tests/spark/function/features/datetime/dayofyear.feature
@@ -1,7 +1,6 @@
-@dayofyear
 Feature: dayofyear output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/extract.feature
+++ b/python/pysail/tests/spark/function/features/datetime/extract.feature
@@ -1,7 +1,6 @@
-@extract
 Feature: extract output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to extract yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/datetime/from_unixtime.feature
+++ b/python/pysail/tests/spark/function/features/datetime/from_unixtime.feature
@@ -1,4 +1,3 @@
-@from_unixtime
 Feature: from_unixtime with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: from_unixtime with an argument coming from a column
 
   Rule: from_unixtime — the argument is resolved per row, not taken from the first row
 
-    @column_args
+    @function(columnargs)
     Scenario: from_unixtime with the argument as a literal
       When query
         """
@@ -16,7 +15,7 @@ Feature: from_unixtime with an argument coming from a column
         | result              |
         | 1970-01-01 00:00:00 |
 
-    @column_args
+    @function(columnargs)
     Scenario: from_unixtime takes argument 2 from a column containing NULL
       When query
         """
@@ -27,7 +26,7 @@ Feature: from_unixtime with an argument coming from a column
         | 1970-01-01 00:00:00 |
         | NULL                |
 
-    @column_args
+    @function(columnargs)
     Scenario: from_unixtime takes argument 2 from a column holding two different values
       When query
         """
@@ -38,7 +37,7 @@ Feature: from_unixtime with an argument coming from a column
         | 1970   |
         | 01     |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null bigint literal yields a string

--- a/python/pysail/tests/spark/function/features/datetime/from_utc_timestamp.feature
+++ b/python/pysail/tests/spark/function/features/datetime/from_utc_timestamp.feature
@@ -1,4 +1,3 @@
-@from_utc_timestamp
 Feature: from_utc_timestamp
 
   Rule: Type coercion
@@ -44,7 +43,7 @@ Feature: from_utc_timestamp
         | '2025-03-09 17:30:00' | 2025-03-09 09:30:00 |
         | '2025-03-09 18:30:00' | 2025-03-09 11:30:00 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to from_utc_timestamp yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/datetime/hour.feature
+++ b/python/pysail/tests/spark/function/features/datetime/hour.feature
@@ -1,7 +1,6 @@
-@hour
 Feature: hour output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/interval_day_to_second.feature
+++ b/python/pysail/tests/spark/function/features/datetime/interval_day_to_second.feature
@@ -1,4 +1,3 @@
-@interval_day_to_second
 Feature: INTERVAL DAY TO SECOND literal parsing and operations
 
   Rule: Basic literals

--- a/python/pysail/tests/spark/function/features/datetime/last_day.feature
+++ b/python/pysail/tests/spark/function/features/datetime/last_day.feature
@@ -1,4 +1,3 @@
-@last_day
 Feature: last_day comprehensive tests
 
   Rule: Argument count validation
@@ -530,7 +529,7 @@ Feature: last_day comprehensive tests
         """
       Then query plan matches snapshot
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/make_date.feature
+++ b/python/pysail/tests/spark/function/features/datetime/make_date.feature
@@ -1,7 +1,6 @@
-@make_date
 Feature: make_date output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/make_dt_interval.feature
+++ b/python/pysail/tests/spark/function/features/datetime/make_dt_interval.feature
@@ -1,7 +1,6 @@
-@make_dt_interval
 Feature: make_dt_interval output schema
 
-  @spark_null @spark-4
+  @function(nullability) @spark-4
   Rule: Output schema
 
     Scenario: a non-null literal input to make_dt_interval yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/datetime/make_interval.feature
+++ b/python/pysail/tests/spark/function/features/datetime/make_interval.feature
@@ -1,7 +1,6 @@
-@make_interval
 Feature: make_interval output schema
 
-  @spark_null @spark-4
+  @function(nullability) @spark-4
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/make_timestamp.feature
+++ b/python/pysail/tests/spark/function/features/datetime/make_timestamp.feature
@@ -1,4 +1,3 @@
-@make_timestamp_ntz
 Feature: make_timestamp_ntz and try_make_timestamp_ntz functions
 
   Rule: Basic timestamp creation with 6 arguments
@@ -185,7 +184,7 @@ Feature: make_timestamp_ntz and try_make_timestamp_ntz functions
         | NULL                |
         | 2020-01-01 00:00:00 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/make_timestamp_ltz.feature
+++ b/python/pysail/tests/spark/function/features/datetime/make_timestamp_ltz.feature
@@ -1,4 +1,3 @@
-@make_timestamp_ltz
 Feature: make_timestamp_ltz
 
   Rule: Daylight saving time handling

--- a/python/pysail/tests/spark/function/features/datetime/make_ym_interval.feature
+++ b/python/pysail/tests/spark/function/features/datetime/make_ym_interval.feature
@@ -1,4 +1,3 @@
-@make_ym_interval
 Feature: make_ym_interval builds a year-month interval from years and months
 
   Rule: A NULL in any argument yields NULL (Spark MakeYMInterval is null-intolerant)
@@ -86,7 +85,7 @@ Feature: make_ym_interval builds a year-month interval from years and months
         | overflow errors with ANSI enabled  | true  |
         | overflow errors with ANSI disabled | false |
 
-  @spark_null @spark-4
+  @function(nullability) @spark-4
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/minute.feature
+++ b/python/pysail/tests/spark/function/features/datetime/minute.feature
@@ -1,7 +1,6 @@
-@minute
 Feature: minute output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/month.feature
+++ b/python/pysail/tests/spark/function/features/datetime/month.feature
@@ -1,7 +1,6 @@
-@month
 Feature: month output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/months_between.feature
+++ b/python/pysail/tests/spark/function/features/datetime/months_between.feature
@@ -1,7 +1,6 @@
-@months_between
 Feature: months_between output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to months_between yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/datetime/next_day.feature
+++ b/python/pysail/tests/spark/function/features/datetime/next_day.feature
@@ -1,4 +1,3 @@
-@next_day
 Feature: next_day comprehensive tests
 
   Rule: Argument count validation
@@ -242,7 +241,7 @@ Feature: next_day comprehensive tests
 
   Rule: next_day — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: next_day with the argument as a literal
       When query
         """
@@ -252,7 +251,7 @@ Feature: next_day comprehensive tests
         | result     |
         | 2015-01-20 |
 
-    @column_args
+    @function(columnargs)
     Scenario Outline: Argument from a column: <case>
       When query
         """
@@ -269,7 +268,7 @@ Feature: next_day comprehensive tests
         | next_day takes argument 2 from a column                              | '2015-01-14'      | 'TU' | 'TU' | 2015-01-20 | 2015-01-20 |
         | next_day takes argument 2 from a column holding two different values | DATE '2015-01-14' | 'TU' | 'FR' | 2015-01-20 | 2015-01-16 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null date literal yields a date

--- a/python/pysail/tests/spark/function/features/datetime/now.feature
+++ b/python/pysail/tests/spark/function/features/datetime/now.feature
@@ -1,7 +1,6 @@
-@now
 Feature: now output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/quarter.feature
+++ b/python/pysail/tests/spark/function/features/datetime/quarter.feature
@@ -1,7 +1,6 @@
-@quarter
 Feature: quarter output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/second.feature
+++ b/python/pysail/tests/spark/function/features/datetime/second.feature
@@ -1,7 +1,6 @@
-@second
 Feature: second output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/sequence_date.feature
+++ b/python/pysail/tests/spark/function/features/datetime/sequence_date.feature
@@ -1,4 +1,3 @@
-@sequence_date
 Feature: sequence() over DATE returns expected arrays
 
     Scenario Outline: sequence over DATE: <case>

--- a/python/pysail/tests/spark/function/features/datetime/time_functions.feature
+++ b/python/pysail/tests/spark/function/features/datetime/time_functions.feature
@@ -1,4 +1,3 @@
-@time_functions
 Feature: TIME functions (make_time, time_diff, time_trunc)
 
   Rule: make_time

--- a/python/pysail/tests/spark/function/features/datetime/time_type.feature
+++ b/python/pysail/tests/spark/function/features/datetime/time_type.feature
@@ -1,4 +1,3 @@
-@time_type
 Feature: TIME data type support
 
   Rule: TIME literal syntax

--- a/python/pysail/tests/spark/function/features/datetime/timestampadd.feature
+++ b/python/pysail/tests/spark/function/features/datetime/timestampadd.feature
@@ -1,4 +1,3 @@
-@timestampadd
 Feature: timestampadd function
 
     Scenario Outline: timestampadd: <case>
@@ -17,7 +16,7 @@ Feature: timestampadd function
         | subtract days    | day         | -5 | '2016-03-11 09:00:07'        | 2016-03-06 09:00:07        |
         | add microseconds | MICROSECOND | 2  | '2016-03-11 09:00:07.000001' | 2016-03-11 09:00:07.000003 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null timestamp literal yields a timestamp

--- a/python/pysail/tests/spark/function/features/datetime/timestampdiff.feature
+++ b/python/pysail/tests/spark/function/features/datetime/timestampdiff.feature
@@ -1,5 +1,4 @@
 # Moved from features/timestampdiff.feature by the datetime/ layout reorganisation.
-@timestampdiff
 Feature: timestampdiff calendar units
 
   Rule: timestampdiff uses calendar-aware month, quarter, and year units

--- a/python/pysail/tests/spark/function/features/datetime/to_date.feature
+++ b/python/pysail/tests/spark/function/features/datetime/to_date.feature
@@ -1,4 +1,3 @@
-@to_date
 Feature: to_date with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: to_date with an argument coming from a column
 
   Rule: to_date — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: to_date with the argument as a literal
       When query
         """
@@ -16,7 +15,7 @@ Feature: to_date with an argument coming from a column
         | result     |
         | 2016-12-31 |
 
-    @column_args
+    @function(columnargs)
     Scenario: to_date takes argument 2 from a column
       When query
         """
@@ -147,7 +146,7 @@ Feature: to_date with an argument coming from a column
         | true  |
         | false |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario Outline: a typed DATE with a literal format respects ANSI <ansi> nullability

--- a/python/pysail/tests/spark/function/features/datetime/to_time.feature
+++ b/python/pysail/tests/spark/function/features/datetime/to_time.feature
@@ -1,4 +1,4 @@
-@to_time @spark-4.1
+@spark-4.1
 Feature: to_time (strict variant)
   Strict to_time that throws an error on invalid input.
 

--- a/python/pysail/tests/spark/function/features/datetime/to_timestamp.feature
+++ b/python/pysail/tests/spark/function/features/datetime/to_timestamp.feature
@@ -1,4 +1,3 @@
-@to_timestamp
 Feature: to_timestamp (strict variant)
   Strict to_timestamp that throws on invalid input,
   contrasting with try_to_timestamp which returns NULL.
@@ -130,7 +129,7 @@ Feature: to_timestamp (strict variant)
         | 2024-01-15 10:30:00 |
         | 2024-01-15 10:30:00 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null string literal yields a timestamp

--- a/python/pysail/tests/spark/function/features/datetime/to_timestamp_ntz.feature
+++ b/python/pysail/tests/spark/function/features/datetime/to_timestamp_ntz.feature
@@ -1,4 +1,3 @@
-@to_timestamp_ntz
 Feature: to_timestamp_ntz
 
   Rule: Result values (migrated from test_to_timestamp_ntz.txt doctests)

--- a/python/pysail/tests/spark/function/features/datetime/to_unix_timestamp.feature
+++ b/python/pysail/tests/spark/function/features/datetime/to_unix_timestamp.feature
@@ -1,4 +1,3 @@
-@to_unix_timestamp
 Feature: to_unix_timestamp with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: to_unix_timestamp with an argument coming from a column
 
   Rule: to_unix_timestamp — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: to_unix_timestamp with the argument as a literal
       When query
         """
@@ -16,7 +15,7 @@ Feature: to_unix_timestamp with an argument coming from a column
         | result     |
         | 1460073600 |
 
-    @column_args
+    @function(columnargs)
     Scenario: to_unix_timestamp takes argument 2 from a column
       When query
         """
@@ -248,7 +247,7 @@ Feature: to_unix_timestamp with an argument coming from a column
          |-- timestamp_ntz_result: long (nullable = false)
         """
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to to_unix_timestamp yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/datetime/to_utc_timestamp.feature
+++ b/python/pysail/tests/spark/function/features/datetime/to_utc_timestamp.feature
@@ -1,4 +1,3 @@
-@to_utc_timestamp
 Feature: to_utc_timestamp
 
   Rule: Type coercion
@@ -45,7 +44,7 @@ Feature: to_utc_timestamp
         | '2025-03-09 10:30:00' | 2025-03-09 18:30:00 |
         | '2025-03-09 11:30:00' | 2025-03-09 18:30:00 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to to_utc_timestamp yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/datetime/trunc.feature
+++ b/python/pysail/tests/spark/function/features/datetime/trunc.feature
@@ -1,4 +1,3 @@
-@trunc
 Feature: trunc with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: trunc with an argument coming from a column
 
   Rule: trunc — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: trunc with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: trunc with an argument coming from a column
         | 2009-02-01 |
 
     # Sail rejects the column: Sail errors: Granularity of `date_trunc` must be non-null scalar Utf8
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario Outline: Trunc: <case>
       When query
         """
@@ -33,7 +32,7 @@ Feature: trunc with an argument coming from a column
         | trunc takes argument 2 from a column holding two different values | '2009-02-12' | 'MM'   | 'week' | 2009-02-01 | 2009-02-09 |
         | trunc takes argument 2 from a column                              | '2019-08-04' | 'week' | 'week' | 2019-07-29 | 2019-07-29 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/try_to_time.feature
+++ b/python/pysail/tests/spark/function/features/datetime/try_to_time.feature
@@ -1,4 +1,4 @@
-@try_to_time @spark-4.1
+@spark-4.1
 Feature: try_to_time
   Safe variant of to_time that returns NULL on parse failure
   instead of throwing an exception.

--- a/python/pysail/tests/spark/function/features/datetime/try_to_timestamp.feature
+++ b/python/pysail/tests/spark/function/features/datetime/try_to_timestamp.feature
@@ -1,4 +1,3 @@
-@try_to_timestamp
 Feature: try_to_timestamp
   Safe variant of to_timestamp that returns NULL on parse failure.
 

--- a/python/pysail/tests/spark/function/features/datetime/unix_timestamp.feature
+++ b/python/pysail/tests/spark/function/features/datetime/unix_timestamp.feature
@@ -1,4 +1,3 @@
-@unix_timestamp
 Feature: unix_timestamp with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: unix_timestamp with an argument coming from a column
 
   Rule: unix_timestamp — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: unix_timestamp with the argument as a literal
       When query
         """
@@ -16,7 +15,7 @@ Feature: unix_timestamp with an argument coming from a column
         | result     |
         | 1460073600 |
 
-    @column_args
+    @function(columnargs)
     Scenario: unix_timestamp takes argument 2 from a column
       When query
         """
@@ -248,7 +247,7 @@ Feature: unix_timestamp with an argument coming from a column
          |-- timestamp_ntz_result: long (nullable = false)
         """
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null string literal yields a bigint

--- a/python/pysail/tests/spark/function/features/datetime/weekday.feature
+++ b/python/pysail/tests/spark/function/features/datetime/weekday.feature
@@ -1,7 +1,6 @@
-@weekday
 Feature: weekday output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/window.feature
+++ b/python/pysail/tests/spark/function/features/datetime/window.feature
@@ -1,4 +1,3 @@
-@window
 Feature: window() time-based windowing function
 
   Rule: Tumbling window

--- a/python/pysail/tests/spark/function/features/datetime/window_time.feature
+++ b/python/pysail/tests/spark/function/features/datetime/window_time.feature
@@ -1,4 +1,3 @@
-@window_time
 Feature: window_time() event-time extraction function
 
   Rule: window_time returns the window end minus one microsecond
@@ -54,7 +53,7 @@ Feature: window_time() event-time extraction function
         """
       Then query error .*window_time requires a window column.*
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/year.feature
+++ b/python/pysail/tests/spark/function/features/datetime/year.feature
@@ -1,4 +1,3 @@
-@year
 Feature: year
 
   Rule: Basic year extraction
@@ -310,7 +309,7 @@ Feature: year
         """
       Then query plan matches snapshot
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/divide_by_zero.feature
+++ b/python/pysail/tests/spark/function/features/divide_by_zero.feature
@@ -1,4 +1,3 @@
-@divide_by_zero
 Feature: Division by zero behavior
 
   Rule: All division by zero returns NULL when ANSI mode is disabled (Spark 4.x behavior)

--- a/python/pysail/tests/spark/function/features/hash/crc32.feature
+++ b/python/pysail/tests/spark/function/features/hash/crc32.feature
@@ -1,7 +1,6 @@
-@crc32
 Feature: crc32 output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to crc32 yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/hash/hash.feature
+++ b/python/pysail/tests/spark/function/features/hash/hash.feature
@@ -1,4 +1,3 @@
-@hash
 Feature: hash() returns murmur3 hash
 
   Rule: Basic usage
@@ -29,7 +28,7 @@ Feature: hash() returns murmur3 hash
         | result |
         | 42     |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/hash/md5.feature
+++ b/python/pysail/tests/spark/function/features/hash/md5.feature
@@ -1,7 +1,6 @@
-@md5
 Feature: md5 output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/hash/sha.feature
+++ b/python/pysail/tests/spark/function/features/hash/sha.feature
@@ -1,7 +1,6 @@
-@sha
 Feature: sha output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to sha yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/hash/sha1.feature
+++ b/python/pysail/tests/spark/function/features/hash/sha1.feature
@@ -1,7 +1,6 @@
-@sha1
 Feature: sha1 output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to sha1 yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/hash/sha2.feature
+++ b/python/pysail/tests/spark/function/features/hash/sha2.feature
@@ -1,4 +1,3 @@
-@sha2
 Feature: sha2 with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: sha2 with an argument coming from a column
 
   Rule: sha2 — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: sha2 with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: sha2 with an argument coming from a column
         | 529bc3b07127ecb7e53a4dcf1991d9152c24537d919178022b2c42657f79a26b |
 
     # Sail rejects the column: Sail errors: invalid argument: The second argument of sha2 must be a literal integer.
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: sha2 takes argument 2 from a column
       When query
         """
@@ -28,7 +27,7 @@ Feature: sha2 with an argument coming from a column
         | 529bc3b07127ecb7e53a4dcf1991d9152c24537d919178022b2c42657f79a26b |
         | 529bc3b07127ecb7e53a4dcf1991d9152c24537d919178022b2c42657f79a26b |
 
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: sha2 takes argument 2 from a column holding two different values
       When query
         """
@@ -39,7 +38,7 @@ Feature: sha2 with an argument coming from a column
         | 529bc3b07127ecb7e53a4dcf1991d9152c24537d919178022b2c42657f79a26b                                                                 |
         | 44844a586c54c9a212da1dbfe05c5f1705de1af5fda1f0d36297623249b279fd8f0ccec03f888f4fb13bf7cd83fdad58591c797f81121a23cfdd5e0897795238 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null binary literal yields a string

--- a/python/pysail/tests/spark/function/features/hash/xxhash64.feature
+++ b/python/pysail/tests/spark/function/features/hash/xxhash64.feature
@@ -1,4 +1,3 @@
-@xxhash64
 Feature: xxhash64() returns 64-bit xxHash
 
   Rule: Basic usage
@@ -72,7 +71,7 @@ Feature: xxhash64() returns 64-bit xxHash
         | i                    | b                    |
         | -6698625589789238999 | -6698625589789238999 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal yields a non-nullable bigint

--- a/python/pysail/tests/spark/function/features/identifier_clause.feature
+++ b/python/pysail/tests/spark/function/features/identifier_clause.feature
@@ -1,4 +1,3 @@
-@identifier_clause
 Feature: IDENTIFIER clause
 
   Rule: IDENTIFIER in expression context

--- a/python/pysail/tests/spark/function/features/isin_subquery.feature
+++ b/python/pysail/tests/spark/function/features/isin_subquery.feature
@@ -1,4 +1,3 @@
-@isin_subquery
 Feature: IN subquery support
 
   Rule: Single-column IN subquery

--- a/python/pysail/tests/spark/function/features/json/from_json.feature
+++ b/python/pysail/tests/spark/function/features/json/from_json.feature
@@ -1,4 +1,3 @@
-@from_json
 Feature: from_json function parses JSON strings into structured types
 
   Rule: Basic struct parsing
@@ -886,7 +885,7 @@ Feature: from_json function parses JSON strings into structured types
         | Parseable JSON number as array target returns null                      | '42', 'ARRAY<INT>'      | NULL   |
         | Parseable JSON number as map target returns null                        | '42', 'MAP<STRING,INT>' | NULL   |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null json literal yields a struct

--- a/python/pysail/tests/spark/function/features/json/get_json_object.feature
+++ b/python/pysail/tests/spark/function/features/json/get_json_object.feature
@@ -1,4 +1,3 @@
-@get_json_object
 Feature: get_json_object extracts values via a Spark JSONPath
 
   # Spark `get_json_object(json, path)` walks a JSONPath subset: a leading `$`,
@@ -118,7 +117,7 @@ Feature: get_json_object extracts values via a Spark JSONPath
 
   Rule: get_json_object — the argument is resolved per row, not taken from the first row
 
-    @column_args
+    @function(columnargs)
     Scenario: get_json_object with the argument as a literal
       When query
         """
@@ -129,7 +128,7 @@ Feature: get_json_object extracts values via a Spark JSONPath
         | b      |
 
     # Sail returns the wrong value on the column path: Sail returns NULL for every row.
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario Outline: Get_json_object: <case>
       When query
         """
@@ -146,7 +145,7 @@ Feature: get_json_object extracts values via a Spark JSONPath
         | get_json_object takes argument 2 from a column containing NULL              | NULL     | NULL |
         | get_json_object takes argument 2 from a column                              | '$[0].a' | b    |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null json literal yields a string

--- a/python/pysail/tests/spark/function/features/json/json_array_length.feature
+++ b/python/pysail/tests/spark/function/features/json/json_array_length.feature
@@ -1,7 +1,6 @@
-@json_array_length
 Feature: json_array_length output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to json_array_length yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/json/json_object_keys.feature
+++ b/python/pysail/tests/spark/function/features/json/json_object_keys.feature
@@ -1,7 +1,6 @@
-@json_object_keys
 Feature: json_object_keys output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to json_object_keys yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/json/json_tuple.feature
+++ b/python/pysail/tests/spark/function/features/json/json_tuple.feature
@@ -1,4 +1,3 @@
-@json_tuple
 Feature: json_tuple with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: json_tuple with an argument coming from a column
 
   Rule: json_tuple — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: json_tuple with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: json_tuple with an argument coming from a column
         | 1  | 2  |
 
     # Sail rejects the column: Sail errors: invalid argument: json_tuple field names must be string literals
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario Outline: Json_tuple: <case>
       When query
         """
@@ -35,7 +34,7 @@ Feature: json_tuple with an argument coming from a column
         | json_tuple takes argument 3 from a column containing NULL | 'a' | c   | 'b' | NULL | 1    | NULL |
         | json_tuple takes argument 3 from a column                 | 'a' | c   | 'b' | 'b'  | 1    | 2    |
 
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: json_tuple takes argument 2 from a column holding two different values
       When query
         """

--- a/python/pysail/tests/spark/function/features/json/schema_of_json.feature
+++ b/python/pysail/tests/spark/function/features/json/schema_of_json.feature
@@ -1,4 +1,3 @@
-@schema_of_json
 Feature: schema_of_json() returns the schema of a JSON string as DDL
 
   Rule: Argument count validation
@@ -790,7 +789,7 @@ Feature: schema_of_json() returns the schema of a JSON string as DDL
         | result            |
         | STRUCT<a: BIGINT> |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to schema_of_json yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/json/to_json.feature
+++ b/python/pysail/tests/spark/function/features/json/to_json.feature
@@ -1,7 +1,6 @@
-@to_json
 Feature: to_json output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to to_json yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/map/map.feature
+++ b/python/pysail/tests/spark/function/features/map/map.feature
@@ -1,7 +1,6 @@
-@map
 Feature: map output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/map/map_concat.feature
+++ b/python/pysail/tests/spark/function/features/map/map_concat.feature
@@ -1,7 +1,6 @@
-@map_concat
 Feature: map_concat output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/map/map_contains_key.feature
+++ b/python/pysail/tests/spark/function/features/map/map_contains_key.feature
@@ -1,7 +1,6 @@
-@map_contains_key
 Feature: map_contains_key output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to map_contains_key yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/map/map_entries.feature
+++ b/python/pysail/tests/spark/function/features/map/map_entries.feature
@@ -1,4 +1,3 @@
-@map_entries
 Feature: map_entries function
 
   Rule: Basic usage
@@ -14,7 +13,7 @@ Feature: map_entries function
         | result           | type                                |
         | [{1, a}, {2, b}] | array<struct<key:int,value:string>> |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/map/map_from_arrays.feature
+++ b/python/pysail/tests/spark/function/features/map/map_from_arrays.feature
@@ -1,7 +1,6 @@
-@map_from_arrays
 Feature: map_from_arrays output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to map_from_arrays yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/map/map_from_entries.feature
+++ b/python/pysail/tests/spark/function/features/map/map_from_entries.feature
@@ -1,7 +1,6 @@
-@map_from_entries
 Feature: map_from_entries output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to map_from_entries yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/map/map_keys.feature
+++ b/python/pysail/tests/spark/function/features/map/map_keys.feature
@@ -1,7 +1,6 @@
-@map_keys
 Feature: map_keys output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/map/map_values.feature
+++ b/python/pysail/tests/spark/function/features/map/map_values.feature
@@ -1,7 +1,6 @@
-@map_values
 Feature: map_values output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/map/str_to_map.feature
+++ b/python/pysail/tests/spark/function/features/map/str_to_map.feature
@@ -1,7 +1,6 @@
-@str_to_map
 Feature: str_to_map output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/math/abs.feature
+++ b/python/pysail/tests/spark/function/features/math/abs.feature
@@ -1,4 +1,3 @@
-@abs
 Feature: abs comprehensive tests
 
   Rule: Argument count validation
@@ -606,7 +605,7 @@ Feature: abs comprehensive tests
       Then query error .*\[ARITHMETIC_OVERFLOW\].*
         | 5 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/math/acos.feature
+++ b/python/pysail/tests/spark/function/features/math/acos.feature
@@ -1,7 +1,6 @@
-@acos
 Feature: acos output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario Outline: acos output schema matches Spark (nullable double)

--- a/python/pysail/tests/spark/function/features/math/acosh.feature
+++ b/python/pysail/tests/spark/function/features/math/acosh.feature
@@ -1,7 +1,6 @@
-@acosh
 Feature: acosh output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to acosh yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/asin.feature
+++ b/python/pysail/tests/spark/function/features/math/asin.feature
@@ -1,7 +1,6 @@
-@asin
 Feature: asin output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to asin yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/asinh.feature
+++ b/python/pysail/tests/spark/function/features/math/asinh.feature
@@ -1,7 +1,6 @@
-@asinh
 Feature: asinh output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to asinh yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/atan.feature
+++ b/python/pysail/tests/spark/function/features/math/atan.feature
@@ -1,7 +1,6 @@
-@atan
 Feature: atan output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to atan yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/atan2.feature
+++ b/python/pysail/tests/spark/function/features/math/atan2.feature
@@ -1,7 +1,6 @@
-@atan2
 Feature: atan2 output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/math/atanh.feature
+++ b/python/pysail/tests/spark/function/features/math/atanh.feature
@@ -1,7 +1,6 @@
-@atanh
 Feature: atanh output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to atanh yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/bin.feature
+++ b/python/pysail/tests/spark/function/features/math/bin.feature
@@ -1,4 +1,3 @@
-@bin
 Feature: bin converts integral values to binary strings
 
   Rule: String arguments follow Spark cast semantics
@@ -196,7 +195,7 @@ Feature: bin converts integral values to binary strings
         | bin Infinity saturates to LONG_MAX under ANSI off            | CAST('Infinity' AS DOUBLE) | 111111111111111111111111111111111111111111111111111111111111111 |
         | bin out-of-range DOUBLE saturates to LONG_MAX under ANSI off | CAST(1e30 AS DOUBLE)       | 111111111111111111111111111111111111111111111111111111111111111 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/math/bround.feature
+++ b/python/pysail/tests/spark/function/features/math/bround.feature
@@ -1,4 +1,3 @@
-@bround
 Feature: bround comprehensive tests
   # bround = banker's rounding (round-half-to-even). The scenarios below use
   # explicit CAST to DOUBLE/FLOAT/INT/BIGINT so they exercise the vectorized
@@ -249,7 +248,7 @@ Feature: bround comprehensive tests
 
   Rule: bround — the argument must be foldable
 
-    @column_args
+    @function(columnargs)
     Scenario: bround with the argument as a literal
       When query
         """
@@ -261,7 +260,7 @@ Feature: bround comprehensive tests
 
     # Spark requires a foldable argument here; Sail accepts a column and returns
     # a value per row instead of raising.
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario Outline: Bround: <case>
       When query
         """
@@ -274,7 +273,7 @@ Feature: bround comprehensive tests
         | bround takes argument 2 from a column holding two different values | 0  |
         | bround takes argument 2 from a column                              | -1 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/math/cbrt.feature
+++ b/python/pysail/tests/spark/function/features/math/cbrt.feature
@@ -1,7 +1,6 @@
-@cbrt
 Feature: cbrt output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to cbrt yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/ceil.feature
+++ b/python/pysail/tests/spark/function/features/math/ceil.feature
@@ -1,7 +1,6 @@
-@ceil
 Feature: ceil output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to ceil yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/ceil_floor.feature
+++ b/python/pysail/tests/spark/function/features/math/ceil_floor.feature
@@ -1,4 +1,3 @@
-@ceil @floor
 Feature: ceil() and floor() round numbers toward +/- infinity
 
   Rule: ceil basic

--- a/python/pysail/tests/spark/function/features/math/ceil_floor_preimage.feature
+++ b/python/pysail/tests/spark/function/features/math/ceil_floor_preimage.feature
@@ -1,4 +1,3 @@
-@ceil_floor_preimage
 Feature: ceil() / floor() — preimage hook (filter pushdown)
 
   # SparkFloor implements `fn preimage`: `floor(x) = N` ⟺ `x ∈ [N, N+1)`.

--- a/python/pysail/tests/spark/function/features/math/ceil_floor_simplify.feature
+++ b/python/pysail/tests/spark/function/features/math/ceil_floor_simplify.feature
@@ -1,4 +1,3 @@
-@ceil_floor_simplify
 Feature: ceil() / floor() — simplify hook (integer identity + idempotence)
 
   # SparkCeil and SparkFloor implement `fn simplify`:

--- a/python/pysail/tests/spark/function/features/math/ceiling.feature
+++ b/python/pysail/tests/spark/function/features/math/ceiling.feature
@@ -1,7 +1,6 @@
-@ceiling
 Feature: ceiling output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to ceiling yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/conv.feature
+++ b/python/pysail/tests/spark/function/features/math/conv.feature
@@ -1,4 +1,3 @@
-@conv
 Feature: conv with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: conv with an argument coming from a column
 
   Rule: conv — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: conv with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: conv with an argument coming from a column
         | 4      |
 
     # Sail rejects the column: Sail errors: Unsupported Data Type: Spark `spark_conv` function expects (Utf8 | Utf8View | LargeUtf8 |...
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: conv takes argument 2 from a column holding two different values
       When query
         """
@@ -29,7 +28,7 @@ Feature: conv with an argument coming from a column
         | 256    |
 
     # Sail rejects the column: Sail errors: Unsupported Data Type: Spark `spark_conv` function expects (Utf8 | Utf8View | LargeUtf8 |...
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: conv takes argument 2 from a column
       When query
         """
@@ -41,7 +40,7 @@ Feature: conv with an argument coming from a column
         | 4      |
 
     # Sail rejects the column: Sail errors: Unsupported Data Type: Spark `spark_conv` function expects (Utf8 | Utf8View | LargeUtf8 |...
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: conv takes argument 3 from a column
       When query
         """
@@ -52,7 +51,7 @@ Feature: conv with an argument coming from a column
         | 4      |
         | 4      |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null string literal is nullable (conv is inherently nullable in Spark)

--- a/python/pysail/tests/spark/function/features/math/cos.feature
+++ b/python/pysail/tests/spark/function/features/math/cos.feature
@@ -1,7 +1,6 @@
-@cos
 Feature: cos output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to cos yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/cosh.feature
+++ b/python/pysail/tests/spark/function/features/math/cosh.feature
@@ -1,7 +1,6 @@
-@cosh
 Feature: cosh output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to cosh yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/cot.feature
+++ b/python/pysail/tests/spark/function/features/math/cot.feature
@@ -1,7 +1,6 @@
-@cot
 Feature: cot output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to cot yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/csc.feature
+++ b/python/pysail/tests/spark/function/features/math/csc.feature
@@ -1,7 +1,6 @@
-@csc
 Feature: csc output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to csc yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/degrees.feature
+++ b/python/pysail/tests/spark/function/features/math/degrees.feature
@@ -1,7 +1,6 @@
-@degrees
 Feature: degrees output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to degrees yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/div.feature
+++ b/python/pysail/tests/spark/function/features/math/div.feature
@@ -1,7 +1,6 @@
-@div
 Feature: div output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to div yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/exp.feature
+++ b/python/pysail/tests/spark/function/features/math/exp.feature
@@ -1,7 +1,6 @@
-@exp
 Feature: exp output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to exp yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/expm1.feature
+++ b/python/pysail/tests/spark/function/features/math/expm1.feature
@@ -1,7 +1,6 @@
-@expm1
 Feature: expm1 output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to expm1 yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/factorial.feature
+++ b/python/pysail/tests/spark/function/features/math/factorial.feature
@@ -1,7 +1,6 @@
-@factorial
 Feature: factorial output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to factorial yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/floor.feature
+++ b/python/pysail/tests/spark/function/features/math/floor.feature
@@ -1,7 +1,6 @@
-@floor
 Feature: floor output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to floor yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/greatest.feature
+++ b/python/pysail/tests/spark/function/features/math/greatest.feature
@@ -1,7 +1,6 @@
-@greatest
 Feature: greatest output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/math/hex.feature
+++ b/python/pysail/tests/spark/function/features/math/hex.feature
@@ -1,7 +1,6 @@
-@hex
 Feature: hex output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/math/hypot.feature
+++ b/python/pysail/tests/spark/function/features/math/hypot.feature
@@ -1,7 +1,6 @@
-@hypot
 Feature: hypot output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/math/least.feature
+++ b/python/pysail/tests/spark/function/features/math/least.feature
@@ -1,7 +1,6 @@
-@least
 Feature: least output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/math/ln.feature
+++ b/python/pysail/tests/spark/function/features/math/ln.feature
@@ -1,7 +1,6 @@
-@ln
 Feature: ln output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to ln yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/log.feature
+++ b/python/pysail/tests/spark/function/features/math/log.feature
@@ -1,7 +1,6 @@
-@log
 Feature: log output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to log yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/log10.feature
+++ b/python/pysail/tests/spark/function/features/math/log10.feature
@@ -1,7 +1,6 @@
-@log10
 Feature: log10 output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to log10 yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/log1p.feature
+++ b/python/pysail/tests/spark/function/features/math/log1p.feature
@@ -1,7 +1,6 @@
-@log1p
 Feature: log1p output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to log1p yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/log2.feature
+++ b/python/pysail/tests/spark/function/features/math/log2.feature
@@ -1,7 +1,6 @@
-@log2
 Feature: log2 output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to log2 yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/mod.feature
+++ b/python/pysail/tests/spark/function/features/math/mod.feature
@@ -1,7 +1,6 @@
-@mod
 Feature: mod output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to mod yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/negative.feature
+++ b/python/pysail/tests/spark/function/features/math/negative.feature
@@ -1,4 +1,3 @@
-@negative
 Feature: unary minus (negative) honors ANSI overflow semantics
 
   Rule: Negating the minimum integral value overflows
@@ -176,7 +175,7 @@ Feature: unary minus (negative) honors ANSI overflow semantics
         | negate the maximum DECIMAL(38,0) errors under ANSI on       | true  |
         | negate the maximum DECIMAL(38,0) also errors under ANSI off | false |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null integer literal yields a non-nullable integer

--- a/python/pysail/tests/spark/function/features/math/pmod.feature
+++ b/python/pysail/tests/spark/function/features/math/pmod.feature
@@ -1,4 +1,3 @@
-@pmod
 Feature: pmod (positive modulo) honors ANSI mode and Spark semantics
 
   # Spark `pmod(a, b)` returns the positive remainder of `a / b` (always in
@@ -119,7 +118,7 @@ Feature: pmod (positive modulo) honors ANSI mode and Spark semantics
         | double pmod decimal returns a double                  | CAST(5.5 AS DOUBLE), 2.0        | 1.5    |
         | infinity double pmod decimal returns NaN not an error | CAST('Infinity' AS DOUBLE), 2.0 | NaN    |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null integer literal is nullable (inherently nullable in Spark)

--- a/python/pysail/tests/spark/function/features/math/positive.feature
+++ b/python/pysail/tests/spark/function/features/math/positive.feature
@@ -1,7 +1,6 @@
-@positive
 Feature: positive output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to positive yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/pow.feature
+++ b/python/pysail/tests/spark/function/features/math/pow.feature
@@ -1,7 +1,6 @@
-@pow
 Feature: pow output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/math/power.feature
+++ b/python/pysail/tests/spark/function/features/math/power.feature
@@ -1,7 +1,6 @@
-@power
 Feature: power output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/math/radians.feature
+++ b/python/pysail/tests/spark/function/features/math/radians.feature
@@ -1,7 +1,6 @@
-@radians
 Feature: radians output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to radians yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/rint.feature
+++ b/python/pysail/tests/spark/function/features/math/rint.feature
@@ -1,7 +1,6 @@
-@rint
 Feature: rint output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/math/round.feature
+++ b/python/pysail/tests/spark/function/features/math/round.feature
@@ -1,4 +1,3 @@
-@round
 Feature: round with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: round with an argument coming from a column
 
   Rule: round — the argument must be foldable
 
-    @column_args
+    @function(columnargs)
     Scenario: round with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: round with an argument coming from a column
         | 3      |
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', 'NULL'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: round takes argument 2 from a column containing NULL
       When query
         """
@@ -26,7 +25,7 @@ Feature: round with an argument coming from a column
       Then query error NON_FOLDABLE_INPUT
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', '3.0'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: round takes argument 2 from a column
       When query
         """
@@ -34,7 +33,7 @@ Feature: round with an argument coming from a column
         """
       Then query error NON_FOLDABLE_INPUT
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/math/sec.feature
+++ b/python/pysail/tests/spark/function/features/math/sec.feature
@@ -1,7 +1,6 @@
-@sec
 Feature: sec output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to sec yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/sign.feature
+++ b/python/pysail/tests/spark/function/features/math/sign.feature
@@ -1,7 +1,6 @@
-@sign
 Feature: sign output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to sign yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/signum.feature
+++ b/python/pysail/tests/spark/function/features/math/signum.feature
@@ -1,7 +1,6 @@
-@signum
 Feature: signum output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to signum yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/sin.feature
+++ b/python/pysail/tests/spark/function/features/math/sin.feature
@@ -1,7 +1,6 @@
-@sin
 Feature: sin output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to sin yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/sinh.feature
+++ b/python/pysail/tests/spark/function/features/math/sinh.feature
@@ -1,7 +1,6 @@
-@sinh
 Feature: sinh output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to sinh yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/sqrt.feature
+++ b/python/pysail/tests/spark/function/features/math/sqrt.feature
@@ -1,7 +1,6 @@
-@sqrt
 Feature: sqrt output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to sqrt yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/tan.feature
+++ b/python/pysail/tests/spark/function/features/math/tan.feature
@@ -1,7 +1,6 @@
-@tan
 Feature: tan output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to tan yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/tanh.feature
+++ b/python/pysail/tests/spark/function/features/math/tanh.feature
@@ -1,7 +1,6 @@
-@tanh
 Feature: tanh output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to tanh yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/try_add.feature
+++ b/python/pysail/tests/spark/function/features/math/try_add.feature
@@ -1,7 +1,6 @@
-@try_add
 Feature: try_add output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to try_add yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/try_divide.feature
+++ b/python/pysail/tests/spark/function/features/math/try_divide.feature
@@ -1,7 +1,6 @@
-@try_divide
 Feature: try_divide output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to try_divide yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/try_mod.feature
+++ b/python/pysail/tests/spark/function/features/math/try_mod.feature
@@ -1,7 +1,6 @@
-@try_mod
 Feature: try_mod output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to try_mod yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/try_multiply.feature
+++ b/python/pysail/tests/spark/function/features/math/try_multiply.feature
@@ -1,7 +1,6 @@
-@try_multiply
 Feature: try_multiply output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to try_multiply yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/try_subtract.feature
+++ b/python/pysail/tests/spark/function/features/math/try_subtract.feature
@@ -1,7 +1,6 @@
-@try_subtract
 Feature: try_subtract output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to try_subtract yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/unhex.feature
+++ b/python/pysail/tests/spark/function/features/math/unhex.feature
@@ -1,7 +1,6 @@
-@unhex
 Feature: unhex output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to unhex yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/math/uniform.feature
+++ b/python/pysail/tests/spark/function/features/math/uniform.feature
@@ -1,4 +1,3 @@
-@uniform
 Feature: uniform() generates random numbers within a range
 
   # IMPLEMENTATION NOTE:

--- a/python/pysail/tests/spark/function/features/math/width_bucket.feature
+++ b/python/pysail/tests/spark/function/features/math/width_bucket.feature
@@ -1,7 +1,6 @@
-@width_bucket
 Feature: width_bucket output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to width_bucket yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/misc/aes_decrypt.feature
+++ b/python/pysail/tests/spark/function/features/misc/aes_decrypt.feature
@@ -1,4 +1,3 @@
-@aes_decrypt
 Feature: aes_decrypt with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: aes_decrypt with an argument coming from a column
 
   Rule: aes_decrypt — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: aes_decrypt with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: aes_decrypt with an argument coming from a column
         | 41706163686520537061726B |
 
     # Sail rejects the column: Sail errors: Spark `aes_decrypt`: Key requires a single value, got StringArray [ "1234567890abcdef", "1...
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: aes_decrypt takes argument 2 from a column
       When query
         """
@@ -29,7 +28,7 @@ Feature: aes_decrypt with an argument coming from a column
         | 41706163686520537061726B |
 
     # Sail rejects the column: Sail errors: Spark `aes_decrypt`: Mode requires a single value, got StringArray [ "CBC", "CBC", ]
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: aes_decrypt takes argument 3 from a column
       When query
         """
@@ -41,7 +40,7 @@ Feature: aes_decrypt with an argument coming from a column
         | 41706163686520537061726B |
 
     # Sail rejects the column: Sail errors: Spark `aes_decrypt`: AAD requires a single value, got StringArray [ "This is an AAD mixed...
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: aes_decrypt takes argument 5 from a column
       When query
         """
@@ -52,7 +51,7 @@ Feature: aes_decrypt with an argument coming from a column
         | 537061726B |
         | 537061726B |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal yields binary

--- a/python/pysail/tests/spark/function/features/misc/aes_encrypt.feature
+++ b/python/pysail/tests/spark/function/features/misc/aes_encrypt.feature
@@ -1,4 +1,3 @@
-@aes_encrypt
 Feature: aes_encrypt with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: aes_encrypt with an argument coming from a column
 
   Rule: aes_encrypt — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: aes_encrypt with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: aes_encrypt with an argument coming from a column
         | AAAAAAAAAAAAAAAAAAAAAPSd4mWyMZ5mhvjiAPQJnfg= |
 
     # Sail rejects the column: Sail errors: Spark `aes_encrypt`: Expr requires a single value, got StringArray [ "Spark", "Spark SQL",...
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: aes_encrypt takes argument 1 from a column holding two different values
       When query
         """
@@ -29,7 +28,7 @@ Feature: aes_encrypt with an argument coming from a column
         | AAAAAAAAAAAAAAAAAAAAAFfH3r/2mb/RDzBWeYjUD7c= |
 
     # Sail rejects the column: Sail errors: Spark `aes_encrypt`: Expr requires a single value, got StringArray [ "Spark", "Spark", ]
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: aes_encrypt takes argument 1 from a column
       When query
         """
@@ -41,7 +40,7 @@ Feature: aes_encrypt with an argument coming from a column
         | AAAAAAAAAAAAAAAAAAAAAPSd4mWyMZ5mhvjiAPQJnfg= |
 
     # Sail rejects the column: Sail errors: Spark `aes_encrypt`: Key requires a single value, got StringArray [ "abcdefghijklmnop12345...
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: aes_encrypt takes argument 2 from a column holding two different values
       When query
         """
@@ -53,7 +52,7 @@ Feature: aes_encrypt with an argument coming from a column
         | AAAAAAAAAAAAAAAAAAAAADSP83694Ft4gLozkGj72l4= |
 
     # Sail rejects the column: Sail errors: Spark `aes_encrypt`: Key requires a single value, got StringArray [ "abcdefghijklmnop12345...
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: aes_encrypt takes argument 2 from a column
       When query
         """
@@ -65,7 +64,7 @@ Feature: aes_encrypt with an argument coming from a column
         | AAAAAAAAAAAAAAAAAAAAAPSd4mWyMZ5mhvjiAPQJnfg= |
 
     # Sail rejects the column: Sail errors: Spark `aes_encrypt`: Mode requires a single value, got StringArray [ "CBC", "CBC", ]
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: aes_encrypt takes argument 3 from a column
       When query
         """
@@ -77,7 +76,7 @@ Feature: aes_encrypt with an argument coming from a column
         | AAAAAAAAAAAAAAAAAAAAAPSd4mWyMZ5mhvjiAPQJnfg= |
 
     # Sail rejects the column: Sail errors: Spark `aes_encrypt`: AAD requires a single value, got StringArray [ "This is an AAD mixed...
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: aes_encrypt takes argument 6 from a column
       When query
         """
@@ -88,7 +87,7 @@ Feature: aes_encrypt with an argument coming from a column
         | AAAAAAAAAAAAAAAAQiYi+sTLm7KD9UcZ2nlRdYDe/PX4 |
         | AAAAAAAAAAAAAAAAQiYi+sTLm7KD9UcZ2nlRdYDe/PX4 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal yields binary

--- a/python/pysail/tests/spark/function/features/misc/assert_true.feature
+++ b/python/pysail/tests/spark/function/features/misc/assert_true.feature
@@ -1,7 +1,6 @@
-@assert_true
 Feature: assert_true output schema
 
-  @spark_null @spark-4
+  @function(nullability) @spark-4
   Rule: Output schema
 
     Scenario: a non-null literal input to assert_true yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/misc/bitmap_bit_position.feature
+++ b/python/pysail/tests/spark/function/features/misc/bitmap_bit_position.feature
@@ -1,7 +1,6 @@
-@bitmap_bit_position
 Feature: bitmap_bit_position output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/misc/bitmap_bucket_number.feature
+++ b/python/pysail/tests/spark/function/features/misc/bitmap_bucket_number.feature
@@ -1,7 +1,6 @@
-@bitmap_bucket_number
 Feature: bitmap_bucket_number output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/misc/bitmap_count.feature
+++ b/python/pysail/tests/spark/function/features/misc/bitmap_count.feature
@@ -1,7 +1,6 @@
-@bitmap_count
 Feature: bitmap_count output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to bitmap_count yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/misc/current_catalog.feature
+++ b/python/pysail/tests/spark/function/features/misc/current_catalog.feature
@@ -1,7 +1,6 @@
-@current_catalog
 Feature: current_catalog output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to current_catalog yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/misc/current_database.feature
+++ b/python/pysail/tests/spark/function/features/misc/current_database.feature
@@ -1,7 +1,6 @@
-@current_database
 Feature: current_database output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to current_database yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/misc/current_schema.feature
+++ b/python/pysail/tests/spark/function/features/misc/current_schema.feature
@@ -1,7 +1,6 @@
-@current_schema
 Feature: current_schema output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to current_schema yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/misc/current_user.feature
+++ b/python/pysail/tests/spark/function/features/misc/current_user.feature
@@ -1,7 +1,6 @@
-@current_user
 Feature: current_user output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to current_user yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/misc/datasketches.feature
+++ b/python/pysail/tests/spark/function/features/misc/datasketches.feature
@@ -1,4 +1,4 @@
-@datasketches
+@function(sketch)
 Feature: DataSketches functions
 
   Rule: HLL sketch functions estimate distinct values

--- a/python/pysail/tests/spark/function/features/misc/raise_error.feature
+++ b/python/pysail/tests/spark/function/features/misc/raise_error.feature
@@ -1,7 +1,6 @@
-@raise_error
 Feature: raise_error output schema
 
-  @spark_null @spark-4
+  @function(nullability) @spark-4
   Rule: Output schema
 
     Scenario: a non-null literal input to raise_error yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/misc/session_user.feature
+++ b/python/pysail/tests/spark/function/features/misc/session_user.feature
@@ -1,7 +1,6 @@
-@session_user
 Feature: session_user output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to session_user yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/misc/spark_partition_id.feature
+++ b/python/pysail/tests/spark/function/features/misc/spark_partition_id.feature
@@ -1,7 +1,6 @@
-@spark_partition_id
 Feature: spark_partition_id output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to spark_partition_id yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/misc/theta_sketch.feature
+++ b/python/pysail/tests/spark/function/features/misc/theta_sketch.feature
@@ -1,4 +1,4 @@
-@datasketches
+@function(sketch)
 Feature: Theta sketch functions
 
   Rule: theta_sketch_agg builds compact theta sketches

--- a/python/pysail/tests/spark/function/features/misc/try_aes_decrypt.feature
+++ b/python/pysail/tests/spark/function/features/misc/try_aes_decrypt.feature
@@ -1,4 +1,3 @@
-@try_aes_decrypt
 Feature: try_aes_decrypt with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: try_aes_decrypt with an argument coming from a column
 
   Rule: try_aes_decrypt — the argument is resolved per row, not taken from the first row
 
-    @column_args
+    @function(columnargs)
     Scenario: try_aes_decrypt with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: try_aes_decrypt with an argument coming from a column
         | 537061726B2053514C |
 
     # Sail returns the wrong value on the column path: Sail returns NULL for every row.
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario Outline: Try_aes_decrypt: <case>
       When query
         """
@@ -35,7 +34,7 @@ Feature: try_aes_decrypt with an argument coming from a column
         | try_aes_decrypt takes argument 3 from a column containing NULL | '0000111122223333', c | 'GCM'              | NULL               | NULL               |
         | try_aes_decrypt takes argument 3 from a column                 | '0000111122223333', c | 'GCM'              | 'GCM'              | 537061726B2053514C |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to try_aes_decrypt yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/misc/typeof.feature
+++ b/python/pysail/tests/spark/function/features/misc/typeof.feature
@@ -1,7 +1,6 @@
-@typeof
 Feature: typeof output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to typeof yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/misc/user.feature
+++ b/python/pysail/tests/spark/function/features/misc/user.feature
@@ -1,7 +1,6 @@
-@user
 Feature: user output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to user yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/misc/uuid.feature
+++ b/python/pysail/tests/spark/function/features/misc/uuid.feature
@@ -1,7 +1,6 @@
-@uuid
 Feature: uuid output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/misc/version.feature
+++ b/python/pysail/tests/spark/function/features/misc/version.feature
@@ -1,7 +1,6 @@
-@version
 Feature: version output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/null_literal_inference.feature
+++ b/python/pysail/tests/spark/function/features/null_literal_inference.feature
@@ -1,4 +1,3 @@
-@null_literal_inference
 Feature: NULL literal and timestamp inference
 
   Rule: untyped NULL literals

--- a/python/pysail/tests/spark/function/features/pivot.feature
+++ b/python/pysail/tests/spark/function/features/pivot.feature
@@ -1,4 +1,3 @@
-@pivot
 Feature: PIVOT rotates rows into columns
 
   Pivot groups by the remaining (or explicitly grouped) columns and produces one

--- a/python/pysail/tests/spark/function/features/predicate/equal_null.feature
+++ b/python/pysail/tests/spark/function/features/predicate/equal_null.feature
@@ -1,7 +1,6 @@
-@equal_null
 Feature: equal_null output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to equal_null yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/predicate/ilike.feature
+++ b/python/pysail/tests/spark/function/features/predicate/ilike.feature
@@ -1,7 +1,6 @@
-@ilike
 Feature: ilike output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to ilike yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/predicate/in.feature
+++ b/python/pysail/tests/spark/function/features/predicate/in.feature
@@ -1,7 +1,6 @@
-@predicate_in
 Feature: in output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to in yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/predicate/isnan.feature
+++ b/python/pysail/tests/spark/function/features/predicate/isnan.feature
@@ -1,7 +1,6 @@
-@isnan
 Feature: isnan output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/predicate/isnull.feature
+++ b/python/pysail/tests/spark/function/features/predicate/isnull.feature
@@ -1,7 +1,6 @@
-@isnull
 Feature: isnull output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to isnull yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/predicate/like.feature
+++ b/python/pysail/tests/spark/function/features/predicate/like.feature
@@ -1,7 +1,6 @@
-@like
 Feature: like output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to like yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/predicate/regexp.feature
+++ b/python/pysail/tests/spark/function/features/predicate/regexp.feature
@@ -1,7 +1,6 @@
-@regexp
 Feature: regexp output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to regexp yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/predicate/regexp_like.feature
+++ b/python/pysail/tests/spark/function/features/predicate/regexp_like.feature
@@ -1,7 +1,6 @@
-@regexp_like
 Feature: regexp_like output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to regexp_like yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/predicate/rlike.feature
+++ b/python/pysail/tests/spark/function/features/predicate/rlike.feature
@@ -1,7 +1,6 @@
-@rlike
 Feature: rlike output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to rlike yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/sample.feature
+++ b/python/pysail/tests/spark/function/features/sample.feature
@@ -1,4 +1,3 @@
-@sample
 Feature: DataFrame sample operations
 
   Rule: Sample without replacement

--- a/python/pysail/tests/spark/function/features/semi_join.feature
+++ b/python/pysail/tests/spark/function/features/semi_join.feature
@@ -1,4 +1,3 @@
-@semi_join
 Feature: Semi join support
 
   Rule: LEFT SEMI JOIN with ON condition

--- a/python/pysail/tests/spark/function/features/set_operations.feature
+++ b/python/pysail/tests/spark/function/features/set_operations.feature
@@ -1,4 +1,3 @@
-@set_operations
 Feature: Set operations (INTERSECT, EXCEPT)
 
   Rule: INTERSECT DISTINCT

--- a/python/pysail/tests/spark/function/features/string/ascii.feature
+++ b/python/pysail/tests/spark/function/features/string/ascii.feature
@@ -1,7 +1,6 @@
-@ascii
 Feature: ascii output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/base64.feature
+++ b/python/pysail/tests/spark/function/features/string/base64.feature
@@ -1,4 +1,3 @@
-@base64
 Feature: base64 functions encode and decode binary strings
 
   Rule: Null propagation
@@ -104,7 +103,7 @@ Feature: base64 functions encode and decode binary strings
         | [62 61 72] |
         | [66 6F 6F] |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/bit_length.feature
+++ b/python/pysail/tests/spark/function/features/string/bit_length.feature
@@ -1,7 +1,6 @@
-@bit_length
 Feature: bit_length output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to bit_length yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/btrim.feature
+++ b/python/pysail/tests/spark/function/features/string/btrim.feature
@@ -1,7 +1,6 @@
-@btrim
 Feature: btrim output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/char.feature
+++ b/python/pysail/tests/spark/function/features/string/char.feature
@@ -1,7 +1,6 @@
-@char
 Feature: char output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/char_length.feature
+++ b/python/pysail/tests/spark/function/features/string/char_length.feature
@@ -1,7 +1,6 @@
-@char_length
 Feature: char_length output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to char_length yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/character_length.feature
+++ b/python/pysail/tests/spark/function/features/string/character_length.feature
@@ -1,7 +1,6 @@
-@character_length
 Feature: character_length output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to character_length yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/chr.feature
+++ b/python/pysail/tests/spark/function/features/string/chr.feature
@@ -1,7 +1,6 @@
-@chr
 Feature: chr output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/concat_simplify.feature
+++ b/python/pysail/tests/spark/function/features/string/concat_simplify.feature
@@ -1,4 +1,3 @@
-@concat_simplify
 Feature: concat() — simplify hook (single-argument identity)
 
   Rule: String, array, and binary inputs — identity, no coercion needed

--- a/python/pysail/tests/spark/function/features/string/concat_ws.feature
+++ b/python/pysail/tests/spark/function/features/string/concat_ws.feature
@@ -1,4 +1,3 @@
-@concat_ws
 Feature: concat_ws function
 
   Rule: concat_ws with scalar arguments
@@ -139,7 +138,7 @@ Feature: concat_ws function
         | result   |
         | a,b\|c,d |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null separator yields a non-nullable string

--- a/python/pysail/tests/spark/function/features/string/concat_ws_simplify.feature
+++ b/python/pysail/tests/spark/function/features/string/concat_ws_simplify.feature
@@ -1,4 +1,3 @@
-@concat_ws_simplify
 Feature: concat_ws() — simplify hook (null folding and null-arg pruning)
 
   Rule: A null separator literal folds the whole call to null

--- a/python/pysail/tests/spark/function/features/string/contains.feature
+++ b/python/pysail/tests/spark/function/features/string/contains.feature
@@ -1,7 +1,6 @@
-@contains
 Feature: contains output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/decode.feature
+++ b/python/pysail/tests/spark/function/features/string/decode.feature
@@ -1,4 +1,3 @@
-@decode
 Feature: decode with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: decode with an argument coming from a column
 
   Rule: decode — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: decode with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: decode with an argument coming from a column
         | abc    |
 
     # Sail rejects the column: Sail errors: Unsupported args [Scalar(Binary("97,98,99")), Array(StringArray [ "utf-8", null, ])] for S...
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: decode takes argument 2 from a column containing NULL
       When query
         """
@@ -29,7 +28,7 @@ Feature: decode with an argument coming from a column
         | NULL   |
 
     # Sail rejects the column: Sail errors: Unsupported args [Scalar(Binary("97,98,99")), Array(StringArray [ "utf-8", "utf-8", ])] fo...
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: decode takes argument 2 from a column
       When query
         """
@@ -40,7 +39,7 @@ Feature: decode with an argument coming from a column
         | abc    |
         | abc    |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null binary literal is nullable (decode is inherently nullable in Spark)

--- a/python/pysail/tests/spark/function/features/string/elt.feature
+++ b/python/pysail/tests/spark/function/features/string/elt.feature
@@ -1,7 +1,6 @@
-@elt
 Feature: elt output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to elt yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/encode.feature
+++ b/python/pysail/tests/spark/function/features/string/encode.feature
@@ -1,4 +1,3 @@
-@encode
 Feature: encode with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: encode with an argument coming from a column
 
   Rule: encode — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: encode with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: encode with an argument coming from a column
         | 616263 |
 
     # Sail rejects the column: Sail errors: Unsupported args [Scalar(Utf8("abc")), Array(StringArray [ "utf-8", null, ])] for Spark fu...
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: encode takes argument 2 from a column containing NULL
       When query
         """
@@ -29,7 +28,7 @@ Feature: encode with an argument coming from a column
         | NULL   |
 
     # Sail rejects the column: Sail errors: Unsupported args [Scalar(Utf8("abc")), Array(StringArray [ "utf-8", "utf-8", ])] for Spark...
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: encode takes argument 2 from a column
       When query
         """
@@ -40,7 +39,7 @@ Feature: encode with an argument coming from a column
         | 616263 |
         | 616263 |
 
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: encode takes argument 2 from a column holding two different values
       When query
         """
@@ -51,7 +50,7 @@ Feature: encode with an argument coming from a column
         | 6162         |
         | FEFF00610062 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null string literal is nullable (encode is inherently nullable in Spark)

--- a/python/pysail/tests/spark/function/features/string/endswith.feature
+++ b/python/pysail/tests/spark/function/features/string/endswith.feature
@@ -1,7 +1,6 @@
-@endswith
 Feature: endswith output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/find_in_set.feature
+++ b/python/pysail/tests/spark/function/features/string/find_in_set.feature
@@ -1,7 +1,6 @@
-@find_in_set
 Feature: find_in_set output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/format_number.feature
+++ b/python/pysail/tests/spark/function/features/string/format_number.feature
@@ -1,7 +1,6 @@
-@format_number
 Feature: format_number output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to format_number yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/initcap.feature
+++ b/python/pysail/tests/spark/function/features/string/initcap.feature
@@ -1,7 +1,6 @@
-@initcap
 Feature: initcap output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/instr.feature
+++ b/python/pysail/tests/spark/function/features/string/instr.feature
@@ -1,7 +1,6 @@
-@instr
 Feature: instr output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to instr yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/is_valid_utf8.feature
+++ b/python/pysail/tests/spark/function/features/string/is_valid_utf8.feature
@@ -1,7 +1,6 @@
-@is_valid_utf8
 Feature: is_valid_utf8 output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/lcase.feature
+++ b/python/pysail/tests/spark/function/features/string/lcase.feature
@@ -1,7 +1,6 @@
-@lcase
 Feature: lcase output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/left.feature
+++ b/python/pysail/tests/spark/function/features/string/left.feature
@@ -1,7 +1,6 @@
-@left
 Feature: left output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/len.feature
+++ b/python/pysail/tests/spark/function/features/string/len.feature
@@ -1,7 +1,6 @@
-@len
 Feature: len output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to len yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/length.feature
+++ b/python/pysail/tests/spark/function/features/string/length.feature
@@ -1,4 +1,3 @@
-@length
 Feature: length() returns character length for strings and byte length for binary
 
   Rule: Character length for string data
@@ -265,7 +264,7 @@ Feature: length() returns character length for strings and byte length for binar
         """
       Then query error .*
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null string literal yields a non-nullable integer

--- a/python/pysail/tests/spark/function/features/string/levenshtein.feature
+++ b/python/pysail/tests/spark/function/features/string/levenshtein.feature
@@ -1,4 +1,3 @@
-@levenshtein
 Feature: levenshtein() returns edit distance between two strings
 
   Rule: Basic usage
@@ -183,7 +182,7 @@ Feature: levenshtein() returns edit distance between two strings
         | case sensitive comparison | 'ABC'            | 'abc'            | 3      |
         | long strings              | REPEAT('a', 100) | REPEAT('b', 100) | 100    |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/like_escape.feature
+++ b/python/pysail/tests/spark/function/features/string/like_escape.feature
@@ -1,4 +1,3 @@
-@like_escape
 Feature: LIKE and ILIKE with ESCAPE clause
 
   Rule: Custom ESCAPE character

--- a/python/pysail/tests/spark/function/features/string/locate.feature
+++ b/python/pysail/tests/spark/function/features/string/locate.feature
@@ -1,7 +1,6 @@
-@locate
 Feature: locate output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to locate yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/lower.feature
+++ b/python/pysail/tests/spark/function/features/string/lower.feature
@@ -1,7 +1,6 @@
-@lower
 Feature: lower output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/lpad.feature
+++ b/python/pysail/tests/spark/function/features/string/lpad.feature
@@ -1,7 +1,6 @@
-@lpad
 Feature: lpad output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/ltrim.feature
+++ b/python/pysail/tests/spark/function/features/string/ltrim.feature
@@ -1,7 +1,6 @@
-@ltrim
 Feature: ltrim output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/luhn_check.feature
+++ b/python/pysail/tests/spark/function/features/string/luhn_check.feature
@@ -1,7 +1,6 @@
-@luhn_check
 Feature: luhn_check output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to luhn_check yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/make_valid_utf8.feature
+++ b/python/pysail/tests/spark/function/features/string/make_valid_utf8.feature
@@ -1,7 +1,6 @@
-@make_valid_utf8
 Feature: make_valid_utf8 output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to make_valid_utf8 yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/mask.feature
+++ b/python/pysail/tests/spark/function/features/string/mask.feature
@@ -1,7 +1,6 @@
-@mask
 Feature: mask output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to mask yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/octet_length.feature
+++ b/python/pysail/tests/spark/function/features/string/octet_length.feature
@@ -1,7 +1,6 @@
-@octet_length
 Feature: octet_length output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to octet_length yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/overlay.feature
+++ b/python/pysail/tests/spark/function/features/string/overlay.feature
@@ -1,7 +1,6 @@
-@overlay
 Feature: overlay output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/position.feature
+++ b/python/pysail/tests/spark/function/features/string/position.feature
@@ -1,4 +1,3 @@
-@position
 Feature: position() finds the position of a substring in a string
 
   Rule: Basic usage
@@ -50,7 +49,7 @@ Feature: position() finds the position of a substring in a string
         | position with start position 1 finds substring        | 1     | 4 |
         | position with start position past the match returns 0 | 5     | 0 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to position yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/quote.feature
+++ b/python/pysail/tests/spark/function/features/string/quote.feature
@@ -1,7 +1,6 @@
-@quote
 Feature: quote output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to quote yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/regexp_count.feature
+++ b/python/pysail/tests/spark/function/features/string/regexp_count.feature
@@ -1,7 +1,6 @@
-@regexp_count
 Feature: regexp_count output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/regexp_extract.feature
+++ b/python/pysail/tests/spark/function/features/string/regexp_extract.feature
@@ -1,4 +1,3 @@
-@regexp_extract
 Feature: regexp_extract() extracts regex capture groups from strings
 
   Rule: Basic extraction
@@ -55,7 +54,7 @@ Feature: regexp_extract() extracts regex capture groups from strings
         | regexp_extract with anchored pattern at beginning | '123abc' | '^(\\d+)' | 123    |
         | regexp_extract with anchored pattern at end       | 'abc123' | '(\\d+)$' | 123    |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/regexp_extract_all.feature
+++ b/python/pysail/tests/spark/function/features/string/regexp_extract_all.feature
@@ -1,4 +1,3 @@
-@regexp_extract_all
 Feature: regexp_extract_all() extracts all regex capture group matches from strings
 
   Rule: Basic extraction with group index
@@ -74,7 +73,7 @@ Feature: regexp_extract_all() extracts all regex capture group matches from stri
         | regexp_extract_all returns NULL when input is NULL   | NULL, r'(\d+)' |
         | regexp_extract_all returns NULL when pattern is NULL | 'abc', NULL    |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/regexp_instr.feature
+++ b/python/pysail/tests/spark/function/features/string/regexp_instr.feature
@@ -1,7 +1,6 @@
-@regexp_instr
 Feature: regexp_instr output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/regexp_replace.feature
+++ b/python/pysail/tests/spark/function/features/string/regexp_replace.feature
@@ -1,7 +1,6 @@
-@regexp_replace
 Feature: regexp_replace output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/regexp_substr.feature
+++ b/python/pysail/tests/spark/function/features/string/regexp_substr.feature
@@ -1,7 +1,6 @@
-@regexp_substr
 Feature: regexp_substr output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to regexp_substr yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/repeat.feature
+++ b/python/pysail/tests/spark/function/features/string/repeat.feature
@@ -1,7 +1,6 @@
-@repeat
 Feature: repeat output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/replace.feature
+++ b/python/pysail/tests/spark/function/features/string/replace.feature
@@ -1,7 +1,6 @@
-@replace
 Feature: replace output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/right.feature
+++ b/python/pysail/tests/spark/function/features/string/right.feature
@@ -1,7 +1,6 @@
-@right
 Feature: right output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to right yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/rpad.feature
+++ b/python/pysail/tests/spark/function/features/string/rpad.feature
@@ -1,7 +1,6 @@
-@rpad
 Feature: rpad output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/rtrim.feature
+++ b/python/pysail/tests/spark/function/features/string/rtrim.feature
@@ -1,7 +1,6 @@
-@rtrim
 Feature: rtrim output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/sentences.feature
+++ b/python/pysail/tests/spark/function/features/string/sentences.feature
@@ -1,7 +1,6 @@
-@sentences
 Feature: sentences output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/soundex.feature
+++ b/python/pysail/tests/spark/function/features/string/soundex.feature
@@ -1,4 +1,3 @@
-@soundex
 Feature: soundex() returns the Soundex code of a string
 
   Rule: Basic usage
@@ -103,7 +102,7 @@ Feature: soundex() returns the Soundex code of a string
         | soundex on column values    | ('Robert'), ('Rupert'), ('Smith')            | R163 | R163 | S530 |
         | soundex with null in column | ('Hello'), (CAST(NULL AS STRING)), ('World') | H400 | NULL | W643 |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/space.feature
+++ b/python/pysail/tests/spark/function/features/string/space.feature
@@ -1,7 +1,6 @@
-@space
 Feature: space output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/split.feature
+++ b/python/pysail/tests/spark/function/features/string/split.feature
@@ -1,7 +1,6 @@
-@split
 Feature: split output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/split_part.feature
+++ b/python/pysail/tests/spark/function/features/string/split_part.feature
@@ -1,7 +1,6 @@
-@split_part
 Feature: split_part output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to split_part yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/startswith.feature
+++ b/python/pysail/tests/spark/function/features/string/startswith.feature
@@ -1,7 +1,6 @@
-@startswith
 Feature: startswith output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/substr.feature
+++ b/python/pysail/tests/spark/function/features/string/substr.feature
@@ -1,7 +1,6 @@
-@substr
 Feature: substr output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/substring.feature
+++ b/python/pysail/tests/spark/function/features/string/substring.feature
@@ -1,4 +1,3 @@
-@substring
 Feature: substring() and substr() extract substrings
 
   Rule: Basic usage with positive positions (1-based)
@@ -80,7 +79,7 @@ Feature: substring() and substr() extract substrings
         | result          |
         | abcdefghijklmno |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/substring_index.feature
+++ b/python/pysail/tests/spark/function/features/string/substring_index.feature
@@ -1,7 +1,6 @@
-@substring_index
 Feature: substring_index output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/to_binary.feature
+++ b/python/pysail/tests/spark/function/features/string/to_binary.feature
@@ -1,7 +1,6 @@
-@to_binary
 Feature: to_binary output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to to_binary yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/to_char.feature
+++ b/python/pysail/tests/spark/function/features/string/to_char.feature
@@ -1,4 +1,3 @@
-@to_char
 Feature: to_char with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: to_char with an argument coming from a column
 
   Rule: to_char — a numeric format must be foldable
 
-    @column_args
+    @function(columnargs)
     Scenario: to_char with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: to_char with an argument coming from a column
         | 454    |
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['454', '454'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: to_char takes argument 2 from a column holding two different values
       When query
         """
@@ -26,7 +25,7 @@ Feature: to_char with an argument coming from a column
       Then query error NON_FOLDABLE_INPUT
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['454', '454'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: to_char takes argument 2 from a column containing NULL
       When query
         """
@@ -35,7 +34,7 @@ Feature: to_char with an argument coming from a column
       Then query error NON_FOLDABLE_INPUT
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['454', '454'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: to_char takes argument 2 from a column
       When query
         """
@@ -48,7 +47,7 @@ Feature: to_char with an argument coming from a column
   # numeric format; here the column is legal and each row must use its own format.
   Rule: to_char — a date format is resolved per row
 
-    @column_args
+    @function(columnargs)
     Scenario: to_char takes the date format from a column holding two different values
       When query
         """
@@ -59,7 +58,7 @@ Feature: to_char with an argument coming from a column
         | 2026   |
         | 02     |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/to_number.feature
+++ b/python/pysail/tests/spark/function/features/string/to_number.feature
@@ -1,4 +1,3 @@
-@to_number
 Feature: to_number comprehensive tests
 
   Rule: Argument count validation
@@ -350,7 +349,7 @@ Feature: to_number comprehensive tests
         """
       Then query error .*
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/to_varchar.feature
+++ b/python/pysail/tests/spark/function/features/string/to_varchar.feature
@@ -1,4 +1,3 @@
-@to_varchar
 Feature: to_varchar with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: to_varchar with an argument coming from a column
 
   Rule: to_varchar — a numeric format must be foldable
 
-    @column_args
+    @function(columnargs)
     Scenario: to_varchar with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: to_varchar with an argument coming from a column
         | 454    |
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['454', '454'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: to_varchar takes argument 2 from a column holding two different values
       When query
         """
@@ -26,7 +25,7 @@ Feature: to_varchar with an argument coming from a column
       Then query error NON_FOLDABLE_INPUT
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['454', '454'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: to_varchar takes argument 2 from a column containing NULL
       When query
         """
@@ -35,7 +34,7 @@ Feature: to_varchar with an argument coming from a column
       Then query error NON_FOLDABLE_INPUT
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['454', '454'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: to_varchar takes argument 2 from a column
       When query
         """
@@ -49,7 +48,7 @@ Feature: to_varchar with an argument coming from a column
 
   Rule: to_varchar — a date format is resolved per row
 
-    @column_args
+    @function(columnargs)
     Scenario: to_varchar takes the date format from a column holding two different values
       When query
         """
@@ -60,7 +59,7 @@ Feature: to_varchar with an argument coming from a column
         | 2026   |
         | 02     |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/translate.feature
+++ b/python/pysail/tests/spark/function/features/string/translate.feature
@@ -1,7 +1,6 @@
-@translate
 Feature: translate output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/try_to_binary.feature
+++ b/python/pysail/tests/spark/function/features/string/try_to_binary.feature
@@ -1,4 +1,3 @@
-@try_to_binary
 Feature: try_to_binary with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: try_to_binary with an argument coming from a column
 
   Rule: try_to_binary — the argument is resolved per row, not taken from the first row
 
-    @column_args
+    @function(columnargs)
     Scenario: try_to_binary with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: try_to_binary with an argument coming from a column
         | 616263 |
 
     # Sail returns the wrong value on the column path: Sail returns NULL for every row.
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: try_to_binary takes argument 1 from a column holding two different values
       When query
         """
@@ -31,7 +30,7 @@ Feature: try_to_binary with an argument coming from a column
   Rule: try_to_binary — the argument must be foldable
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns NULL for every row.
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: try_to_binary takes argument 2 from a column holding two different values
       When query
         """
@@ -40,7 +39,7 @@ Feature: try_to_binary with an argument coming from a column
       Then query error NON_FOLDABLE_INPUT
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns NULL for every row.
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: try_to_binary takes argument 2 from a column containing NULL
       When query
         """
@@ -49,7 +48,7 @@ Feature: try_to_binary with an argument coming from a column
       Then query error NON_FOLDABLE_INPUT
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns NULL for every row.
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: try_to_binary takes argument 2 from a column
       When query
         """
@@ -57,7 +56,7 @@ Feature: try_to_binary with an argument coming from a column
         """
       Then query error NON_FOLDABLE_INPUT
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to try_to_binary yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/try_to_number.feature
+++ b/python/pysail/tests/spark/function/features/string/try_to_number.feature
@@ -1,4 +1,3 @@
-@try_to_number
 Feature: try_to_number comprehensive tests (safe version of to_number)
 
   Rule: Argument count validation

--- a/python/pysail/tests/spark/function/features/string/try_validate_utf8.feature
+++ b/python/pysail/tests/spark/function/features/string/try_validate_utf8.feature
@@ -1,7 +1,6 @@
-@try_validate_utf8
 Feature: try_validate_utf8 output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to try_validate_utf8 yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/string/ucase.feature
+++ b/python/pysail/tests/spark/function/features/string/ucase.feature
@@ -1,7 +1,6 @@
-@ucase
 Feature: ucase output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/unbase64.feature
+++ b/python/pysail/tests/spark/function/features/string/unbase64.feature
@@ -1,7 +1,6 @@
-@unbase64
 Feature: unbase64 output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/upper.feature
+++ b/python/pysail/tests/spark/function/features/string/upper.feature
@@ -1,7 +1,6 @@
-@upper
 Feature: upper output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/string/validate_utf8.feature
+++ b/python/pysail/tests/spark/function/features/string/validate_utf8.feature
@@ -1,7 +1,6 @@
-@validate_utf8
 Feature: validate_utf8 output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/struct/named_struct.feature
+++ b/python/pysail/tests/spark/function/features/struct/named_struct.feature
@@ -1,7 +1,6 @@
-@named_struct
 Feature: named_struct output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/struct/struct.feature
+++ b/python/pysail/tests/spark/function/features/struct/struct.feature
@@ -1,7 +1,6 @@
-@struct
 Feature: struct output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to struct yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/struct/struct_function.feature
+++ b/python/pysail/tests/spark/function/features/struct/struct_function.feature
@@ -1,4 +1,3 @@
-@struct_function
 Feature: struct function
 
   Rule: Basic struct construction

--- a/python/pysail/tests/spark/function/features/table_function.feature
+++ b/python/pysail/tests/spark/function/features/table_function.feature
@@ -1,4 +1,3 @@
-@table_function
 Feature: Table function queries
 
   Rule: Wildcard aggregation for table function

--- a/python/pysail/tests/spark/function/features/tablesample.feature
+++ b/python/pysail/tests/spark/function/features/tablesample.feature
@@ -1,4 +1,3 @@
-@tablesample
 Feature: TABLESAMPLE clause
 
   Rule: TABLESAMPLE with PERCENT

--- a/python/pysail/tests/spark/function/features/url/parse_url.feature
+++ b/python/pysail/tests/spark/function/features/url/parse_url.feature
@@ -1,4 +1,3 @@
-@parse_url
 Feature: parse_url() extracts URL component
 
   Rule: Basic usage
@@ -147,7 +146,7 @@ Feature: parse_url() extracts URL component
         | parse_url null url  | CAST(NULL AS STRING), 'HOST'                |
         | parse_url null part | 'https://example.com', CAST(NULL AS STRING) |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null url literal yields a string

--- a/python/pysail/tests/spark/function/features/url/try_parse_url.feature
+++ b/python/pysail/tests/spark/function/features/url/try_parse_url.feature
@@ -1,4 +1,3 @@
-@try_parse_url
 Feature: try_parse_url migration tests
   Tests exposing differences between Sail and DataFusion fork implementations.
   Fork inherits parse_url limitations: fewer string type combinations (3 vs 27).
@@ -91,7 +90,7 @@ Feature: try_parse_url migration tests
         | try_parse_url extracts REF (fragment) | https://spark.apache.org/path#section1       | REF       | section1                        |
         | try_parse_url extracts FILE           | https://spark.apache.org/path?query=1        | FILE      | /path?query=1                   |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to try_parse_url yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/url/try_url_decode.feature
+++ b/python/pysail/tests/spark/function/features/url/try_url_decode.feature
@@ -1,7 +1,6 @@
-@try_url_decode
 Feature: try_url_decode output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to try_url_decode yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/url/url_decode.feature
+++ b/python/pysail/tests/spark/function/features/url/url_decode.feature
@@ -1,7 +1,6 @@
-@url_decode
 Feature: url_decode output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to url_decode yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/url/url_encode.feature
+++ b/python/pysail/tests/spark/function/features/url/url_encode.feature
@@ -1,7 +1,6 @@
-@url_encode
 Feature: url_encode output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to url_encode yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/variant/cast_to_variant.feature
+++ b/python/pysail/tests/spark/function/features/variant/cast_to_variant.feature
@@ -1,8 +1,7 @@
 @spark-4
-@cast_to_variant
 Feature: CAST(... AS VARIANT) output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/variant/is_variant_null.feature
+++ b/python/pysail/tests/spark/function/features/variant/is_variant_null.feature
@@ -1,7 +1,6 @@
-@is_variant_null
 Feature: is_variant_null output schema
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/variant/parse_json.feature
+++ b/python/pysail/tests/spark/function/features/variant/parse_json.feature
@@ -1,5 +1,4 @@
 @spark-4
-@parse_json
 Feature: parse_json (strict version; errors on invalid JSON)
 
   Rule: Valid JSON parsing
@@ -189,7 +188,7 @@ Feature: parse_json (strict version; errors on invalid JSON)
         | NULL   |
         | NULL   |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/variant/schema_of_variant.feature
+++ b/python/pysail/tests/spark/function/features/variant/schema_of_variant.feature
@@ -1,5 +1,4 @@
 @spark-4
-@schema_of_variant
 Feature: schema_of_variant
 
   Rule: Primitive types
@@ -156,7 +155,7 @@ Feature: schema_of_variant
         | schema_of_variant nested null array                    | '[[null]]'                 | ARRAY<ARRAY<VOID>>         |
         | schema_of_variant array with objects and null merges   | '[{"a":1}, null, {"a":2}]' | ARRAY<OBJECT<a: BIGINT>>   |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/variant/schema_of_variant_agg.feature
+++ b/python/pysail/tests/spark/function/features/variant/schema_of_variant_agg.feature
@@ -1,5 +1,4 @@
 @spark-4
-@schema_of_variant_agg
 Feature: schema_of_variant_agg
 
   Rule: Uniform types

--- a/python/pysail/tests/spark/function/features/variant/to_variant_object.feature
+++ b/python/pysail/tests/spark/function/features/variant/to_variant_object.feature
@@ -1,5 +1,4 @@
 @spark-4
-@to_variant_object
 Feature: to_variant_object
 
   Rule: Struct input
@@ -184,7 +183,7 @@ Feature: to_variant_object
         | to_variant_object rejects empty array | array() |
         | to_variant_object rejects empty map   | map()   |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     @sail-bug

--- a/python/pysail/tests/spark/function/features/variant/try_parse_json.feature
+++ b/python/pysail/tests/spark/function/features/variant/try_parse_json.feature
@@ -1,5 +1,4 @@
 @spark-4
-@try_parse_json
 Feature: try_parse_json comprehensive tests
 
   Rule: Argument count validation
@@ -461,7 +460,7 @@ Feature: try_parse_json comprehensive tests
         | NULL   |
         | NULL   |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: try_parse_json stays nullable because it returns NULL on invalid input

--- a/python/pysail/tests/spark/function/features/variant/try_variant_get.feature
+++ b/python/pysail/tests/spark/function/features/variant/try_variant_get.feature
@@ -1,4 +1,3 @@
-@try_variant_get
 Feature: try_variant_get with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: try_variant_get with an argument coming from a column
 
   Rule: try_variant_get — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: try_variant_get with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: try_variant_get with an argument coming from a column
         | "hello" |
 
     # Sail rejects the column: Sail errors: Spark `try_variant_get` function: path must be a constant string
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: try_variant_get takes argument 2 from a column holding two different values
       When query
         """
@@ -29,7 +28,7 @@ Feature: try_variant_get with an argument coming from a column
         | NULL    |
 
     # Sail rejects the column: Sail errors: Spark `try_variant_get` function: path must be a constant string
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: try_variant_get takes argument 2 from a column
       When query
         """
@@ -40,7 +39,7 @@ Feature: try_variant_get with an argument coming from a column
         | "hello" |
         | "hello" |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to try_variant_get yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/variant/variant.feature
+++ b/python/pysail/tests/spark/function/features/variant/variant.feature
@@ -1,5 +1,4 @@
 @spark-4
-@variant
 Feature: Variant type functions (parse_json, is_variant_null, variant_get)
 
   Rule: parse_json + variant_get roundtrip

--- a/python/pysail/tests/spark/function/features/variant/variant_get.feature
+++ b/python/pysail/tests/spark/function/features/variant/variant_get.feature
@@ -1,4 +1,3 @@
-@variant_get
 Feature: variant_get with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: variant_get with an argument coming from a column
 
   Rule: variant_get — the argument may come from a column
 
-    @column_args
+    @function(columnargs)
     Scenario: variant_get with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: variant_get with an argument coming from a column
         | "hello" |
 
     # Sail rejects the column: Sail errors: Spark `variant_get` function: path must be a constant string
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: variant_get takes argument 2 from a column holding two different values
       When query
         """
@@ -29,7 +28,7 @@ Feature: variant_get with an argument coming from a column
         | NULL    |
 
     # Sail rejects the column: Sail errors: Spark `variant_get` function: path must be a constant string
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: variant_get takes argument 2 from a column
       When query
         """
@@ -40,7 +39,7 @@ Feature: variant_get with an argument coming from a column
         | "hello" |
         | "hello" |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to variant_get yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/window/array_join_window.feature
+++ b/python/pysail/tests/spark/function/features/window/array_join_window.feature
@@ -1,4 +1,3 @@
-@array_join_window
 Feature: array_join as window function
 
   Rule: array_join with window aggregation (expanding windows)

--- a/python/pysail/tests/spark/function/features/window/ntile.feature
+++ b/python/pysail/tests/spark/function/features/window/ntile.feature
@@ -1,4 +1,3 @@
-@ntile
 Feature: ntile window function comprehensive tests
 
   Rule: Ntile distributes extra rows to first buckets (Spark behavior)

--- a/python/pysail/tests/spark/function/features/window/percentile_window.feature
+++ b/python/pysail/tests/spark/function/features/window/percentile_window.feature
@@ -1,4 +1,3 @@
-@percentile_window
 Feature: percentile() window function computes running percentiles
 
   Rule: Running percentile with ORDER BY

--- a/python/pysail/tests/spark/function/features/window/window_collect_set.feature
+++ b/python/pysail/tests/spark/function/features/window/window_collect_set.feature
@@ -1,4 +1,3 @@
-@window_collect_set
 Feature: collect_set over window functions
 
   Rule: collect_set over expanding window

--- a/python/pysail/tests/spark/function/features/window/window_first_last.feature
+++ b/python/pysail/tests/spark/function/features/window/window_first_last.feature
@@ -1,4 +1,3 @@
-@window_first_last
 Feature: first_value and last_value window functions with sliding frames
 
   Rule: first_value with sliding window frame

--- a/python/pysail/tests/spark/function/features/window/window_range_interval.feature
+++ b/python/pysail/tests/spark/function/features/window/window_range_interval.feature
@@ -1,4 +1,3 @@
-@window_range_interval
 Feature: Window RANGE frame with interval boundaries
 
   Rule: RANGE frame with INTERVAL PRECEDING on timestamp ORDER BY

--- a/python/pysail/tests/spark/function/features/window/window_skewness.feature
+++ b/python/pysail/tests/spark/function/features/window/window_skewness.feature
@@ -1,4 +1,3 @@
-@window_skewness
 Feature: skewness and kurtosis over window functions
 
   Rule: skewness over expanding window

--- a/python/pysail/tests/spark/function/features/xml/from_xml.feature
+++ b/python/pysail/tests/spark/function/features/xml/from_xml.feature
@@ -1,4 +1,3 @@
-@from_xml
 Feature: from_xml parses an XML string into a struct value
 
   Rule: Primitive types
@@ -356,7 +355,7 @@ Feature: from_xml parses an XML string into a struct value
         | DECIMAL bad value returns NULL | '<p><a>bad</a></p>'             | 'a DECIMAL(10,2)'        | NULL         |
         | DECIMAL in array               | '<p><a>1.10</a><a>2.20</a></p>' | 'a ARRAY<DECIMAL(10,2)>' | [1.10, 2.20] |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null xml literal yields a struct

--- a/python/pysail/tests/spark/function/features/xml/to_xml.feature
+++ b/python/pysail/tests/spark/function/features/xml/to_xml.feature
@@ -1,4 +1,3 @@
-@to_xml
 Feature: to_xml converts a struct value to an XML string
 
   Rule: Basic serialization
@@ -712,7 +711,7 @@ Feature: to_xml converts a struct value to an XML string
         | r                                                                         |
         | <ROW>~    <m>~        <val>10</val>~        <val>20</val>~    </m>~</ROW> |
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null struct literal is nullable (to_xml is inherently nullable in Spark)

--- a/python/pysail/tests/spark/function/features/xml/xpath.feature
+++ b/python/pysail/tests/spark/function/features/xml/xpath.feature
@@ -1,4 +1,3 @@
-@xpath
 Feature: xpath() extracts XML nodes with Spark-compatible semantics
 
   Rule: Node selection returns arrays of string-like values
@@ -72,7 +71,7 @@ Feature: xpath() extracts XML nodes with Spark-compatible semantics
 
   Rule: xpath — the argument must be foldable
 
-    @column_args
+    @function(columnargs)
     Scenario: xpath with the argument as a literal
       When query
         """
@@ -83,7 +82,7 @@ Feature: xpath() extracts XML nodes with Spark-compatible semantics
         | [NULL, NULL, NULL] |
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ["['b1', 'b2', 'b3']", '[None, None, None]'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath takes argument 2 from a column holding two different values
       When query
         """
@@ -92,7 +91,7 @@ Feature: xpath() extracts XML nodes with Spark-compatible semantics
       Then query error NON_FOLDABLE_INPUT
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['[None, None, None]', 'NULL'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath takes argument 2 from a column containing NULL
       When query
         """
@@ -101,7 +100,7 @@ Feature: xpath() extracts XML nodes with Spark-compatible semantics
       Then query error NON_FOLDABLE_INPUT
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['[None, None, None]', '[None, None, None]'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath takes argument 2 from a column
       When query
         """
@@ -109,7 +108,7 @@ Feature: xpath() extracts XML nodes with Spark-compatible semantics
         """
       Then query error NON_FOLDABLE_INPUT
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null xml literal yields an array

--- a/python/pysail/tests/spark/function/features/xml/xpath_boolean.feature
+++ b/python/pysail/tests/spark/function/features/xml/xpath_boolean.feature
@@ -1,4 +1,3 @@
-@xpath_boolean
 Feature: xpath_boolean with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: xpath_boolean with an argument coming from a column
 
   Rule: xpath_boolean — the argument must be foldable
 
-    @column_args
+    @function(columnargs)
     Scenario: xpath_boolean with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: xpath_boolean with an argument coming from a column
         | true   |
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['True', 'NULL'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath_boolean takes argument 2 from a column containing NULL
       When query
         """
@@ -26,7 +25,7 @@ Feature: xpath_boolean with an argument coming from a column
       Then query error NON_FOLDABLE_INPUT
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['True', 'True'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath_boolean takes argument 2 from a column
       When query
         """
@@ -34,7 +33,7 @@ Feature: xpath_boolean with an argument coming from a column
         """
       Then query error NON_FOLDABLE_INPUT
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null xml literal yields a boolean

--- a/python/pysail/tests/spark/function/features/xml/xpath_double.feature
+++ b/python/pysail/tests/spark/function/features/xml/xpath_double.feature
@@ -1,4 +1,3 @@
-@xpath_double
 Feature: xpath_double with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: xpath_double with an argument coming from a column
 
   Rule: xpath_double — the argument must be foldable
 
-    @column_args
+    @function(columnargs)
     Scenario: xpath_double with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: xpath_double with an argument coming from a column
         | 3.0    |
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', 'NULL'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath_double takes argument 2 from a column containing NULL
       When query
         """
@@ -26,7 +25,7 @@ Feature: xpath_double with an argument coming from a column
       Then query error NON_FOLDABLE_INPUT
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', '3.0'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath_double takes argument 2 from a column
       When query
         """

--- a/python/pysail/tests/spark/function/features/xml/xpath_float.feature
+++ b/python/pysail/tests/spark/function/features/xml/xpath_float.feature
@@ -1,4 +1,3 @@
-@xpath_float
 Feature: xpath_float with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: xpath_float with an argument coming from a column
 
   Rule: xpath_float — the argument must be foldable
 
-    @column_args
+    @function(columnargs)
     Scenario: xpath_float with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: xpath_float with an argument coming from a column
         | 3.0    |
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', 'NULL'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath_float takes argument 2 from a column containing NULL
       When query
         """
@@ -26,7 +25,7 @@ Feature: xpath_float with an argument coming from a column
       Then query error NON_FOLDABLE_INPUT
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', '3.0'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath_float takes argument 2 from a column
       When query
         """
@@ -34,7 +33,7 @@ Feature: xpath_float with an argument coming from a column
         """
       Then query error NON_FOLDABLE_INPUT
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to xpath_float yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/xml/xpath_int.feature
+++ b/python/pysail/tests/spark/function/features/xml/xpath_int.feature
@@ -1,4 +1,3 @@
-@xpath_int
 Feature: xpath_int with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: xpath_int with an argument coming from a column
 
   Rule: xpath_int — the argument must be foldable
 
-    @column_args
+    @function(columnargs)
     Scenario: xpath_int with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: xpath_int with an argument coming from a column
         | 3      |
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', 'NULL'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath_int takes argument 2 from a column containing NULL
       When query
         """
@@ -26,7 +25,7 @@ Feature: xpath_int with an argument coming from a column
       Then query error NON_FOLDABLE_INPUT
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', '3'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath_int takes argument 2 from a column
       When query
         """
@@ -34,7 +33,7 @@ Feature: xpath_int with an argument coming from a column
         """
       Then query error NON_FOLDABLE_INPUT
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null xml literal yields an integer

--- a/python/pysail/tests/spark/function/features/xml/xpath_long.feature
+++ b/python/pysail/tests/spark/function/features/xml/xpath_long.feature
@@ -1,4 +1,3 @@
-@xpath_long
 Feature: xpath_long with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: xpath_long with an argument coming from a column
 
   Rule: xpath_long — the argument must be foldable
 
-    @column_args
+    @function(columnargs)
     Scenario: xpath_long with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: xpath_long with an argument coming from a column
         | 3      |
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', 'NULL'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath_long takes argument 2 from a column containing NULL
       When query
         """
@@ -26,7 +25,7 @@ Feature: xpath_long with an argument coming from a column
       Then query error NON_FOLDABLE_INPUT
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', '3'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath_long takes argument 2 from a column
       When query
         """
@@ -34,7 +33,7 @@ Feature: xpath_long with an argument coming from a column
         """
       Then query error NON_FOLDABLE_INPUT
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to xpath_long yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/xml/xpath_number.feature
+++ b/python/pysail/tests/spark/function/features/xml/xpath_number.feature
@@ -1,4 +1,3 @@
-@xpath_number
 Feature: xpath_number with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: xpath_number with an argument coming from a column
 
   Rule: xpath_number — the argument must be foldable
 
-    @column_args
+    @function(columnargs)
     Scenario: xpath_number with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: xpath_number with an argument coming from a column
         | 3.0    |
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', 'NULL'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath_number takes argument 2 from a column containing NULL
       When query
         """
@@ -26,7 +25,7 @@ Feature: xpath_number with an argument coming from a column
       Then query error NON_FOLDABLE_INPUT
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3.0', '3.0'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath_number takes argument 2 from a column
       When query
         """

--- a/python/pysail/tests/spark/function/features/xml/xpath_short.feature
+++ b/python/pysail/tests/spark/function/features/xml/xpath_short.feature
@@ -1,4 +1,3 @@
-@xpath_short
 Feature: xpath_short with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: xpath_short with an argument coming from a column
 
   Rule: xpath_short — the argument must be foldable
 
-    @column_args
+    @function(columnargs)
     Scenario: xpath_short with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: xpath_short with an argument coming from a column
         | 3      |
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', 'NULL'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath_short takes argument 2 from a column containing NULL
       When query
         """
@@ -26,7 +25,7 @@ Feature: xpath_short with an argument coming from a column
       Then query error NON_FOLDABLE_INPUT
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['3', '3'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath_short takes argument 2 from a column
       When query
         """
@@ -34,7 +33,7 @@ Feature: xpath_short with an argument coming from a column
         """
       Then query error NON_FOLDABLE_INPUT
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null literal input to xpath_short yields the schema Spark declares

--- a/python/pysail/tests/spark/function/features/xml/xpath_string.feature
+++ b/python/pysail/tests/spark/function/features/xml/xpath_string.feature
@@ -1,4 +1,3 @@
-@xpath_string
 Feature: xpath_string with an argument coming from a column
   # A behaviour-governing argument given as a literal is constant-folded, so the literal
   # scenarios never exercise the columnar kernel. These scenarios pass the same argument
@@ -6,7 +5,7 @@ Feature: xpath_string with an argument coming from a column
 
   Rule: xpath_string — the argument must be foldable
 
-    @column_args
+    @function(columnargs)
     Scenario: xpath_string with the argument as a literal
       When query
         """
@@ -17,7 +16,7 @@ Feature: xpath_string with an argument coming from a column
         | cc     |
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['cc', 'NULL'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath_string takes argument 2 from a column containing NULL
       When query
         """
@@ -26,7 +25,7 @@ Feature: xpath_string with an argument coming from a column
       Then query error NON_FOLDABLE_INPUT
 
     # Spark requires a foldable argument here; Sail accepts a column: Sail returns ['cc', 'cc'].
-    @column_args @sail-bug
+    @function(columnargs) @sail-bug
     Scenario: xpath_string takes argument 2 from a column
       When query
         """
@@ -34,7 +33,7 @@ Feature: xpath_string with an argument coming from a column
         """
       Then query error NON_FOLDABLE_INPUT
 
-  @spark_null
+  @function(nullability)
   Rule: Output schema
 
     Scenario: a non-null xml literal yields a string

--- a/python/pysail/tests/spark/function/features/xml/xpath_typed.feature
+++ b/python/pysail/tests/spark/function/features/xml/xpath_typed.feature
@@ -1,4 +1,3 @@
-@xpath_typed
 Feature: xpath_boolean/double/float/int/long/number/short/string extract typed values from XML
 
   Rule: xpath_boolean evaluates XPath to a boolean

--- a/python/pysail/tests/spark/function/test_nullability_schema.py
+++ b/python/pysail/tests/spark/function/test_nullability_schema.py
@@ -1,6 +1,6 @@
 """Output-schema nullability via the DataFrame API.
 
-Complements the SQL `@spark_null` feature suite with the DataFrame path: build a
+Complements the SQL `@function(nullability)` feature suite with the DataFrame path: build a
 DataFrame from an explicit `StructType` (so the input nullability is exactly what
 we declare — a non-nullable and a nullable column), apply functions through the
 `F.*` API, and assert the resulting schema's `nullable` flags.


### PR DESCRIPTION
1. Add BDD tag processing logic to convert tags to registered `function` marker to avoid pytest unknown marker warning.
2. Add BDD `.feature` file path as keywords so that we can select BDD tests by file names without adding tag for each file.

Here are a few examples.

```bash
# select tests by tags with arguments
hatch run pytest -m "function(group='nullability')" --collect-only
hatch run pytest -m "function(group='columnargs')" --collect-only
hatch run pytest -m "function(group='lambda')" --collect-only
hatch run pytest -m "function(group='sketch')" --collect-only

# select tests by keywords (file name or partial file name)
hatch run pytest -k "csv" --collect-only
hatch run pytest -k "xpath_typed" --collect-only
hatch run pytest -k "variant.feature" --collect-only
hatch run pytest -k "xpath_" --collect-only
```

cc @davidlghellin