### PR TITLE
fix: align non-ANSI STRING-to-INT casts with Spark

### DIFF
--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -211,6 +211,7 @@ use sail_function::scalar::misc::theta_sketch::{
 use sail_function::scalar::misc::version::SparkVersion;
 use sail_function::scalar::multi_expr::MultiExpr;
 use sail_function::scalar::predicate::rewrite_like_pattern::RewriteLikePatternFunc;
+use sail_function::scalar::spark_cast_string_to_int32::SparkCastStringToInt32;
 use sail_function::scalar::spark_struct_rename::SparkStructRename;
 use sail_function::scalar::spark_to_string::{SparkToLargeUtf8, SparkToUtf8, SparkToUtf8View};
 use sail_function::scalar::string::format_number::FormatNumber;
@@ -2728,6 +2729,9 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 Ok(Arc::new(ScalarUDF::from(SparkArrayPosition::new())))
             }
             "spark_array_compact" => Ok(Arc::new(ScalarUDF::from(SparkArrayCompact::new()))),
+            "spark_cast_string_to_int32" => {
+                Ok(Arc::new(ScalarUDF::from(SparkCastStringToInt32::new())))
+            }
             "vector_inner_product" => Ok(Arc::new(ScalarUDF::from(VectorInnerProduct::new()))),
             "bitmap_count" => Ok(Arc::new(ScalarUDF::from(BitmapCount::new()))),
             "format_string" => Ok(Arc::new(ScalarUDF::from(FormatStringFunc::new()))),
@@ -2915,6 +2919,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node_inner.is::<ArrayIntersect>()
             || node_inner.is::<SparkArrayPosition>()
             || node_inner.is::<SparkArrayCompact>()
+            || node_inner.is::<SparkCastStringToInt32>()
             || node_inner.is::<VectorInnerProduct>()
             || node_inner.is::<BitmapCount>()
             || node_inner.is::<FormatStringFunc>()
@@ -5100,6 +5105,16 @@ mod tests {
                 .is_some()
         );
         assert_eq!(decoded.name(), "spark_variant_explode");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_round_trip_spark_cast_string_to_int32_udf() -> Result<()> {
+        let decoded = round_trip_udf(ScalarUDF::from(SparkCastStringToInt32::new()))?;
+
+        downcast_udf::<SparkCastStringToInt32>(&decoded, "SparkCastStringToInt32")?;
+        assert_eq!(decoded.name(), "spark_cast_string_to_int32");
 
         Ok(())
     }

--- a/crates/sail-function/src/scalar/mod.rs
+++ b/crates/sail-function/src/scalar/mod.rs
@@ -13,6 +13,7 @@ pub mod math;
 pub mod misc;
 pub mod multi_expr;
 pub mod predicate;
+pub mod spark_cast_string_to_int32;
 pub mod spark_struct_rename;
 pub mod spark_to_string;
 pub mod string;

