### PR TITLE
fix: honor ANSI mode for invalid to_date strings

### DIFF
--- a/crates/sail-plan/src/function/scalar/datetime.rs
+++ b/crates/sail-plan/src/function/scalar/datetime.rs
@@ -423,9 +423,16 @@ fn declare_nullable_result(expr: Expr, nullable: bool, schema: &DFSchemaRef) -> 
 }
 
 fn to_date(input: ScalarFunctionInput) -> PlanResult<Expr> {
+    let null_on_error = !input.function_context.plan_config.ansi_mode;
     if input.arguments.len() == 1 {
         // If format is not supplied, the function is a synonym for cast(expr AS DATE).
-        crate::function::scalar::conversion::cast_to_date(input)
+        let expr = input.arguments[0].clone();
+        let data_type = expr.get_type(input.function_context.schema)?;
+        if data_type.is_string() {
+            Ok(ScalarUDF::from(SparkDate::new(null_on_error)).call(vec![expr]))
+        } else {
+            Ok(cast(expr, DataType::Date32))
+        }
     } else if input.arguments.len() == 2 {
         let expr = input.arguments[0].clone();
         let format = coerce_datetime_format(
@@ -453,7 +460,7 @@ fn to_date(input: ScalarFunctionInput) -> PlanResult<Expr> {
             Ok(_other) => expr,
             Err(_) => cast(expr, DataType::Utf8), // In case of error, cast to string
         };
-        Ok(ScalarUDF::from(SparkDate::new(false)).call(vec![expr, format]))
+        Ok(ScalarUDF::from(SparkDate::new(null_on_error)).call(vec![expr, format]))
     } else {
         Err(PlanError::invalid("to_date requires 1 or 2 arguments"))
     }

--- a/python/pysail/tests/spark/function/features/datetime/to_date.feature
+++ b/python/pysail/tests/spark/function/features/datetime/to_date.feature
@@ -26,6 +26,95 @@ Feature: to_date with an argument coming from a column
         | 2016-12-31 |
         | 2016-12-31 |
 
+  Rule: Invalid string input follows ANSI mode
+
+    Scenario Outline: To date returns NULL for <case> with ANSI disabled
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT to_date(<args>) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+      Examples:
+        | case                       | args                    |
+        | default invalid leap day   | '2026-02-29'            |
+        | default invalid month      | '2026-00-15'            |
+        | formatted invalid leap day | '20260229', 'yyyyMMdd' |
+        | formatted invalid month    | '20260015', 'yyyyMMdd' |
+
+    Scenario: To date returns NULL for invalid string columns with ANSI disabled
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT
+          id,
+          to_date(value) AS default_result,
+          to_date(compact_value, 'yyyyMMdd') AS formatted_result
+        FROM VALUES
+          (1, '2026-01-01', '20260101'),
+          (2, '2026-02-29', '20260229'),
+          (3, '2026-00-15', '20260015'),
+          (4, CAST(NULL AS STRING), CAST(NULL AS STRING))
+          AS t(id, value, compact_value)
+        ORDER BY id
+        """
+      Then query result ordered
+        | id | default_result | formatted_result |
+        | 1  | 2026-01-01     | 2026-01-01       |
+        | 2  | NULL           | NULL             |
+        | 3  | NULL           | NULL             |
+        | 4  | NULL           | NULL             |
+
+    Scenario Outline: To date rejects <case> literal with ANSI enabled
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT to_date(<args>) AS result
+        """
+      Then query error (?i)(CANNOT_PARSE_TIMESTAMP|CAST_INVALID_INPUT|invalid parsed (date|month)|out of range|DateValue)
+
+      Examples:
+        | case                       | args                    |
+        | default invalid leap day   | '2026-02-29'            |
+        | default invalid month      | '2026-00-15'            |
+        | formatted invalid leap day | '20260229', 'yyyyMMdd' |
+        | formatted invalid month    | '20260015', 'yyyyMMdd' |
+
+    Scenario Outline: To date rejects <case> column with ANSI enabled
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT <call> AS result FROM VALUES ('<value>') AS t(value)
+        """
+      Then query error (?i)(CANNOT_PARSE_TIMESTAMP|CAST_INVALID_INPUT|invalid parsed (date|month)|out of range|DateValue)
+
+      Examples:
+        | case                       | call                       | value      |
+        | default invalid leap day   | to_date(value)             | 2026-02-29 |
+        | default invalid month      | to_date(value)             | 2026-00-15 |
+        | formatted invalid leap day | to_date(value, 'yyyyMMdd') | 20260229   |
+        | formatted invalid month    | to_date(value, 'yyyyMMdd') | 20260015   |
+
+    Scenario Outline: To date <case> is nullable with ANSI disabled
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT to_date(<args>) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: date (nullable = true)
+        """
+
+      Examples:
+        | case            | args                    |
+        | default format  | '2026-01-01'            |
+        | explicit format | '20260101', 'yyyyMMdd' |
+
   Rule: Explicit NULL format semantics
 
     Scenario: To date NULL format semantics distinguishes omitted and explicit format


### PR DESCRIPTION
## Summary

Make `to_date` honor `spark.sql.ansi.enabled` when parsing invalid string dates in both `to_date(value)` and `to_date(value, format)`.

Invalid string values return `NULL` in non-ANSI mode and report a parsing or cast error in ANSI mode. This change uses the existing session setting and does not alter version-specific ANSI defaults or non-string date casts.

Closes #2369
