### PR TITLE
fix: resolve Delta MERGE constraints by visible names

### DIFF
--- a/crates/sail-plan/src/resolver/command/delta.rs
+++ b/crates/sail-plan/src/resolver/command/delta.rs
@@ -366,10 +366,19 @@ impl PlanResolver<'_> {
                 properties.extend(items.clone());
             }
         }
-        let constraints = delta_constraints_from_schema_and_properties(
-            target_schema.fields().iter().map(|field| field.as_ref()),
-            &properties,
-        );
+
+        // MERGE target schemas use opaque field IDs internally. Constraint source text and
+        // diagnostics must use the corresponding user-facing names; resolving that source text
+        // against `target_schema` maps it back to the opaque field safely.
+        let target_field_names = Self::get_field_names(target_schema, state)?;
+        let target_fields = target_schema
+            .fields()
+            .iter()
+            .zip(target_field_names)
+            .map(|(field, name)| field.as_ref().clone().with_name(name))
+            .collect::<Vec<_>>();
+        let constraints =
+            delta_constraints_from_schema_and_properties(target_fields.iter(), &properties);
         self.resolve_delta_check_constraints(constraints, target_schema, state)
             .await
     }

--- a/python/pysail/tests/spark/delta/features/check_constraints.feature
+++ b/python/pysail/tests/spark/delta/features/check_constraints.feature
@@ -207,3 +207,57 @@ Feature: Delta Lake CHECK Constraints
         WHEN NOT MATCHED THEN INSERT *
         """
       Then query error DELTA_VIOLATE_CONSTRAINT_WITH_VALUES
+
+  Rule: MERGE respects NOT NULL constraints
+
+    Background:
+      Given variable location for temporary directory delta_not_null_merge
+      Given final statement
+        """
+        DROP TABLE IF EXISTS delta_not_null_merge_test
+        """
+      Given statement template
+        """
+        CREATE TABLE delta_not_null_merge_test (
+          id INT NOT NULL,
+          value STRING
+        )
+        USING DELTA
+        LOCATION {{ location.sql }}
+        """
+
+    Scenario: MERGE inserts valid rows into a table with a NOT NULL column
+      Given statement
+        """
+        CREATE OR REPLACE TEMP VIEW src_delta_not_null_merge AS
+        SELECT 1 AS id, 'valid' AS value
+        """
+      Given statement
+        """
+        MERGE INTO delta_not_null_merge_test AS t
+        USING src_delta_not_null_merge AS s
+        ON t.id = s.id
+        WHEN NOT MATCHED THEN INSERT (id, value) VALUES (s.id, s.value)
+        """
+      When query
+        """
+        SELECT id, value FROM delta_not_null_merge_test
+        """
+      Then query result ordered
+        | id | value |
+        | 1  | valid |
+
+    Scenario: MERGE rejects null values for non-nullable target columns
+      Given statement
+        """
+        CREATE OR REPLACE TEMP VIEW src_delta_not_null_merge AS
+        SELECT CAST(NULL AS INT) AS id, 'invalid' AS value
+        """
+      When query
+        """
+        MERGE INTO delta_not_null_merge_test AS t
+        USING src_delta_not_null_merge AS s
+        ON t.id = s.id
+        WHEN NOT MATCHED THEN INSERT (id, value) VALUES (s.id, s.value)
+        """
+      Then query error DELTA_NOT_NULL_CONSTRAINT_VIOLATED.*column: id


### PR DESCRIPTION
## Summary

Resolve Delta MERGE constraints from visible source names so the generic Sail correction used by Grust cognition can land upstream.

## Verification

- Built the exact local Sail source revision.
- Ran the bounded Grust Sail integration harness in source mode: 26 Sail executor tests, two live backend tests, and two live cognition parity/secrecy tests passed.