### PR TITLE
fix: make Python data source options case-insensitive

### DIFF
--- a/crates/sail-data-source/src/formats/python/table_format.rs
+++ b/crates/sail-data-source/src/formats/python/table_format.rs
@@ -145,11 +145,16 @@ impl PythonTableFormat {
                 .call_method1("loads", (class_bytes,))
                 .map_err(py_err)?;
 
-            // Create options dict
+            // Create Spark-compatible case-insensitive options
             let py_options = PyDict::new(py);
             for (k, v) in &options {
                 py_options.set_item(k, v).map_err(py_err)?;
             }
+            let py_options = py
+                .import("pyspark.sql.datasource")
+                .and_then(|module| module.getattr("CaseInsensitiveDict"))
+                .and_then(|class| class.call1((py_options,)))
+                .map_err(py_err)?;
 
             // Instantiate the datasource with options
             let ds_instance = ds_class.call1((py_options,)).map_err(py_err)?;

--- a/python/pysail/tests/spark/datasource/test_python.py
+++ b/python/pysail/tests/spark/datasource/test_python.py
@@ -747,6 +747,14 @@ def test_python_ddl_schema_fallback(spark):
     assert rows[0].id == 0
 
 
+def test_python_datasource_options_are_case_insensitive(spark):
+    spark.dataSource.register(RangeDataSource)
+
+    rows = spark.read.format("range").option("END", "2").load().collect()
+
+    assert sorted(row.id for row in rows) == [0, 1]
+
+
 def test_python_filter_pushdown_comparison(spark):
     """Test that comparison filters (>, <, >=, <=) work correctly.
 


### PR DESCRIPTION
## Summary

- wrap Python data source options in PySpark native `CaseInsensitiveDict`
- preserve Spark case-insensitive option behavior
- add an uppercase `END` regression test

## Context

Small independent compatibility fix found while reviewing #2167. Contains no JDBC implementation, CI workflow, or database-specific changes.

## Tests

- `.venv/bin/pytest -q python/pysail/tests/spark/datasource/test_python.py` — 32 passed
- `cargo fmt --all -- --check`