### PR TITLE
fix: coerce string sum across aggregate and window paths

### DIFF
--- a/crates/sail-plan/src/function/aggregate.rs
+++ b/crates/sail-plan/src/function/aggregate.rs
@@ -12,7 +12,7 @@ use datafusion::functions_nested::string::array_to_string;
 use datafusion_common::ScalarValue;
 use datafusion_expr::expr::{AggregateFunction, AggregateFunctionParams};
 use datafusion_expr::{
-    AggregateUDF, BinaryExpr, ExprSchemable, Operator, ScalarUDF, cast, expr, lit, when,
+    AggregateUDF, BinaryExpr, ExprSchemable, Operator, ScalarUDF, cast, expr, lit, try_cast, when,
 };
 use datafusion_spark::function::aggregate::try_sum::SparkTrySum;
 use lazy_static::lazy_static;
@@ -87,6 +87,16 @@ fn spark_sum(input: AggFunctionInput) -> PlanResult<expr::Expr> {
     } = input;
     let supports_linear_rewrite =
         !distinct && ignore_nulls.is_none() && filter.is_none() && order_by.is_empty();
+    let arguments = arguments
+        .into_iter()
+        .map(|argument| {
+            coerce_string_sum_argument(
+                argument,
+                function_context.schema.as_ref(),
+                function_context.plan_config.ansi_mode,
+            )
+        })
+        .collect::<PlanResult<Vec<_>>>()?;
     let arguments = if supports_linear_rewrite {
         arguments
             .into_iter()
@@ -108,6 +118,23 @@ fn spark_sum(input: AggFunctionInput) -> PlanResult<expr::Expr> {
             null_treatment: get_null_treatment(ignore_nulls),
         },
     }))
+}
+
+fn coerce_string_sum_argument(
+    argument: expr::Expr,
+    schema: &datafusion_common::DFSchema,
+    ansi_mode: bool,
+) -> PlanResult<expr::Expr> {
+    match argument.get_type(schema)? {
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
+            if ansi_mode {
+                Ok(cast(argument, DataType::Float64))
+            } else {
+                Ok(try_cast(argument, DataType::Float64))
+            }
+        }
+        _ => Ok(argument),
+    }
 }
 
 fn widen_safe_linear_sum_argument(

--- a/crates/sail-plan/src/function/aggregate.rs
+++ b/crates/sail-plan/src/function/aggregate.rs
@@ -9,7 +9,7 @@ use datafusion::functions_aggregate::{
     variance,
 };
 use datafusion::functions_nested::string::array_to_string;
-use datafusion_common::ScalarValue;
+use datafusion_common::{DFSchema, ScalarValue};
 use datafusion_expr::expr::{AggregateFunction, AggregateFunctionParams};
 use datafusion_expr::{
     AggregateUDF, BinaryExpr, ExprSchemable, Operator, ScalarUDF, cast, expr, lit, try_cast, when,
@@ -87,16 +87,12 @@ fn spark_sum(input: AggFunctionInput) -> PlanResult<expr::Expr> {
     } = input;
     let supports_linear_rewrite =
         !distinct && ignore_nulls.is_none() && filter.is_none() && order_by.is_empty();
-    let arguments = arguments
-        .into_iter()
-        .map(|argument| {
-            coerce_string_sum_argument(
-                argument,
-                function_context.schema.as_ref(),
-                function_context.plan_config.ansi_mode,
-            )
-        })
-        .collect::<PlanResult<Vec<_>>>()?;
+    let arguments = coerce_string_sum_arguments(
+        arguments,
+        filter.as_deref(),
+        function_context.schema.as_ref(),
+        function_context.plan_config.ansi_mode,
+    )?;
     let arguments = if supports_linear_rewrite {
         arguments
             .into_iter()
@@ -120,21 +116,36 @@ fn spark_sum(input: AggFunctionInput) -> PlanResult<expr::Expr> {
     }))
 }
 
