### PR TITLE
refactor: improve child actor management

### DIFF
--- a/crates/sail-common/src/actor.rs
+++ b/crates/sail-common/src/actor.rs
@@ -143,6 +143,9 @@ impl ActorSystem {
 
     /// Wait for all the spawned actors to stop.
     /// The system can still be used to spawn new actors after this method is called.
+    ///
+    /// Please note that the actors must have been sent a stop message before calling this method,
+    /// otherwise this method will wait indefinitely, causing a deadlock.
     pub async fn join(&mut self) {
         while let Some(result) = self.tasks.join_next().await {
             match result {

--- a/crates/sail-common/src/actor.rs
+++ b/crates/sail-common/src/actor.rs
@@ -43,6 +43,8 @@ pub struct ActorContext<T: Actor> {
     /// A set of tasks spawned by the actor when processing messages.
     /// All these tasks will be aborted when the context is dropped.
     tasks: JoinSet<()>,
+    /// Actors owned by this actor. All child actors will be aborted when the context is dropped.
+    children: ActorSystem,
 }
 
 impl<T: Actor> ActorContext<T> {
@@ -50,6 +52,7 @@ impl<T: Actor> ActorContext<T> {
         Self {
             handle: handle.clone(),
             tasks: JoinSet::new(),
+            children: ActorSystem::new(),
         }
     }
 
@@ -84,7 +87,13 @@ impl<T: Actor> ActorContext<T> {
         self.tasks.spawn(task.in_span(span))
     }
 
+    /// Return the system that owns the children of this actor.
+    pub fn children_mut(&mut self) -> &mut ActorSystem {
+        &mut self.children
+    }
+
     /// Join tasks that have completed.
+    ///
     /// Any unhandled errors will be logged here.
     pub fn reap(&mut self) {
         while let Some(result) = self.tasks.try_join_next() {
@@ -96,6 +105,7 @@ impl<T: Actor> ActorContext<T> {
                 }
             }
         }
+        self.children.reap();
     }
 }
 
@@ -142,6 +152,24 @@ impl ActorSystem {
                 }
             }
         }
+    }
+
+    /// Join actors that have already stopped.
+    ///
+    /// Any unhandled errors will be logged here.
+    pub fn reap(&mut self) {
+        while let Some(result) = self.tasks.try_join_next() {
+            match result {
+                Ok(()) => {}
+                Err(e) => {
+                    error!("failed to join actor: {e}");
+                }
+            }
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.tasks.len()
     }
 }
 
@@ -230,6 +258,10 @@ impl<T: Actor> ActorRunner<T> {
         if n > 0 {
             warn!("aborting {n} task(s) for {}", T::name());
         }
+        let n = self.ctx.children.len();
+        if n > 0 {
+            warn!("aborting {n} child actor(s) for {}", T::name());
+        }
     }
 }
 
@@ -249,11 +281,19 @@ mod tests {
 
     struct TestActor;
 
+    struct ParentActor {
+        child: Option<oneshot::Sender<ActorHandle<TestActor>>>,
+    }
+
     enum TestMessage {
         Echo {
             value: String,
             reply: oneshot::Sender<String>,
         },
+        Stop,
+    }
+
+    enum ParentMessage {
         Stop,
     }
 
@@ -270,6 +310,18 @@ mod tests {
                 TestMessage::Echo { value, .. } => vec![("value".into(), value.clone().into())],
                 TestMessage::Stop => vec![],
             }
+        }
+    }
+
+    impl SpanAssociation for ParentMessage {
+        fn name(&self) -> Cow<'static, str> {
+            match self {
+                ParentMessage::Stop => "Stop".into(),
+            }
+        }
+
+        fn properties(&self) -> impl IntoIterator<Item = (Cow<'static, str>, Cow<'static, str>)> {
+            vec![]
         }
     }
 
@@ -297,6 +349,33 @@ mod tests {
         }
     }
 
