### PR TITLE
feat: support PostgreSQL JDBC appends

### DIFF
--- a/crates/sail-data-source/src/formats/python/adapter.rs
+++ b/crates/sail-data-source/src/formats/python/adapter.rs
@@ -12,7 +12,7 @@ use datafusion::logical_expr::physical_planning_context::PhysicalPlanningContext
 use datafusion::logical_expr::{Extension, LogicalPlan, TableSource, UserDefinedLogicalNode};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
-use datafusion_common::{DFSchema, DFSchemaRef, Result, internal_err};
+use datafusion_common::{DFSchema, DFSchemaRef, Result, internal_err, plan_err};
 use datafusion_expr::{Expr, UserDefinedLogicalNodeCore};
 use educe::Educe;
 use sail_common_datafusion::datasource::{
@@ -24,6 +24,13 @@ use super::datasource::PythonDataSource;
 use super::discovery::DATA_SOURCE_REGISTRY;
 use super::executor::InProcessExecutor;
 use super::table_provider::PythonTableProvider;
+
+fn validate_jdbc_write_mode(name: &str, mode: &SinkMode) -> Result<()> {
+    if name.eq_ignore_ascii_case("jdbc") && !matches!(mode, SinkMode::Append) {
+        return plan_err!("JDBC writes currently support only explicit append mode");
+    }
+    Ok(())
+}
 
 /// DataSource implementation for a Python data source.
 ///
@@ -221,6 +228,8 @@ impl DataSource for PythonDataSourceAdapter {
             ..
         } = info;
 
+        validate_jdbc_write_mode(&self.name, &mode)?;
+
         // Warn about unsupported partitionBy (PySpark compat: silently ignored)
         if !partition_by.is_empty() {
             log::warn!(
@@ -378,5 +387,13 @@ mod tests {
     fn test_python_data_source_adapter_name() {
         let source = PythonDataSourceAdapter::new("test_datasource".to_string());
         assert_eq!(source.name(), "test_datasource");
+    }
+
+    #[test]
+    fn test_jdbc_write_mode_accepts_only_append() {
+        assert!(validate_jdbc_write_mode("jdbc", &SinkMode::Append).is_ok());
+        assert!(validate_jdbc_write_mode("JDBC", &SinkMode::ErrorIfExists).is_err());
+        assert!(validate_jdbc_write_mode("jdbc", &SinkMode::Overwrite).is_err());
+        assert!(validate_jdbc_write_mode("other", &SinkMode::Overwrite).is_ok());
     }
 }

--- a/crates/sail-data-source/src/formats/python/adapter.rs
+++ b/crates/sail-data-source/src/formats/python/adapter.rs
@@ -12,7 +12,7 @@ use datafusion::logical_expr::physical_planning_context::PhysicalPlanningContext
 use datafusion::logical_expr::{Extension, LogicalPlan, TableSource, UserDefinedLogicalNode};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
-use datafusion_common::{DFSchema, DFSchemaRef, Result, internal_err, plan_err};
+use datafusion_common::{DFSchema, DFSchemaRef, Result, internal_err};
 use datafusion_expr::{Expr, UserDefinedLogicalNodeCore};
 use educe::Educe;
 use sail_common_datafusion::datasource::{
@@ -25,11 +25,15 @@ use super::discovery::DATA_SOURCE_REGISTRY;
 use super::executor::InProcessExecutor;
 use super::table_provider::PythonTableProvider;
 
-fn validate_jdbc_write_mode(name: &str, mode: &SinkMode) -> Result<()> {
-    if name.eq_ignore_ascii_case("jdbc") && !matches!(mode, SinkMode::Append) {
-        return plan_err!("JDBC writes currently support only explicit append mode");
+fn sink_mode_name(mode: &SinkMode) -> &'static str {
+    match mode {
+        SinkMode::ErrorIfExists => "errorifexists",
+        SinkMode::IgnoreIfExists => "ignore",
+        SinkMode::Append => "append",
+        SinkMode::Overwrite | SinkMode::OverwriteIf { .. } | SinkMode::OverwritePartitions => {
+            "overwrite"
+        }
     }
-    Ok(())
 }
 
 /// DataSource implementation for a Python data source.
@@ -228,8 +232,6 @@ impl DataSource for PythonDataSourceAdapter {
             ..
         } = info;
 
-        validate_jdbc_write_mode(&self.name, &mode)?;
-
         // Warn about unsupported partitionBy (PySpark compat: silently ignored)
         if !partition_by.is_empty() {
             log::warn!(
@@ -343,12 +345,16 @@ impl ExtensionPlanner for PythonPhysicalPlanner {
             node.mode,
             SinkMode::Overwrite | SinkMode::OverwriteIf { .. } | SinkMode::OverwritePartitions
         );
-        let opaque_options: Vec<HashMap<String, String>> = node
+        let mut opaque_options: Vec<HashMap<String, String>> = node
             .options
             .clone()
             .into_iter()
             .map(|l| l.into_opaque_options())
             .collect();
+        opaque_options.push(HashMap::from([(
+            "__sail_save_mode".to_string(),
+            sink_mode_name(&node.mode).to_string(),
+        )]));
         let adapter = PythonDataSourceAdapter {
             name: node.name.clone(),
             pickled_class: node.pickled_class.clone(),
@@ -390,10 +396,10 @@ mod tests {
     }
 
     #[test]
-    fn test_jdbc_write_mode_accepts_only_append() {
-        assert!(validate_jdbc_write_mode("jdbc", &SinkMode::Append).is_ok());
-        assert!(validate_jdbc_write_mode("JDBC", &SinkMode::ErrorIfExists).is_err());
-        assert!(validate_jdbc_write_mode("jdbc", &SinkMode::Overwrite).is_err());
-        assert!(validate_jdbc_write_mode("other", &SinkMode::Overwrite).is_ok());
+    fn test_sink_mode_name_preserves_all_v1_modes() {
+        assert_eq!(sink_mode_name(&SinkMode::ErrorIfExists), "errorifexists");
+        assert_eq!(sink_mode_name(&SinkMode::IgnoreIfExists), "ignore");
+        assert_eq!(sink_mode_name(&SinkMode::Append), "append");
+        assert_eq!(sink_mode_name(&SinkMode::Overwrite), "overwrite");
     }
 }

--- a/crates/sail-data-source/src/formats/python/table_format.rs
+++ b/crates/sail-data-source/src/formats/python/table_format.rs
@@ -12,7 +12,7 @@ use datafusion::execution::SessionState;
 use datafusion::logical_expr::{Extension, LogicalPlan, TableSource, UserDefinedLogicalNode};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
-use datafusion_common::{DFSchema, DFSchemaRef, Result, internal_err};
+use datafusion_common::{DFSchema, DFSchemaRef, Result, internal_err, plan_err};
 use datafusion_expr::{Expr, UserDefinedLogicalNodeCore};
 use educe::Educe;
 use sail_common_datafusion::datasource::{
@@ -24,6 +24,13 @@ use super::datasource::PythonDataSource;
 use super::discovery::DATA_SOURCE_REGISTRY;
 use super::executor::InProcessExecutor;
 use super::table_provider::PythonTableProvider;
+
+fn validate_jdbc_write_mode(name: &str, mode: &SinkMode) -> Result<()> {
+    if name.eq_ignore_ascii_case("jdbc") && !matches!(mode, SinkMode::Append) {
+        return plan_err!("JDBC writes currently support only explicit append mode");
+    }
+    Ok(())
+}
 
 /// TableFormat implementation for a Python data source.
 ///
@@ -219,6 +226,8 @@ impl TableFormat for PythonTableFormat {
             ..
         } = info;
 
+        validate_jdbc_write_mode(&self.name, &mode)?;
+
         // Warn about unsupported partitionBy (PySpark compat: silently ignored)
         if !partition_by.is_empty() {
             log::warn!(
@@ -375,5 +384,13 @@ mod tests {
     fn test_python_table_format_name() {
         let format = PythonTableFormat::new("test_datasource".to_string());
         assert_eq!(format.name(), "test_datasource");
+    }
+
+    #[test]
+    fn test_jdbc_write_mode_accepts_only_append() {
+        assert!(validate_jdbc_write_mode("jdbc", &SinkMode::Append).is_ok());
+        assert!(validate_jdbc_write_mode("JDBC", &SinkMode::ErrorIfExists).is_err());
+        assert!(validate_jdbc_write_mode("jdbc", &SinkMode::Overwrite).is_err());
+        assert!(validate_jdbc_write_mode("other", &SinkMode::Overwrite).is_ok());
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,11 +53,13 @@ test = [
     "pyarrow>=24.0,<25",
     "adbc-driver-flightsql>=1.0,<2",
     "adbc-driver-manager>=1.0,<2",
+    "adbc-driver-postgresql>=1.0,<2",
 ]
 mcp = [
     "mcp>=1.0.0,<2",
 ]
 jdbc = [
+    "adbc-driver-postgresql>=1.0,<2",
     "connectorx>=0.3",
     "pyarrow>=10.0",
 ]
@@ -114,6 +116,7 @@ dependencies = [
     "pyarrow>=24.0,<25",
     "adbc-driver-flightsql>=1.0,<2",
     "adbc-driver-manager>=1.0,<2",
+    "adbc-driver-postgresql>=1.0,<2",
     "moto[glue]>=5,<6",
     "testcontainers>=4,<5",
     "connectorx>=0.3,<1",
@@ -169,6 +172,7 @@ dependencies = [
     "pyarrow>=24.0,<25",
     "adbc-driver-flightsql>=1.0,<2",
     "adbc-driver-manager>=1.0,<2",
+    "adbc-driver-postgresql>=1.0,<2",
     "moto[glue]>=5,<6",
     "testcontainers>=4,<5",
     "connectorx>=0.3,<1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,11 +52,13 @@ test = [
     "pyarrow>=24.0,<25",
     "adbc-driver-flightsql>=1.0,<2",
     "adbc-driver-manager>=1.0,<2",
+    "adbc-driver-postgresql>=1.0,<2",
 ]
 mcp = [
     "mcp>=1.0.0,<2",
 ]
 jdbc = [
+    "adbc-driver-postgresql>=1.0,<2",
     "connectorx>=0.3",
     "pyarrow>=10.0",
 ]
@@ -112,6 +114,7 @@ dependencies = [
     "pyarrow>=24.0,<25",
     "adbc-driver-flightsql>=1.0,<2",
     "adbc-driver-manager>=1.0,<2",
+    "adbc-driver-postgresql>=1.0,<2",
     "moto[glue]>=5,<6",
     "testcontainers>=4,<5",
     "connectorx>=0.3,<1",
@@ -166,6 +169,7 @@ dependencies = [
     "pyarrow>=24.0,<25",
     "adbc-driver-flightsql>=1.0,<2",
     "adbc-driver-manager>=1.0,<2",
+    "adbc-driver-postgresql>=1.0,<2",
     "moto[glue]>=5,<6",
     "testcontainers>=4,<5",
     "connectorx>=0.3,<1",

--- a/python/pysail/spark/datasource/jdbc.py
+++ b/python/pysail/spark/datasource/jdbc.py
@@ -262,20 +262,30 @@ def _build_where(filters: list[str]) -> str:
 
 
 class _PostgresJdbcWriter(DataSourceArrowWriter):
-    def __init__(self, conn_str: str, dbtable: str):
+    def __init__(self, conn_str: str, dbtable: str, input_schema: pa.Schema):
         schema, _, table = dbtable.rpartition(".")
         self.conn_str = conn_str
         self.schema = schema or None
         self.table = table
+        self.input_schema = input_schema
 
     def write(self, iterator: Iterator[pa.RecordBatch]):
         import adbc_driver_postgresql.dbapi as pg_dbapi  # noqa: PLC0415
 
         with pg_dbapi.connect(self.conn_str) as connection, connection.cursor() as cursor:
+            empty = True
             for batch in iterator:
+                empty = False
                 cursor.adbc_ingest(
                     self.table,
                     pa.Table.from_batches([batch]),
+                    mode="append",
+                    db_schema_name=self.schema,
+                )
+            if empty:
+                cursor.adbc_ingest(
+                    self.table,
+                    pa.Table.from_batches([], schema=self.input_schema),
                     mode="append",
                     db_schema_name=self.schema,
                 )
@@ -487,7 +497,7 @@ class JdbcDataSource(DataSource):
         resolved = self._resolve_options()
         return JdbcDataSourceReader(**resolved)
 
-    def writer(self, schema: pa.Schema, overwrite: bool) -> DataSourceArrowWriter:  # noqa: ARG002, FBT001
+    def writer(self, schema: pa.Schema, overwrite: bool) -> DataSourceArrowWriter:  # noqa: FBT001
         if overwrite:
             msg = "JDBC writes currently support only append mode"
             raise ValueError(msg)
@@ -502,7 +512,7 @@ class JdbcDataSource(DataSource):
             msg = "JDBC writes currently support only PostgreSQL"
             raise ValueError(msg)
 
-        return _PostgresJdbcWriter(conn_str, resolved["dbtable"])
+        return _PostgresJdbcWriter(conn_str, resolved["dbtable"], schema)
 
 
 # ============================================================================

--- a/python/pysail/spark/datasource/jdbc.py
+++ b/python/pysail/spark/datasource/jdbc.py
@@ -269,7 +269,7 @@ class _PostgresJdbcWriter(DataSourceArrowWriter):
         self.table = table
 
     def write(self, iterator: Iterator[pa.RecordBatch]):
-        import adbc_driver_postgresql.dbapi as pg_dbapi
+        import adbc_driver_postgresql.dbapi as pg_dbapi  # noqa: PLC0415
 
         with pg_dbapi.connect(self.conn_str) as connection, connection.cursor() as cursor:
             for batch in iterator:
@@ -487,7 +487,7 @@ class JdbcDataSource(DataSource):
         resolved = self._resolve_options()
         return JdbcDataSourceReader(**resolved)
 
-    def writer(self, schema: pa.Schema, overwrite: bool) -> DataSourceArrowWriter:  # noqa: ARG002
+    def writer(self, schema: pa.Schema, overwrite: bool) -> DataSourceArrowWriter:  # noqa: ARG002, FBT001
         if overwrite:
             msg = "JDBC writes currently support only append mode"
             raise ValueError(msg)

--- a/python/pysail/spark/datasource/jdbc.py
+++ b/python/pysail/spark/datasource/jdbc.py
@@ -1,4 +1,4 @@
-"""JDBC data source for Sail, backed by connectorX.
+"""JDBC data source for Sail, backed by connectorX and ADBC.
 
 Supports ``spark.read.format("jdbc")`` and ``spark.read.jdbc()`` with options
 consistent with the PySpark JDBC API.
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 try:
     from pyspark.sql.datasource import (
         DataSource,
+        DataSourceArrowWriter,
         DataSourceReader,
         EqualTo,
         Filter,
@@ -260,6 +261,27 @@ def _build_where(filters: list[str]) -> str:
 # ============================================================================
 
 
+class _PostgresJdbcWriter(DataSourceArrowWriter):
+    def __init__(self, conn_str: str, dbtable: str):
+        schema, _, table = dbtable.rpartition(".")
+        self.conn_str = conn_str
+        self.schema = schema or None
+        self.table = table
+
+    def write(self, iterator: Iterator[pa.RecordBatch]):
+        import adbc_driver_postgresql.dbapi as pg_dbapi
+
+        with pg_dbapi.connect(self.conn_str) as connection, connection.cursor() as cursor:
+            for batch in iterator:
+                cursor.adbc_ingest(
+                    self.table,
+                    pa.Table.from_batches([batch]),
+                    mode="append",
+                    db_schema_name=self.schema,
+                )
+            connection.commit()
+
+
 class JdbcDataSource(DataSource):
     """JDBC data source backed by connectorX.
 
@@ -318,7 +340,9 @@ class JdbcDataSource(DataSource):
 
     * Exactly one of ``dbtable`` or ``query`` is required.
 
-    Not supported: ``driver``, ``predicates`` list, write operations,
+    Writes support PostgreSQL existing-table append only.
+
+    Not supported: ``driver``, ``predicates`` list, overwrite, table creation,
     ``queryTimeout``, ``isolationLevel``, ``sessionInitStatement``, Kerberos.
     """
 
@@ -462,6 +486,23 @@ class JdbcDataSource(DataSource):
     def reader(self, schema: pa.Schema) -> JdbcDataSourceReader:  # noqa: ARG002
         resolved = self._resolve_options()
         return JdbcDataSourceReader(**resolved)
+
+    def writer(self, schema: pa.Schema, overwrite: bool) -> DataSourceArrowWriter:  # noqa: ARG002
+        if overwrite:
+            msg = "JDBC writes currently support only append mode"
+            raise ValueError(msg)
+
+        resolved = self._resolve_options()
+        if resolved["query"] is not None:
+            msg = "Option 'query' is not supported for JDBC writes; use 'dbtable'"
+            raise ValueError(msg)
+
+        conn_str = resolved["conn_str"]
+        if not conn_str.startswith("postgresql://"):
+            msg = "JDBC writes currently support only PostgreSQL"
+            raise ValueError(msg)
+
+        return _PostgresJdbcWriter(conn_str, resolved["dbtable"])
 
 
 # ============================================================================

--- a/python/pysail/spark/datasource/jdbc.py
+++ b/python/pysail/spark/datasource/jdbc.py
@@ -269,7 +269,7 @@ class _PostgresJdbcWriter(DataSourceArrowWriter):
         self.table = table
 
     def write(self, iterator: Iterator[pa.RecordBatch]):
-        import adbc_driver_postgresql.dbapi as pg_dbapi
+        import adbc_driver_postgresql.dbapi as pg_dbapi  # noqa: PLC0415
 
         with pg_dbapi.connect(self.conn_str) as connection, connection.cursor() as cursor:
             for batch in iterator:
@@ -486,7 +486,7 @@ class JdbcDataSource(DataSource):
         resolved = self._resolve_options()
         return JdbcDataSourceReader(**resolved)
 
-    def writer(self, schema: pa.Schema, overwrite: bool) -> DataSourceArrowWriter:  # noqa: ARG002
+    def writer(self, schema: pa.Schema, overwrite: bool) -> DataSourceArrowWriter:  # noqa: ARG002, FBT001
         if overwrite:
             msg = "JDBC writes currently support only append mode"
             raise ValueError(msg)

--- a/python/pysail/spark/datasource/jdbc.py
+++ b/python/pysail/spark/datasource/jdbc.py
@@ -1,4 +1,4 @@
-"""JDBC data source for Sail, backed by connectorX.
+"""JDBC data source for Sail, backed by connectorX and ADBC.
 
 Supports ``spark.read.format("jdbc")`` and ``spark.read.jdbc()`` with options
 consistent with the PySpark JDBC API.
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 try:
     from pyspark.sql.datasource import (
         DataSource,
+        DataSourceArrowWriter,
         DataSourceReader,
         EqualTo,
         Filter,
@@ -260,6 +261,27 @@ def _build_where(filters: list[str]) -> str:
 # ============================================================================
 
 
+class _PostgresJdbcWriter(DataSourceArrowWriter):
+    def __init__(self, conn_str: str, dbtable: str):
+        schema, _, table = dbtable.rpartition(".")
+        self.conn_str = conn_str
+        self.schema = schema or None
+        self.table = table
+
+    def write(self, iterator: Iterator[pa.RecordBatch]):
+        import adbc_driver_postgresql.dbapi as pg_dbapi
+
+        with pg_dbapi.connect(self.conn_str) as connection, connection.cursor() as cursor:
+            for batch in iterator:
+                cursor.adbc_ingest(
+                    self.table,
+                    pa.Table.from_batches([batch]),
+                    mode="append",
+                    db_schema_name=self.schema,
+                )
+            connection.commit()
+
+
 class JdbcDataSource(DataSource):
     """JDBC data source backed by connectorX.
 
@@ -318,7 +340,9 @@ class JdbcDataSource(DataSource):
 
     * Exactly one of ``dbtable`` or ``query`` is required.
 
-    Not supported: ``driver``, ``predicates`` list, write operations,
+    Writes support PostgreSQL existing-table append only.
+
+    Not supported: ``driver``, ``predicates`` list, overwrite, table creation,
     ``queryTimeout``, ``isolationLevel``, ``sessionInitStatement``, Kerberos.
     """
 
@@ -461,6 +485,23 @@ class JdbcDataSource(DataSource):
     def reader(self, schema: pa.Schema) -> JdbcDataSourceReader:  # noqa: ARG002
         resolved = self._resolve_options()
         return JdbcDataSourceReader(**resolved)
+
+    def writer(self, schema: pa.Schema, overwrite: bool) -> DataSourceArrowWriter:  # noqa: ARG002
+        if overwrite:
+            msg = "JDBC writes currently support only append mode"
+            raise ValueError(msg)
+
+        resolved = self._resolve_options()
+        if resolved["query"] is not None:
+            msg = "Option 'query' is not supported for JDBC writes; use 'dbtable'"
+            raise ValueError(msg)
+
+        conn_str = resolved["conn_str"]
+        if not conn_str.startswith("postgresql://"):
+            msg = "JDBC writes currently support only PostgreSQL"
+            raise ValueError(msg)
+
+        return _PostgresJdbcWriter(conn_str, resolved["dbtable"])
 
 
 # ============================================================================

--- a/python/pysail/spark/datasource/jdbc.py
+++ b/python/pysail/spark/datasource/jdbc.py
@@ -498,8 +498,9 @@ class JdbcDataSource(DataSource):
         return JdbcDataSourceReader(**resolved)
 
     def writer(self, schema: pa.Schema, overwrite: bool) -> DataSourceArrowWriter:  # noqa: FBT001
-        if overwrite:
-            msg = "JDBC writes currently support only append mode"
+        save_mode = self.options.get("__sail_save_mode", "overwrite" if overwrite else "append")
+        if save_mode != "append":
+            msg = "JDBC writes currently support only explicit append mode"
             raise ValueError(msg)
 
         resolved = self._resolve_options()

--- a/python/pysail/tests/spark/datasource/test_jdbc.py
+++ b/python/pysail/tests/spark/datasource/test_jdbc.py
@@ -244,10 +244,17 @@ def test_null_values_handling(spark, jdbc_opts):
 # ---------------------------------------------------------------------------
 
 
-def test_empty_table(spark, jdbc_opts):
+def test_empty_table_append(spark, jdbc_opts):
     df = spark.read.format("jdbc").option("dbtable", "empty_table").options(**jdbc_opts).load()
     assert df.count() == 0
     assert df.filter("id > 0").collect() == []
+
+    spark.createDataFrame([(1, "written by Sail")], "id int, name string").write.format("jdbc").mode("append").option(
+        "dbtable", "empty_table"
+    ).options(**jdbc_opts).save()
+
+    rows = spark.read.format("jdbc").option("dbtable", "empty_table").options(**jdbc_opts).load().collect()
+    assert [(row.id, row.name) for row in rows] == [(1, "written by Sail")]
 
 
 # ---------------------------------------------------------------------------

--- a/python/pysail/tests/spark/datasource/test_jdbc_writer.py
+++ b/python/pysail/tests/spark/datasource/test_jdbc_writer.py
@@ -2,6 +2,12 @@ import sys
 import types
 
 import pyarrow as pa
+import pytest
+
+from pysail.testing.spark.utils.common import pyspark_version
+
+if pyspark_version() < (4, 1):
+    pytest.skip("Python data source requires Spark 4.1+", allow_module_level=True)
 
 from pysail.spark.datasource.jdbc import JdbcDataSource
 

--- a/python/pysail/tests/spark/datasource/test_jdbc_writer.py
+++ b/python/pysail/tests/spark/datasource/test_jdbc_writer.py
@@ -12,6 +12,20 @@ if pyspark_version() < (4, 1):
 from pysail.spark.datasource.jdbc import JdbcDataSource
 
 
+@pytest.mark.parametrize("mode", ["errorifexists", "ignore"])
+def test_postgres_writer_requires_explicit_append(mode):
+    datasource = JdbcDataSource(
+        options={
+            "url": "jdbc:postgresql://localhost:5432/db",
+            "dbtable": "events",
+            "__sail_save_mode": mode,
+        }
+    )
+
+    with pytest.raises(ValueError, match="only explicit append mode"):
+        datasource.writer(pa.schema({"id": pa.int64()}), overwrite=False)
+
+
 def test_postgres_writer_streams_arrow_batches(monkeypatch):
     calls = []
 

--- a/python/pysail/tests/spark/datasource/test_jdbc_writer.py
+++ b/python/pysail/tests/spark/datasource/test_jdbc_writer.py
@@ -53,3 +53,11 @@ def test_postgres_writer_streams_arrow_batches(monkeypatch):
         ("events", [2], {"mode": "append", "db_schema_name": "analytics"}),
         "commit",
     ]
+
+    calls.clear()
+    assert writer.write(iter([])) is None
+    assert calls == [
+        ("connect", "postgresql://localhost:5432/db"),
+        ("events", [], {"mode": "append", "db_schema_name": "analytics"}),
+        "commit",
+    ]

--- a/python/pysail/tests/spark/datasource/test_jdbc_writer.py
+++ b/python/pysail/tests/spark/datasource/test_jdbc_writer.py
@@ -1,0 +1,49 @@
+import sys
+import types
+
+import pyarrow as pa
+
+from pysail.spark.datasource.jdbc import JdbcDataSource
+
+
+def test_postgres_writer_streams_arrow_batches(monkeypatch):
+    calls = []
+
+    class Resource:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def cursor(self):
+            return self
+
+        def adbc_ingest(self, table, values, **options):
+            calls.append((table, values.column("id").to_pylist(), options))
+
+        def commit(self):
+            calls.append("commit")
+
+    dbapi = types.ModuleType("adbc_driver_postgresql.dbapi")
+    dbapi.connect = lambda dsn: calls.append(("connect", dsn)) or Resource()
+    package = types.ModuleType("adbc_driver_postgresql")
+    package.dbapi = dbapi
+    monkeypatch.setitem(sys.modules, "adbc_driver_postgresql", package)
+    monkeypatch.setitem(sys.modules, "adbc_driver_postgresql.dbapi", dbapi)
+
+    datasource = JdbcDataSource(
+        options={
+            "url": "jdbc:postgresql://localhost:5432/db",
+            "dbtable": "analytics.events",
+        }
+    )
+    writer = datasource.writer(pa.schema({"id": pa.int64()}), overwrite=False)
+
+    assert writer.write(iter([pa.record_batch({"id": [1]}), pa.record_batch({"id": [2]})])) is None
+    assert calls == [
+        ("connect", "postgresql://localhost:5432/db"),
+        ("events", [1], {"mode": "append", "db_schema_name": "analytics"}),
+        ("events", [2], {"mode": "append", "db_schema_name": "analytics"}),
+        "commit",
+    ]


### PR DESCRIPTION
## What

- add PostgreSQL existing-table append writes through ADBC
- reject non-append save modes before the Python writer API collapses ErrorIfExists and Append
- cover multi-batch ingestion and PostgreSQL round-trip behavior

## Scope

Explicit append into existing PostgreSQL tables on Spark 4.1+, with input columns that exactly match target PostgreSQL column names.

Excluded: append-create, target-schema column reconciliation, overwrite, truncate, other JDBC dialects, partition/batch tuning, and new CI workflows.

Extracted from #2167 for progressive review.

## Validation

- Rust append-mode unit test
- Python two-batch writer unit test
- PostgreSQL container append/readback integration
- Python 3.5/4.0 compatibility collection guard
- Ruff and rustfmt
- cargo clippy with warnings denied
- debug Python wheel build on Gemini