-fn coerce_string_sum_argument(
-    argument: expr::Expr,
-    schema: &datafusion_common::DFSchema,
+pub(super) fn coerce_string_sum_arguments(
+    arguments: Vec<expr::Expr>,
+    filter: Option<&expr::Expr>,
+    schema: &DFSchema,
     ansi_mode: bool,
-) -> PlanResult<expr::Expr> {
-    match argument.get_type(schema)? {
-        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
-            if ansi_mode {
-                Ok(cast(argument, DataType::Float64))
-            } else {
-                Ok(try_cast(argument, DataType::Float64))
+) -> PlanResult<Vec<expr::Expr>> {
+    arguments
+        .into_iter()
+        .map(|argument| {
+            let argument_type = argument.get_type(schema)?;
+            match argument_type {
+                DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
+                    if ansi_mode {
+                        let argument = if let Some(filter) = filter {
+                            // Grouped aggregates evaluate arguments before FILTER, so mask
+                            // excluded rows before applying the fallible ANSI cast.
+                            let null_value = ScalarValue::try_from(&argument_type)?;
+                            when(filter.clone(), argument).otherwise(lit(null_value))?
+                        } else {
+                            argument
+                        };
+                        Ok(cast(argument, DataType::Float64))
+                    } else {
+                        Ok(try_cast(argument, DataType::Float64))
+                    }
+                }
+                _ => Ok(argument),
             }
-        }
-        _ => Ok(argument),
-    }
+        })
+        .collect()
 }
 
 fn widen_safe_linear_sum_argument(
@@ -933,4 +944,79 @@ pub(crate) fn get_built_in_aggregate_function(name: &str) -> PlanResult<AggFunct
 
 pub(crate) fn list_built_in_aggregate_function_names() -> impl Iterator<Item = &'static str> {
     BUILT_IN_AGGREGATE_FUNCTIONS.keys().copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::datatypes::Schema;
+    use datafusion::prelude::SessionContext;
+    use datafusion_expr::{ExprSchemable, col};
+
+    use super::*;
+    use crate::config::PlanConfig;
+    use crate::function::common::FunctionContextInput;
+
+    fn sum_test_schema(data_type: DataType) -> PlanResult<Arc<DFSchema>> {
+        Ok(Arc::new(DFSchema::try_from(Schema::new(vec![
+            Field::new("value", data_type, true),
+            Field::new("included", DataType::Boolean, true),
+        ]))?))
+    }
+
+    #[test]
+    fn string_sum_uses_mode_specific_cast_for_all_string_types() -> PlanResult<()> {
+        for data_type in [DataType::Utf8, DataType::LargeUtf8, DataType::Utf8View] {
+            let schema = sum_test_schema(data_type)?;
+            let ansi_arguments =
+                coerce_string_sum_arguments(vec![col("value")], None, schema.as_ref(), true)?;
+            assert_eq!(ansi_arguments, vec![cast(col("value"), DataType::Float64)]);
+
+            let legacy_arguments =
+                coerce_string_sum_arguments(vec![col("value")], None, schema.as_ref(), false)?;
+            assert_eq!(
+                legacy_arguments,
+                vec![try_cast(col("value"), DataType::Float64)]
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn ansi_string_sum_masks_filter_before_cast_and_preserves_clauses() -> PlanResult<()> {
+        let schema = sum_test_schema(DataType::Utf8)?;
+        let argument_display_names = ["value".to_string()];
+        let plan_config = Arc::new(PlanConfig::default());
+        let session_context = SessionContext::new();
+        let filter = col("included");
+        let expression = spark_sum(AggFunctionInput {
+            arguments: vec![col("value")],
+            distinct: true,
+            ignore_nulls: None,
+            filter: Some(Box::new(filter.clone())),
+            order_by: vec![],
+            function_context: FunctionContextInput {
+                argument_display_names: &argument_display_names,
+                plan_config: &plan_config,
+                session_context: &session_context,
+                schema: &schema,
+            },
+        })?;
+
+        assert_eq!(expression.get_type(schema.as_ref())?, DataType::Float64);
+        assert!(expression.nullable(schema.as_ref())?);
+        let expr::Expr::AggregateFunction(sum) = expression else {
+            return Err(PlanError::internal("expected aggregate SUM expression"));
+        };
+        let masked_argument =
+            when(filter.clone(), col("value")).otherwise(lit(ScalarValue::Utf8(None)))?;
+        assert_eq!(
+            sum.params.args,
+            vec![cast(masked_argument, DataType::Float64)]
+        );
+        assert_eq!(sum.params.filter, Some(Box::new(filter)));
+        assert!(sum.params.distinct);
+        Ok(())
+    }
 }

--- a/crates/sail-plan/src/function/window.rs
+++ b/crates/sail-plan/src/function/window.rs
@@ -41,6 +41,7 @@ use sail_function::aggregate::try_avg::TryAvgFunction;
 use sail_function::window::{spark_first_value_udwf, spark_last_value_udwf, spark_ntile_udwf};
 
 use crate::error::{PlanError, PlanResult};
+use crate::function::aggregate::coerce_string_sum_arguments;
 use crate::function::common::{
     WinFunction, WinFunctionInput, count_min_sketch_args, get_arguments_and_null_treatment,
     get_null_treatment, hll_args_with_default_lg, hll_union_args_with_default_allow_different_lg,
@@ -119,6 +120,36 @@ fn avg(input: WinFunctionInput) -> PlanResult<expr::Expr> {
             window_frame,
             filter: None,
             null_treatment,
+            distinct,
+        },
+    })))
+}
+
+fn spark_sum(input: WinFunctionInput) -> PlanResult<expr::Expr> {
+    let WinFunctionInput {
+        arguments,
+        partition_by,
+        order_by,
+        window_frame,
+        ignore_nulls,
+        distinct,
+        function_context,
+    } = input;
+    let arguments = coerce_string_sum_arguments(
+        arguments,
+        None,
+        function_context.schema.as_ref(),
+        function_context.plan_config.ansi_mode,
+    )?;
+    Ok(expr::Expr::WindowFunction(Box::new(expr::WindowFunction {
+        fun: WindowFunctionDefinition::AggregateUDF(sum::sum_udaf()),
+        params: WindowFunctionParams {
+            args: arguments,
+            partition_by,
+            order_by,
+            window_frame,
+            filter: None,
+            null_treatment: get_null_treatment(ignore_nulls),
             distinct,
         },
     })))
@@ -801,7 +832,7 @@ fn list_built_in_window_functions() -> Vec<(&'static str, WinFunction)> {
         ("stddev_pop", F::aggregate(stddev::stddev_pop_udaf)),
         ("stddev_samp", F::aggregate(stddev::stddev_udaf)),
         ("string_agg", F::custom(listagg)),
-        ("sum", F::aggregate(sum::sum_udaf)),
+        ("sum", F::custom(spark_sum)),
         (
             "try_avg",
             F::aggregate(|| Arc::new(AggregateUDF::from(TryAvgFunction::new()))),
@@ -825,4 +856,71 @@ pub(crate) fn get_built_in_window_function(name: &str) -> PlanResult<WinFunction
 
 pub(crate) fn list_built_in_window_function_names() -> impl Iterator<Item = &'static str> {
     BUILT_IN_WINDOW_FUNCTIONS.keys().copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow::datatypes::Schema;
+    use datafusion::prelude::SessionContext;
+    use datafusion_common::DFSchema;
+    use datafusion_expr::{ExprSchemable, col, try_cast};
+
+    use super::*;
+    use crate::config::PlanConfig;
+    use crate::function::common::FunctionContextInput;
+
+    #[test]
+    fn string_sum_window_reuses_mode_specific_coercion_and_window_spec() -> PlanResult<()> {
+        let schema = Arc::new(DFSchema::try_from(Schema::new(vec![
+            Field::new("group_name", DataType::Utf8, false),
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::Utf8, false),
+        ]))?);
+        let session_context = SessionContext::new();
+        let argument_display_names = ["value".to_string()];
+
+        for ansi_mode in [false, true] {
+            let mut plan_config = PlanConfig::default();
+            plan_config.ansi_mode = ansi_mode;
+            let plan_config = Arc::new(plan_config);
+            let partition_by = vec![col("group_name")];
+            let order_by = vec![col("id").sort(true, true)];
+            let window_frame = WindowFrame::new(Some(true));
+            let function = get_built_in_window_function("sum")?;
+            let expression = function(WinFunctionInput {
+                arguments: vec![col("value")],
+                partition_by: partition_by.clone(),
+                order_by: order_by.clone(),
+                window_frame: window_frame.clone(),
+                ignore_nulls: None,
+                distinct: false,
+                function_context: FunctionContextInput {
+                    argument_display_names: &argument_display_names,
+                    plan_config: &plan_config,
+                    session_context: &session_context,
+                    schema: &schema,
+                },
+            })?;
+
+            assert_eq!(expression.get_type(schema.as_ref())?, DataType::Float64);
+            assert!(expression.nullable(schema.as_ref())?);
+            let expr::Expr::WindowFunction(sum) = expression else {
+                return Err(PlanError::internal("expected window SUM expression"));
+            };
+            let expected_argument = if ansi_mode {
+                cast(col("value"), DataType::Float64)
+            } else {
+                try_cast(col("value"), DataType::Float64)
+            };
+            assert_eq!(sum.params.args, vec![expected_argument]);
+            assert_eq!(sum.params.partition_by, partition_by);
+            assert_eq!(sum.params.order_by, order_by);
+            assert_eq!(sum.params.window_frame, window_frame);
+            assert_eq!(sum.params.filter, None);
+            assert!(!sum.params.distinct);
+        }
+        Ok(())
+    }
 }

--- a/crates/sail-plan/src/function/window.rs
+++ b/crates/sail-plan/src/function/window.rs
@@ -882,9 +882,10 @@ mod tests {
         let argument_display_names = ["value".to_string()];
 
         for ansi_mode in [false, true] {
-            let mut plan_config = PlanConfig::default();
-            plan_config.ansi_mode = ansi_mode;
-            let plan_config = Arc::new(plan_config);
+            let plan_config = Arc::new(PlanConfig {
+                ansi_mode,
+                ..PlanConfig::default()
+            });
             let partition_by = vec![col("group_name")];
             let order_by = vec![col("id").sort(true, true)];
             let window_frame = WindowFrame::new(Some(true));

--- a/python/pysail/tests/spark/function/features/aggregate/sum.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/sum.feature
@@ -1,0 +1,87 @@
+Feature: sum
+
+  Rule: String inputs are implicitly cast to double
+
+    Scenario: sum groups numeric strings
+      When query
+        """
+        SELECT group_name, sum(value) AS total
+        FROM VALUES
+          ('a', '1'),
+          ('a', '2'),
+          ('b', '3')
+          AS tab(group_name, value)
+        GROUP BY group_name
+        ORDER BY group_name
+        """
+      Then query result ordered
+        | group_name | total |
+        | a          | 3.0   |
+        | b          | 3.0   |
+
+    @function(nullability)
+    Scenario: sum of strings returns nullable double
+      When query
+        """
+        SELECT sum(value) AS total
+        FROM VALUES ('1'), ('2') AS tab(value)
+        """
+      Then query schema
+        """
+        root
+         |-- total: double (nullable = true)
+        """
+
+    Scenario: sum skips null string values
+      When query
+        """
+        SELECT sum(value) AS total
+        FROM VALUES ('1'), (CAST(NULL AS STRING)), ('2') AS tab(value)
+        """
+      Then query result
+        | total |
+        | 3.0   |
+
+    Scenario: sum applies distinct after converting strings to numbers
+      When query
+        """
+        SELECT sum(DISTINCT value) AS total
+        FROM VALUES ('1'), ('1.0'), ('2') AS tab(value)
+        """
+      Then query result
+        | total |
+        | 3.0   |
+
+  Rule: Invalid strings follow ANSI mode
+
+    Scenario: invalid strings become null when ANSI mode is disabled
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT sum(value) AS total
+        FROM VALUES ('1'), ('invalid'), ('2') AS tab(value)
+        """
+      Then query result
+        | total |
+        | 3.0   |
+
+    Scenario: invalid strings fail when ANSI mode is enabled
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT sum(value) AS total
+        FROM VALUES ('1'), ('invalid'), ('2') AS tab(value)
+        """
+      Then query error .*
+
+  Rule: Numeric inputs retain their Spark sum type
+
+    Scenario: sum of integers remains a long
+      When query
+        """
+        SELECT typeof(sum(value)) AS result_type, sum(value) AS total
+        FROM VALUES (1), (2), (3) AS tab(value)
+        """
+      Then query result
+        | result_type | total |
+        | bigint      | 6     |

--- a/python/pysail/tests/spark/function/features/aggregate/sum.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/sum.feature
@@ -52,6 +52,46 @@ Feature: sum
         | total |
         | 3.0   |
 
+    Scenario: window sum respects partitions and explicit frames
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT group_name, id,
+          sum(value) OVER (
+            PARTITION BY group_name
+            ORDER BY id
+            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+          ) AS total
+        FROM VALUES
+          ('a', 1, '1'),
+          ('a', 2, '2'),
+          ('b', 1, '3')
+          AS tab(group_name, id, value)
+        ORDER BY group_name, id
+        """
+      Then query result ordered
+        | group_name | id | total |
+        | a          | 1  | 1.0   |
+        | a          | 2  | 3.0   |
+        | b          | 1  | 3.0   |
+
+    @function(nullability)
+    Scenario: window sum of strings returns nullable double
+      When query
+        """
+        SELECT sum(value) OVER (
+          PARTITION BY group_name
+          ORDER BY id
+          ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS total
+        FROM VALUES ('a', 1, '1') AS tab(group_name, id, value)
+        """
+      Then query schema
+        """
+        root
+         |-- total: double (nullable = true)
+        """
+
   Rule: Invalid strings follow ANSI mode
 
     Scenario: invalid strings become null when ANSI mode is disabled
@@ -73,6 +113,71 @@ Feature: sum
         FROM VALUES ('1'), ('invalid'), ('2') AS tab(value)
         """
       Then query error .*
+
+    Scenario: invalid strings become null in a legacy window sum
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT id, sum(value) OVER (
+          ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS total
+        FROM VALUES (1, '1'), (2, 'invalid'), (3, '2') AS tab(id, value)
+        ORDER BY id
+        """
+      Then query result ordered
+        | id | total |
+        | 1  | 1.0   |
+        | 2  | 1.0   |
+        | 3  | 3.0   |
+
+    Scenario: invalid strings fail in an ANSI window sum
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT sum(value) OVER (
+          ORDER BY id ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS total
+        FROM VALUES (1, '1'), (2, 'invalid') AS tab(id, value)
+        """
+      Then query error .*
+
+  Rule: Filtered strings are cast only after excluded rows are masked
+
+    Scenario: ANSI global sum filters malformed strings before casting
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT sum(value) FILTER (WHERE included) AS total
+        FROM VALUES
+          ('1', true),
+          ('invalid', false),
+          ('2', true)
+          AS tab(value, included)
+        """
+      Then query result
+        | total |
+        | 3.0   |
+
+    Scenario: ANSI grouped distinct sum filters malformed strings before casting
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT group_name, sum(DISTINCT value) FILTER (WHERE included) AS total
+        FROM VALUES
+          ('a', '1', true),
+          ('a', '1.0', true),
+          ('a', 'invalid', false),
+          ('a', '2', true),
+          ('b', 'invalid', false),
+          ('b', '4', true)
+          AS tab(group_name, value, included)
+        GROUP BY group_name
+        ORDER BY group_name
+        """
+      Then query result ordered
+        | group_name | total |
+        | a          | 3.0   |
+        | b          | 4.0   |
 
   Rule: Numeric inputs retain their Spark sum type
 


### PR DESCRIPTION
## Summary

Match Spark's implicit coercion for `sum` over string-typed expressions in both ordinary aggregates and window aggregates.

String arguments are converted to `DOUBLE` before aggregation. Malformed included values become `NULL` in non-ANSI mode and report an error in ANSI mode, while rows excluded by an aggregate `FILTER` are not evaluated. `DISTINCT` is applied after numeric coercion, and non-string SUM arguments retain their existing behavior and result types.

Closes #2386