+    #[tonic::async_trait]
+    impl Actor for ParentActor {
+        type Message = ParentMessage;
+        type Options = oneshot::Sender<ActorHandle<TestActor>>;
+
+        fn name() -> &'static str {
+            "ParentActor"
+        }
+
+        fn new(child: Self::Options) -> Self {
+            Self { child: Some(child) }
+        }
+
+        async fn start(&mut self, ctx: &mut ActorContext<Self>) {
+            let child = ctx.children_mut().spawn::<TestActor>(());
+            if let Some(sender) = self.child.take() {
+                let _ = sender.send(child);
+            }
+        }
+
+        fn receive(&mut self, _: &mut ActorContext<Self>, message: Self::Message) -> ActorAction {
+            match message {
+                ParentMessage::Stop => ActorAction::Stop,
+            }
+        }
+    }
+
     #[tokio::test]
     async fn test_actor_handle_send() {
         let mut system = ActorSystem::new();
@@ -320,5 +399,23 @@ mod tests {
         let result = handle.send(TestMessage::Stop).await;
         assert!(matches!(result, Ok(())));
         system.join().await;
+    }
+
+    #[tokio::test]
+    async fn test_child_actor_stops_with_parent() {
+        let mut system = ActorSystem::new();
+        let (tx, rx) = oneshot::channel();
+        let parent = system.spawn::<ParentActor>(tx);
+        let child = rx.await;
+        assert!(child.is_ok());
+        let Ok(child) = child else {
+            return;
+        };
+
+        assert!(parent.send(ParentMessage::Stop).await.is_ok());
+        system.join().await;
+
+        child.sender.closed().await;
+        assert!(child.sender.is_closed());
     }
 }

