### PR TITLE
feat: implement vector inner product

### DIFF
--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -243,6 +243,7 @@ use sail_function::scalar::variant::spark_to_variant_object::SparkToVariantObjec
 use sail_function::scalar::variant::spark_variant_explode::SparkVariantExplodeUdf;
 use sail_function::scalar::variant::spark_variant_get::SparkVariantGet;
 use sail_function::scalar::variant::spark_variant_to_json::SparkVariantToJsonUdf;
+use sail_function::scalar::vector::inner_product::VectorInnerProduct;
 use sail_function::scalar::xml::from_xml::SparkFromXml;
 use sail_function::scalar::xml::to_xml::SparkToXml;
 use sail_function::scalar::xml::xpath::Xpath;
@@ -2725,6 +2726,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 Ok(Arc::new(ScalarUDF::from(SparkArrayPosition::new())))
             }
             "spark_array_compact" => Ok(Arc::new(ScalarUDF::from(SparkArrayCompact::new()))),
+            "vector_inner_product" => Ok(Arc::new(ScalarUDF::from(VectorInnerProduct::new()))),
             "bitmap_count" => Ok(Arc::new(ScalarUDF::from(BitmapCount::new()))),
             "format_string" => Ok(Arc::new(ScalarUDF::from(FormatStringFunc::new()))),
             "greatest" => Ok(Arc::new(ScalarUDF::from(GreatestFunc::new()))),
@@ -2911,6 +2913,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node_inner.is::<ArrayIntersect>()
             || node_inner.is::<SparkArrayPosition>()
             || node_inner.is::<SparkArrayCompact>()
+            || node_inner.is::<VectorInnerProduct>()
             || node_inner.is::<BitmapCount>()
             || node_inner.is::<FormatStringFunc>()
             || node_inner.is::<GreatestFunc>()
@@ -4936,6 +4939,21 @@ mod tests {
                 .is_some()
         );
         assert_eq!(decoded.name(), "spark_variant_explode");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_round_trip_vector_inner_product_udf() -> Result<()> {
+        let decoded = round_trip_udf(ScalarUDF::from(VectorInnerProduct::new()))?;
+
+        assert!(
+            decoded
+                .inner()
+                .downcast_ref::<VectorInnerProduct>()
+                .is_some()
+        );
+        assert_eq!(decoded.name(), "vector_inner_product");
 
         Ok(())
     }

--- a/crates/sail-function/src/scalar/mod.rs
+++ b/crates/sail-function/src/scalar/mod.rs
@@ -21,4 +21,5 @@ pub mod table_input;
 pub mod update_struct_field;
 pub mod url;
 pub mod variant;
+pub mod vector;
 pub mod xml;

--- a/crates/sail-function/src/scalar/vector/inner_product.rs
+++ b/crates/sail-function/src/scalar/vector/inner_product.rs
@@ -77,6 +77,32 @@ fn vector_inner_product_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
     }
 }
 
+/// Spark 4.2 `vectorInnerProduct` accumulates products eight at a time:
+/// `sum += a0*b0 + ... + a7*b7` then a scalar tail. Sequential f32 folds can
+/// differ when large values cancel across an eight-element boundary.
+fn dot_product_spark(left: &[f32], right: &[f32]) -> f32 {
+    debug_assert_eq!(left.len(), right.len());
+    let mut sum = 0.0f32;
+    let mut i = 0;
+    let simd_limit = (left.len() / 8) * 8;
+    while i < simd_limit {
+        sum += left[i] * right[i]
+            + left[i + 1] * right[i + 1]
+            + left[i + 2] * right[i + 2]
+            + left[i + 3] * right[i + 3]
+            + left[i + 4] * right[i + 4]
+            + left[i + 5] * right[i + 5]
+            + left[i + 6] * right[i + 6]
+            + left[i + 7] * right[i + 7];
+        i += 8;
+    }
+    while i < left.len() {
+        sum += left[i] * right[i];
+        i += 1;
+    }
+    sum
+}
+
 fn compute_inner_product<O: OffsetSizeTrait>(
     left: &GenericListArray<O>,
     right: &GenericListArray<O>,
@@ -99,13 +125,9 @@ fn compute_inner_product<O: OffsetSizeTrait>(
         if left.null_count() > 0 || right.null_count() > 0 {
             return Ok(None);
         }
-        Ok(Some(
-            left.values()
-                .iter()
-                .zip(right.values())
-                .map(|(left, right)| left * right)
-                .fold(0.0, |sum, value| sum + value),
-        ))
+        // Match Spark 4.2: accumulate products in groups of eight so floating-point
+        // cancellation across an 8-element boundary stays Spark-compatible.
+        Ok(Some(dot_product_spark(left.values(), right.values())))
     });
     let values = values.collect::<Result<Vec<Option<f32>>>>()?;
     Ok(Arc::new(Float32Array::from(values)))
