### PR TITLE
fix: align empty structs and to_json key ordering with Spark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8499,6 +8499,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",

--- a/crates/sail-function/Cargo.toml
+++ b/crates/sail-function/Cargo.toml
@@ -45,6 +45,6 @@ percent-encoding = { workspace = true }
 jiter = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
+serde_json = { workspace = true, features = ["preserve_order"] }
 xee-xpath = { workspace = true }
 xot = { workspace = true }

--- a/crates/sail-function/src/scalar/json/to_json.rs
+++ b/crates/sail-function/src/scalar/json/to_json.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::sync::{Arc, OnceLock};
 
 use base64::Engine;
@@ -43,11 +44,13 @@ macro_rules! downcast_and_convert {
 struct ToJsonOptions {
     timestamp_format: DateTimeFormat,
     date_format: DateTimeFormat,
+    sort_keys: bool,
 }
 
 impl ToJsonOptions {
     pub const TIMESTAMP_FORMAT_OPTION: &'static str = "timestampFormat";
     pub const DATE_FORMAT_OPTION: &'static str = "dateFormat";
+    pub const SORT_KEYS_OPTION: &'static str = "sortKeys";
     // Default ISO 8601 format with timezone offset (not Z)
     // Using Java DateTimeFormatter patterns
     pub const TIMESTAMP_FORMAT_DEFAULT: &'static str = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSXXX";
@@ -75,9 +78,16 @@ impl ToJsonOptions {
                     .expect("default date format should be valid")
             });
 
+        let sort_keys = find_key_value(map, Self::SORT_KEYS_OPTION)
+            .as_deref()
+            .map(parse_boolean_option)
+            .transpose()?
+            .unwrap_or(false);
+
         Ok(Self {
             timestamp_format,
             date_format,
+            sort_keys,
         })
     }
 }
@@ -90,6 +100,7 @@ impl Default for ToJsonOptions {
                 .expect("default timestamp format should be valid"),
             date_format: DateTimeFormat::for_formatting(Self::DATE_FORMAT_DEFAULT)
                 .expect("default date format should be valid"),
+            sort_keys: false,
         }
     }
 }