--- a/crates/sail-execution/src/driver/actor/core.rs
+++ b/crates/sail-execution/src/driver/actor/core.rs
@@ -122,6 +122,7 @@ impl Actor for DriverActor {
         if let Err(e) = self.worker_pool.close(ctx).await {
             error!("encountered error while stopping workers: {e}");
         }
+        ctx.children_mut().join().await;
         let history = self.build_history();
         self.history_reporter.report(history).await;
         if let Some(result) = self.shutdown_notifier.take() {

--- a/crates/sail-execution/src/driver/worker_pool/core.rs
+++ b/crates/sail-execution/src/driver/worker_pool/core.rs
@@ -29,12 +29,10 @@ impl WorkerPool {
     pub async fn close(&mut self, ctx: &mut ActorContext<DriverActor>) -> ExecutionResult<()> {
         let worker_ids = self.workers.keys().cloned().collect::<Vec<_>>();
         for worker_id in worker_ids.into_iter() {
-            // TODO: Should we wait for the spawned tasks for stopping the workers?
             self.stop_worker(ctx, worker_id, Some("closing worker pool".to_string()));
         }
         // TODO: support timeout for worker manager stop
         self.worker_manager.stop().await?;
-        ctx.children_mut().join().await;
         Ok(())
     }
 

--- a/crates/sail-execution/src/driver/worker_pool/core.rs
+++ b/crates/sail-execution/src/driver/worker_pool/core.rs
@@ -34,6 +34,7 @@ impl WorkerPool {
         }
         // TODO: support timeout for worker manager stop
         self.worker_manager.stop().await?;
+        ctx.children_mut().join().await;
         Ok(())
     }
 
@@ -82,9 +83,11 @@ impl WorkerPool {
             rpc_retry_strategy: self.options.rpc_retry_strategy.clone(),
             shuffle_backend: self.options.shuffle_backend.clone(),
         };
-        let worker_manager = Arc::clone(&self.worker_manager);
+        let task = self
+            .worker_manager
+            .launch_worker(ctx.children_mut(), worker_id, options);
         ctx.spawn(async move {
-            if let Err(e) = worker_manager.launch_worker(worker_id, options).await {
+            if let Err(e) = task.await {
                 error!("failed to start worker {worker_id}: {e}");
             }
         });

--- a/crates/sail-execution/src/worker_manager/kubernetes.rs
+++ b/crates/sail-execution/src/worker_manager/kubernetes.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
 use std::env;
+use std::sync::Arc;
 
 use fastrace::collector::SpanContext;
+use futures::future::BoxFuture;
 use k8s_openapi::api::core::v1::{
     Container, EnvVar, EnvVarSource, ObjectFieldSelector, Pod, PodSpec, PodTemplateSpec,
 };
@@ -11,6 +13,7 @@ use kube::Api;
 use kube::api::{DeleteParams, ListParams};
 use rand::RngExt;
 use rand::distr::Uniform;
+use sail_common::actor::ActorSystem;
 use sail_common::config::ClusterConfigEnv;
 use sail_common::telemetry::ContextPropagationEnv;
 use sail_common::utils::retry::RetryStrategy;
@@ -32,15 +35,27 @@ pub struct KubernetesWorkerManagerOptions {
     pub worker_pod_template: String,
 }
 
-pub struct KubernetesWorkerManager {
+pub struct KubernetesWorkerService {
     /// An opaque name that can be used to create names to uniquely identify Kubernetes resources.
     name: String,
     options: KubernetesWorkerManagerOptions,
     pods: OnceCell<Api<Pod>>,
 }
 
+pub struct KubernetesWorkerManager {
+    service: Arc<KubernetesWorkerService>,
+}
+
 impl KubernetesWorkerManager {
     pub fn new(options: KubernetesWorkerManagerOptions) -> Self {
+        Self {
+            service: Arc::new(KubernetesWorkerService::new(options)),
+        }
+    }
+}
+
+impl KubernetesWorkerService {
+    fn new(options: KubernetesWorkerManagerOptions) -> Self {
         Self {
             name: Self::generate_name(),
             options,
@@ -48,7 +63,7 @@ impl KubernetesWorkerManager {
         }
     }
 
-    pub fn generate_name() -> String {
+    fn generate_name() -> String {
         #[expect(clippy::unwrap_used)]
         rand::rng()
             .sample_iter(Uniform::new(0, 36).unwrap())
@@ -102,7 +117,7 @@ impl KubernetesWorkerManager {
             ),
             (
                 "app.kubernetes.io/instance".to_string(),
-                format!("{}-{}", self.name, id),
+                format!("{}-{id}", self.name),
             ),
             (
                 "sail.lakesail.com/worker-manager".to_string(),
@@ -282,6 +297,22 @@ impl KubernetesWorkerManager {
 
 #[tonic::async_trait]
 impl WorkerManager for KubernetesWorkerManager {
+    fn launch_worker(
+        &self,
+        _system: &mut ActorSystem,
+        id: WorkerId,
+        options: WorkerLaunchOptions,
+    ) -> BoxFuture<'static, ExecutionResult<()>> {
+        let service = self.service.clone();
+        Box::pin(async move { service.launch_worker(id, options).await })
+    }
+
+    async fn stop(&self) -> ExecutionResult<()> {
+        self.service.stop().await
+    }
+}
+
+impl KubernetesWorkerService {
     async fn launch_worker(
         &self,
         id: WorkerId,

--- a/crates/sail-execution/src/worker_manager/local.rs
+++ b/crates/sail-execution/src/worker_manager/local.rs
@@ -1,62 +1,38 @@
-use std::collections::HashMap;
-
 use datafusion::prelude::SessionContext;
-use sail_common::actor::{ActorHandle, ActorSystem};
+use futures::future::BoxFuture;
+use sail_common::actor::ActorSystem;
 use sail_common::runtime::RuntimeHandle;
-use tokio::sync::Mutex;
 
 use crate::error::ExecutionResult;
 use crate::id::WorkerId;
 use crate::worker::{WorkerActor, WorkerOptions};
 use crate::worker_manager::{WorkerLaunchOptions, WorkerManager};
 
-struct LocalWorkerManagerState {
-    system: ActorSystem,
-    workers: HashMap<WorkerId, ActorHandle<WorkerActor>>,
-}
-
-impl LocalWorkerManagerState {
-    fn new() -> Self {
-        Self {
-            system: ActorSystem::new(),
-            workers: HashMap::new(),
-        }
-    }
-}
-
 pub struct LocalWorkerManager {
-    state: Mutex<LocalWorkerManagerState>,
     runtime: RuntimeHandle,
     session: SessionContext,
 }
 
 impl LocalWorkerManager {
     pub fn new(runtime: RuntimeHandle, session: SessionContext) -> Self {
-        Self {
-            state: Mutex::new(LocalWorkerManagerState::new()),
-            runtime,
-            session,
-        }
+        Self { runtime, session }
     }
 }
 
 #[tonic::async_trait]
 impl WorkerManager for LocalWorkerManager {
-    async fn launch_worker(
+    fn launch_worker(
         &self,
+        system: &mut ActorSystem,
         id: WorkerId,
         options: WorkerLaunchOptions,
-    ) -> ExecutionResult<()> {
+    ) -> BoxFuture<'static, ExecutionResult<()>> {
         let options = WorkerOptions::local(id, options, self.runtime.clone(), self.session.clone());
-        let mut state = self.state.lock().await;
-        let handle = state.system.spawn(options);
-        state.workers.insert(id, handle);
-        Ok(())
+        system.spawn::<WorkerActor>(options);
+        Box::pin(std::future::ready(Ok(())))
     }
 
     async fn stop(&self) -> ExecutionResult<()> {
-        let mut state = self.state.lock().await;
-        state.system.join().await;
         Ok(())
     }
 }

--- a/crates/sail-execution/src/worker_manager/mod.rs
+++ b/crates/sail-execution/src/worker_manager/mod.rs
@@ -2,19 +2,25 @@ mod kubernetes;
 mod local;
 mod options;
 
+use futures::future::BoxFuture;
 pub(crate) use options::WorkerLaunchOptions;
+use sail_common::actor::ActorSystem;
 
 use crate::error::ExecutionResult;
 use crate::id::WorkerId;
 
 #[tonic::async_trait]
 pub trait WorkerManager: Send + Sync + 'static {
-    /// Launch a worker.
-    async fn launch_worker(
+    /// Start launching a worker.
+    ///
+    /// Local workers are spawned into `system` immediately. The returned task launches an
+    /// external worker when necessary.
+    fn launch_worker(
         &self,
+        system: &mut ActorSystem,
         id: WorkerId,
         options: WorkerLaunchOptions,
-    ) -> ExecutionResult<()>;
+    ) -> BoxFuture<'static, ExecutionResult<()>>;
 
     /// Stop all workers on a best-effort basis.
     /// The driver have attempted to sent shutdown events to all workers

--- a/crates/sail-flight/src/entrypoint.rs
+++ b/crates/sail-flight/src/entrypoint.rs
@@ -2,6 +2,7 @@ use std::future::Future;
 use std::sync::Arc;
 
 use arrow_flight::flight_service_server::FlightServiceServer;
+use sail_common::actor::ActorSystem;
 use sail_common::config::AppConfig;
 use sail_common::runtime::RuntimeHandle;
 use sail_common::server::{ServerBuilder, ServerBuilderOptions};
@@ -19,7 +20,8 @@ pub async fn serve<F>(
 where
     F: Future<Output = ()>,
 {
-    let session_manager = create_flight_session_manager(config, runtime).await?;
+    let mut system = ActorSystem::new();
+    let session_manager = create_flight_session_manager(config, runtime, &mut system).await?;
     let result = {
         let service = SailFlightSqlService::new(session_manager.clone());
         let flight_service = FlightServiceServer::new(service);
@@ -34,5 +36,6 @@ where
             .map_err(|e| std::io::Error::other(e.to_string()))
     };
     session_manager.shutdown().await?;
+    system.join().await;
     result.map_err(Into::into)
 }

--- a/crates/sail-flight/src/session.rs
+++ b/crates/sail-flight/src/session.rs
@@ -5,6 +5,7 @@ use datafusion::common::{Result, internal_datafusion_err};
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::prelude::SessionConfig;
+use sail_common::actor::ActorSystem;
 use sail_common::config::AppConfig;
 use sail_common::runtime::RuntimeHandle;
 use sail_common_datafusion::catalog::display::DefaultCatalogDisplay;
@@ -66,12 +67,14 @@ fn create_flight_session_factory(
 pub async fn create_flight_session_manager(
     config: Arc<AppConfig>,
     runtime: RuntimeHandle,
+    system: &mut ActorSystem,
 ) -> Result<SessionManager, FlightError> {
     create_session_manager(
         config.clone(),
         runtime,
         create_flight_session_factory,
         Duration::from_secs(config.flight.session_timeout_secs),
+        system,
     )
     .await
     .map_err(|e| {

--- a/crates/sail-session/src/session_factory/job_runner.rs
+++ b/crates/sail-session/src/session_factory/job_runner.rs
@@ -1,5 +1,4 @@
-use std::ops::DerefMut;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use datafusion::common::{Result, internal_err};
 use sail_common::actor::ActorSystem;
@@ -49,30 +48,26 @@ pub struct SessionJobRunnerInfo {
 }
 
 pub trait SessionJobRunnerFactory: Send {
-    fn create(&mut self, info: SessionJobRunnerInfo) -> Result<SessionJobRunner>;
+    fn create(
+        &mut self,
+        system: &mut ActorSystem,
+        info: SessionJobRunnerInfo,
+    ) -> Result<SessionJobRunner>;
 }
 
 pub struct ServerSessionJobRunnerFactory {
     config: Arc<AppConfig>,
     runtime: RuntimeHandle,
-    system: Arc<Mutex<ActorSystem>>,
 }
 
 impl ServerSessionJobRunnerFactory {
-    pub fn new(
-        config: Arc<AppConfig>,
-        runtime: RuntimeHandle,
-        system: Arc<Mutex<ActorSystem>>,
-    ) -> Self {
-        Self {
-            config,
-            runtime,
-            system,
-        }
+    pub fn new(config: Arc<AppConfig>, runtime: RuntimeHandle) -> Self {
+        Self { config, runtime }
     }
 
     fn create_cluster_runner(
         &self,
+        system: &mut ActorSystem,
         info: SessionJobRunnerInfo,
         worker_manager: Box<dyn sail_execution::worker_manager::WorkerManager>,
     ) -> Result<SessionJobRunner> {
@@ -90,20 +85,18 @@ impl ServerSessionJobRunnerFactory {
             worker_manager,
             history_reporter: info.history_reporter,
         };
-        let mut system = self
-            .system
-            .lock()
-            .map_err(|e| datafusion::common::internal_datafusion_err!("{e}"))?;
         Ok(SessionJobRunner::cluster(ClusterJobRunner::new(
-            system.deref_mut(),
-            options,
-            components,
+            system, options, components,
         )))
     }
 }
 
 impl SessionJobRunnerFactory for ServerSessionJobRunnerFactory {
-    fn create(&mut self, info: SessionJobRunnerInfo) -> Result<SessionJobRunner> {
+    fn create(
+        &mut self,
+        system: &mut ActorSystem,
+        info: SessionJobRunnerInfo,
+    ) -> Result<SessionJobRunner> {
         match self.config.mode {
             ExecutionMode::Local => Ok(SessionJobRunner::local(LocalJobRunner::new(
                 info.history_reporter,
@@ -113,6 +106,7 @@ impl SessionJobRunnerFactory for ServerSessionJobRunnerFactory {
                     WorkerSessionFactory::new(self.config.clone(), self.runtime.clone())
                         .create(())?;
                 self.create_cluster_runner(
+                    system,
                     info,
                     Box::new(LocalWorkerManager::new(
                         self.runtime.clone(),
@@ -134,7 +128,11 @@ impl SessionJobRunnerFactory for ServerSessionJobRunnerFactory {
                         .clone(),
                     worker_pod_template: self.config.kubernetes.worker_pod_template.clone(),
                 };
-                self.create_cluster_runner(info, Box::new(KubernetesWorkerManager::new(options)))
+                self.create_cluster_runner(
+                    system,
+                    info,
+                    Box::new(KubernetesWorkerManager::new(options)),
+                )
             }
         }
     }

--- a/crates/sail-session/src/session_manager/actor/core.rs
+++ b/crates/sail-session/src/session_manager/actor/core.rs
@@ -102,7 +102,7 @@ impl Actor for SessionManagerActor {
         }
     }
 
-    async fn stop(mut self, _ctx: &mut ActorContext<Self>) {
+    async fn stop(mut self, ctx: &mut ActorContext<Self>) {
         // Keep the gateway available while drivers stop. Graceful gateway shutdown waits for
         // active task stream connections, which are owned by the drivers.
         let drivers = self.drivers.drain().collect::<Vec<_>>();
@@ -111,6 +111,7 @@ impl Actor for SessionManagerActor {
                 warn!("failed to shut down driver {driver_id}: {e}");
             }
         }
+        ctx.children_mut().join().await;
         if let Some(mut driver_gateway) = self.driver_gateway {
             driver_gateway.stop().await;
             info!("driver server has stopped");

--- a/crates/sail-session/src/session_manager/actor/handler.rs
+++ b/crates/sail-session/src/session_manager/actor/handler.rs
@@ -92,15 +92,19 @@ impl SessionManagerActor {
                     return ActorAction::Continue;
                 }
             };
-            let runner = self.job_runner_factory.create(SessionJobRunnerInfo {
-                session_id: session_id.clone(),
-                driver_id,
-                driver_server_port: self.driver_gateway.as_ref().map(|x| x.port()),
-                history_reporter: Box::new(SessionJobRunnerHistoryReporter {
+            let session_manager = ctx.handle().clone();
+            let runner = self.job_runner_factory.create(
+                ctx.children_mut(),
+                SessionJobRunnerInfo {
                     session_id: session_id.clone(),
-                    session_manager: ctx.handle().clone(),
-                }),
-            });
+                    driver_id,
+                    driver_server_port: self.driver_gateway.as_ref().map(|x| x.port()),
+                    history_reporter: Box::new(SessionJobRunnerHistoryReporter {
+                        session_id: session_id.clone(),
+                        session_manager,
+                    }),
+                },
+            );
             match runner {
                 Ok(runner) => {
                     let (runner, driver) = runner.into_parts();

--- a/crates/sail-session/src/session_manager/mod.rs
+++ b/crates/sail-session/src/session_manager/mod.rs
@@ -4,7 +4,7 @@ mod options;
 mod session;
 
 use std::fmt;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use datafusion::prelude::SessionContext;
@@ -40,11 +40,9 @@ impl SessionManager {
     pub fn try_new(
         options: SessionManagerOptions,
         components: SessionManagerComponents,
+        system: &mut ActorSystem,
     ) -> SessionResult<Self> {
-        let system = options.system.clone();
-        let handle = system
-            .lock()?
-            .spawn::<SessionManagerActor>((options, components));
+        let handle = system.spawn::<SessionManagerActor>((options, components));
         Ok(Self { handle })
     }
 
@@ -93,13 +91,12 @@ pub async fn create_session_manager(
     runtime: RuntimeHandle,
     session_factory_fn: ServerSessionFactoryFn,
     session_timeout: Duration,
+    system: &mut ActorSystem,
 ) -> SessionResult<SessionManager> {
-    let system = Arc::new(Mutex::new(ActorSystem::new()));
     let session_factory = session_factory_fn(config.clone(), runtime.clone());
     let job_runner_factory = Box::new(ServerSessionJobRunnerFactory::new(
         config.clone(),
         runtime.clone(),
-        system.clone(),
     )) as Box<dyn SessionJobRunnerFactory>;
     let driver_gateway = if matches!(&config.mode, ExecutionMode::Local) {
         None
@@ -112,7 +109,7 @@ pub async fn create_session_manager(
                 })?,
         )
     };
-    let options = SessionManagerOptions::new(runtime, system)
+    let options = SessionManagerOptions::new(runtime)
         .with_session_timeout(session_timeout)
         .with_options(
             config
@@ -124,5 +121,5 @@ pub async fn create_session_manager(
         job_runner_factory,
         driver_gateway,
     };
-    SessionManager::try_new(options, components)
+    SessionManager::try_new(options, components, system)
 }

--- a/crates/sail-session/src/session_manager/options.rs
+++ b/crates/sail-session/src/session_manager/options.rs
@@ -1,7 +1,5 @@
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use sail_common::actor::ActorSystem;
 use sail_common::runtime::RuntimeHandle;
 use sail_execution::driver::DriverGateway;
 
@@ -11,7 +9,6 @@ use crate::session_factory::{ServerSessionInfo, SessionFactory, SessionJobRunner
 pub struct SessionManagerOptions {
     pub session_timeout: Duration,
     pub runtime: RuntimeHandle,
-    pub system: Arc<Mutex<ActorSystem>>,
     /// The application configuration options as key-value pairs,
     /// used to populate the `system.session.options` table.
     pub options: Vec<(String, String)>,
@@ -24,11 +21,10 @@ pub struct SessionManagerComponents {
 }
 
 impl SessionManagerOptions {
-    pub fn new(runtime: RuntimeHandle, system: Arc<Mutex<ActorSystem>>) -> Self {
+    pub fn new(runtime: RuntimeHandle) -> Self {
         Self {
             session_timeout: Duration::MAX,
             runtime,
-            system,
             options: Vec::new(),
         }
     }

--- a/crates/sail-spark-connect/src/entrypoint.rs
+++ b/crates/sail-spark-connect/src/entrypoint.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
 use std::sync::Arc;
 
+use sail_common::actor::ActorSystem;
 use sail_common::config::{AppConfig, GRPC_MAX_MESSAGE_LENGTH_DEFAULT};
 use sail_common::runtime::RuntimeHandle;
 use sail_common::server::ServerBuilder;
@@ -22,7 +23,8 @@ pub async fn serve<F>(
 where
     F: Future<Output = ()>,
 {
-    let session_manager = create_spark_session_manager(config, runtime).await?;
+    let mut system = ActorSystem::new();
+    let session_manager = create_spark_session_manager(config, runtime, &mut system).await?;
     let result = {
         let server = SparkConnectServer::new(session_manager.clone());
         let service = SparkConnectServiceServer::new(server)
@@ -41,5 +43,6 @@ where
             .map_err(|e| std::io::Error::other(e.to_string()))
     };
     session_manager.shutdown().await?;
+    system.join().await;
     result.map_err(Into::into)
 }

--- a/crates/sail-spark-connect/src/proto/function.rs
+++ b/crates/sail-spark-connect/src/proto/function.rs
@@ -9,6 +9,7 @@ mod tests {
     use datafusion::arrow::util::display::{ArrayFormatter, FormatOptions};
     use futures::stream::TryStreamExt;
     use pyo3::Python;
+    use sail_common::actor::ActorSystem;
     use sail_common::config::AppConfig;
     use sail_common::runtime::RuntimeManager;
     use sail_common::tests::test_gold_set;
@@ -61,11 +62,14 @@ mod tests {
         let config = Arc::new(AppConfig::load()?);
         let runtime = RuntimeManager::try_new(&config.runtime)?;
         let handle = runtime.handle();
+        let mut system = ActorSystem::new();
         // The driver gateway is initialized before the session manager in cluster mode, so the
         // manager must be created inside an async context.
-        let manager = handle
-            .primary()
-            .block_on(create_spark_session_manager(config, handle.clone()))?;
+        let manager = handle.primary().block_on(create_spark_session_manager(
+            config,
+            handle.clone(),
+            &mut system,
+        ))?;
         let context = handle
             .primary()
             .block_on(manager.get_or_create_session_context("test".to_string(), "".to_string()))?;

--- a/crates/sail-spark-connect/src/session_manager.rs
+++ b/crates/sail-spark-connect/src/session_manager.rs
@@ -5,6 +5,7 @@ use datafusion::common::{Result, internal_datafusion_err};
 use datafusion::execution::SessionStateBuilder;
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::prelude::SessionConfig;
+use sail_common::actor::ActorSystem;
 use sail_common::config::AppConfig;
 use sail_common::runtime::RuntimeHandle;
 use sail_common_datafusion::catalog::display::DefaultCatalogDisplay;
@@ -78,12 +79,14 @@ fn create_spark_session_factory(
 pub async fn create_spark_session_manager(
     config: Arc<AppConfig>,
     runtime: RuntimeHandle,
+    system: &mut ActorSystem,
 ) -> SparkResult<SessionManager> {
     Ok(create_session_manager(
         config.clone(),
         runtime,
         create_spark_session_factory,
         Duration::from_secs(config.spark.session_timeout_secs),
+        system,
     )
     .await?)
 }


### PR DESCRIPTION
Right now there are various use cases of actor hierarchy but they are implicit.

1. The driver actor owns worker actors in local cluster mode.
2. The session manager actor owns driver actors.

This PR makes actor hierarchy explicit by managing child actors in a dedicated `ActorSystem` instance.