--- a/crates/sail-function/src/scalar/spark_cast_string_to_int32.rs
+++ b/crates/sail-function/src/scalar/spark_cast_string_to_int32.rs
@@ -1,0 +1,235 @@
+use std::sync::Arc;
+
+use datafusion::arrow::array::{ArrayRef, Int32Array};
+use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
+use datafusion_common::Result;
+use datafusion_common::cast::{as_large_string_array, as_string_array, as_string_view_array};
+use datafusion_expr::{
+    ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+};
+
+use crate::error::{invalid_arg_count_exec_err, unsupported_data_type_exec_err};
+use crate::functions_utils::make_scalar_function;
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct SparkCastStringToInt32 {
+    signature: Signature,
+}
+
+impl Default for SparkCastStringToInt32 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SparkCastStringToInt32 {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::uniform(
+                1,
+                vec![DataType::Utf8, DataType::LargeUtf8, DataType::Utf8View],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for SparkCastStringToInt32 {
+    fn name(&self) -> &str {
+        "spark_cast_string_to_int32"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Int32)
+    }
+
+    fn return_field_from_args(&self, _args: ReturnFieldArgs) -> Result<FieldRef> {
+        Ok(Arc::new(Field::new(self.name(), DataType::Int32, true)))
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(cast_string_array_to_int32, vec![])(&args.args)
+    }
+}
+
+fn cast_string_array_to_int32(args: &[ArrayRef]) -> Result<ArrayRef> {
+    let [array] = args else {
+        return Err(invalid_arg_count_exec_err(
+            "spark_cast_string_to_int32",
+            (1, 1),
+            args.len(),
+        ));
+    };
+    let result = match array.data_type() {
+        DataType::Utf8 => parse_string_values(as_string_array(array)?.iter()),
+        DataType::LargeUtf8 => parse_string_values(as_large_string_array(array)?.iter()),
+        DataType::Utf8View => parse_string_values(as_string_view_array(array)?.iter()),
+        other => {
+            return Err(unsupported_data_type_exec_err(
+                "spark_cast_string_to_int32",
+                "STRING",
+                other,
+            ));
+        }
+    };
+    Ok(Arc::new(result))
+}
+
+fn parse_string_values<'a>(values: impl Iterator<Item = Option<&'a str>>) -> Int32Array {
+    values
+        .map(|value| value.and_then(parse_spark_legacy_string_to_i32))
+        .collect()
+}
+
+fn parse_spark_legacy_string_to_i32(value: &str) -> Option<i32> {
+    let bytes = value.as_bytes();
+    let mut offset = 0;
+    while offset < bytes.len() && is_spark_trim_byte(bytes[offset]) {
+        offset += 1;
+    }
+    if offset == bytes.len() {
+        return None;
+    }
+
+    let mut end = bytes.len() - 1;
+    while end > offset && is_spark_trim_byte(bytes[end]) {
+        end -= 1;
+    }
+
+    let negative = bytes[offset] == b'-';
+    if negative || bytes[offset] == b'+' {
+        if offset == end {
+            return None;
+        }
+        offset += 1;
+    }
+
+    let stop_value = i32::MIN / 10;
+    let mut result = 0_i32;
+    while offset <= end {
+        let byte = bytes[offset];
+        offset += 1;
+        if byte == b'.' {
+            break;
+        }
+        if !byte.is_ascii_digit() || result < stop_value {
+            return None;
+        }
+        result = result.checked_mul(10)?.checked_sub((byte - b'0') as i32)?;
+    }
+
+    while offset <= end {
+        if !bytes[offset].is_ascii_digit() {
+            return None;
+        }
+        offset += 1;
+    }
+
+    if negative {
+        Some(result)
+    } else {
+        result.checked_neg()
+    }
+}
+
+fn is_spark_trim_byte(byte: u8) -> bool {
+    byte <= b' ' || byte == 0x7f
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::array::{Array, LargeStringArray, StringArray, StringViewArray};
+    use datafusion_common::exec_err;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_spark_legacy_string_to_i32() {
+        let cases = [
+            ("100", Some(100)),
+            (" +100 ", Some(100)),
+            ("1.23", Some(1)),
+            ("-4.56", Some(-4)),
+            (".9", Some(0)),
+            ("1.", Some(1)),
+            (".", Some(0)),
+            ("2147483647.999", Some(i32::MAX)),
+            ("-2147483648.999", Some(i32::MIN)),
+            ("2147483648", None),
+            ("2178802287", None),
+            ("-2147483649", None),
+            ("2147483648.0", None),
+            ("123.a", None),
+            ("1e2", None),
+            ("", None),
+            ("+", None),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(
+                parse_spark_legacy_string_to_i32(input),
+                expected,
+                "input: {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_cast_all_string_array_representations_to_nullable_int32() -> Result<()> {
+        let values = vec![
+            Some("100"),
+            Some("1.23"),
+            Some("-4.56"),
+            Some("2147483647"),
+            Some("2178802287"),
+            Some("2147483648.0"),
+            Some("bad"),
+            None,
+        ];
+        let expected = vec![
+            Some(100),
+            Some(1),
+            Some(-4),
+            Some(i32::MAX),
+            None,
+            None,
+            None,
+            None,
+        ];
+        let inputs = [
+            Arc::new(StringArray::from(values.clone())) as ArrayRef,
+            Arc::new(LargeStringArray::from(values.clone())) as ArrayRef,
+            Arc::new(StringViewArray::from(values)) as ArrayRef,
+        ];
+
+        for input in inputs {
+            let output = cast_string_array_to_int32(&[input])?;
+            assert_eq!(output.data_type(), &DataType::Int32);
+            let Some(output) = output.as_any().downcast_ref::<Int32Array>() else {
+                return exec_err!("expected Int32Array");
+            };
+            assert_eq!(output.iter().collect::<Vec<_>>(), expected);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_return_field_is_nullable_for_non_nullable_input() -> Result<()> {
+        let udf = SparkCastStringToInt32::new();
+        let input = Arc::new(Field::new("value", DataType::Utf8, false));
+        let arg_fields = [input];
+        let scalar_arguments = [None];
+        let field = udf.return_field_from_args(ReturnFieldArgs {
+            arg_fields: &arg_fields,
+            scalar_arguments: &scalar_arguments,
+        })?;
+
+        assert_eq!(field.data_type(), &DataType::Int32);
+        assert!(field.is_nullable());
+        Ok(())
+    }
+}

--- a/crates/sail-plan/src/resolver/expression/cast.rs
+++ b/crates/sail-plan/src/resolver/expression/cast.rs
@@ -15,6 +15,7 @@ use sail_function::scalar::datetime::spark_interval::{
     SparkCalendarInterval, SparkDayTimeInterval, SparkYearMonthInterval,
 };
 use sail_function::scalar::datetime::spark_timestamp::SparkTimestamp;
+use sail_function::scalar::spark_cast_string_to_int32::SparkCastStringToInt32;
 use sail_function::scalar::spark_struct_rename::SparkStructRename;
 use sail_function::scalar::spark_to_string::{SparkToLargeUtf8, SparkToUtf8, SparkToUtf8View};
 use sail_function::scalar::variant::spark_cast_to_variant::SparkCastToVariant;
@@ -121,6 +122,11 @@ impl PlanResolver<'_> {
                     lit("$"),
                     lit(data_type_string),
                 ])
+            }
+            (DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View, DataType::Int32, false)
+                if !self.config.ansi_mode =>
+            {
+                ScalarUDF::new_from_impl(SparkCastStringToInt32::new()).call(vec![expr])
             }
             (from, DataType::Timestamp(time_unit, _) | DataType::Duration(time_unit), _)
                 if from.is_numeric() =>

--- a/python/pysail/tests/spark/dataframe/test_cast_string_to_int.py
+++ b/python/pysail/tests/spark/dataframe/test_cast_string_to_int.py
@@ -1,0 +1,33 @@
+import pyspark.sql.functions as F  # noqa: N812
+from pyspark.sql import Row
+
+
+def test_legacy_string_to_int_cast_handles_decimals_and_overflow(spark):
+    expected_filter_value = 100
+    original_ansi = spark.conf.get("spark.sql.ansi.enabled")
+    spark.conf.set("spark.sql.ansi.enabled", "false")
+    try:
+        source = spark.createDataFrame(
+            [
+                (0, "2178802287"),
+                (1, "100"),
+                (2, "2147483648"),
+                (3, "1.23"),
+                (4, "-4.56"),
+            ],
+            "id INT, value STRING",
+        )
+
+        projected = source.select("id", F.col("value").cast("int").alias("result")).orderBy("id").collect()
+        assert projected == [
+            Row(id=0, result=None),
+            Row(id=1, result=100),
+            Row(id=2, result=None),
+            Row(id=3, result=1),
+            Row(id=4, result=-4),
+        ]
+
+        filtered = source.filter(F.col("value").cast("int") == expected_filter_value).collect()
+        assert filtered == [Row(id=1, value="100")]
+    finally:
+        spark.conf.set("spark.sql.ansi.enabled", original_ansi)

--- a/python/pysail/tests/spark/function/features/conversion/cast.feature
+++ b/python/pysail/tests/spark/function/features/conversion/cast.feature
@@ -1,10 +1,10 @@
-Feature: cast output schema
+Feature: CAST expressions
 
   @function(nullability)
   Rule: Output schema
 
-    @sail-bug
     Scenario: a non-null literal input to cast yields the schema Spark declares
+      Given config spark.sql.ansi.enabled = false
       When query
         """
         SELECT cast('10' as int) AS result
@@ -14,3 +14,83 @@ Feature: cast output schema
         root
          |-- result: integer (nullable = true)
         """
+
+  Rule: Legacy STRING to INT casts
+
+    Scenario: decimal strings truncate and overflowing strings return NULL
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT id, CAST(value AS INT) AS result
+        FROM VALUES
+          (0, '100'),
+          (1, '1.23'),
+          (2, '-4.56'),
+          (3, '2147483647.999'),
+          (4, '-2147483648.999'),
+          (5, '2178802287'),
+          (6, '2147483648'),
+          (7, '-2147483649'),
+          (8, '2147483648.0'),
+          (9, '123.a'),
+          (10, CAST(NULL AS STRING))
+        AS data(id, value)
+        ORDER BY id
+        """
+      Then query result ordered
+        | id | result      |
+        | 0  | 100         |
+        | 1  | 1           |
+        | 2  | -4          |
+        | 3  | 2147483647  |
+        | 4  | -2147483648 |
+        | 5  | NULL        |
+        | 6  | NULL        |
+        | 7  | NULL        |
+        | 8  | NULL        |
+        | 9  | NULL        |
+        | 10 | NULL        |
+
+    Scenario: overflowing strings do not abort a filter predicate
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT value
+        FROM VALUES ('2178802287'), ('100'), ('2147483648') AS data(value)
+        WHERE CAST(value AS INT) = 100
+        """
+      Then query result
+        | value |
+        | 100   |
+
+  Rule: ANSI and TRY casts stay strict
+
+    Scenario Outline: ANSI CAST rejects <case>
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT CAST(<input> AS INT) AS result
+        """
+      Then query error <error>
+
+      Examples:
+        | case                    | input        | error      |
+        | a decimal string        | '1.23'       | 1.23       |
+        | an overflowing integer  | '2147483648' | 2147483648 |
+
+    Scenario: TRY_CAST returns NULL for decimal and overflowing strings
+      When query
+        """
+        SELECT id, TRY_CAST(value AS INT) AS result
+        FROM VALUES
+          (0, '100'),
+          (1, '1.23'),
+          (2, '2147483648')
+        AS data(id, value)
+        ORDER BY id
+        """
+      Then query result ordered
+        | id | result |
+        | 0  | 100    |
+        | 1  | NULL   |
+        | 2  | NULL   |


### PR DESCRIPTION
## Summary

Align direct `STRING`-to-`INT` casts with Spark when `spark.sql.ansi.enabled=false`.

Spark's legacy parser truncates decimal-formatted strings toward zero and returns `NULL` for overflow or inputs it rejects instead of aborting the query. ANSI `CAST` and `TRY_CAST` remain on their existing paths. The upstream legacy edge cases `.`, `+.`, and `-.` continue to produce `0`.

Closes #2379
Closes #2396