@@ -381,17 +392,31 @@ fn array_value_to_json(array: &ArrayRef, index: usize, options: &ToJsonOptions) 
 
 fn struct_to_json(
     struct_array: &StructArray,
-    index: usize,
+    row_index: usize,
     options: &ToJsonOptions,
 ) -> Result<Value> {
     let fields = struct_array.fields();
     let columns = struct_array.columns();
+    let sorted_indices = if options.sort_keys {
+        let mut indices = (0..fields.len()).collect::<Vec<_>>();
+        indices.sort_by(|left, right| {
+            compare_spark_json_keys(fields[*left].name(), fields[*right].name())
+        });
+        Some(indices)
+    } else {
+        None
+    };
 
     let mut map = Map::new();
-    for (field, column) in fields.iter().zip(columns.iter()) {
+    for position in 0..fields.len() {
+        let field_index = sorted_indices
+            .as_ref()
+            .map_or(position, |indices| indices[position]);
+        let field = &fields[field_index];
+        let column = &columns[field_index];
         // Skip NULL values - PySpark doesn't include them in JSON output
-        if !column.is_null(index) {
-            let value = array_value_to_json(column, index, options)?;
+        if !column.is_null(row_index) {
+            let value = array_value_to_json(column, row_index, options)?;
             map.insert(field.name().clone(), value);
         }
     }
@@ -426,20 +451,49 @@ fn map_to_json(map_array: &MapArray, index: usize, options: &ToJsonOptions) -> R
     let values = struct_array.column(1);
 
     let mut map = Map::new();
-    for i in 0..keys.len() {
-        // For map keys, Spark serializes structs as arrays of values (without field names)
-        // e.g., named_struct('a', 1) becomes [1] instead of {"a":1}
-        let key = map_key_to_json(keys, i, options)?;
-        let key_str = match key {
-            Value::String(s) => s,
-            other => serde_json::to_string(&other)
-                .map_err(|e| datafusion_common::DataFusionError::External(Box::new(e)))?,
-        };
-        let value = array_value_to_json(values, i, options)?;
-        map.insert(key_str, value);
+    if options.sort_keys {
+        let mut entries = (0..keys.len())
+            .map(|index| Ok((map_key_to_string(keys, index, options)?, index)))
+            .collect::<Result<Vec<_>>>()?;
+        entries.sort_by(|(left, _), (right, _)| compare_spark_json_keys(left, right));
+        for (key, index) in entries {
+            insert_json_map_value(&mut map, key, values, index, options)?;
+        }
+    } else {
+        for index in 0..keys.len() {
+            let key = map_key_to_string(keys, index, options)?;
+            insert_json_map_value(&mut map, key, values, index, options)?;
+        }
     }
 
     Ok(Value::Object(map))
+}
+
+fn map_key_to_string(array: &ArrayRef, index: usize, options: &ToJsonOptions) -> Result<String> {
+    // For map keys, Spark serializes structs as arrays of values (without field names)
+    // e.g., named_struct('a', 1) becomes [1] instead of {"a":1}
+    match map_key_to_json(array, index, options)? {
+        Value::String(value) => Ok(value),
+        value => serde_json::to_string(&value)
+            .map_err(|error| datafusion_common::DataFusionError::External(Box::new(error))),
+    }
+}
+
+fn insert_json_map_value(
+    map: &mut Map<String, Value>,
+    key: String,
+    values: &ArrayRef,
+    index: usize,
+    options: &ToJsonOptions,
+) -> Result<()> {
+    let value = array_value_to_json(values, index, options)?;
+    map.insert(key, value);
+    Ok(())
+}
+
+// Spark orders JSON keys with Java String ordering, which compares UTF-16 code units.
+fn compare_spark_json_keys(left: &str, right: &str) -> Ordering {
+    left.encode_utf16().cmp(right.encode_utf16())
 }
 
 /// Converts a map key to JSON. For struct keys, Spark serializes them as arrays
@@ -583,6 +637,14 @@ fn number_from_f64(value: f64) -> Value {
         .unwrap_or_else(|| Value::String(value.to_string()))
 }
 
+fn parse_boolean_option(value: &str) -> Result<bool> {
+    match value.to_lowercase().as_str() {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        _ => datafusion_common::exec_err!("For input string: \"{value}\""),
+    }
+}
+
 /// Finds the index of a specified key in a MapArray.
 fn find_key_index(options: &MapArray, search_key: &str) -> Option<usize> {
     options
@@ -607,5 +669,140 @@ fn find_key_value(options: &MapArray, search_key: &str) -> Option<String> {
             .map(|values| values.value(index).to_string())
     } else {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::buffer::{OffsetBuffer, ScalarBuffer};
+    use datafusion::arrow::datatypes::{Field, Fields};
+    use sail_common::spec::SAIL_MAP_FIELD_NAME;
+
+    use super::*;
+
+    fn make_map_array(keys: ArrayRef, values: ArrayRef, offsets: Vec<i32>) -> Result<MapArray> {
+        let fields = Fields::from(vec![
+            Field::new(SAIL_MAP_KEY_FIELD_NAME, keys.data_type().clone(), false),
+            Field::new(SAIL_MAP_VALUE_FIELD_NAME, values.data_type().clone(), true),
+        ]);
+        let entries = StructArray::try_new(fields.clone(), vec![keys, values], None)?;
+        let entries_field = Arc::new(Field::new(
+            SAIL_MAP_FIELD_NAME,
+            DataType::Struct(fields),
+            false,
+        ));
+        Ok(MapArray::try_new(
+            entries_field,
+            OffsetBuffer::new(ScalarBuffer::from(offsets)),
+            entries,
+            None,
+            false,
+        )?)
+    }
+
+    fn json_string(value: &Value) -> Result<String> {
+        serde_json::to_string(value)
+            .map_err(|error| datafusion_common::DataFusionError::External(Box::new(error)))
+    }
+
+    #[test]
+    fn sort_keys_recursively_orders_structs_inside_arrays() -> Result<()> {
+        let nested_fields = Fields::from(vec![
+            Field::new("zeta_inner", DataType::Utf8, false),
+            Field::new("alpha_inner", DataType::Utf8, false),
+        ]);
+        let nested = StructArray::try_new(
+            nested_fields,
+            vec![
+                Arc::new(StringArray::from(vec!["z"])),
+                Arc::new(StringArray::from(vec!["a"])),
+            ],
+            None,
+        )?;
+        let list = ListArray::new(
+            Arc::new(Field::new("element", nested.data_type().clone(), false)),
+            OffsetBuffer::new(ScalarBuffer::from(vec![0_i32, 1])),
+            Arc::new(nested),
+            None,
+        );
+        let outer_fields = Fields::from(vec![
+            Field::new("zeta", list.data_type().clone(), false),
+            Field::new("alpha", DataType::Utf8, false),
+            Field::new("mid", DataType::Utf8, false),
+        ]);
+        let outer = StructArray::try_new(
+            outer_fields,
+            vec![
+                Arc::new(list),
+                Arc::new(StringArray::from(vec!["a"])),
+                Arc::new(StringArray::from(vec!["m"])),
+            ],
+            None,
+        )?;
+
+        let default_json = struct_to_json(&outer, 0, &ToJsonOptions::default())?;
+        assert_eq!(
+            json_string(&default_json)?,
+            r#"{"zeta":[{"zeta_inner":"z","alpha_inner":"a"}],"alpha":"a","mid":"m"}"#
+        );
+
+        let sorted_json = struct_to_json(
+            &outer,
+            0,
+            &ToJsonOptions {
+                sort_keys: true,
+                ..ToJsonOptions::default()
+            },
+        )?;
+        assert_eq!(
+            json_string(&sorted_json)?,
+            r#"{"alpha":"a","mid":"m","zeta":[{"alpha_inner":"a","zeta_inner":"z"}]}"#
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn sort_keys_recursively_orders_maps() -> Result<()> {
+        let nested = make_map_array(
+            Arc::new(StringArray::from(vec![
+                "zeta_inner",
+                "alpha_inner",
+                "zeta_inner",
+                "alpha_inner",
+            ])),
+            Arc::new(StringArray::from(vec!["z", "a", "Z", "A"])),
+            vec![0, 2, 4],
+        )?;
+        let outer = make_map_array(
+            Arc::new(StringArray::from(vec!["zeta", "alpha"])),
+            Arc::new(nested),
+            vec![0, 2],
+        )?;
+
+        let default_json = map_to_json(&outer, 0, &ToJsonOptions::default())?;
+        assert_eq!(
+            json_string(&default_json)?,
+            r#"{"zeta":{"zeta_inner":"z","alpha_inner":"a"},"alpha":{"zeta_inner":"Z","alpha_inner":"A"}}"#
+        );
+
+        let option_map = make_map_array(
+            Arc::new(StringArray::from(vec![ToJsonOptions::SORT_KEYS_OPTION])),
+            Arc::new(StringArray::from(vec!["TRUE"])),
+            vec![0, 1],
+        )?;
+        let sorted_json = map_to_json(&outer, 0, &ToJsonOptions::from_map(&option_map)?)?;
+        assert_eq!(
+            json_string(&sorted_json)?,
+            r#"{"alpha":{"alpha_inner":"A","zeta_inner":"Z"},"zeta":{"alpha_inner":"a","zeta_inner":"z"}}"#
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn sort_keys_uses_java_utf16_order() {
+        assert_eq!(
+            compare_spark_json_keys("\u{10000}", "\u{e000}"),
+            Ordering::Less
+        );
     }
 }

--- a/crates/sail-function/src/scalar/struct_function.rs
+++ b/crates/sail-function/src/scalar/struct_function.rs
@@ -4,7 +4,8 @@ use datafusion::arrow::array::{ArrayRef, StructArray};
 use datafusion::arrow::datatypes::{DataType, Field, FieldRef, Fields};
 use datafusion_common::{Result, exec_err};
 use datafusion_expr::{
-    ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+    ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature,
+    Volatility,
 };
 
 pub fn to_struct_array(
@@ -55,7 +56,10 @@ pub struct StructFunction {
 impl StructFunction {
     pub fn new(field_names: Vec<String>) -> Self {
         Self {
-            signature: Signature::variadic_any(Volatility::Immutable),
+            signature: Signature::one_of(
+                vec![TypeSignature::Nullary, TypeSignature::VariadicAny],
+                Volatility::Immutable,
+            ),
             field_names,
         }
     }
@@ -104,12 +108,21 @@ impl ScalarUDFImpl for StructFunction {
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         let ScalarFunctionArgs {
-            args, return_field, ..
+            args,
+            number_rows,
+            return_field,
+            ..
         } = args;
         let arg_fields = match return_field.data_type() {
             DataType::Struct(fields) => fields.iter().cloned().collect::<Vec<_>>(),
             other => return exec_err!("struct: expected struct return field, got {}", other),
         };
+        // With no child arrays, Arrow cannot infer the output batch length.
+        if args.is_empty() {
+            return Ok(ColumnarValue::Array(Arc::new(
+                StructArray::new_empty_fields(number_rows, None),
+            )));
+        }
         let arrays = ColumnarValue::values_to_arrays(&args)?;
         Ok(ColumnarValue::Array(to_struct_array(
             arrays.as_slice(),

--- a/python/pysail/tests/spark/function/features/json/to_json.feature
+++ b/python/pysail/tests/spark/function/features/json/to_json.feature
@@ -1,4 +1,4 @@
-Feature: to_json output schema
+Feature: to_json
 
   @function(nullability)
   Rule: Output schema
@@ -13,3 +13,88 @@ Feature: to_json output schema
         root
          |-- result: string (nullable = true)
         """
+
+    Scenario: an empty struct input to to_json yields the schema Spark declares
+      When query
+        """
+        SELECT to_json(struct()) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: string (nullable = true)
+        """
+
+  Rule: Empty struct
+
+    Scenario: an empty struct has no fields, is non-null, and has a byte-exact JSON representation
+      When query
+        """
+        SELECT
+          typeof(struct()) AS struct_type,
+          struct() IS NOT NULL AS is_non_null,
+          to_json(struct()) AS result,
+          hex(to_json(struct())) AS bytes
+        """
+      Then query result
+        | struct_type | is_non_null | result | bytes |
+        | struct<>    | true        | {}     | 7B7D  |
+
+    Scenario: to_json preserves row cardinality for an empty struct
+      When query
+        """
+        SELECT id, to_json(struct()) AS result
+        FROM range(3)
+        ORDER BY id
+        """
+      Then query result ordered
+        | id | result |
+        | 0  | {}     |
+        | 1  | {}     |
+        | 2  | {}     |
+
+    Scenario: to_json distinguishes nested empty structs from null structs
+      When query
+        """
+        SELECT
+          to_json(named_struct('empty', struct())) AS nested,
+          to_json(CAST(NULL AS STRUCT<>)) AS null_struct
+        """
+      Then query result
+        | nested       | null_struct |
+        | {"empty":{}} | NULL        |
+
+  Rule: Struct field order
+
+    Scenario: to_json preserves struct field declaration order byte-for-byte
+      When query
+        """
+        SELECT to_json(struct(zeta, alpha, mid)) AS result
+        FROM VALUES ('z', 'a', 'm') AS t(zeta, alpha, mid)
+        """
+      Then query result
+        | result                                 |
+        | {"zeta":"z","alpha":"a","mid":"m"}     |
+
+    Scenario: to_json preserves nested struct field declaration order byte-for-byte
+      When query
+        """
+        SELECT to_json(named_struct(
+          'zeta', named_struct('zeta_inner', 'z', 'alpha_inner', 'a'),
+          'alpha', 'a',
+          'mid', 'm'
+        )) AS result
+        """
+      Then query result
+        | result                                                                         |
+        | {"zeta":{"zeta_inner":"z","alpha_inner":"a"},"alpha":"a","mid":"m"}            |
+
+    Scenario: omitted null fields do not reorder the remaining struct fields
+      When query
+        """
+        SELECT to_json(struct(zeta, alpha, mid)) AS result
+        FROM VALUES ('z', CAST(NULL AS STRING), 'm') AS t(zeta, alpha, mid)
+        """
+      Then query result
+        | result                     |
+        | {"zeta":"z","mid":"m"}     |

--- a/python/pysail/tests/spark/function/features/json/to_json.feature
+++ b/python/pysail/tests/spark/function/features/json/to_json.feature
@@ -98,3 +98,60 @@ Feature: to_json
       Then query result
         | result                     |
         | {"zeta":"z","mid":"m"}     |
+
+  Rule: Map key order
+
+    Scenario: to_json preserves map entry order when sortKeys is disabled
+      When query
+        """
+        SELECT
+          to_json(value) AS default_result,
+          to_json(value, map('sortKeys', 'false')) AS false_result
+        FROM (
+          SELECT map_from_arrays(
+            array('zeta', 'alpha', 'mid'),
+            array(1, 2, 3)
+          ) AS value
+        )
+        """
+      Then query result
+        | default_result                   | false_result                     |
+        | {"zeta":1,"alpha":2,"mid":3} | {"zeta":1,"alpha":2,"mid":3} |
+
+  Rule: Sorted JSON object keys
+
+    # The sortKeys JSON writer option was added in Spark 4.2.
+    @spark-4.2
+    Scenario: sortKeys recursively sorts struct fields including structs inside arrays
+      When query
+        """
+        SELECT
+          to_json(named_struct(
+            'zeta', named_struct('zeta_inner', 'z', 'alpha_inner', 'a'),
+            'alpha', 'a',
+            'mid', 'm'
+          ), map('sortKeys', 'true')) AS nested,
+          to_json(array(named_struct(
+            'zeta', 'z',
+            'alpha', 'a'
+          )), map('sortKeys', 'true')) AS array_result
+        """
+      Then query result
+        | nested                                                                         | array_result                   |
+        | {"alpha":"a","mid":"m","zeta":{"alpha_inner":"a","zeta_inner":"z"}} | [{"alpha":"a","zeta":"z"}] |
+
+    @spark-4.2
+    Scenario: sortKeys recursively sorts map keys
+      When query
+        """
+        SELECT to_json(map_from_arrays(
+          array('zeta', 'alpha'),
+          array(
+            map_from_arrays(array('zeta_inner', 'alpha_inner'), array('z', 'a')),
+            map_from_arrays(array('zeta_inner', 'alpha_inner'), array('Z', 'A'))
+          )
+        ), map('sortKeys', 'true')) AS result
+        """
+      Then query result
+        | result                                                                                         |
+        | {"alpha":{"alpha_inner":"A","zeta_inner":"Z"},"zeta":{"alpha_inner":"a","zeta_inner":"z"}} |


### PR DESCRIPTION
## Summary

Align zero-argument `struct()` and `to_json` object-key ordering with Spark.

`to_json(struct())` now returns `{}` while preserving input row cardinality. By default, and with `sortKeys=false`, struct fields and map entries retain their input order. With Spark 4.2's canonical `sortKeys=true` option, struct fields and map keys are sorted recursively using Java UTF-16 string ordering. Other JSON option behavior is unchanged.

Closes #2381
Closes #2384
