### PR TITLE
fix: replace malformed UTF-8 in CSV reads

### DIFF
--- a/crates/sail-data-source/src/formats/csv/decoder.rs
+++ b/crates/sail-data-source/src/formats/csv/decoder.rs
@@ -1,0 +1,222 @@
+use std::io::{self, Read};
+
+use bytes::Bytes;
+use datafusion_common::Result;
+use futures::stream::{self, BoxStream};
+use futures::{StreamExt, TryStreamExt};
+
+const READ_BUFFER_SIZE: usize = 8 * 1024;
+const REPLACEMENT_CHARACTER: &[u8] = "\u{FFFD}".as_bytes();
+
+#[derive(Debug, Default)]
+struct LossyUtf8Decoder {
+    incomplete: Vec<u8>,
+}
+
+impl LossyUtf8Decoder {
+    fn decode_bytes(&mut self, input: Bytes) -> Bytes {
+        if self.incomplete.is_empty() && std::str::from_utf8(&input).is_ok() {
+            return input;
+        }
+        self.decode(&input)
+    }
+
+    fn decode(&mut self, input: &[u8]) -> Bytes {
+        let mut bytes = std::mem::take(&mut self.incomplete);
+        bytes.extend_from_slice(input);
+        self.repair(bytes, false)
+    }
+
+    fn finish(&mut self) -> Bytes {
+        let bytes = std::mem::take(&mut self.incomplete);
+        self.repair(bytes, true)
+    }
+
+    fn repair(&mut self, bytes: Vec<u8>, end_of_input: bool) -> Bytes {
+        let mut output = Vec::with_capacity(bytes.len());
+        let mut offset = 0;
+
+        while offset < bytes.len() {
+            match std::str::from_utf8(&bytes[offset..]) {
+                Ok(valid) => {
+                    output.extend_from_slice(valid.as_bytes());
+                    break;
+                }
+                Err(error) => {
+                    let valid_end = offset + error.valid_up_to();
+                    output.extend_from_slice(&bytes[offset..valid_end]);
+
+                    match error.error_len() {
+                        Some(invalid_length) => {
+                            output.extend_from_slice(REPLACEMENT_CHARACTER);
+                            offset = valid_end + invalid_length;
+                        }
+                        None if end_of_input => {
+                            output.extend_from_slice(REPLACEMENT_CHARACTER);
+                            break;
+                        }
+                        None => {
+                            self.incomplete.extend_from_slice(&bytes[valid_end..]);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        debug_assert!(self.incomplete.len() <= 3);
+        Bytes::from(output)
+    }
+}
+
+pub(super) struct LossyUtf8Reader<R> {
+    input: R,
+    decoder: LossyUtf8Decoder,
+    decoded: Bytes,
+    decoded_offset: usize,
+    finished: bool,
+}
+
+impl<R> LossyUtf8Reader<R> {
+    pub(super) fn new(input: R) -> Self {
+        Self {
+            input,
+            decoder: LossyUtf8Decoder::default(),
+            decoded: Bytes::new(),
+            decoded_offset: 0,
+            finished: false,
+        }
+    }
+}
+
+impl<R: Read> Read for LossyUtf8Reader<R> {
+    fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
+        if output.is_empty() {
+            return Ok(0);
+        }
+
+        loop {
+            if self.decoded_offset < self.decoded.len() {
+                let available = &self.decoded[self.decoded_offset..];
+                let length = available.len().min(output.len());
+                output[..length].copy_from_slice(&available[..length]);
+                self.decoded_offset += length;
+                return Ok(length);
+            }
+
+            if self.finished {
+                return Ok(0);
+            }
+
+            let mut input = [0; READ_BUFFER_SIZE];
+            let length = self.input.read(&mut input)?;
+            self.decoded = if length == 0 {
+                self.finished = true;
+                self.decoder.finish()
+            } else {
+                self.decoder.decode(&input[..length])
+            };
+            self.decoded_offset = 0;
+        }
+    }
+}
+
+pub(super) fn decode_utf8_lossy_stream<'a>(
+    input: BoxStream<'a, Result<Bytes>>,
+) -> BoxStream<'a, Result<Bytes>> {
+    stream::unfold(
+        (input, LossyUtf8Decoder::default(), false),
+        |(mut input, mut decoder, mut finished)| async move {
+            loop {
+                if finished {
+                    return None;
+                }
+
+                match input.try_next().await {
+                    Ok(Some(bytes)) => {
+                        let decoded = decoder.decode_bytes(bytes);
+                        if !decoded.is_empty() {
+                            return Some((Ok(decoded), (input, decoder, finished)));
+                        }
+                    }
+                    Ok(None) => {
+                        finished = true;
+                        let decoded = decoder.finish();
+                        if !decoded.is_empty() {
+                            return Some((Ok(decoded), (input, decoder, finished)));
+                        }
+                    }
+                    Err(error) => {
+                        return Some((Err(error), (input, decoder, finished)));
+                    }
+                }
+            }
+        },
+    )
+    .boxed()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, Read};
+
+    use bytes::Bytes;
+    use datafusion_common::Result;
+    use futures::{StreamExt, stream};
+
+    use super::{LossyUtf8Decoder, LossyUtf8Reader, decode_utf8_lossy_stream};
+
+    #[test]
+    fn test_lossy_utf8_decoder_replaces_invalid_sequences() {
+        let mut decoder = LossyUtf8Decoder::default();
+        let mut output = decoder.decode(b"caf\xe9_bad_\xff").to_vec();
+        output.extend_from_slice(&decoder.finish());
+
+        assert_eq!(output, "caf\u{FFFD}_bad_\u{FFFD}".as_bytes());
+    }
+
+    #[test]
+    fn test_lossy_utf8_decoder_preserves_multibyte_characters_across_chunks() {
+        let input = "caf\u{e9}_\u{1F980}".as_bytes();
+        let chunks = [&input[..4], &input[4..7], &input[7..9], &input[9..]];
+        let mut decoder = LossyUtf8Decoder::default();
+        let mut output = Vec::new();
+
+        for chunk in chunks {
+            output.extend_from_slice(&decoder.decode(chunk));
+        }
+        output.extend_from_slice(&decoder.finish());
+
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn test_lossy_utf8_reader_replaces_incomplete_sequence_at_end_of_input() -> std::io::Result<()>
+    {
+        let mut reader = LossyUtf8Reader::new(Cursor::new(b"value\xf0\x9f"));
+        let mut output = String::new();
+        reader.read_to_string(&mut output)?;
+
+        assert_eq!(output, "value\u{FFFD}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_lossy_utf8_stream_preserves_split_multibyte_character() -> Result<()> {
+        let input = stream::iter([
+            Ok(Bytes::from_static(b"caf\xc3")),
+            Ok(Bytes::from_static(b"\xa9\xf0\x9f")),
+            Ok(Bytes::from_static(b"\xa6\x80")),
+        ])
+        .boxed();
+        let output = decode_utf8_lossy_stream(input)
+            .collect::<Vec<Result<Bytes>>>()
+            .await
+            .into_iter()
+            .collect::<Result<Vec<_>>>()?
+            .concat();
+
+        assert_eq!(output, "caf\u{e9}\u{1F980}".as_bytes());
+        Ok(())
+    }
+}

--- a/crates/sail-data-source/src/formats/csv/decoder.rs
+++ b/crates/sail-data-source/src/formats/csv/decoder.rs
@@ -8,6 +8,112 @@ use futures::{StreamExt, TryStreamExt};
 const READ_BUFFER_SIZE: usize = 8 * 1024;
 const REPLACEMENT_CHARACTER: &[u8] = "\u{FFFD}".as_bytes();
 
+#[derive(Debug, PartialEq)]
+enum Utf8Unit {
+    Valid(usize),
+    Malformed(usize),
+    Incomplete,
+}
+
+fn is_continuation(byte: u8) -> bool {
+    byte & 0xc0 == 0x80
+}
+
+/// Classifies the next UTF-8 unit and returns the maximal malformed prefix length.
+fn classify_utf8_unit(input: &[u8], end_of_input: bool) -> Utf8Unit {
+    let first = input[0];
+    match first {
+        0x00..=0x7f => Utf8Unit::Valid(1),
+        0xc2..=0xdf => {
+            if input.len() < 2 {
+                return if end_of_input {
+                    Utf8Unit::Malformed(1)
+                } else {
+                    Utf8Unit::Incomplete
+                };
+            }
+            if is_continuation(input[1]) {
+                Utf8Unit::Valid(2)
+            } else {
+                Utf8Unit::Malformed(1)
+            }
+        }
+        0xe0..=0xef => {
+            if input.len() < 2 {
+                return if end_of_input {
+                    Utf8Unit::Malformed(1)
+                } else {
+                    Utf8Unit::Incomplete
+                };
+            }
+
+            let second = input[1];
+            if !is_continuation(second) || (first == 0xe0 && second < 0xa0) {
+                return Utf8Unit::Malformed(1);
+            }
+            if input.len() < 3 {
+                return if end_of_input {
+                    Utf8Unit::Malformed(2)
+                } else {
+                    Utf8Unit::Incomplete
+                };
+            }
+
+            let third = input[2];
+            if !is_continuation(third) {
+                Utf8Unit::Malformed(2)
+            } else if first == 0xed && second >= 0xa0 {
+                // A complete UTF-16 surrogate sequence is one malformed three-byte unit.
+                Utf8Unit::Malformed(3)
+            } else {
+                Utf8Unit::Valid(3)
+            }
+        }
+        0xf0..=0xf4 => {
+            if input.len() < 2 {
+                return if end_of_input {
+                    Utf8Unit::Malformed(1)
+                } else {
+                    Utf8Unit::Incomplete
+                };
+            }
+
+            let second = input[1];
+            if !is_continuation(second)
+                || (first == 0xf0 && second < 0x90)
+                || (first == 0xf4 && second > 0x8f)
+            {
+                return Utf8Unit::Malformed(1);
+            }
+            if input.len() < 3 {
+                return if end_of_input {
+                    Utf8Unit::Malformed(2)
+                } else {
+                    Utf8Unit::Incomplete
+                };
+            }
+
+            if !is_continuation(input[2]) {
+                return Utf8Unit::Malformed(2);
+            }
+            if input.len() < 4 {
+                return if end_of_input {
+                    Utf8Unit::Malformed(3)
+                } else {
+                    Utf8Unit::Incomplete
+                };
+            }
+
+            if is_continuation(input[3]) {
+                Utf8Unit::Valid(4)
+            } else {
+                Utf8Unit::Malformed(3)
+            }
+        }
+        _ => Utf8Unit::Malformed(1),
+    }
+}
+
 #[derive(Debug, Default)]
 struct LossyUtf8Decoder {
     incomplete: Vec<u8>,
@@ -33,33 +139,26 @@ impl LossyUtf8Decoder {
     }
 
     fn repair(&mut self, bytes: Vec<u8>, end_of_input: bool) -> Bytes {
+        if std::str::from_utf8(&bytes).is_ok() {
+            return Bytes::from(bytes);
+        }
+
         let mut output = Vec::with_capacity(bytes.len());
         let mut offset = 0;
 
         while offset < bytes.len() {
-            match std::str::from_utf8(&bytes[offset..]) {
-                Ok(valid) => {
-                    output.extend_from_slice(valid.as_bytes());
-                    break;
+            match classify_utf8_unit(&bytes[offset..], end_of_input) {
+                Utf8Unit::Valid(length) => {
+                    output.extend_from_slice(&bytes[offset..offset + length]);
+                    offset += length;
                 }
-                Err(error) => {
-                    let valid_end = offset + error.valid_up_to();
-                    output.extend_from_slice(&bytes[offset..valid_end]);
-
-                    match error.error_len() {
-                        Some(invalid_length) => {
-                            output.extend_from_slice(REPLACEMENT_CHARACTER);
-                            offset = valid_end + invalid_length;
-                        }
-                        None if end_of_input => {
-                            output.extend_from_slice(REPLACEMENT_CHARACTER);
-                            break;
-                        }
-                        None => {
-                            self.incomplete.extend_from_slice(&bytes[valid_end..]);
-                            break;
-                        }
-                    }
+                Utf8Unit::Malformed(length) => {
+                    output.extend_from_slice(REPLACEMENT_CHARACTER);
+                    offset += length;
+                }
+                Utf8Unit::Incomplete => {
+                    self.incomplete.extend_from_slice(&bytes[offset..]);
+                    break;
                 }
             }
         }
@@ -166,6 +265,32 @@ mod tests {
 
     use super::{LossyUtf8Decoder, LossyUtf8Reader, decode_utf8_lossy_stream};
 
+    fn split_bytes(input: &[u8], boundary_mask: usize) -> Vec<Bytes> {
+        let mut chunks = Vec::new();
+        let mut start = 0;
+        for boundary in 1..input.len() {
+            if boundary_mask & (1 << (boundary - 1)) != 0 {
+                chunks.push(Bytes::copy_from_slice(&input[start..boundary]));
+                start = boundary;
+            }
+        }
+        chunks.push(Bytes::copy_from_slice(&input[start..]));
+        chunks
+    }
+
+    fn assert_decoder_output_for_all_chunkings(input: &[u8], expected: &[u8]) {
+        let boundary_count = input.len().saturating_sub(1);
+        for boundary_mask in 0..(1 << boundary_count) {
+            let mut decoder = LossyUtf8Decoder::default();
+            let mut output = Vec::new();
+            for chunk in split_bytes(input, boundary_mask) {
+                output.extend_from_slice(&decoder.decode_bytes(chunk));
+            }
+            output.extend_from_slice(&decoder.finish());
+            assert_eq!(output, expected, "boundary mask {boundary_mask:#b}");
+        }
+    }
+
     #[test]
     fn test_lossy_utf8_decoder_replaces_invalid_sequences() {
         let mut decoder = LossyUtf8Decoder::default();
@@ -191,6 +316,23 @@ mod tests {
     }
 
     #[test]
+    fn test_lossy_utf8_decoder_matches_jdk_malformed_units_for_all_chunkings() {
+        let replacement = "\u{FFFD}".as_bytes();
+        let triple_replacement = "\u{FFFD}\u{FFFD}\u{FFFD}".as_bytes();
+
+        for input in [b"\xed\xa0\x80".as_slice(), b"\xed\xbf\xbf", b"\xed\xa0"] {
+            assert_decoder_output_for_all_chunkings(input, replacement);
+        }
+        assert_decoder_output_for_all_chunkings(b"\xed\xa0x", "\u{FFFD}x".as_bytes());
+        assert_decoder_output_for_all_chunkings(b"\xe0\x80\x80", triple_replacement);
+        assert_decoder_output_for_all_chunkings(b"\xf0\x90\x80x", "\u{FFFD}x".as_bytes());
+        assert_decoder_output_for_all_chunkings(
+            "\u{e9}\u{1F980}".as_bytes(),
+            "\u{e9}\u{1F980}".as_bytes(),
+        );
+    }
+
+    #[test]
     fn test_lossy_utf8_reader_replaces_incomplete_sequence_at_end_of_input() -> std::io::Result<()>
     {
         let mut reader = LossyUtf8Reader::new(Cursor::new(b"value\xf0\x9f"));
@@ -198,6 +340,18 @@ mod tests {
         reader.read_to_string(&mut output)?;
 
         assert_eq!(output, "value\u{FFFD}");
+        Ok(())
+    }
+
+    #[test]
+    fn test_lossy_utf8_reader_replaces_surrogate_unit_once() -> std::io::Result<()> {
+        let input = b"value_\xed\xa0\x80_done";
+        let chunks = Cursor::new(&input[..7]).chain(Cursor::new(&input[7..]));
+        let mut reader = LossyUtf8Reader::new(chunks);
+        let mut output = String::new();
+        reader.read_to_string(&mut output)?;
+
+        assert_eq!(output, "value_\u{FFFD}_done");
         Ok(())
     }
 
@@ -217,6 +371,32 @@ mod tests {
             .concat();
 
         assert_eq!(output, "caf\u{e9}\u{1F980}".as_bytes());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_lossy_utf8_stream_replaces_surrogate_unit_once_for_all_chunkings() -> Result<()> {
+        let input = b"\xed\xa0\x80";
+        for boundary_mask in 0..(1 << (input.len() - 1)) {
+            let stream = stream::iter(
+                split_bytes(input, boundary_mask)
+                    .into_iter()
+                    .map(Ok::<_, datafusion_common::DataFusionError>),
+            )
+            .boxed();
+            let output = decode_utf8_lossy_stream(stream)
+                .collect::<Vec<Result<Bytes>>>()
+                .await
+                .into_iter()
+                .collect::<Result<Vec<_>>>()?
+                .concat();
+
+            assert_eq!(
+                output,
+                "\u{FFFD}".as_bytes(),
+                "boundary mask {boundary_mask:#b}"
+            );
+        }
         Ok(())
     }
 }

--- a/crates/sail-data-source/src/formats/csv/mod.rs
+++ b/crates/sail-data-source/src/formats/csv/mod.rs
@@ -18,6 +18,7 @@ mod source;
 mod write;
 
 pub use read::CsvReadFormat;
+pub use source::CsvSource;
 pub use write::CsvWriteFormat;
 
 pub type CsvTableFormat = ListingTableFormat<CsvFormatFactory>;

--- a/crates/sail-data-source/src/formats/csv/mod.rs
+++ b/crates/sail-data-source/src/formats/csv/mod.rs
@@ -7,11 +7,14 @@ use crate::listing::source::{FormatFactory, ListingTableFormat};
 use crate::options::ResolveOptions;
 use crate::options::r#gen::{CsvReadOptions, CsvWriteOptions};
 
-// Some of the code in the `read` and `write` modules is adapted from the DataFusion `CsvFormat` implementation.
-// [CREDIT]: https://github.com/apache/datafusion/blob/53.1.0/datafusion/datasource-csv/src/file_format.rs
+// Some of the CSV implementation is adapted from DataFusion's `CsvFormat` and `CsvSource`.
+// [CREDIT]: https://github.com/apache/datafusion/blob/54.1.0/datafusion/datasource-csv/src/file_format.rs
+// [CREDIT]: https://github.com/apache/datafusion/blob/54.1.0/datafusion/datasource-csv/src/source.rs
 
+mod decoder;
 mod options;
 mod read;
+mod source;
 mod write;
 
 pub use read::CsvReadFormat;

--- a/crates/sail-data-source/src/formats/csv/read.rs
+++ b/crates/sail-data-source/src/formats/csv/read.rs
@@ -4,15 +4,17 @@ use bytes::Bytes;
 use datafusion::arrow::datatypes::{Schema, SchemaRef};
 use datafusion::catalog::Session;
 use datafusion::datasource::file_format::csv::CsvFormat;
-use datafusion::datasource::physical_plan::CsvSource;
 use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_common::{DataFusionError, Result};
 use datafusion_datasource::file_compression_type::FileCompressionType;
 use datafusion_datasource::file_scan_config::{FileScanConfig, FileScanConfigBuilder};
 use futures::stream::BoxStream;
 use futures::{StreamExt, TryStreamExt};
-use object_store::ObjectStoreExt;
+use object_store::delimited::newline_delimited_stream;
+use object_store::{Error as ObjectStoreError, ObjectStoreExt};
 
+use super::decoder::decode_utf8_lossy_stream;
+use super::source::CsvSource;
 use crate::listing::source::{ListingFileSample, ListingScanInput, ReadFormat};
 use crate::listing::utils::infer_listing_compression;
 use crate::options::r#gen::CsvReadOptions;
@@ -65,9 +67,18 @@ impl ReadFormat for CsvReadFormat {
                     .map_err(|e| DataFusionError::ObjectStore(Box::new(e)))
                     .boxed();
 
-                let stream = csv_format
-                    .read_to_delimited_chunks_from_stream(stream)
-                    .await;
+                let stream =
+                    FileCompressionType::from(options.compression).convert_stream(stream)?;
+                let stream = decode_utf8_lossy_stream(stream);
+                let stream = newline_delimited_stream(stream.map_err(|error| match error {
+                    DataFusionError::ObjectStore(error) => *error,
+                    error => ObjectStoreError::Generic {
+                        store: "CSV schema inference",
+                        source: Box::new(error),
+                    },
+                }))
+                .map_err(DataFusionError::from)
+                .boxed();
                 let (schema, records_read) = csv_format
                     .infer_schema_from_stream(ctx, records_to_read, stream)
                     .await

--- a/crates/sail-data-source/src/formats/csv/source.rs
+++ b/crates/sail-data-source/src/formats/csv/source.rs
@@ -1,0 +1,273 @@
+use std::fmt;
+use std::io::{Read, Seek, SeekFrom};
+use std::sync::Arc;
+use std::task::Poll;
+
+use datafusion::arrow::csv;
+use datafusion::datasource::file_format::csv::CsvDecoder;
+use datafusion::physical_expr::projection::ProjectionExprs;
+use datafusion::physical_plan::DisplayFormatType;
+use datafusion::physical_plan::metrics::{BaselineMetrics, ExecutionPlanMetricsSet};
+use datafusion_common::config::CsvOptions;
+use datafusion_common::{DataFusionError, Result};
+use datafusion_datasource::decoder::{DecoderDeserializer, deserialize_stream};
+use datafusion_datasource::file::FileSource;
+use datafusion_datasource::file_compression_type::FileCompressionType;
+use datafusion_datasource::file_scan_config::FileScanConfig;
+use datafusion_datasource::file_stream::{FileOpenFuture, FileOpener};
+use datafusion_datasource::projection::{ProjectionOpener, SplitProjection};
+use datafusion_datasource::{
+    FileRange, PartitionedFile, RangeCalculation, TableSchema, calculate_range,
+};
+use futures::{StreamExt, TryStreamExt};
+use object_store::{GetOptions, GetResultPayload, ObjectStore};
+
+use super::decoder::{LossyUtf8Reader, decode_utf8_lossy_stream};
+
+#[derive(Debug, Clone)]
+pub(super) struct CsvSource {
+    options: CsvOptions,
+    batch_size: Option<usize>,
+    table_schema: TableSchema,
+    projection: SplitProjection,
+    metrics: ExecutionPlanMetricsSet,
+}
+
+impl CsvSource {
+    pub(super) fn new(table_schema: impl Into<TableSchema>) -> Self {
+        let table_schema = table_schema.into();
+        Self {
+            options: CsvOptions::default(),
+            batch_size: None,
+            projection: SplitProjection::unprojected(&table_schema),
+            table_schema,
+            metrics: ExecutionPlanMetricsSet::new(),
+        }
+    }
+
+    pub(super) fn with_csv_options(mut self, options: CsvOptions) -> Self {
+        self.options = options;
+        self
+    }
+
+    fn has_header(&self) -> bool {
+        self.options.has_header.unwrap_or(true)
+    }
+
+    fn truncate_rows(&self) -> bool {
+        self.options.truncated_rows.unwrap_or(false)
+    }
+
+    fn delimiter(&self) -> u8 {
+        self.options.delimiter
+    }
+
+    fn quote(&self) -> u8 {
+        self.options.quote
+    }
+
+    fn terminator(&self) -> Option<u8> {
+        self.options.terminator
+    }
+
+    fn comment(&self) -> Option<u8> {
+        self.options.comment
+    }
+
+    fn escape(&self) -> Option<u8> {
+        self.options.escape
+    }
+
+    fn open<R: Read>(&self, reader: R) -> Result<csv::Reader<R>> {
+        Ok(self.builder()?.build(reader)?)
+    }
+
+    fn builder(&self) -> Result<csv::ReaderBuilder> {
+        let batch_size = self.batch_size.ok_or_else(|| {
+            DataFusionError::Internal("batch_size must be set before calling builder()".to_string())
+        })?;
+        let mut builder = csv::ReaderBuilder::new(Arc::clone(self.table_schema.file_schema()))
+            .with_delimiter(self.delimiter())
+            .with_batch_size(batch_size)
+            .with_header(self.has_header())
+            .with_quote(self.quote())
+            .with_truncated_rows(self.truncate_rows())
+            .with_projection(self.projection.file_indices.clone());
+
+        if let Some(terminator) = self.terminator() {
+            builder = builder.with_terminator(terminator);
+        }
+        if let Some(escape) = self.escape() {
+            builder = builder.with_escape(escape);
+        }
+        if let Some(comment) = self.comment() {
+            builder = builder.with_comment(comment);
+        }
+
+        Ok(builder)
+    }
+}
+
+impl From<CsvSource> for Arc<dyn FileSource> {
+    fn from(source: CsvSource) -> Self {
+        Arc::new(source)
+    }
+}
+
+impl FileSource for CsvSource {
+    fn create_file_opener(
+        &self,
+        object_store: Arc<dyn ObjectStore>,
+        base_config: &FileScanConfig,
+        partition: usize,
+    ) -> Result<Arc<dyn FileOpener>> {
+        let opener = Arc::new(CsvOpener {
+            config: Arc::new(self.clone()),
+            file_compression_type: base_config.file_compression_type,
+            object_store,
+            partition,
+        }) as Arc<dyn FileOpener>;
+
+        ProjectionOpener::try_new(
+            self.projection.clone(),
+            opener,
+            self.table_schema.file_schema(),
+        )
+    }
+
+    fn table_schema(&self) -> &TableSchema {
+        &self.table_schema
+    }
+
+    fn with_batch_size(&self, batch_size: usize) -> Arc<dyn FileSource> {
+        let mut source = self.clone();
+        source.batch_size = Some(batch_size);
+        Arc::new(source)
+    }
+
+    fn metrics(&self) -> &ExecutionPlanMetricsSet {
+        &self.metrics
+    }
+
+    fn try_pushdown_projection(
+        &self,
+        projection: &ProjectionExprs,
+    ) -> Result<Option<Arc<dyn FileSource>>> {
+        let mut source = self.clone();
+        let projection = self.projection.source.try_merge(projection)?;
+        source.projection = SplitProjection::new(self.table_schema.file_schema(), &projection);
+        Ok(Some(Arc::new(source)))
+    }
+
+    fn projection(&self) -> Option<&ProjectionExprs> {
+        Some(&self.projection.source)
+    }
+
+    fn file_type(&self) -> &str {
+        "csv"
+    }
+
+    fn supports_repartitioning(&self) -> bool {
+        !self.options.newlines_in_values.unwrap_or(false)
+    }
+
+    fn fmt_extra(&self, format: DisplayFormatType, output: &mut fmt::Formatter) -> fmt::Result {
+        match format {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(output, ", has_header={}", self.has_header())
+            }
+            DisplayFormatType::TreeRender => Ok(()),
+        }
+    }
+}
+
+struct CsvOpener {
+    config: Arc<CsvSource>,
+    file_compression_type: FileCompressionType,
+    object_store: Arc<dyn ObjectStore>,
+    partition: usize,
+}
+
+impl FileOpener for CsvOpener {
+    fn open(&self, partitioned_file: PartitionedFile) -> Result<FileOpenFuture> {
+        let mut has_header = self.config.has_header();
+        if let Some(FileRange { start, .. }) = partitioned_file.range
+            && start != 0
+        {
+            has_header = false;
+        }
+
+        let mut config = (*self.config).clone();
+        config.options.has_header = Some(has_header);
+        config.options.truncated_rows = Some(config.truncate_rows());
+
+        let file_compression_type = self.file_compression_type;
+        if partitioned_file.range.is_some() && file_compression_type.is_compressed() {
+            return Err(DataFusionError::Internal(
+                "Reading compressed .csv in parallel is not supported".to_string(),
+            ));
+        }
+
+        let object_store = Arc::clone(&self.object_store);
+        let terminator = self.config.terminator();
+        let baseline_metrics = BaselineMetrics::new(&self.config.metrics, self.partition);
+
+        Ok(Box::pin(async move {
+            let calculated_range =
+                calculate_range(&partitioned_file, &object_store, terminator).await?;
+            let range = match calculated_range {
+                RangeCalculation::Range(None) => None,
+                RangeCalculation::Range(Some(range)) => Some(range.into()),
+                RangeCalculation::TerminateEarly => {
+                    return Ok(futures::stream::poll_fn(move |_| Poll::Ready(None)).boxed());
+                }
+            };
+            let result = object_store
+                .get_opts(
+                    &partitioned_file.object_meta.location,
+                    GetOptions {
+                        range,
+                        ..Default::default()
+                    },
+                )
+                .await?;
+
+            match result.payload {
+                #[cfg(not(target_arch = "wasm32"))]
+                GetResultPayload::File(mut file, _) => {
+                    let decompressed = if partitioned_file.range.is_none() {
+                        file_compression_type.convert_read(file)?
+                    } else {
+                        file.seek(SeekFrom::Start(result.range.start as _))?;
+                        file_compression_type.convert_read(
+                            file.take((result.range.end - result.range.start) as u64),
+                        )?
+                    };
+                    let mut reader = config.open(LossyUtf8Reader::new(decompressed))?;
+                    let iterator = std::iter::from_fn(move || {
+                        let mut timer = baseline_metrics.elapsed_compute().timer();
+                        let result = reader.next();
+                        timer.stop();
+                        result
+                    });
+
+                    Ok(futures::stream::iter(iterator)
+                        .map_err(DataFusionError::from)
+                        .boxed())
+                }
+                GetResultPayload::Stream(stream) => {
+                    let decoder = config.builder()?.build_decoder();
+                    let input = stream.map_err(DataFusionError::from).boxed();
+                    let input = file_compression_type.convert_stream(input)?;
+                    let input = decode_utf8_lossy_stream(input).fuse();
+                    let stream = deserialize_stream(
+                        input,
+                        DecoderDeserializer::new(CsvDecoder::new(decoder)),
+                    );
+
+                    Ok(stream.map_err(DataFusionError::from).boxed())
+                }
+            }
+        }))
+    }
+}

--- a/crates/sail-data-source/src/formats/csv/source.rs
+++ b/crates/sail-data-source/src/formats/csv/source.rs
@@ -25,7 +25,7 @@ use object_store::{GetOptions, GetResultPayload, ObjectStore};
 use super::decoder::{LossyUtf8Reader, decode_utf8_lossy_stream};
 
 #[derive(Debug, Clone)]
-pub(super) struct CsvSource {
+pub struct CsvSource {
     options: CsvOptions,
     batch_size: Option<usize>,
     table_schema: TableSchema,
@@ -34,7 +34,7 @@ pub(super) struct CsvSource {
 }
 
 impl CsvSource {
-    pub(super) fn new(table_schema: impl Into<TableSchema>) -> Self {
+    pub fn new(table_schema: impl Into<TableSchema>) -> Self {
         let table_schema = table_schema.into();
         Self {
             options: CsvOptions::default(),
@@ -45,9 +45,13 @@ impl CsvSource {
         }
     }
 
-    pub(super) fn with_csv_options(mut self, options: CsvOptions) -> Self {
+    pub fn with_csv_options(mut self, options: CsvOptions) -> Self {
         self.options = options;
         self
+    }
+
+    pub fn options(&self) -> &CsvOptions {
+        &self.options
     }
 
     fn has_header(&self) -> bool {

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -16,8 +16,8 @@ use datafusion::datasource::file_format::file_compression_type::FileCompressionT
 use datafusion::datasource::memory::MemorySourceConfig;
 use datafusion::datasource::physical_plan::parquet::CachedParquetFileReaderFactory;
 use datafusion::datasource::physical_plan::{
-    ArrowSource, AvroSource, CsvSource, FileScanConfig, FileScanConfigBuilder, FileSink,
-    FileSinkConfig, FileSource, JsonSource, ParquetSource,
+    ArrowSource, AvroSource, FileScanConfig, FileScanConfigBuilder, FileSink, FileSinkConfig,
+    FileSource, JsonSource, ParquetSource,
 };
 use datafusion::datasource::sink::DataSinkExec;
 use datafusion::datasource::source::{DataSource, DataSourceExec};
@@ -95,6 +95,7 @@ use sail_common_datafusion::system::catalog::SystemTable;
 use sail_common_datafusion::udf::StreamUDF;
 use sail_data_source::formats::binary::source::BinarySource;
 use sail_data_source::formats::console::ConsoleSinkExec;
+use sail_data_source::formats::csv::CsvSource;
 use sail_data_source::formats::noop::NoopSinkExec;
 use sail_data_source::formats::python::{
     InputPartition, PythonDataSourceExec, PythonDataSourceWriteCommitExec,
@@ -1836,18 +1837,8 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                         self,
                         &RemotePhysicalProtoConverter {},
                     )?)?;
-                    let csv_options = CsvOptions {
-                        has_header: Some(csv_source.has_header()),
-                        delimiter: csv_source.delimiter(),
-                        quote: csv_source.quote(),
-                        terminator: csv_source.terminator(),
-                        escape: csv_source.escape(),
-                        comment: csv_source.comment(),
-                        newlines_in_values: Some(csv_source.newlines_in_values()),
-                        truncated_rows: Some(csv_source.truncate_rows()),
-                        compression: file_scan.file_compression_type.into(),
-                        ..Default::default()
-                    };
+                    let mut csv_options = csv_source.options().clone();
+                    csv_options.compression = file_scan.file_compression_type.into();
                     let options = try_encode_message(gen_datafusion_common::CsvOptions::try_from(
                         &csv_options,
                     )?)?;
@@ -4978,6 +4969,54 @@ mod tests {
                 );
             }
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_round_trip_csv_source_preserves_sail_source_and_options() -> Result<()> {
+        let table_schema = Arc::new(Schema::new(vec![Field::new("value", DataType::Utf8, true)]));
+        let csv_options = CsvOptions {
+            has_header: Some(false),
+            delimiter: b'|',
+            quote: b'\'',
+            terminator: Some(b';'),
+            escape: Some(b'\\'),
+            double_quote: Some(false),
+            newlines_in_values: Some(true),
+            compression_level: Some(7),
+            schema_infer_max_rec: Some(123),
+            date_format: Some("yyyy-MM-dd".to_string()),
+            null_regex: Some("^(NULL|-)$".to_string()),
+            comment: Some(b'#'),
+            truncated_rows: Some(true),
+            ignore_leading_whitespace: Some(true),
+            ignore_trailing_whitespace: Some(true),
+            ..Default::default()
+        };
+        let mut expected_options = csv_options.clone();
+        expected_options.compression = CompressionTypeVariant::GZIP;
+        let source = Arc::new(CsvSource::new(table_schema).with_csv_options(csv_options));
+        let file_scan = FileScanConfigBuilder::new(
+            datafusion::execution::object_store::ObjectStoreUrl::local_filesystem(),
+            source,
+        )
+        .with_file_compression_type(FileCompressionType::GZIP)
+        .build();
+        let plan = DataSourceExec::from_data_source(file_scan) as Arc<dyn ExecutionPlan>;
+        let codec = RemoteExecutionCodec;
+
+        let bytes = crate::proto::encode_remote_physical_plan(&codec, plan)?;
+        let decoded =
+            crate::proto::decode_remote_physical_plan(&TaskContext::default(), &codec, &bytes)?;
+        let decoded = decoded
+            .downcast_ref::<DataSourceExec>()
+            .ok_or_else(|| plan_datafusion_err!("decoded plan is not a data source"))?;
+        let (file_scan, csv_source) = decoded
+            .downcast_to_file_source::<CsvSource>()
+            .ok_or_else(|| plan_datafusion_err!("decoded file source is not Sail CSV"))?;
+
+        assert_eq!(file_scan.file_compression_type, FileCompressionType::GZIP);
+        assert_eq!(csv_source.options(), &expected_options);
         Ok(())
     }
 

--- a/python/pysail/tests/spark/datasource/test_csv.py
+++ b/python/pysail/tests/spark/datasource/test_csv.py
@@ -54,6 +54,32 @@ def test_csv_path_glob_filter(spark, tmp_path):
 
 
 @pytest.mark.parametrize("infer_schema", [True, False])
+@pytest.mark.parametrize("compression", [None, "gzip"])
+def test_csv_read_replaces_invalid_utf8(spark, tmp_path, infer_schema, compression):
+    path = tmp_path / f"csv_invalid_utf8_{infer_schema}_{compression}"
+    path.mkdir()
+    content = b"id,label\n1,ok\n2,caf\xe9_bad_\xff\n"
+
+    if compression == "gzip":
+        with gzip.open(path / "data.csv.gz", "wb") as file:
+            file.write(content)
+    else:
+        (path / "data.csv").write_bytes(content)
+
+    reader = spark.read.option("header", True).option("inferSchema", infer_schema)
+    if compression is not None:
+        reader = reader.option("compression", compression)
+    rows = reader.csv(str(path)).collect()
+
+    first_id = 1 if infer_schema else "1"
+    second_id = 2 if infer_schema else "2"
+    assert rows == [
+        Row(id=first_id, label="ok"),
+        Row(id=second_id, label="caf\ufffd_bad_\ufffd"),
+    ]
+
+
+@pytest.mark.parametrize("infer_schema", [True, False])
 def test_csv_read_write_compressed(spark, sample_df, sample_pandas_df, tmp_path, infer_schema):
     # Round-tripped values are typed under `inferSchema=True` and STRING-only
     # under the Spark default `inferSchema=False`. Both behaviors are pinned.

--- a/python/pysail/tests/spark/execution/test_csv.py
+++ b/python/pysail/tests/spark/execution/test_csv.py
@@ -1,0 +1,36 @@
+import pytest
+from pyspark.sql import Row
+
+from pysail.testing.spark.utils.common import is_jvm_spark
+
+pytestmark = pytest.mark.skipif(is_jvm_spark(), reason="Sail local-cluster mode only")
+
+
+def test_csv_read_uses_sail_source_on_worker(spark, tmp_path):
+    path = tmp_path / "ordinary.csv"
+    path.write_text("id,label\n1,caf\u00e9\n2,crab_\U0001f980\n", encoding="utf-8")
+
+    rows = (
+        spark.read.option("header", True)
+        .option("inferSchema", True)
+        .csv(str(path))
+        .orderBy("id")
+        .collect()
+    )
+
+    assert rows == [Row(id=1, label="caf\u00e9"), Row(id=2, label="crab_\U0001f980")]
+
+
+def test_csv_read_replaces_surrogate_unit_once_on_worker(spark, tmp_path):
+    path = tmp_path / "surrogate.csv"
+    path.write_bytes(b"id,label\n1,ok\n2,before_\xed\xa0\x80_after\n")
+
+    rows = (
+        spark.read.option("header", True)
+        .schema("id INT, label STRING")
+        .csv(str(path))
+        .orderBy("id")
+        .collect()
+    )
+
+    assert rows == [Row(id=1, label="ok"), Row(id=2, label="before_\ufffd_after")]

--- a/python/pysail/tests/spark/execution/test_csv.py
+++ b/python/pysail/tests/spark/execution/test_csv.py
@@ -10,13 +10,7 @@ def test_csv_read_uses_sail_source_on_worker(spark, tmp_path):
     path = tmp_path / "ordinary.csv"
     path.write_text("id,label\n1,caf\u00e9\n2,crab_\U0001f980\n", encoding="utf-8")
 
-    rows = (
-        spark.read.option("header", True)
-        .option("inferSchema", True)
-        .csv(str(path))
-        .orderBy("id")
-        .collect()
-    )
+    rows = spark.read.option("header", True).option("inferSchema", True).csv(str(path)).orderBy("id").collect()
 
     assert rows == [Row(id=1, label="caf\u00e9"), Row(id=2, label="crab_\U0001f980")]
 
@@ -25,12 +19,6 @@ def test_csv_read_replaces_surrogate_unit_once_on_worker(spark, tmp_path):
     path = tmp_path / "surrogate.csv"
     path.write_bytes(b"id,label\n1,ok\n2,before_\xed\xa0\x80_after\n")
 
-    rows = (
-        spark.read.option("header", True)
-        .schema("id INT, label STRING")
-        .csv(str(path))
-        .orderBy("id")
-        .collect()
-    )
+    rows = spark.read.option("header", True).schema("id INT, label STRING").csv(str(path)).orderBy("id").collect()
 
     assert rows == [Row(id=1, label="ok"), Row(id=2, label="before_\ufffd_after")]


### PR DESCRIPTION
## Summary

Make UTF-8 CSV reads tolerant of malformed and incomplete input by replacing invalid units with `U+FFFD` using JDK-compatible replacement boundaries instead of failing the entire read.

The same decoding behavior is applied during schema inference and data scanning, after decompression and before CSV parsing, and is preserved across worker execution. This change covers Sail's currently supported UTF-8 CSV reads; configured `encoding` or `charset` handling, CSV writes, and row-level corrupt-record modes are unchanged.

Closes #2388