@@ -151,5 +173,29 @@ mod tests {
             compute_inner_product(&left, &right),
             Err(error) if error.to_string().contains("matching dimensions")
         ));
+    }
+
+    #[test]
+    fn accumulation_matches_spark_for_large_cancellation() -> Result<()> {
+        // Left:  [1e20, 0,0,0,0,0,0,0, -1e20, 1,1,1,1,1,1,1]
+        // Right: [1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1]
+        // Spark 8-wide sum => 0.0; naive sequential fold => 7.0.
+        let left_vals = [
+            1.0e20f32, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0e20, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+            1.0,
+        ];
+        let right_vals = [1.0f32; 16];
+        let left = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(
+            left_vals.iter().copied().map(Some).collect::<Vec<_>>(),
+        )]);
+        let right = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(
+            right_vals.iter().copied().map(Some).collect::<Vec<_>>(),
+        )]);
+
+        let actual = compute_inner_product(&left, &right)?;
+        let actual = actual.as_primitive::<Float32Type>();
+        assert_eq!(actual.value(0), 0.0);
+        assert_eq!(dot_product_spark(&left_vals, &right_vals), 0.0);
+        Ok(())
     }
 }

--- a/crates/sail-function/src/scalar/vector/inner_product.rs
+++ b/crates/sail-function/src/scalar/vector/inner_product.rs
@@ -1,0 +1,153 @@
+use std::sync::Arc;
+
+use datafusion::arrow::array::{
+    Array, ArrayRef, AsArray, Float32Array, GenericListArray, OffsetSizeTrait, as_large_list_array,
+    as_list_array,
+};
+use datafusion::arrow::datatypes::{DataType, Float32Type};
+use datafusion_common::{Result, exec_err, plan_err};
+use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+
+use crate::functions_nested_utils::make_scalar_function;
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct VectorInnerProduct {
+    signature: Signature,
+}
+
+impl Default for VectorInnerProduct {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VectorInnerProduct {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::any(2, Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for VectorInnerProduct {
+    fn name(&self) -> &str {
+        "vector_inner_product"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        if arg_types.len() != 2 || !arg_types.iter().all(is_float_vector) {
+            return plan_err!(
+                "vector_inner_product expects two ARRAY<FLOAT> arguments, got {arg_types:?}"
+            );
+        }
+        Ok(DataType::Float32)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(vector_inner_product_inner)(&args.args)
+    }
+}
+
+fn is_float_vector(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::List(field) | DataType::LargeList(field)
+            if field.data_type() == &DataType::Float32
+    )
+}
+
+fn vector_inner_product_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    if args.len() != 2 {
+        return exec_err!("vector_inner_product needs exactly two arguments");
+    }
+    match (args[0].data_type(), args[1].data_type()) {
+        (DataType::List(_), DataType::List(_)) => {
+            compute_inner_product(as_list_array(&args[0]), as_list_array(&args[1]))
+        }
+        (DataType::LargeList(_), DataType::LargeList(_)) => {
+            compute_inner_product(as_large_list_array(&args[0]), as_large_list_array(&args[1]))
+        }
+        (left, right) => exec_err!(
+            "vector_inner_product expects matching array types, got {left:?} and {right:?}"
+        ),
+    }
+}
+
+fn compute_inner_product<O: OffsetSizeTrait>(
+    left: &GenericListArray<O>,
+    right: &GenericListArray<O>,
+) -> Result<ArrayRef> {
+    let values = (0..left.len()).map(|row| {
+        if left.is_null(row) || right.is_null(row) {
+            return Ok(None);
+        }
+        let left = left.value(row);
+        let right = right.value(row);
+        if left.len() != right.len() {
+            return exec_err!(
+                "vector_inner_product requires vectors with matching dimensions, got {} and {}",
+                left.len(),
+                right.len()
+            );
+        }
+        let left = left.as_primitive::<Float32Type>();
+        let right = right.as_primitive::<Float32Type>();
+        if left.null_count() > 0 || right.null_count() > 0 {
+            return Ok(None);
+        }
+        Ok(Some(
+            left.values()
+                .iter()
+                .zip(right.values())
+                .map(|(left, right)| left * right)
+                .fold(0.0, |sum, value| sum + value),
+        ))
+    });
+    let values = values.collect::<Result<Vec<Option<f32>>>>()?;
+    Ok(Arc::new(Float32Array::from(values)))
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::array::ListArray;
+
+    use super::*;
+
+    #[test]
+    fn computes_spark_compatible_results() -> Result<()> {
+        let left = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![
+            Some(vec![Some(1.0), Some(2.0), Some(3.0)]),
+            Some(vec![]),
+            Some(vec![Some(1.0), None, Some(3.0)]),
+            None,
+        ]);
+        let right = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![
+            Some(vec![Some(4.0), Some(5.0), Some(6.0)]),
+            Some(vec![]),
+            Some(vec![Some(1.0), Some(2.0), Some(3.0)]),
+            Some(vec![Some(1.0)]),
+        ]);
+
+        let actual = compute_inner_product(&left, &right)?;
+        let actual = actual.as_primitive::<Float32Type>();
+        let expected = Float32Array::from(vec![Some(32.0), Some(0.0), None, None]);
+        assert_eq!(actual, &expected);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_dimension_mismatch() {
+        let left = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(vec![Some(1.0)])]);
+        let right = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(vec![
+            Some(1.0),
+            Some(2.0),
+        ])]);
+
+        let error = compute_inner_product(&left, &right).unwrap_err();
+        assert!(error.to_string().contains("matching dimensions"));
+    }
+}

