### PR TITLE
test: initialize the global state when reusing an existing server

### DIFF
--- a/python/pysail/testing/spark/session.py
+++ b/python/pysail/testing/spark/session.py
@@ -51,6 +51,8 @@ def spark_connect_server(envs: Mapping[str, str] | None = None) -> Iterator[_Ser
     if remote := os.environ.get("SPARK_REMOTE"):
         if envs is not None:
             pytest.skip("the server from `SPARK_REMOTE` may not be compatible with the custom environment variables")
+        # Creating a server, without starting it, initializes the global state that config warnings rely on.
+        _ = SparkConnectServer("127.0.0.1", 0)
         yield _ServerHandle(remote=remote)
         return
 

--- a/python/pysail/testing/spark/session.py
+++ b/python/pysail/testing/spark/session.py
@@ -51,8 +51,6 @@ def spark_connect_server(envs: Mapping[str, str] | None = None) -> Iterator[_Ser
     if remote := os.environ.get("SPARK_REMOTE"):
         if envs is not None:
             pytest.skip("the server from `SPARK_REMOTE` may not be compatible with the custom environment variables")
-        # Creating a server, without starting it, initializes the global state that config warnings rely on.
-        _ = SparkConnectServer("127.0.0.1", 0)
         yield _ServerHandle(remote=remote)
         return
 

--- a/python/pysail/tests/spark/test_config.py
+++ b/python/pysail/tests/spark/test_config.py
@@ -8,7 +8,7 @@ from pysail.spark import SparkConnectServer
 @pytest.fixture(scope="module", autouse=True)
 def server():
     # The tests below need the global state to be initialized while the environment variables
-    # are still pristine, which does not happen when running against a server from `SPARK_REMOTE`.
+    # are still pristine. This fixture ensures this even when running the tests against a server from `SPARK_REMOTE`.
     _ = SparkConnectServer()
 
 

--- a/python/pysail/tests/spark/test_config.py
+++ b/python/pysail/tests/spark/test_config.py
@@ -5,6 +5,13 @@ import pytest
 from pysail.spark import SparkConnectServer
 
 
+@pytest.fixture(scope="module", autouse=True)
+def server():
+    # The tests below need the global state to be initialized while the environment variables
+    # are still pristine, which does not happen when running against a server from `SPARK_REMOTE`.
+    _ = SparkConnectServer()
+
+
 def test_warning_on_static_config_addition(monkeypatch):
     key = "SAIL_TELEMETRY__EXPORTER__OTLP__ENDPOINT"
     assert key not in os.environ


### PR DESCRIPTION
When it starts a server in process, `spark_connect_server` creates a `SparkConnectServer`, which initializes the process-global state as a side effect. That state holds the snapshot of environment variables that static configuration warnings are compared against, and it is captured lazily, the first time the global state is initialized.

When `SPARK_REMOTE` points to an existing server the helper returns early and never creates one, so the global state stays uninitialized. The first test in `test_config.py` then captures the snapshot itself, after its own `monkeypatch`, so `warn_if_changed` finds no difference and emits no warning. Whichever of the three tests runs first fails, and the other two pass only because the first one left the global state initialized.

Creating the server here, without starting it, makes both branches behave the same. The constructor does not bind a listener; `start` does.


```
SPARK_REMOTE="sc://localhost:50051" hatch run pytest python/pysail/tests/spark/test_config.py -k deletion
```
fail:
<img width="1276" height="385" alt="image" src="https://github.com/user-attachments/assets/f2e61a84-42b8-4275-94c3-2497b7014e36" />

```
SPARK_REMOTE="sc://localhost:50051" hatch run pytest python/pysail/tests/spark/test_config.py -k "deletion or modification"
```
With two tests, the first one fails.


<img width="1275" height="392" alt="image" src="https://github.com/user-attachments/assets/2eee79e6-d82e-4eef-bfcb-b0729ea5202d" />

ok:
<img width="1276" height="163" alt="image" src="https://github.com/user-attachments/assets/4d627549-54f0-4a27-8f48-a64c3eddfecf" />
