### PR TITLE
fix: align USING and NATURAL join output-key ownership with Spark

### DIFF
--- a/crates/sail-plan/src/resolver/query/join.rs
+++ b/crates/sail-plan/src/resolver/query/join.rs
@@ -3,11 +3,12 @@ use std::sync::Arc;
 use datafusion_common::{Column, JoinType, NullEquality};
 use datafusion_expr::utils::split_conjunction;
 use datafusion_expr::{Expr, LogicalPlan, LogicalPlanBuilder, build_join_schema};
-use datafusion_functions::expr_fn::coalesce;
 use sail_common::spec;
 use sail_python_udf::udf::pyspark_udf::PySparkUDF;
 
 use crate::error::{PlanError, PlanResult};
+use crate::function::common::{FunctionContextInput, ScalarFunctionInput};
+use crate::function::get_built_in_function;
 use crate::resolver::PlanResolver;
 use crate::resolver::state::PlanResolverState;
 
@@ -221,15 +222,36 @@ impl PlanResolver<'_> {
             })
             .collect::<PlanResult<Vec<_>>>()?;
         let builder = match join_type {
-            JoinType::Inner | JoinType::Left | JoinType::Right | JoinType::Full => {
+            JoinType::Inner | JoinType::Left | JoinType::Right => {
+                let uses_right = matches!(join_type, JoinType::Right);
                 let projections = join_columns
                     .into_iter()
                     .map(|(name, (left, right))| {
-                        coalesce(vec![Expr::Column(left), Expr::Column(right)])
-                            .alias(state.register_field_name(name))
+                        let column = if uses_right { right } else { left };
+                        Expr::Column(column).alias(state.register_field_name(name))
                     })
                     .chain(hidden_columns);
                 builder.project(projections)?
+            }
+            JoinType::Full => {
+                let join_schema = builder.schema().clone();
+                let coalesce_function = get_built_in_function("coalesce")?;
+                let projections = join_columns
+                    .into_iter()
+                    .map(|(name, (left, right))| {
+                        let expression = coalesce_function(ScalarFunctionInput {
+                            arguments: vec![Expr::Column(left), Expr::Column(right)],
+                            function_context: FunctionContextInput {
+                                argument_display_names: &[],
+                                plan_config: &self.config,
+                                session_context: self.ctx,
+                                schema: &join_schema,
+                            },
+                        })?;
+                        Ok(expression.alias(state.register_field_name(name)))
+                    })
+                    .collect::<PlanResult<Vec<_>>>()?;
+                builder.project(projections.into_iter().chain(hidden_columns))?
             }
             JoinType::LeftSemi
             | JoinType::RightSemi

--- a/python/pysail/tests/spark/dataframe/test_join_using_coercion.py
+++ b/python/pysail/tests/spark/dataframe/test_join_using_coercion.py
@@ -1,0 +1,43 @@
+from datetime import date
+
+import pyspark.sql.functions as F  # noqa: N812
+import pyspark.sql.types as T  # noqa: N812
+import pytest
+from pyspark.sql import Row
+
+
+@pytest.mark.parametrize(
+    ("join_type", "expected_data_type", "expected_period_end"),
+    [
+        ("inner", T.DateType(), date(2026, 1, 31)),
+        ("left", T.DateType(), date(2026, 1, 31)),
+        ("right", T.StringType(), "2026-01-31"),
+        ("full", T.StringType(), "2026-01-31"),
+    ],
+)
+def test_using_join_coerces_condition_and_selects_spark_output_key(
+    spark, join_type, expected_data_type, expected_period_end
+):
+    original_ansi = spark.conf.get("spark.sql.ansi.enabled")
+    spark.conf.set("spark.sql.ansi.enabled", "false")
+    try:
+        left = spark.createDataFrame(
+            [("p1", "2026-01-31")],
+            ["pid", "period_end"],
+        ).withColumn("period_end", F.last_day("period_end"))
+        right = spark.createDataFrame(
+            [("p1", "2026-01-31")],
+            ["pid", "period_end"],
+        )
+
+        result = left.join(right, on=["pid", "period_end"], how=join_type)
+
+        assert result.schema == T.StructType(
+            [
+                T.StructField("pid", T.StringType(), True),
+                T.StructField("period_end", expected_data_type, True),
+            ]
+        )
+        assert result.collect() == [Row(pid="p1", period_end=expected_period_end)]
+    finally:
+        spark.conf.set("spark.sql.ansi.enabled", original_ansi)

--- a/python/pysail/tests/spark/execution/__snapshots__/test_shuffle_storage.plan.yaml
+++ b/python/pysail/tests/spark/execution/__snapshots__/test_shuffle_storage.plan.yaml
@@ -13,7 +13,7 @@ data:
         Aggregate: groupBy=[[#12]], aggr=[[count(Int64(1)), sum(#10), sum(#11)]]
           Projection: #8 AS #9, #2 AS #10, #5 AS #11, #8 % CASE WHEN Int32(4) = Int32(0) THEN raise_error(Utf8("Remainder by zero")) ELSE Int32(4) END AS #12
             Projection: #8, #2, #5
-              Projection: coalesce(#1, #4) AS #8, #1 AS #6, #2, #4 AS #7, #5
+              Projection: #1 AS #8, #1 AS #6, #2, #4 AS #7, #5
                 Inner Join: #1 = #4
                   ExplicitRepartition: kind=hash, n=Some(8), expr=[#1]
                     Projection: #0 AS k AS #1, #0 * Int32(2) AS v1 AS #2
@@ -34,7 +34,7 @@ data:
         Aggregate: groupBy=[[#12]], aggr=[[count(Int64(1)), sum(#10), sum(#11)]]
           Projection: #8 AS #9, #2 AS #10, #5 AS #11, #8 % CAST(CASE WHEN Int32(4) = Int32(0) THEN CAST(raise_error(Utf8("Remainder by zero")) AS Int32) ELSE Int32(4) END AS Int64) AS #12
             Projection: #8, #2, #5
-              Projection: coalesce(#1, #4) AS #8, #1 AS #6, #2, #4 AS #7, #5
+              Projection: #1 AS #8, #1 AS #6, #2, #4 AS #7, #5
                 Inner Join: #1 = #4
                   ExplicitRepartition: kind=hash, n=Some(8), expr=[#1]
                     Projection: #0 AS k AS #1, #0 * CAST(Int32(2) AS Int64) AS v1 AS #2


### PR DESCRIPTION
## Summary

Align visible output-key ownership for `USING` and `NATURAL` joins with Spark.

Inner and left joins retain the left key, right joins retain the right key, and only full outer joins synthesize a coalesced key using Spark-compatible coercion. Join-predicate type coercion remains a separate existing path, and hidden child-key aliases remain available for qualified DataFrame column resolution.

Closes #2387
