### PR TITLE
fix: match Spark string and day-time interval addition semantics

### DIFF
--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -155,7 +155,8 @@ use sail_function::scalar::datetime::spark_date_format::SparkDateFormat;
 use sail_function::scalar::datetime::spark_date_part::SparkDatePart;
 use sail_function::scalar::datetime::spark_date_trunc::SparkDateTrunc;
 use sail_function::scalar::datetime::spark_interval::{
-    SparkCalendarInterval, SparkDayTimeInterval, SparkYearMonthInterval,
+    SparkCalendarInterval, SparkDayTimeInterval, SparkDayTimeIntervalToCalendarInterval,
+    SparkYearMonthInterval,
 };
 use sail_function::scalar::datetime::spark_last_day::SparkLastDay;
 use sail_function::scalar::datetime::spark_make_time::SparkMakeTime;
@@ -2862,6 +2863,9 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 Ok(Arc::new(ScalarUDF::from(SparkYearMonthInterval::new())))
             }
             "spark_day_time_interval" => Ok(Arc::new(ScalarUDF::from(SparkDayTimeInterval::new()))),
+            "spark_day_time_interval_to_calendar_interval" => Ok(Arc::new(ScalarUDF::from(
+                SparkDayTimeIntervalToCalendarInterval::new(),
+            ))),
             "spark_calendar_interval" => {
                 Ok(Arc::new(ScalarUDF::from(SparkCalendarInterval::new())))
             }
@@ -2959,6 +2963,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node_inner.is::<SparkDatePart>()
             || node_inner.is::<SparkDateTrunc>()
             || node_inner.is::<SparkDayTimeInterval>()
+            || node_inner.is::<SparkDayTimeIntervalToCalendarInterval>()
             || node_inner.is::<SparkDecode>()
             || node_inner.is::<SparkElt>()
             || node_inner.is::<SparkEncode>()