--- a/crates/sail-function/src/scalar/vector/inner_product.rs
+++ b/crates/sail-function/src/scalar/vector/inner_product.rs
@@ -147,7 +147,9 @@ mod tests {
             Some(2.0),
         ])]);
 
-        let error = compute_inner_product(&left, &right).unwrap_err();
-        assert!(error.to_string().contains("matching dimensions"));
+        assert!(matches!(
+            compute_inner_product(&left, &right),
+            Err(error) if error.to_string().contains("matching dimensions")
+        ));
     }
 }

--- a/crates/sail-function/src/scalar/vector/mod.rs
+++ b/crates/sail-function/src/scalar/vector/mod.rs
@@ -1,0 +1,1 @@
+pub mod inner_product;

--- a/crates/sail-plan/src/function/scalar/vector.rs
+++ b/crates/sail-plan/src/function/scalar/vector.rs
@@ -1,3 +1,5 @@
+use sail_function::scalar::vector::inner_product::VectorInnerProduct;
+
 use crate::function::common::ScalarFunction;
 
 pub(super) fn list_built_in_vector_functions() -> Vec<(&'static str, ScalarFunction)> {
@@ -8,7 +10,7 @@ pub(super) fn list_built_in_vector_functions() -> Vec<(&'static str, ScalarFunct
             "vector_cosine_similarity",
             F::unknown("vector_cosine_similarity"),
         ),
-        ("vector_inner_product", F::unknown("vector_inner_product")),
+        ("vector_inner_product", F::udf(VectorInnerProduct::new())),
         ("vector_l2_distance", F::unknown("vector_l2_distance")),
         ("vector_norm", F::unknown("vector_norm")),
         ("vector_normalize", F::unknown("vector_normalize")),

--- a/crates/sail-spark-connect/tests/gold_data/function/vector.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/vector.json
@@ -67,7 +67,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: vector_inner_product"
+        "success": "ok"
       }
     },
     {

--- a/python/pysail/tests/spark/function/features/vector/vector_inner_product.feature
+++ b/python/pysail/tests/spark/function/features/vector/vector_inner_product.feature
@@ -1,0 +1,143 @@
+@spark-4.2
+Feature: vector_inner_product
+
+  Rule: Basic results
+
+    Scenario: basic, orthogonal, and self product
+      When query
+        """
+        SELECT
+          vector_inner_product(array(1.0F, 2.0F, 3.0F), array(4.0F, 5.0F, 6.0F)) AS basic,
+          vector_inner_product(array(1.0F, 0.0F), array(0.0F, 1.0F)) AS orthogonal,
+          vector_inner_product(array(3.0F, 4.0F), array(3.0F, 4.0F)) AS self_product
+        """
+      Then query result
+        | basic | orthogonal | self_product |
+        | 32.0  | 0.0        | 25.0         |
+
+    Scenario: vector columns from VALUES execute the UDF
+      When query
+        """
+        SELECT vector_inner_product(left_vector, right_vector) AS result
+        FROM VALUES
+          (array(1.0F, 2.0F, 3.0F), array(4.0F, 5.0F, 6.0F)),
+          (array(1.0F, 0.0F), array(0.0F, 1.0F)),
+          (array(3.0F, 4.0F), array(3.0F, 4.0F))
+        AS t(left_vector, right_vector)
+        """
+      Then query result
+        | result |
+        | 32.0   |
+        | 0.0    |
+        | 25.0   |
+
+    Scenario: empty ARRAY<FLOAT> inputs return 0.0
+      When query
+        """
+        SELECT vector_inner_product(array(), array()) AS result
+        """
+      Then query result
+        | result |
+        | 0.0    |
+
+    Scenario: upstream 16-element case returns 816.0
+      When query
+        """
+        SELECT vector_inner_product(
+          array(1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F, 13.0F, 14.0F, 15.0F, 16.0F),
+          array(1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F, 13.0F, 14.0F, 15.0F, 16.0F)
+        ) AS result
+        """
+      Then query result
+        | result |
+        | 816.0  |
+
+    Scenario: accumulation matches Spark for vectors with large cancellation
+      When query
+        """
+        SELECT vector_inner_product(left_vector, right_vector) AS result
+        FROM VALUES (
+          array(
+            1.0E20F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F,
+            -1.0E20F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F
+          ),
+          array(
+            1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F,
+            1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F, 1.0F
+          )
+        ) AS t(left_vector, right_vector)
+        """
+      Then query result
+        | result |
+        | 0.0    |
+
+  Rule: Null handling
+
+    Scenario: typed null vector returns NULL
+      When query
+        """
+        SELECT vector_inner_product(CAST(NULL AS ARRAY<FLOAT>), array(1.0F, 2.0F)) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: array containing a null element returns NULL
+      When query
+        """
+        SELECT vector_inner_product(array(1.0F, CAST(NULL AS FLOAT), 3.0F), array(4.0F, 5.0F, 6.0F)) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+  Rule: Output schema
+
+    @function(nullability)
+    Scenario: declared FLOAT output schema and nullability
+      When query
+        """
+        SELECT vector_inner_product(array(1.0F, 2.0F), array(3.0F, 4.0F)) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: float (nullable = true)
+        """
+
+  Rule: Error cases
+
+    Scenario: unequal dimensions produce a dimension mismatch error
+      When query
+        """
+        SELECT vector_inner_product(array(1.0F), array(1.0F, 2.0F)) AS result
+        """
+      Then query error (?i)(VECTOR_DIMENSION_MISMATCH|matching dimensions|dimension)
+
+    Scenario: untyped NULL is rejected
+      When query
+        """
+        SELECT vector_inner_product(NULL, array(1.0F, 2.0F)) AS result
+        """
+      Then query error (?i)(DATATYPE_MISMATCH|UNEXPECTED_INPUT_TYPE|ARRAY|FLOAT|vector_inner_product)
+
+    Scenario: ARRAY<DOUBLE> inputs are rejected
+      When query
+        """
+        SELECT vector_inner_product(array(1.0D, 2.0D), array(3.0D, 4.0D)) AS result
+        """
+      Then query error (?i)(DATATYPE_MISMATCH|UNEXPECTED_INPUT_TYPE|ARRAY|FLOAT|vector_inner_product)
+
+    Scenario: ARRAY<INT> inputs are rejected
+      When query
+        """
+        SELECT vector_inner_product(array(1, 2), array(3, 4)) AS result
+        """
+      Then query error (?i)(DATATYPE_MISMATCH|UNEXPECTED_INPUT_TYPE|ARRAY|FLOAT|vector_inner_product)
+
+    Scenario: non-array values are rejected
+      When query
+        """
+        SELECT vector_inner_product(1.0F, 2.0F) AS result
+        """
+      Then query error (?i)(DATATYPE_MISMATCH|UNEXPECTED_INPUT_TYPE|ARRAY|FLOAT|vector_inner_product)

--- a/python/pysail/tests/spark/function/features/vector/vector_inner_product.feature
+++ b/python/pysail/tests/spark/function/features/vector/vector_inner_product.feature
@@ -34,13 +34,16 @@ Feature: vector_inner_product
     Scenario: empty ARRAY<FLOAT> inputs return 0.0
       When query
         """
-        SELECT vector_inner_product(array(), array()) AS result
+        SELECT vector_inner_product(
+          CAST(array() AS ARRAY<FLOAT>),
+          CAST(array() AS ARRAY<FLOAT>)
+        ) AS result
         """
       Then query result
         | result |
         | 0.0    |
 
-    Scenario: upstream 16-element case returns 816.0
+    Scenario: upstream 16-element case returns sum of squares 1496.0
       When query
         """
         SELECT vector_inner_product(
@@ -50,7 +53,7 @@ Feature: vector_inner_product
         """
       Then query result
         | result |
-        | 816.0  |
+        | 1496.0 |
 
     Scenario: accumulation matches Spark for vectors with large cancellation
       When query


### PR DESCRIPTION
## Summary

- implement Spark 4.2's `vector_inner_product` for `ARRAY<FLOAT>` inputs
- preserve Spark-compatible null, empty-vector, and dimension-mismatch behavior
- register the UDF in scalar planning and remote execution serialization
- accumulate products in groups of eight to match Spark's floating-point reduction order

Part of #2358.

## Evidence

Spark documents this function as returning the inner (dot) product of two float vectors:
https://spark.apache.org/docs/latest/api/sql/#vector_inner_product

Upstream implementation (equal dimensions, null element → null, 8-wide product accumulation):
https://github.com/apache/spark/blob/v4.2.0/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/VectorFunctionImplUtils.java

## Validation

- `cargo +stable test -p sail-function vector::inner_product` — **3 passed**, 0 failed
  - basic / empty / null-element results
  - dimension mismatch
  - large-cancellation accumulation (`0.0`, Spark-compatible)
- BDD: `python/pysail/tests/spark/function/features/vector/vector_inner_product.feature` (`@spark-4.2`)
  - basic / orthogonal / self product (`32.0`, `0.0`, `25.0`)
  - VALUES vector columns (avoids pure constant-fold-only coverage)
  - empty arrays → `0.0`
  - 16-element self product → `816.0`
  - large-cancellation case → `0.0`
  - typed null vector / null element → `NULL`
  - FLOAT schema nullability
  - dimension mismatch and invalid input types rejected
- CI re-runs the Spark/BDD and Cargo suites for this PR after push

## Review response

Addressed @lonless9 feedback:

1. PR description uses **Part of #2358** (does not auto-close the multi-function issue).
2. Removed Risk and rollback section.
3. Validation lists actual Cargo unit results; BDD feature added for CI.
4. Accumulation matches Spark 8-wide product groups; inline cancellation BDD case included.