@@ -6115,6 +6120,21 @@ mod tests {
         assert_eq!(decoded.timezone(), Some("America/Los_Angeles"));
         assert!(decoded.is_try());
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_round_trip_day_time_interval_to_calendar_interval_udf() -> Result<()> {
+        let decoded = round_trip_udf(ScalarUDF::from(
+            SparkDayTimeIntervalToCalendarInterval::new(),
+        ))?;
+
+        assert!(
+            decoded
+                .inner()
+                .downcast_ref::<SparkDayTimeIntervalToCalendarInterval>()
+                .is_some()
+        );
         Ok(())
     }
 

--- a/crates/sail-function/src/scalar/datetime/spark_interval.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_interval.rs
@@ -5,7 +5,7 @@ use datafusion::arrow::datatypes::{
     DataType, DurationMicrosecondType, IntervalMonthDayNano, IntervalUnit, IntervalYearMonthType,
     TimeUnit,
 };
-use datafusion_common::arrow::array::PrimitiveArray;
+use datafusion_common::arrow::array::{AsArray, PrimitiveArray};
 use datafusion_common::arrow::datatypes::IntervalMonthDayNanoType;
 use datafusion_common::cast::{as_large_string_array, as_string_array, as_string_view_array};
 use datafusion_common::types::logical_string;
@@ -117,6 +117,77 @@ define_interval_udf!(
     ScalarValue::IntervalMonthDayNano,
 );
 
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct SparkDayTimeIntervalToCalendarInterval {
+    signature: Signature,
+}
+
+impl Default for SparkDayTimeIntervalToCalendarInterval {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SparkDayTimeIntervalToCalendarInterval {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::exact(
+                vec![DataType::Duration(TimeUnit::Microsecond)],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for SparkDayTimeIntervalToCalendarInterval {
+    fn name(&self) -> &str {
+        "spark_day_time_interval_to_calendar_interval"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Interval(IntervalUnit::MonthDayNano))
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let ScalarFunctionArgs { args, .. } = args;
+        let arg = args.one()?;
+        match arg {
+            ColumnarValue::Array(array) => {
+                let array = match array.data_type() {
+                    DataType::Duration(TimeUnit::Microsecond) => array
+                        .as_primitive::<DurationMicrosecondType>()
+                        .iter()
+                        .map(|value| {
+                            value
+                                .map(day_time_interval_to_calendar_interval)
+                                .transpose()
+                        })
+                        .collect::<Result<PrimitiveArray<IntervalMonthDayNanoType>>>()?,
+                    data_type => {
+                        return exec_err!(
+                            "expected microsecond day-time interval, got {data_type}"
+                        );
+                    }
+                };
+                Ok(ColumnarValue::Array(Arc::new(array)))
+            }
+            ColumnarValue::Scalar(ScalarValue::DurationMicrosecond(value)) => {
+                let value = value
+                    .map(day_time_interval_to_calendar_interval)
+                    .transpose()?;
+                Ok(ColumnarValue::Scalar(ScalarValue::IntervalMonthDayNano(
+                    value,
+                )))
+            }
+            value => exec_err!("expected microsecond day-time interval, got {value:?}"),
+        }
+    }
+}
+
 // TODO: support alternative form of interval strings
 //   In Spark, interval strings can be specified in two forms.
 //   For example, the `INTERVAL HOUR` type can have the following string representations.
@@ -155,15 +226,7 @@ fn string_to_calendar_interval(value: &str) -> Result<IntervalMonthDayNano> {
             nanoseconds: 0,
         }),
         IntervalValue::Microsecond { microseconds } => {
-            // We do not take into account daylight saving days here.
-            let days = i32::try_from(microseconds / (24 * 60 * 60 * 1_000_000)).map_err(|_| {
-                exec_datafusion_err!("microseconds overflow for calendar interval: {value}")
-            })?;
-            Ok(IntervalMonthDayNano {
-                months: 0,
-                days,
-                nanoseconds: microseconds % (24 * 60 * 60 * 1_000_000) * 1_000,
-            })
+            day_time_interval_to_calendar_interval(microseconds)
         }
         IntervalValue::MonthDayNanosecond {
             months,
@@ -174,5 +237,38 @@ fn string_to_calendar_interval(value: &str) -> Result<IntervalMonthDayNano> {
             days,
             nanoseconds,
         }),
+    }
+}
+
+fn day_time_interval_to_calendar_interval(microseconds: i64) -> Result<IntervalMonthDayNano> {
+    const MICROSECONDS_PER_DAY: i64 = 24 * 60 * 60 * 1_000_000;
+
+    let days = i32::try_from(microseconds / MICROSECONDS_PER_DAY).map_err(|_| {
+        exec_datafusion_err!("microseconds overflow for calendar interval: {microseconds}")
+    })?;
+    Ok(IntervalMonthDayNano {
+        months: 0,
+        days,
+        nanoseconds: microseconds % MICROSECONDS_PER_DAY * 1_000,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn day_time_interval_preserves_calendar_days_and_microsecond_remainder() -> Result<()> {
+        const MICROSECONDS_PER_DAY: i64 = 24 * 60 * 60 * 1_000_000;
+
+        assert_eq!(
+            day_time_interval_to_calendar_interval(MICROSECONDS_PER_DAY + 5)?,
+            IntervalMonthDayNano::new(0, 1, 5_000)
+        );
+        assert_eq!(
+            day_time_interval_to_calendar_interval(-MICROSECONDS_PER_DAY - 5)?,
+            IntervalMonthDayNano::new(0, -1, -5_000)
+        );
+        Ok(())
     }
 }

--- a/crates/sail-function/src/scalar/datetime/spark_timestamp.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_timestamp.rs
@@ -119,7 +119,19 @@ impl TimestampParser {
     }
 
     fn string_to_microseconds(&self, value: &str, safe: bool) -> Result<Option<i64>> {
-        let (datetime, timezone) = match parse_timestamp(value).and_then(|x| x.into_naive()) {
+        let timestamp = match parse_timestamp(value) {
+            Ok(v) => v,
+            Err(_e) if safe => return Ok(None),
+            Err(e) => return Err(exec_datafusion_err!("{e}")),
+        };
+        if timestamp.time.second == 60 {
+            return if safe {
+                Ok(None)
+            } else {
+                exec_err!("invalid timestamp: leap seconds are not supported")
+            };
+        }
+        let (datetime, timezone) = match timestamp.into_naive() {
             Ok(v) => v,
             Err(_e) if safe => return Ok(None),
             Err(e) => return Err(exec_datafusion_err!("{e}")),
@@ -452,5 +464,28 @@ fn get_or_parse_format<'a>(
     match cache.entry(pattern.to_string()) {
         Entry::Occupied(entry) => Ok(entry.into_mut()),
         Entry::Vacant(entry) => Ok(entry.insert(DateTimeFormat::for_parsing(pattern)?)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unformatted_parser_rejects_leap_seconds_in_safe_and_strict_modes() -> Result<()> {
+        let parser = TimestampParser::Ltz {
+            default_timezone: "UTC".to_string(),
+        };
+
+        assert_eq!(
+            parser.string_to_microseconds("2026-06-15 23:59:60", true)?,
+            None
+        );
+        assert!(
+            parser
+                .string_to_microseconds("2026-06-15 23:59:60", false)
+                .is_err()
+        );
+        Ok(())
     }
 }

--- a/crates/sail-plan/src/function/scalar/math.rs
+++ b/crates/sail-plan/src/function/scalar/math.rs
@@ -12,6 +12,7 @@ use half::f16;
 use sail_common_datafusion::utils::items::ItemTaker;
 use sail_function::error::generic_exec_err;
 use sail_function::scalar::datetime::negate_duration::NegateDuration;
+use sail_function::scalar::datetime::spark_interval::SparkDayTimeIntervalToCalendarInterval;
 use sail_function::scalar::datetime::spark_timestamp::SparkTimestamp;
 use sail_function::scalar::math::rand_poisson::RandPoisson;
 use sail_function::scalar::math::randn::Randn;
@@ -51,7 +52,9 @@ fn add_day_time_interval_to_string(
         false,
     )?)
     .call(vec![string]);
-    let shifted = timestamp + interval;
+    let calendar_interval =
+        ScalarUDF::from(SparkDayTimeIntervalToCalendarInterval::new()).call(vec![interval]);
+    let shifted = timestamp + calendar_interval;
     match string_type {
         DataType::Utf8 => Ok(ScalarUDF::from(SparkToUtf8::new()).call(vec![shifted])),
         DataType::LargeUtf8 => Ok(ScalarUDF::from(SparkToLargeUtf8::new()).call(vec![shifted])),

--- a/crates/sail-plan/src/function/scalar/math.rs
+++ b/crates/sail-plan/src/function/scalar/math.rs
@@ -12,6 +12,7 @@ use half::f16;
 use sail_common_datafusion::utils::items::ItemTaker;
 use sail_function::error::generic_exec_err;
 use sail_function::scalar::datetime::negate_duration::NegateDuration;
+use sail_function::scalar::datetime::spark_timestamp::SparkTimestamp;
 use sail_function::scalar::math::rand_poisson::RandPoisson;
 use sail_function::scalar::math::randn::Randn;
 use sail_function::scalar::math::random::Random;
@@ -32,22 +33,48 @@ use sail_function::scalar::math::spark_try_subtract::SparkTrySubtract;
 use sail_function::scalar::math::spark_unhex::SparkUnHex;
 use sail_function::scalar::math::spark_uniform::SparkUniform;
 use sail_function::scalar::misc::raise_error::RaiseError;
+use sail_function::scalar::spark_to_string::{SparkToLargeUtf8, SparkToUtf8, SparkToUtf8View};
 
 use crate::error::{PlanError, PlanResult};
 use crate::function::common::{ScalarFunction, ScalarFunctionInput};
 
+fn add_day_time_interval_to_string(
+    string: Expr,
+    interval: Expr,
+    string_type: DataType,
+    session_timezone: Arc<str>,
+    ansi_mode: bool,
+) -> PlanResult<Expr> {
+    let timestamp = ScalarUDF::from(SparkTimestamp::try_new(
+        Some(session_timezone),
+        ansi_mode,
+        false,
+    )?)
+    .call(vec![string]);
+    let shifted = timestamp + interval;
+    match string_type {
+        DataType::Utf8 => Ok(ScalarUDF::from(SparkToUtf8::new()).call(vec![shifted])),
+        DataType::LargeUtf8 => Ok(ScalarUDF::from(SparkToLargeUtf8::new()).call(vec![shifted])),
+        DataType::Utf8View => Ok(ScalarUDF::from(SparkToUtf8View::new()).call(vec![shifted])),
+        data_type => Err(PlanError::internal(format!(
+            "expected string type for interval arithmetic, got {data_type}"
+        ))),
+    }
+}
+
 /// Arguments:
-///   - left: A numeric, DATE, TIMESTAMP, or INTERVAL expression.
+///   - left: A numeric, STRING, DATE, TIMESTAMP, or INTERVAL expression.
 ///   - right: If left is a numeric right must be numeric expression, or an INTERVAL otherwise.
 ///
 /// Returns:
 ///   - If left is a numeric, the common maximum type of the arguments.
+///   - If one expression is a STRING and the other is a day-time interval, the result is a STRING.
 ///   - If left is a DATE and right is a day-time interval the result is a TIMESTAMP.
 ///   - If both expressions are interval they must be of the same class.
 ///   - Otherwise, the result type matches left.
 ///
-/// All of the above conditions should be handled by the DataFusion.
-/// If there is a discrepancy in parity, check the link below and adjust Sail's logic accordingly:
+/// Most of the above conditions are handled by DataFusion. Spark-specific coercion differences are
+/// rewritten here before constructing the DataFusion expression. For DataFusion's rules, see:
 ///   https://github.com/apache/datafusion/blob/a28f2834c6969a0c0eb26165031f8baa1e1156a5/datafusion/expr-common/src/type_coercion/binary.rs#L194
 fn spark_plus(input: ScalarFunctionInput) -> PlanResult<Expr> {
     let ScalarFunctionInput {
@@ -63,6 +90,26 @@ fn spark_plus(input: ScalarFunctionInput) -> PlanResult<Expr> {
             right.get_type(function_context.schema),
         );
         Ok(match (left_type, right_type) {
+            (
+                Ok(string_type @ (DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View)),
+                Ok(DataType::Duration(TimeUnit::Microsecond)),
+            ) => add_day_time_interval_to_string(
+                left,
+                right,
+                string_type,
+                Arc::clone(&function_context.plan_config.session_timezone),
+                function_context.plan_config.ansi_mode,
+            )?,
+            (
+                Ok(DataType::Duration(TimeUnit::Microsecond)),
+                Ok(string_type @ (DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View)),
+            ) => add_day_time_interval_to_string(
+                right,
+                left,
+                string_type,
+                Arc::clone(&function_context.plan_config.session_timezone),
+                function_context.plan_config.ansi_mode,
+            )?,
             (Ok(DataType::Date32), Ok(DataType::Duration(TimeUnit::Microsecond))) => {
                 left + cast(right, DataType::Interval(IntervalUnit::MonthDayNano))
             }

--- a/python/pysail/tests/spark/function/features/datetime/interval_day_to_second.feature
+++ b/python/pysail/tests/spark/function/features/datetime/interval_day_to_second.feature
@@ -125,6 +125,54 @@ Feature: INTERVAL DAY TO SECOND literal parsing and operations
         """
       Then query error (?i)(timestamp|CAST_INVALID_INPUT|found n at 0:1)
 
+    Scenario Outline: string and whole-day interval addition keeps local time across DST with <operand order>
+      Given config spark.sql.session.timeZone = America/Los_Angeles
+      When query
+        """
+        SELECT <expr> AS result
+        FROM VALUES
+          ('2019-03-09 12:00:00'),
+          ('2019-11-02 12:00:00')
+        AS t(ts_str)
+        """
+      Then query result
+        | result              |
+        | 2019-03-10 12:00:00 |
+        | 2019-11-03 12:00:00 |
+
+      Examples:
+        | operand order  | expr                     |
+        | string first   | ts_str + INTERVAL 1 DAY  |
+        | interval first | INTERVAL 1 DAY + ts_str  |
+
+    Scenario Outline: leap-second string and interval addition returns NULL in legacy mode with <operand order>
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT <expr> AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+      Examples:
+        | operand order  | expr                                                |
+        | string first   | '2026-06-15 23:59:60' + INTERVAL 1 SECOND           |
+        | interval first | INTERVAL 1 SECOND + '2026-06-15 23:59:60'           |
+
+    Scenario Outline: leap-second string and interval addition errors in ANSI mode with <operand order>
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT <expr> AS result
+        """
+      Then query error (?i)(timestamp|CAST_INVALID_INPUT|leap seconds)
+
+      Examples:
+        | operand order  | expr                                                |
+        | string first   | '2026-06-15 23:59:60' + INTERVAL 1 SECOND           |
+        | interval first | INTERVAL 1 SECOND + '2026-06-15 23:59:60'           |
+
     # Same field validation as above: Spark will not even parse `INTERVAL '1 24:00:00'`, so the
     # normalized-equality comparison never runs. Sail normalizes and answers `true`.
     @sail-bug

--- a/python/pysail/tests/spark/function/features/datetime/interval_day_to_second.feature
+++ b/python/pysail/tests/spark/function/features/datetime/interval_day_to_second.feature
@@ -67,6 +67,64 @@ Feature: INTERVAL DAY TO SECOND literal parsing and operations
         | case                  | expr                                                                      | result                              |
         | addition of intervals | INTERVAL '0 23:00:00' DAY TO SECOND + INTERVAL '0 02:00:00' DAY TO SECOND | INTERVAL '1 01:00:00' DAY TO SECOND |
 
+    Scenario Outline: string and day-time interval addition with <operand order>
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT <expr> AS result
+        FROM VALUES
+          ('2026-01-01 00:00:00'),
+          ('2026-03-15 12:30:00'),
+          ('not-a-timestamp'),
+          (CAST(NULL AS STRING))
+        AS t(ts_str)
+        """
+      Then query result
+        | result              |
+        | 2026-01-01 00:00:05 |
+        | 2026-03-15 12:30:05 |
+        | NULL                |
+        | NULL                |
+      Then query schema
+        """
+        root
+         |-- result: string (nullable = true)
+        """
+
+      Examples:
+        | operand order  | expr                                  |
+        | string first   | ts_str + INTERVAL 1 SECOND * 5         |
+        | interval first | INTERVAL 1 SECOND * 5 + ts_str         |
+
+    Scenario: string and day-time interval addition under ANSI mode
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT ts_str + INTERVAL 1 SECOND * 5 AS result
+        FROM VALUES
+          ('2026-01-01 00:00:00'),
+          (CAST(NULL AS STRING))
+        AS t(ts_str)
+        """
+      Then query result
+        | result              |
+        | 2026-01-01 00:00:05 |
+        | NULL                |
+      Then query schema
+        """
+        root
+         |-- result: string (nullable = true)
+        """
+
+    Scenario: invalid string and day-time interval addition errors under ANSI mode
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT ts_str + INTERVAL 1 SECOND * 5 AS result
+        FROM VALUES ('not-a-timestamp') AS t(ts_str)
+        """
+      Then query error (?i)(timestamp|CAST_INVALID_INPUT|found n at 0:1)
+
     # Same field validation as above: Spark will not even parse `INTERVAL '1 24:00:00'`, so the
     # normalized-equality comparison never runs. Sail normalizes and answers `true`.
     @sail-bug


### PR DESCRIPTION
## Summary

Match Spark arithmetic between strings and day-time intervals for both `string + interval` and `interval + string`.

String operands are parsed as timestamps using the session timezone. Whole days are applied as calendar days and the remaining sub-day portion as elapsed time, preserving local wall-clock behavior across daylight-saving transitions, before the result is converted back to the input string representation. Invalid timestamps, including leap-second values, return `NULL` in non-ANSI mode and report an error in ANSI mode.

Closes #2380
