### PR TITLE
feat: implement Iceberg copy-on-write row operations

### DIFF
--- a/crates/sail-iceberg/src/lake_source.rs
+++ b/crates/sail-iceberg/src/lake_source.rs
@@ -16,11 +16,9 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use datafusion::arrow::datatypes::{Field as ArrowField, Schema as ArrowSchema};
 use datafusion::catalog::{Session, TableProvider};
-use datafusion::common::{
-    DataFusionError, Result, TableReference, ToDFSchema, not_impl_err, plan_err,
-};
+use datafusion::common::{DataFusionError, Result, not_impl_err, plan_err};
 use datafusion::execution::SessionState;
-use datafusion::logical_expr::{LogicalPlan, TableScan, TableSource};
+use datafusion::logical_expr::{LogicalPlan, TableSource};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_expr::expr::Sort;
 use datafusion_expr::{Expr, Extension, UserDefinedLogicalNodeCore};
@@ -30,20 +28,16 @@ use object_store::ObjectStoreExt;
 use sail_common_datafusion::catalog::iceberg::is_iceberg_table_marker;
 use sail_common_datafusion::catalog::managed::metadata_location_value;
 use sail_common_datafusion::catalog::{
-    CatalogPartitionField, CommitAuthority, LakehouseExecutionContext, LakehouseOperation,
-    ScanAuthority,
+    CatalogPartitionField, CommitAuthority, LakehouseExecutionContext, ScanAuthority,
 };
 use sail_common_datafusion::datasource::{
-    BucketBy, DataSource, DeleteInfo, OptionLayer, PhysicalSinkMode, SinkInfo, SinkMode,
-    SourceInfo, create_sort_order, find_path_in_options,
+    BucketBy, DataSource, OptionLayer, PhysicalSinkMode, SinkInfo, SinkMode, SourceInfo,
+    create_sort_order, find_path_in_options,
 };
 use sail_common_datafusion::lakesource::{
     LakeSource, LakeSourceAlterTableOperation, LakeSourceCreateTableColumn,
     LakeSourceCreateTableInfo, LakeSourceCreateTableResult, LakeSourceMetadata, RowLevelOperation,
 };
-use sail_common_datafusion::logical_expr::ExprWithSource;
-use sail_common_datafusion::rename::expression::expression_before_rename;
-use sail_common_datafusion::rename::schema::rename_schema;
 use sail_common_datafusion::utils::items::ItemTaker;
 use sail_common_datafusion::variant::with_variant_extension_if_marked_storage;
 use sail_data_source::options::ResolveOptions;
@@ -157,91 +151,14 @@ impl LakeSource for IcebergLakeSource {
 
     async fn plan_row_level_operation(
         &self,
-        ctx: &dyn Session,
+        _ctx: &dyn Session,
         operation: RowLevelOperation,
     ) -> Result<LogicalPlan> {
-        let DeleteInfo {
-            target,
-            condition,
-            input_schema,
-            resolved_target_field_names,
-            ..
-        } = match operation {
-            RowLevelOperation::Delete(info) => *info,
-            RowLevelOperation::Update(_) => {
-                return not_impl_err!("UPDATE is not yet implemented for Iceberg");
-            }
-            RowLevelOperation::Merge(info) => {
-                return crate::logical::merge::expand_merge_node(*info);
-            }
-        };
-        let table_name = target.table_name.clone();
-        let path = target.location.clone();
-        let options = target.options.clone();
-        let lakehouse_table = target.lakehouse_table.clone();
-
-        let read_lakehouse_table = lakehouse_table
-            .as_ref()
-            .map(|context| context.for_operation(LakehouseOperation::Read));
-        let source_info = SourceInfo {
-            paths: vec![path.clone()],
-            lakehouse_table: read_lakehouse_table,
-            schema: None,
-            constraints: Default::default(),
-            partition_by: vec![],
-            bucket_by: None,
-            sort_order: vec![],
-            options: options.clone(),
-            // TODO: Thread resolver session case-sensitivity into row-level planning.
-            read_case_sensitive: true,
-        };
-        let provider = build_iceberg_provider(ctx, source_info).await?;
-        let expected_snapshot_id = Some(
-            provider
-                .current_snapshot()
-                .map(|snapshot| snapshot.snapshot_id()),
-        );
-        let table_source: Arc<dyn TableSource> = Arc::new(IcebergTableSource::new(provider));
-        let raw_input_schema = table_source.schema().to_dfschema_ref()?;
-        let resolved_input_schema =
-            rename_schema(input_schema.as_arrow(), &resolved_target_field_names)?;
-        let input_field_names = input_schema
-            .fields()
-            .iter()
-            .map(|field| field.name().clone())
-            .collect::<Vec<_>>();
-        let condition = condition
-            .map(|condition| -> Result<_> {
-                Ok(ExprWithSource::new(
-                    expression_before_rename(
-                        &condition.expr,
-                        &input_field_names,
-                        &resolved_input_schema,
-                        true,
-                    )?,
-                    condition.source,
-                ))
-            })
-            .transpose()?;
-        let target_scan = LogicalPlan::TableScan(TableScan::try_new(
-            table_reference_from_parts(&table_name),
-            table_source,
-            None,
-            vec![],
-            None,
-        )?);
-
-        let write_node = sail_logical_plan::row_level::RowLevelWriteNode::new_delete(
-            Arc::new(target_scan),
-            raw_input_schema,
-            condition,
-            target,
-        )
-        .with_expected_snapshot_id(expected_snapshot_id);
-
-        Ok(LogicalPlan::Extension(Extension {
-            node: Arc::new(write_node),
-        }))
+        match operation {
+            RowLevelOperation::Delete(info) => crate::logical::delete::expand_delete_node(*info),
+            RowLevelOperation::Update(info) => crate::logical::update::expand_update_node(*info),
+            RowLevelOperation::Merge(info) => crate::logical::merge::expand_merge_node(*info),
+        }
     }
 
     async fn create_table_metadata(
@@ -910,26 +827,6 @@ fn partition_columns_from_table_metadata(
     }
 
     Ok(columns)
-}
-
-fn table_reference_from_parts(parts: &[String]) -> TableReference {
-    match parts {
-        [table] => TableReference::Bare {
-            table: table.as_str().into(),
-        },
-        [schema, table] => TableReference::Partial {
-            schema: schema.as_str().into(),
-            table: table.as_str().into(),
-        },
-        [catalog, schema, table] => TableReference::Full {
-            catalog: catalog.as_str().into(),
-            schema: schema.as_str().into(),
-            table: table.as_str().into(),
-        },
-        _ => TableReference::Bare {
-            table: parts.join(".").into(),
-        },
-    }
 }
 
 fn create_table_arrow_schema(columns: Vec<LakeSourceCreateTableColumn>) -> Result<ArrowSchema> {

--- a/crates/sail-iceberg/src/logical/delete.rs
+++ b/crates/sail-iceberg/src/logical/delete.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use datafusion_common::Result;
+use datafusion_expr::LogicalPlan;
+use datafusion_expr::logical_plan::Extension;
+use sail_common_datafusion::datasource::{DeleteInfo, MERGE_FILE_COLUMN};
+use sail_logical_plan::row_level::expand_delete;
+
+use super::merge::{ensure_row_level_metadata_columns, row_level_target_snapshot_id};
+
+pub fn expand_delete_node(mut info: DeleteInfo) -> Result<LogicalPlan> {
+    let expected_snapshot_id = Some(row_level_target_snapshot_id(&info.target_plan)?);
+    info.target_plan = Arc::new(ensure_row_level_metadata_columns(
+        info.target_plan.as_ref().clone(),
+        MERGE_FILE_COLUMN,
+        None,
+    )?);
+    Ok(LogicalPlan::Extension(Extension {
+        node: Arc::new(
+            expand_delete(info, MERGE_FILE_COLUMN, None)?
+                .with_expected_snapshot_id(expected_snapshot_id),
+        ),
+    }))
+}

--- a/crates/sail-iceberg/src/logical/merge.rs
+++ b/crates/sail-iceberg/src/logical/merge.rs
@@ -18,9 +18,9 @@ use crate::row_level_metadata::{MERGE_PARTITION_COLUMN, MERGE_PARTITION_SPEC_ID_
 
 /// Expand MERGE information into a unified row-level write node for Iceberg.
 ///
-/// Iceberg MERGE is planned as merge-on-read: target rows affected by DELETE or
-/// UPDATE clauses are represented by position deletes, and UPDATE/INSERT output
-/// rows are appended as new data files.
+/// The expanded effects support both copy-on-write and merge-on-read physical
+/// strategies. Iceberg metadata columns remain available for the MOR writer,
+/// while the touched-file effect identifies the files rewritten by COW.
 pub fn expand_merge_node(info: MergeInfo) -> Result<LogicalPlan> {
     // TODO: Add Iceberg MERGE schema evolution support.
     if info.options.with_schema_evolution {
@@ -35,9 +35,9 @@ pub fn expand_merge_node(info: MergeInfo) -> Result<LogicalPlan> {
             MERGE_PARTITION_COLUMN,
         ],
     )?;
-    let expected_snapshot_id = Some(merge_target_snapshot_id(info.target.as_ref())?);
+    let expected_snapshot_id = Some(row_level_target_snapshot_id(info.target.as_ref())?);
     let row_index_column = merge_needs_position_deletes(&info).then_some(MERGE_ROW_INDEX_COLUMN);
-    let mut target_plan = ensure_merge_metadata_columns(
+    let mut target_plan = ensure_row_level_metadata_columns(
         info.target.as_ref().clone(),
         MERGE_FILE_COLUMN,
         row_index_column,
@@ -93,16 +93,12 @@ pub fn expand_merge_node(info: MergeInfo) -> Result<LogicalPlan> {
         row_index_column,
         &[MERGE_PARTITION_SPEC_ID_COLUMN, MERGE_PARTITION_COLUMN],
     )?;
-    // Iceberg consumes delete metadata from the write plan. RowLevelWriteNode still
-    // requires a touched-file input, so use an empty placeholder instead of planning
-    // cloned joins that would duplicate the source and target scans.
-    let placeholder_touched_plan = LogicalPlanBuilder::empty(false).build()?;
     let write_node = RowLevelWriteNode::new_merge(
         raw_target,
         raw_source,
         raw_input_schema,
         Arc::new(expansion.write_plan),
-        Arc::new(placeholder_touched_plan),
+        Arc::new(expansion.touched_files_plan),
         None,
         expansion.options,
         expansion.output_schema,
@@ -114,7 +110,7 @@ pub fn expand_merge_node(info: MergeInfo) -> Result<LogicalPlan> {
     }))
 }
 
-fn merge_target_snapshot_id(plan: &LogicalPlan) -> Result<Option<i64>> {
+pub(super) fn row_level_target_snapshot_id(plan: &LogicalPlan) -> Result<Option<i64>> {
     let mut snapshot_id = None;
     plan.apply(|node| {
         if let LogicalPlan::TableScan(scan) = node
@@ -186,7 +182,7 @@ fn try_enable_merge_metadata_columns(
     Ok(None)
 }
 
-fn ensure_merge_metadata_columns(
+pub(super) fn ensure_row_level_metadata_columns(
     plan: LogicalPlan,
     file_col: &str,
     row_index_col: Option<&str>,

--- a/crates/sail-iceberg/src/logical/mod.rs
+++ b/crates/sail-iceberg/src/logical/mod.rs
@@ -1,4 +1,6 @@
+pub mod delete;
 pub mod merge;
 pub mod table_source;
+pub mod update;
 
 pub use table_source::IcebergTableSource;

--- a/crates/sail-iceberg/src/logical/update.rs
+++ b/crates/sail-iceberg/src/logical/update.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use datafusion_common::Result;
+use datafusion_expr::LogicalPlan;
+use datafusion_expr::logical_plan::Extension;
+use sail_common_datafusion::datasource::{MERGE_FILE_COLUMN, UpdateInfo};
+use sail_logical_plan::row_level::expand_update;
+
+use super::merge::{ensure_row_level_metadata_columns, row_level_target_snapshot_id};
+
+pub fn expand_update_node(mut info: UpdateInfo) -> Result<LogicalPlan> {
+    let expected_snapshot_id = Some(row_level_target_snapshot_id(&info.target_plan)?);
+    info.target_plan = Arc::new(ensure_row_level_metadata_columns(
+        info.target_plan.as_ref().clone(),
+        MERGE_FILE_COLUMN,
+        None,
+    )?);
+    Ok(LogicalPlan::Extension(Extension {
+        node: Arc::new(
+            expand_update(info, MERGE_FILE_COLUMN, None)?
+                .with_expected_snapshot_id(expected_snapshot_id),
+        ),
+    }))
+}

--- a/crates/sail-iceberg/src/operations/snapshot.rs
+++ b/crates/sail-iceberg/src/operations/snapshot.rs
@@ -806,6 +806,17 @@ impl<'a> SnapshotProducer<'a> {
         if removed_data_file_paths.iter().any(String::is_empty) {
             return Err("Iceberg removed data file path cannot be empty".to_string());
         }
+        // A mixed MERGE can produce inserts without touching any target file at
+        // runtime. That is an append, even though the planned strategy is COW.
+        let update_kind = if update_kind == SnapshotUpdateKind::CopyOnWrite
+            && removed_data_file_paths.is_empty()
+            && !self.added_data_files.is_empty()
+            && self.added_delete_files.is_empty()
+        {
+            SnapshotUpdateKind::FastAppend
+        } else {
+            update_kind
+        };
         if update_kind.is_targeted_rewrite() {
             if !self.added_delete_files.is_empty() {
                 return Err(

--- a/crates/sail-iceberg/src/physical/row_level_planner.rs
+++ b/crates/sail-iceberg/src/physical/row_level_planner.rs
@@ -1,12 +1,25 @@
 use std::sync::Arc;
 
-use datafusion::common::{DataFusionError, Result, not_impl_err, plan_err};
+use datafusion::common::{
+    DataFusionError, JoinType, NullEquality, Result, ScalarValue, TableReference, internal_err,
+    not_impl_err, plan_err,
+};
 use datafusion::execution::SessionState;
 use datafusion::logical_expr::logical_plan::builder::LogicalPlanBuilder;
+use datafusion::logical_expr::{Operator, TableScan, TableSource};
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::expressions::{BinaryExpr, Column, IsNullExpr, Literal};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::execution_plan::reset_plan_states;
+use datafusion::physical_plan::filter::FilterExec;
+use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode};
+use datafusion::physical_plan::projection::ProjectionExec;
+use datafusion::physical_plan::union::UnionExec;
 use datafusion::physical_planner::PhysicalPlanner;
-use sail_common_datafusion::datasource::{PhysicalSinkMode, RowLevelCommand};
+use sail_common_datafusion::datasource::{
+    MERGE_FILE_COLUMN, PhysicalSinkMode, RowLevelCommand, RowLevelOperationType,
+};
 use sail_data_source::options::ResolveOptions;
 use sail_logical_plan::row_level::RowLevelWriteNode;
 
@@ -14,14 +27,22 @@ use crate::lake_source::{
     IcebergLakeSource, catalog_managed_iceberg_from_options, metadata_location_from_options,
     split_iceberg_write_options_and_table_properties,
 };
+use crate::logical::IcebergTableSource;
 use crate::operations::SnapshotUpdateKind;
-use crate::options::r#gen::IcebergWriteOptions;
+use crate::options::r#gen::{IcebergReadOptions, IcebergWriteOptions};
 use crate::physical_plan::merge_row_projection::IcebergMergeRowProjection;
 use crate::physical_plan::{
-    IcebergCommitExec, IcebergEqualityDeleteWriterExec, IcebergWriterExec,
-    IcebergWriterExecOptions, prepare_iceberg_write_context,
+    IcebergCommitExec, IcebergEqualityDeleteWriterExec, IcebergRemoveDataFilesExec,
+    IcebergWriterExec, IcebergWriterExecOptions, prepare_iceberg_write_context,
 };
+use crate::row_level_metadata::{MERGE_PARTITION_COLUMN, MERGE_PARTITION_SPEC_ID_COLUMN};
 use crate::table::Table;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IcebergRowLevelMode {
+    CopyOnWrite,
+    MergeOnRead,
+}
 
 pub(crate) async fn plan_iceberg_row_level_write(
     session_state: &SessionState,
@@ -30,9 +51,11 @@ pub(crate) async fn plan_iceberg_row_level_write(
     physical_inputs: &[Arc<dyn ExecutionPlan>],
 ) -> Result<Arc<dyn ExecutionPlan>> {
     match node.command() {
-        RowLevelCommand::Delete => plan_iceberg_delete(session_state, planner, node).await,
+        RowLevelCommand::Delete => {
+            plan_iceberg_delete(session_state, planner, node, physical_inputs).await
+        }
+        RowLevelCommand::Update => plan_iceberg_update(session_state, node, physical_inputs).await,
         RowLevelCommand::Merge => plan_iceberg_merge(session_state, node, physical_inputs).await,
-        command => not_impl_err!("Iceberg row-level {command:?} operations"),
     }
 }
 
@@ -41,27 +64,33 @@ async fn plan_iceberg_merge(
     node: &RowLevelWriteNode,
     physical_inputs: &[Arc<dyn ExecutionPlan>],
 ) -> Result<Arc<dyn ExecutionPlan>> {
+    let (table_url, table) = load_row_level_table(session_state, node).await?;
+    match current_row_level_mode(&table, RowLevelCommand::Merge)? {
+        IcebergRowLevelMode::CopyOnWrite => plan_iceberg_copy_on_write(
+            session_state,
+            node,
+            physical_inputs,
+            table_url,
+            &table,
+            SnapshotUpdateKind::CopyOnWrite,
+        ),
+        IcebergRowLevelMode::MergeOnRead => {
+            plan_iceberg_merge_on_read(session_state, node, physical_inputs, table_url, &table)
+        }
+    }
+}
+
+fn plan_iceberg_merge_on_read(
+    session_state: &SessionState,
+    node: &RowLevelWriteNode,
+    physical_inputs: &[Arc<dyn ExecutionPlan>],
+    table_url: url::Url,
+    table: &Table,
+) -> Result<Arc<dyn ExecutionPlan>> {
     let write_plan = physical_inputs.first().cloned().ok_or_else(|| {
         DataFusionError::Internal("Iceberg MERGE missing write plan input".to_string())
     })?;
-    if node.touched_files_plan().is_some() && physical_inputs.len() < 2 {
-        return plan_err!("Iceberg MERGE missing touched-file plan input");
-    }
-    let table_url =
-        IcebergLakeSource::parse_table_url(vec![node.target_location().to_string()]).await?;
-    let metadata_location = metadata_location_from_options(node.target_options());
-    let catalog_managed_table = catalog_managed_iceberg_from_options(node.target_options());
-    let metadata_location_for_load = catalog_managed_table
-        .then_some(metadata_location.clone())
-        .flatten();
-    let table = Table::load_with_metadata_location(
-        session_state,
-        table_url.clone(),
-        metadata_location_for_load,
-    )
-    .await?;
-    ensure_current_row_level_mode(&table, RowLevelCommand::Merge)?;
-    let partition_columns = IcebergLakeSource::partition_columns_from_metadata(&table)?;
+    let partition_columns = IcebergLakeSource::partition_columns_from_metadata(table)?;
     let writer_options = resolve_row_level_writer_options(session_state, node)?;
 
     let merge_projection = IcebergMergeRowProjection::try_new(write_plan.schema())?;
@@ -99,6 +128,51 @@ async fn plan_iceberg_delete(
     session_state: &SessionState,
     planner: &dyn PhysicalPlanner,
     node: &RowLevelWriteNode,
+    physical_inputs: &[Arc<dyn ExecutionPlan>],
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let (table_url, table) = load_row_level_table(session_state, node).await?;
+    match current_row_level_mode(&table, RowLevelCommand::Delete)? {
+        IcebergRowLevelMode::CopyOnWrite => plan_iceberg_copy_on_write(
+            session_state,
+            node,
+            physical_inputs,
+            table_url,
+            &table,
+            SnapshotUpdateKind::CopyOnWriteDelete,
+        ),
+        IcebergRowLevelMode::MergeOnRead => {
+            plan_iceberg_delete_merge_on_read(session_state, planner, node, table_url, &table).await
+        }
+    }
+}
+
+async fn plan_iceberg_update(
+    session_state: &SessionState,
+    node: &RowLevelWriteNode,
+    physical_inputs: &[Arc<dyn ExecutionPlan>],
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let (table_url, table) = load_row_level_table(session_state, node).await?;
+    match current_row_level_mode(&table, RowLevelCommand::Update)? {
+        IcebergRowLevelMode::CopyOnWrite => plan_iceberg_copy_on_write(
+            session_state,
+            node,
+            physical_inputs,
+            table_url,
+            &table,
+            SnapshotUpdateKind::CopyOnWrite,
+        ),
+        IcebergRowLevelMode::MergeOnRead => not_impl_err!(
+            "Iceberg UPDATE with `write.update.mode=merge-on-read` is not supported yet"
+        ),
+    }
+}
+
+async fn plan_iceberg_delete_merge_on_read(
+    session_state: &SessionState,
+    planner: &dyn PhysicalPlanner,
+    node: &RowLevelWriteNode,
+    table_url: url::Url,
+    table: &Table,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     // TODO: Support conditionless DELETE by scanning all rows into equality deletes.
     let condition = node.condition().ok_or_else(|| {
@@ -107,28 +181,26 @@ async fn plan_iceberg_delete(
         )
     })?;
 
-    let table_url =
-        IcebergLakeSource::parse_table_url(vec![node.target_location().to_string()]).await?;
-    let metadata_location = metadata_location_from_options(node.target_options());
-    let catalog_managed_table = catalog_managed_iceberg_from_options(node.target_options());
-    let metadata_location_for_load = catalog_managed_table.then_some(metadata_location).flatten();
-    let table = Table::load_with_metadata_location(
-        session_state,
-        table_url.clone(),
-        metadata_location_for_load,
-    )
-    .await?;
-    ensure_current_row_level_mode(&table, RowLevelCommand::Delete)?;
-
-    let delete_plan = LogicalPlanBuilder::from(node.raw_target().as_ref().clone())
+    let read_options = IcebergReadOptions::resolve(session_state, node.target_options().to_vec())?;
+    let provider = Arc::new(table.to_provider(&read_options)?);
+    let table_source: Arc<dyn TableSource> = Arc::new(IcebergTableSource::new(provider));
+    let target_scan = datafusion::logical_expr::LogicalPlan::TableScan(TableScan::try_new(
+        table_reference_from_parts(node.target_table_name()),
+        table_source,
+        None,
+        vec![],
+        None,
+    )?);
+    let delete_plan = LogicalPlanBuilder::from(target_scan)
         .filter(condition.expr.clone())?
         .build()?;
+    let delete_plan = session_state.optimize(&delete_plan)?;
     let physical_delete = planner
         .create_physical_plan(&delete_plan, session_state)
         .await?;
 
     let writer_options = resolve_row_level_writer_options(session_state, node)?;
-    let partition_columns = IcebergLakeSource::partition_columns_from_metadata(&table)?;
+    let partition_columns = IcebergLakeSource::partition_columns_from_metadata(table)?;
     let current_schema = table.metadata().current_schema().ok_or_else(|| {
         DataFusionError::Plan("Iceberg table metadata is missing current schema".to_string())
     })?;
@@ -143,8 +215,8 @@ async fn plan_iceberg_delete(
         &current_arrow_schema,
     )?;
 
-    let delete_input: Arc<dyn ExecutionPlan> =
-        Arc::new(CoalescePartitionsExec::new(physical_delete));
+    let delete_input = strip_iceberg_metadata_columns(physical_delete)?;
+    let delete_input: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(delete_input));
     let delete_writer: Arc<dyn ExecutionPlan> = Arc::new(IcebergEqualityDeleteWriterExec::new(
         delete_input,
         table_url.clone(),
@@ -166,11 +238,49 @@ async fn plan_iceberg_delete(
     ))
 }
 
-fn ensure_current_row_level_mode(table: &Table, command: RowLevelCommand) -> Result<()> {
-    let (operation, property) = match command {
-        RowLevelCommand::Delete => ("DELETE", "write.delete.mode"),
-        RowLevelCommand::Merge => ("MERGE", "write.merge.mode"),
-        RowLevelCommand::Update => ("UPDATE", "write.update.mode"),
+fn table_reference_from_parts(parts: &[String]) -> TableReference {
+    match parts {
+        [table] => TableReference::Bare {
+            table: table.as_str().into(),
+        },
+        [schema, table] => TableReference::Partial {
+            schema: schema.as_str().into(),
+            table: table.as_str().into(),
+        },
+        [catalog, schema, table] => TableReference::Full {
+            catalog: catalog.as_str().into(),
+            schema: schema.as_str().into(),
+            table: table.as_str().into(),
+        },
+        _ => TableReference::Bare {
+            table: parts.join(".").into(),
+        },
+    }
+}
+
+async fn load_row_level_table(
+    session_state: &SessionState,
+    node: &RowLevelWriteNode,
+) -> Result<(url::Url, Table)> {
+    let table_url =
+        IcebergLakeSource::parse_table_url(vec![node.target_location().to_string()]).await?;
+    let metadata_location = metadata_location_from_options(node.target_options());
+    let catalog_managed_table = catalog_managed_iceberg_from_options(node.target_options());
+    let metadata_location_for_load = catalog_managed_table.then_some(metadata_location).flatten();
+    let table = Table::load_with_metadata_location(
+        session_state,
+        table_url.clone(),
+        metadata_location_for_load,
+    )
+    .await?;
+    Ok((table_url, table))
+}
+
+fn current_row_level_mode(table: &Table, command: RowLevelCommand) -> Result<IcebergRowLevelMode> {
+    let property = match command {
+        RowLevelCommand::Delete => "write.delete.mode",
+        RowLevelCommand::Merge => "write.merge.mode",
+        RowLevelCommand::Update => "write.update.mode",
     };
     let mode = table
         .metadata()
@@ -178,16 +288,232 @@ fn ensure_current_row_level_mode(table: &Table, command: RowLevelCommand) -> Res
         .get(property)
         .map_or("copy-on-write", String::as_str);
     if mode.eq_ignore_ascii_case("merge-on-read") {
-        return Ok(());
+        return Ok(IcebergRowLevelMode::MergeOnRead);
     }
     if mode.eq_ignore_ascii_case("copy-on-write") {
-        return not_impl_err!(
-            "Iceberg {operation} with `{property}=copy-on-write` is not supported yet; set `{property}=merge-on-read`"
-        );
+        return Ok(IcebergRowLevelMode::CopyOnWrite);
     }
     plan_err!(
         "Unknown Iceberg row-level operation mode for `{property}`: {mode}; expected `copy-on-write` or `merge-on-read`"
     )
+}
+
+fn plan_iceberg_copy_on_write(
+    session_state: &SessionState,
+    node: &RowLevelWriteNode,
+    physical_inputs: &[Arc<dyn ExecutionPlan>],
+    table_url: url::Url,
+    table: &Table,
+    snapshot_update_kind: SnapshotUpdateKind,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let write_plan = physical_inputs.first().cloned().ok_or_else(|| {
+        DataFusionError::Internal(format!(
+            "Iceberg {:?} COW missing write plan input",
+            node.command()
+        ))
+    })?;
+    let insert_only_merge = node.command() == RowLevelCommand::Merge
+        && node.merge_options().is_some_and(|options| {
+            options.matched_clauses.is_empty()
+                && options.not_matched_by_source_clauses.is_empty()
+                && !options.not_matched_by_target_clauses.is_empty()
+        });
+
+    let writer_input = if insert_only_merge {
+        write_plan
+    } else {
+        let touched_plan = physical_inputs.get(1).ok_or_else(|| {
+            DataFusionError::Internal(format!(
+                "Iceberg {:?} COW missing touched-file plan input",
+                node.command()
+            ))
+        })?;
+        build_targeted_writer_input(&write_plan, touched_plan)?
+    };
+    let (writer_input, logical_data_schema) = project_copy_on_write_data_rows(writer_input)?;
+    let partition_columns = IcebergLakeSource::partition_columns_from_metadata(table)?;
+    let writer_options = resolve_row_level_writer_options(session_state, node)?;
+    let write_context = prepare_iceberg_write_context(
+        &table_url,
+        Some(table.metadata()),
+        &writer_options,
+        &partition_columns,
+        &PhysicalSinkMode::Append,
+        logical_data_schema.as_ref(),
+    )?;
+    let writer: Arc<dyn ExecutionPlan> = Arc::new(IcebergWriterExec::new(
+        writer_input,
+        table_url.clone(),
+        partition_columns,
+        PhysicalSinkMode::Append,
+        true,
+        writer_options.clone(),
+        write_context,
+    )?);
+
+    let (commit_input, snapshot_update_kind): (Arc<dyn ExecutionPlan>, _) = if insert_only_merge {
+        (writer, SnapshotUpdateKind::FastAppend)
+    } else {
+        let touched_plan = reset_plan_states(Arc::clone(&physical_inputs[1]))?;
+        let remove_actions: Arc<dyn ExecutionPlan> = Arc::new(IcebergRemoveDataFilesExec::try_new(
+            touched_plan,
+            MERGE_FILE_COLUMN,
+        )?);
+        (
+            UnionExec::try_new(vec![writer, remove_actions])?,
+            snapshot_update_kind,
+        )
+    };
+
+    Ok(Arc::new(
+        IcebergCommitExec::new(
+            Arc::new(CoalescePartitionsExec::new(commit_input)),
+            table_url,
+            writer_options.lakehouse_table.clone(),
+            snapshot_update_kind,
+        )
+        .with_expected_snapshot_id(node.expected_snapshot_id()),
+    ))
+}
+
+fn build_targeted_writer_input(
+    write_plan: &Arc<dyn ExecutionPlan>,
+    touched_plan: &Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let write_schema = write_plan.schema();
+    let path_index = write_schema.index_of(MERGE_FILE_COLUMN).map_err(|_| {
+        DataFusionError::Internal(format!(
+            "Iceberg COW writer input is missing path column '{MERGE_FILE_COLUMN}'"
+        ))
+    })?;
+    let touched_schema = touched_plan.schema();
+    let touched_path_index = touched_schema.index_of(MERGE_FILE_COLUMN).map_err(|_| {
+        DataFusionError::Internal(format!(
+            "Iceberg COW touched-file input is missing path column '{MERGE_FILE_COLUMN}'"
+        ))
+    })?;
+
+    let insert_predicate: Arc<dyn PhysicalExpr> = Arc::new(IsNullExpr::new(Arc::new(Column::new(
+        MERGE_FILE_COLUMN,
+        path_index,
+    ))));
+    let insert_rows: Arc<dyn ExecutionPlan> = Arc::new(FilterExec::try_new(
+        insert_predicate,
+        Arc::clone(write_plan),
+    )?);
+
+    let join = Arc::new(HashJoinExec::try_new(
+        reset_plan_states(Arc::clone(touched_plan))?,
+        reset_plan_states(Arc::clone(write_plan))?,
+        vec![(
+            Arc::new(Column::new(MERGE_FILE_COLUMN, touched_path_index)),
+            Arc::new(Column::new(MERGE_FILE_COLUMN, path_index)),
+        )],
+        None,
+        &JoinType::Inner,
+        None,
+        PartitionMode::CollectLeft,
+        NullEquality::NullEqualsNothing,
+        false,
+    )?);
+    let touched_field_count = touched_schema.fields().len();
+    let projection = write_schema
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(index, field)| {
+            (
+                Arc::new(Column::new(field.name(), touched_field_count + index))
+                    as Arc<dyn PhysicalExpr>,
+                field.name().clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let touched_rows: Arc<dyn ExecutionPlan> = Arc::new(ProjectionExec::try_new(projection, join)?);
+    UnionExec::try_new(vec![insert_rows, touched_rows])
+}
+
+fn project_copy_on_write_data_rows(
+    input: Arc<dyn ExecutionPlan>,
+) -> Result<(
+    Arc<dyn ExecutionPlan>,
+    datafusion::arrow::datatypes::SchemaRef,
+)> {
+    let schema = input.schema();
+    let operation_index = schema.index_of(sail_common_datafusion::datasource::OPERATION_COLUMN)?;
+    let operation: Arc<dyn PhysicalExpr> = Arc::new(Column::new(
+        sail_common_datafusion::datasource::OPERATION_COLUMN,
+        operation_index,
+    ));
+    let predicate = [
+        RowLevelOperationType::Copy,
+        RowLevelOperationType::Update,
+        RowLevelOperationType::Insert,
+        RowLevelOperationType::MatchedUpdate,
+        RowLevelOperationType::NotMatchedBySourceUpdate,
+    ]
+    .into_iter()
+    .map(|operation_type| {
+        Arc::new(BinaryExpr::new(
+            Arc::clone(&operation),
+            Operator::Eq,
+            Arc::new(Literal::new(ScalarValue::Int32(Some(
+                operation_type.as_i32(),
+            )))),
+        )) as Arc<dyn PhysicalExpr>
+    })
+    .reduce(|left, right| {
+        Arc::new(BinaryExpr::new(left, Operator::Or, right)) as Arc<dyn PhysicalExpr>
+    })
+    .ok_or_else(|| DataFusionError::Internal("Iceberg COW operation filter is empty".into()))?;
+    let filtered: Arc<dyn ExecutionPlan> = Arc::new(FilterExec::try_new(predicate, input)?);
+
+    let row_projection = IcebergMergeRowProjection::try_new(schema)?;
+    let filtered_schema = filtered.schema();
+    let data_projection = row_projection
+        .data_indices()
+        .iter()
+        .map(|index| {
+            let field = filtered_schema.field(*index);
+            (
+                Arc::new(Column::new(field.name(), *index)) as Arc<dyn PhysicalExpr>,
+                field.name().clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    Ok((
+        Arc::new(ProjectionExec::try_new(data_projection, filtered)?),
+        row_projection.data_schema(),
+    ))
+}
+
+fn strip_iceberg_metadata_columns(input: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionPlan>> {
+    let schema = input.schema();
+    let internal_columns = [
+        MERGE_FILE_COLUMN,
+        sail_common_datafusion::datasource::MERGE_ROW_INDEX_COLUMN,
+        MERGE_PARTITION_SPEC_ID_COLUMN,
+        MERGE_PARTITION_COLUMN,
+    ];
+    let projection = schema
+        .fields()
+        .iter()
+        .enumerate()
+        .filter(|(_, field)| !internal_columns.contains(&field.name().as_str()))
+        .map(|(index, field)| {
+            (
+                Arc::new(Column::new(field.name(), index)) as Arc<dyn PhysicalExpr>,
+                field.name().clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    if projection.len() == schema.fields().len() {
+        return Ok(input);
+    }
+    if projection.is_empty() {
+        return internal_err!("Iceberg MOR DELETE target contains no data columns");
+    }
+    Ok(Arc::new(ProjectionExec::try_new(projection, input)?))
 }
 
 fn resolve_row_level_writer_options(

--- a/crates/sail-iceberg/src/physical/row_level_planner.rs
+++ b/crates/sail-iceberg/src/physical/row_level_planner.rs
@@ -36,6 +36,7 @@ use crate::physical_plan::{
     IcebergWriterExec, IcebergWriterExecOptions, prepare_iceberg_write_context,
 };
 use crate::row_level_metadata::{MERGE_PARTITION_COLUMN, MERGE_PARTITION_SPEC_ID_COLUMN};
+use crate::spec::FormatVersion;
 use crate::table::Table;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -318,6 +319,12 @@ fn plan_iceberg_copy_on_write(
                 && options.not_matched_by_source_clauses.is_empty()
                 && !options.not_matched_by_target_clauses.is_empty()
         });
+    if table.metadata().format_version >= FormatVersion::V3 && !insert_only_merge {
+        return not_impl_err!(
+            "Iceberg v3 copy-on-write {:?} is not supported until row lineage can be preserved",
+            node.command()
+        );
+    }
 
     let writer_input = if insert_only_merge {
         write_plan
@@ -352,7 +359,7 @@ fn plan_iceberg_copy_on_write(
     )?);
 
     let (commit_input, snapshot_update_kind): (Arc<dyn ExecutionPlan>, _) = if insert_only_merge {
-        (writer, SnapshotUpdateKind::FastAppend)
+        (writer, snapshot_update_kind)
     } else {
         let touched_plan = reset_plan_states(Arc::clone(&physical_inputs[1]))?;
         let remove_actions: Arc<dyn ExecutionPlan> = Arc::new(IcebergRemoveDataFilesExec::try_new(

--- a/crates/sail-iceberg/src/physical_plan/merge_row_projection.rs
+++ b/crates/sail-iceberg/src/physical_plan/merge_row_projection.rs
@@ -57,6 +57,10 @@ impl IcebergMergeRowProjection {
         Arc::clone(&self.data_schema)
     }
 
+    pub(crate) fn data_indices(&self) -> &[usize] {
+        &self.data_indices
+    }
+
     pub(crate) fn project_data_rows(&self, batch: &RecordBatch) -> Result<RecordBatch> {
         let mask = merge_operation_mask(batch, self.operation_index, merge_operation_writes_data)?;
         let filtered = filter_record_batch(batch, &mask)

--- a/python/pysail/tests/spark/execution/__snapshots__/features/lakehouse_commit.yaml
+++ b/python/pysail/tests/spark/execution/__snapshots__/features/lakehouse_commit.yaml
@@ -912,3 +912,861 @@ data:
     distribution=RoundRobinBatch(channels=1)
     placement=Worker
     StageInputExec: input=0, partitioning=UnknownPartitioning(1)
+---
+name: "test_iceberg_copyonwrite_keeps_rewriting_on_workers_and_commit_on_the_driver"
+data:
+  |-
+    == Codegen ==
+    Whole-stage codegen is not supported; showing physical plan instead.
+  
+    == Plan Steps ==
+    initial_logical_plan:
+    RowLevelWrite: command=Update, target=distributed_iceberg_commit, format=iceberg, condition=id < 10
+      Projection: CASE WHEN id < Int32(10) THEN CAST(id + Int32(1000) AS Int64) ELSE id END AS id, __sail_file_path AS __sail_file_path, CASE WHEN id < Int32(10) THEN Int32(2) ELSE Int32(0) END AS __sail_operation_type
+        Projection: distributed_iceberg_commit.#0 AS id, __sail_file_path AS __sail_file_path
+          Projection: distributed_iceberg_commit.id AS #0, distributed_iceberg_commit.__sail_file_path AS __sail_file_path, distributed_iceberg_commit.__sail_iceberg_partition_spec_id AS __sail_iceberg_partition_spec_id, distributed_iceberg_commit.__sail_iceberg_partition AS __sail_iceberg_partition
+            TableScan: distributed_iceberg_commit projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition]
+      Projection: __sail_file_path AS __sail_file_path
+        Aggregate: groupBy=[[__sail_file_path]], aggr=[[]]
+          Filter: id < Int32(10)
+            Projection: distributed_iceberg_commit.#0 AS id, __sail_file_path AS __sail_file_path
+              Projection: distributed_iceberg_commit.id AS #0, distributed_iceberg_commit.__sail_file_path AS __sail_file_path, distributed_iceberg_commit.__sail_iceberg_partition_spec_id AS __sail_iceberg_partition_spec_id, distributed_iceberg_commit.__sail_iceberg_partition AS __sail_iceberg_partition
+                TableScan: distributed_iceberg_commit projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition]
+  
+    logical_plan after resolve_lambda_variables:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after resolve_grouping_function:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after type_coercion:
+    RowLevelWrite: command=Update, target=distributed_iceberg_commit, format=iceberg, condition=id < 10
+      Projection: CASE WHEN id < CAST(Int32(10) AS Int64) THEN CAST(id + CAST(Int32(1000) AS Int64) AS Int64) ELSE id END AS id, __sail_file_path AS __sail_file_path, CASE WHEN id < CAST(Int32(10) AS Int64) THEN Int32(2) ELSE Int32(0) END AS __sail_operation_type
+        Projection: distributed_iceberg_commit.#0 AS id, __sail_file_path AS __sail_file_path
+          Projection: distributed_iceberg_commit.id AS #0, distributed_iceberg_commit.__sail_file_path AS __sail_file_path, distributed_iceberg_commit.__sail_iceberg_partition_spec_id AS __sail_iceberg_partition_spec_id, distributed_iceberg_commit.__sail_iceberg_partition AS __sail_iceberg_partition
+            TableScan: distributed_iceberg_commit projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition]
+      Projection: __sail_file_path AS __sail_file_path
+        Aggregate: groupBy=[[__sail_file_path]], aggr=[[]]
+          Filter: id < CAST(Int32(10) AS Int64)
+            Projection: distributed_iceberg_commit.#0 AS id, __sail_file_path AS __sail_file_path
+              Projection: distributed_iceberg_commit.id AS #0, distributed_iceberg_commit.__sail_file_path AS __sail_file_path, distributed_iceberg_commit.__sail_iceberg_partition_spec_id AS __sail_iceberg_partition_spec_id, distributed_iceberg_commit.__sail_iceberg_partition AS __sail_iceberg_partition
+                TableScan: distributed_iceberg_commit projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition]
+  
+    analyzed_logical_plan:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_projection:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after rewrite_set_comparison:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_unions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after unions_to_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after simplify_expressions:
+    RowLevelWrite: command=Update, target=distributed_iceberg_commit, format=iceberg, condition=id < 10
+      Projection: CASE WHEN id < Int64(10) THEN CAST(id + Int64(1000) AS Int64) ELSE id END AS id, __sail_file_path AS __sail_file_path, CASE WHEN id < Int64(10) THEN Int32(2) ELSE Int32(0) END AS __sail_operation_type
+        Projection: distributed_iceberg_commit.#0 AS id, __sail_file_path AS __sail_file_path
+          Projection: distributed_iceberg_commit.id AS #0, distributed_iceberg_commit.__sail_file_path AS __sail_file_path, distributed_iceberg_commit.__sail_iceberg_partition_spec_id AS __sail_iceberg_partition_spec_id, distributed_iceberg_commit.__sail_iceberg_partition AS __sail_iceberg_partition
+            TableScan: distributed_iceberg_commit projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition]
+      Projection: __sail_file_path AS __sail_file_path
+        Aggregate: groupBy=[[__sail_file_path]], aggr=[[]]
+          Filter: id < Int64(10)
+            Projection: distributed_iceberg_commit.#0 AS id, __sail_file_path AS __sail_file_path
+              Projection: distributed_iceberg_commit.id AS #0, distributed_iceberg_commit.__sail_file_path AS __sail_file_path, distributed_iceberg_commit.__sail_iceberg_partition_spec_id AS __sail_iceberg_partition_spec_id, distributed_iceberg_commit.__sail_iceberg_partition AS __sail_iceberg_partition
+                TableScan: distributed_iceberg_commit projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition]
+  
+    logical_plan after replace_distinct_aggregate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_predicate_subquery:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after scalar_subquery_to_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after extract_equijoin_predicate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_duplicated_expr:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_cross_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after propagate_empty_relation:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after filter_null_join_keys:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_outer_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_filter:
+    RowLevelWrite: command=Update, target=distributed_iceberg_commit, format=iceberg, condition=id < 10
+      Projection: CASE WHEN id < Int64(10) THEN CAST(id + Int64(1000) AS Int64) ELSE id END AS id, __sail_file_path AS __sail_file_path, CASE WHEN id < Int64(10) THEN Int32(2) ELSE Int32(0) END AS __sail_operation_type
+        Projection: distributed_iceberg_commit.#0 AS id, __sail_file_path AS __sail_file_path
+          Projection: distributed_iceberg_commit.id AS #0, distributed_iceberg_commit.__sail_file_path AS __sail_file_path, distributed_iceberg_commit.__sail_iceberg_partition_spec_id AS __sail_iceberg_partition_spec_id, distributed_iceberg_commit.__sail_iceberg_partition AS __sail_iceberg_partition
+            TableScan: distributed_iceberg_commit projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition]
+      Projection: __sail_file_path AS __sail_file_path
+        Aggregate: groupBy=[[__sail_file_path]], aggr=[[]]
+          Projection: distributed_iceberg_commit.#0 AS id, __sail_file_path AS __sail_file_path
+            Projection: distributed_iceberg_commit.id AS #0, distributed_iceberg_commit.__sail_file_path AS __sail_file_path, distributed_iceberg_commit.__sail_iceberg_partition_spec_id AS __sail_iceberg_partition_spec_id, distributed_iceberg_commit.__sail_iceberg_partition AS __sail_iceberg_partition
+              Filter: distributed_iceberg_commit.id < Int64(10)
+                TableScan: distributed_iceberg_commit projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition]
+  
+    logical_plan after single_distinct_aggregation_to_group_by:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_group_by_constant:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after common_sub_expression_eliminate:
+    RowLevelWrite: command=Update, target=distributed_iceberg_commit, format=iceberg, condition=id < 10
+      Projection: CASE WHEN __common_expr_1 THEN CAST(id + Int64(1000) AS Int64) ELSE id END AS id, __sail_file_path AS __sail_file_path, CASE WHEN __common_expr_1 THEN Int32(2) ELSE Int32(0) END AS __sail_operation_type
+        Projection: id < Int64(10) AS __common_expr_1, id, __sail_file_path
+          Projection: distributed_iceberg_commit.#0 AS id, __sail_file_path AS __sail_file_path
+            Projection: distributed_iceberg_commit.id AS #0, distributed_iceberg_commit.__sail_file_path AS __sail_file_path, distributed_iceberg_commit.__sail_iceberg_partition_spec_id AS __sail_iceberg_partition_spec_id, distributed_iceberg_commit.__sail_iceberg_partition AS __sail_iceberg_partition
+              TableScan: distributed_iceberg_commit projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition]
+      Projection: __sail_file_path AS __sail_file_path
+        Aggregate: groupBy=[[__sail_file_path]], aggr=[[]]
+          Projection: distributed_iceberg_commit.#0 AS id, __sail_file_path AS __sail_file_path
+            Projection: distributed_iceberg_commit.id AS #0, distributed_iceberg_commit.__sail_file_path AS __sail_file_path, distributed_iceberg_commit.__sail_iceberg_partition_spec_id AS __sail_iceberg_partition_spec_id, distributed_iceberg_commit.__sail_iceberg_partition AS __sail_iceberg_partition
+              Filter: distributed_iceberg_commit.id < Int64(10)
+                TableScan: distributed_iceberg_commit projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition]
+  
+    logical_plan after extract_leaf_expressions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_projections:
+    RowLevelWrite: command=Update, target=distributed_iceberg_commit, format=iceberg, condition=id < 10
+      Projection: CASE WHEN __common_expr_1 THEN CAST(id + Int64(1000) AS Int64) ELSE id END AS id, __sail_file_path AS __sail_file_path, CASE WHEN __common_expr_1 THEN Int32(2) ELSE Int32(0) END AS __sail_operation_type
+        Projection: distributed_iceberg_commit.#0 < Int64(10) AS __common_expr_1, distributed_iceberg_commit.#0 AS id, __sail_file_path
+          Projection: distributed_iceberg_commit.id AS #0, distributed_iceberg_commit.__sail_file_path AS __sail_file_path
+            TableScan: distributed_iceberg_commit projection=[id, __sail_file_path]
+      Projection: __sail_file_path AS __sail_file_path
+        Aggregate: groupBy=[[__sail_file_path]], aggr=[[]]
+          Projection: distributed_iceberg_commit.__sail_file_path AS __sail_file_path
+            Filter: distributed_iceberg_commit.id < Int64(10)
+              TableScan: distributed_iceberg_commit projection=[id, __sail_file_path]
+  
+    logical_plan after resolve_lambda_variables:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_projection:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after rewrite_set_comparison:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_unions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after unions_to_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after simplify_expressions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after replace_distinct_aggregate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_predicate_subquery:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after scalar_subquery_to_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after extract_equijoin_predicate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_duplicated_expr:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_cross_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after propagate_empty_relation:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after filter_null_join_keys:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_outer_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after single_distinct_aggregation_to_group_by:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_group_by_constant:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after common_sub_expression_eliminate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after extract_leaf_expressions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_projections:
+    RowLevelWrite: command=Update, target=distributed_iceberg_commit, format=iceberg, condition=id < 10
+      Projection: CASE WHEN __common_expr_1 THEN CAST(id + Int64(1000) AS Int64) ELSE id END AS id, __sail_file_path AS __sail_file_path, CASE WHEN __common_expr_1 THEN Int32(2) ELSE Int32(0) END AS __sail_operation_type
+        Projection: distributed_iceberg_commit.id < Int64(10) AS __common_expr_1, distributed_iceberg_commit.id AS id, distributed_iceberg_commit.__sail_file_path AS __sail_file_path
+          TableScan: distributed_iceberg_commit projection=[id, __sail_file_path]
+      Projection: __sail_file_path AS __sail_file_path
+        Aggregate: groupBy=[[__sail_file_path]], aggr=[[]]
+          Projection: distributed_iceberg_commit.__sail_file_path AS __sail_file_path
+            Filter: distributed_iceberg_commit.id < Int64(10)
+              TableScan: distributed_iceberg_commit projection=[id, __sail_file_path]
+  
+    logical_plan after resolve_lambda_variables:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_projection:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after rewrite_set_comparison:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_unions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after unions_to_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after simplify_expressions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after replace_distinct_aggregate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_predicate_subquery:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after scalar_subquery_to_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after decorrelate_lateral_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after extract_equijoin_predicate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_duplicated_expr:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_cross_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after propagate_empty_relation:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after filter_null_join_keys:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_outer_join:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_limit:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after push_down_filter:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after single_distinct_aggregation_to_group_by:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after eliminate_group_by_constant:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after common_sub_expression_eliminate:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after extract_leaf_expressions:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after optimize_projections:
+    SAME TEXT AS ABOVE
+  
+    logical_plan after resolve_lambda_variables:
+    SAME TEXT AS ABOVE
+  
+    logical_plan:
+    RowLevelWrite: command=Update, target=distributed_iceberg_commit, format=iceberg, condition=id < 10
+      Projection: CASE WHEN __common_expr_1 THEN CAST(id + Int64(1000) AS Int64) ELSE id END AS id, __sail_file_path AS __sail_file_path, CASE WHEN __common_expr_1 THEN Int32(2) ELSE Int32(0) END AS __sail_operation_type
+        Projection: distributed_iceberg_commit.id < Int64(10) AS __common_expr_1, distributed_iceberg_commit.id AS id, distributed_iceberg_commit.__sail_file_path AS __sail_file_path
+          TableScan: distributed_iceberg_commit projection=[id, __sail_file_path]
+      Projection: __sail_file_path AS __sail_file_path
+        Aggregate: groupBy=[[__sail_file_path]], aggr=[[]]
+          Projection: distributed_iceberg_commit.__sail_file_path AS __sail_file_path
+            Filter: distributed_iceberg_commit.id < Int64(10)
+              TableScan: distributed_iceberg_commit projection=[id, __sail_file_path]
+  
+    initial_physical_plan:
+    IcebergCommitExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+      CoalescePartitionsExec
+        UnionExec
+          IcebergWriterExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+            ProjectionExec: expr=[id@0 as id]
+              FilterExec: __sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8
+                UnionExec
+                  FilterExec: __sail_file_path@1 IS NULL
+                    ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+                      ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                        ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                          IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                            DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+                  ProjectionExec: expr=[id@1 as id, __sail_file_path@2 as __sail_file_path, __sail_operation_type@3 as __sail_operation_type]
+                    HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(__sail_file_path@0, __sail_file_path@1)]
+                      ProjectionExec: expr=[__sail_file_path@0 as __sail_file_path]
+                        AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                          AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                            ProjectionExec: expr=[__sail_file_path@1 as __sail_file_path]
+                              FilterExec: id@0 < 10
+                                ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                                  IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                                    DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+                      ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+                        ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                          ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                            IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                              DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+          IcebergRemoveDataFilesExec(file_path_column=__sail_file_path)
+            ProjectionExec: expr=[__sail_file_path@0 as __sail_file_path]
+              AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                  ProjectionExec: expr=[__sail_file_path@1 as __sail_file_path]
+                    FilterExec: id@0 < 10
+                      ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                        IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                          DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+  
+  
+    initial_physical_plan_with_stats:
+    IcebergCommitExec(table_path=file://<tmp>/distributed_iceberg_commit/), statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+      CoalescePartitionsExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+        UnionExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+          IcebergWriterExec(table_path=file://<tmp>/distributed_iceberg_commit/), statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+            ProjectionExec: expr=[id@0 as id], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+              FilterExec: __sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:),(Col[2]:)]]
+                UnionExec, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:),(Col[2]:)]]
+                  FilterExec: __sail_file_path@1 IS NULL, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:),(Col[2]:)]]
+                    ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:),(Col[2]:)]]
+                      ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:),(Col[2]:)]]
+                        ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:)]]
+                          IcebergMergeMetadataExec: data_file_column=__sail_file_path, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:),(Col[2]:),(Col[3]:)]]
+                            DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:),(Col[2]:),(Col[3]:)]]
+                  ProjectionExec: expr=[id@1 as id, __sail_file_path@2 as __sail_file_path, __sail_operation_type@3 as __sail_operation_type], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:),(Col[2]:)]]
+                    HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(__sail_file_path@0, __sail_file_path@1)], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:),(Col[2]:),(Col[3]:)]]
+                      ProjectionExec: expr=[__sail_file_path@0 as __sail_file_path], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+                        AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+                          AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+                            ProjectionExec: expr=[__sail_file_path@1 as __sail_file_path], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+                              FilterExec: id@0 < 10, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]: Max=Inexact(Int64(9))),(Col[1]:)]]
+                                ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:)]]
+                                  IcebergMergeMetadataExec: data_file_column=__sail_file_path, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:),(Col[2]:),(Col[3]:)]]
+                                    DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:),(Col[2]:),(Col[3]:)]]
+                      ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:),(Col[2]:)]]
+                        ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:),(Col[2]:)]]
+                          ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:)]]
+                            IcebergMergeMetadataExec: data_file_column=__sail_file_path, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:),(Col[2]:),(Col[3]:)]]
+                              DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:),(Col[2]:),(Col[3]:)]]
+          IcebergRemoveDataFilesExec(file_path_column=__sail_file_path), statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+            ProjectionExec: expr=[__sail_file_path@0 as __sail_file_path], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+              AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+                AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+                  ProjectionExec: expr=[__sail_file_path@1 as __sail_file_path], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:)]]
+                    FilterExec: id@0 < 10, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]: Max=Inexact(Int64(9))),(Col[1]:)]]
+                      ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path], statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:)]]
+                        IcebergMergeMetadataExec: data_file_column=__sail_file_path, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:),(Col[2]:),(Col[3]:)]]
+                          DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet, statistics=[Rows=Absent, Bytes=Absent, [(Col[0]:),(Col[1]:),(Col[2]:),(Col[3]:)]]
+  
+  
+    initial_physical_plan_with_schema:
+    IcebergCommitExec(table_path=file://<tmp>/distributed_iceberg_commit/), schema=[count:Int64;N]
+      CoalescePartitionsExec, schema=[action:Union(Dense, 0: ("add": non-null Struct("content": non-null Utf8, "file_path": non-null Utf8, "file_format": non-null Utf8, "partition": non-null List(non-null Union(Dense, 0: ("Boolean": non-null Boolean), 1: ("Int": non-null Int32), 2: ("Long": non-null Int64), 3: ("Float": non-null Float32), 4: ("Double": non-null Float64), 5: ("String": non-null Utf8), 6: ("Int128": non-null Utf8), 7: ("UInt128": non-null Utf8), 8: ("Binary": non-null List(non-null UInt8, field: 'element')), 9: ("Null": non-null Boolean)), field: 'element'), "record_count": non-null UInt64, "file_size_in_bytes": non-null UInt64, "column_sizes": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "value_counts": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "null_value_counts": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "nan_value_counts": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "lower_bounds_json": non-null Utf8, "upper_bounds_json": non-null Utf8, "split_offsets": non-null List(non-null Int64, field: 'element'), "equality_ids": non-null List(non-null Int32, field: 'element'), "sort_order_id": Int32, "first_row_id": Int64, "partition_spec_id": non-null Int32, "referenced_data_file": Utf8, "content_offset": Int64, "content_size_in_bytes": Int64)), 1: ("delete": non-null Struct("data_file": non-null Struct("content": non-null Utf8, "file_path": non-null Utf8, "file_format": non-null Utf8, "partition": non-null List(non-null Union(Dense, 0: ("Boolean": non-null Boolean), 1: ("Int": non-null Int32), 2: ("Long": non-null Int64), 3: ("Float": non-null Float32), 4: ("Double": non-null Float64), 5: ("String": non-null Utf8), 6: ("Int128": non-null Utf8), 7: ("UInt128": non-null Utf8), 8: ("Binary": non-null List(non-null UInt8, field: 'element')), 9: ("Null": non-null Boolean)), field: 'element'), "record_count": non-null UInt64, "file_size_in_bytes": non-null UInt64, "column_sizes": non-null Map("entries": non-null Struct("key": non-null Int32, "value": non-null UInt64), unsorted), "value_counts": non-null Map("entries": non-null Struct("key": non-null Int32, "value": non-null UInt64), unsorted), "null_value_counts": non-null Map("entries": non-null Struct("key": non-null Int32, "value": non-null UInt64), unsorted), "nan_value_counts": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "lower_bounds_json": non-null Utf8, "upper_bounds_json": non-null Utf8, "split_offsets": non-null List(non-null Int64, field: 'element'), "equality_ids": non-null List(non-null Int32, field: 'element'), "sort_order_id": Int32, "first_row_id": Int64, "partition_spec_id": non-null Int32, "referenced_data_file": Utf8, "content_offset": Int64, "content_size_in_bytes": Int64))), 2: ("remove_data_file": non-null Struct("file_path": non-null Utf8)), 3: ("commit_meta": non-null Struct("table_uri": non-null Utf8, "row_count": non-null UInt64, "requirements_json": non-null Utf8, "table_properties_json": non-null Utf8, "lakehouse_table_json": Utf8, "schema_json": Utf8, "partition_spec_json": Utf8)))]
+        UnionExec, schema=[action:Union(Dense, 0: ("add": non-null Struct("content": non-null Utf8, "file_path": non-null Utf8, "file_format": non-null Utf8, "partition": non-null List(non-null Union(Dense, 0: ("Boolean": non-null Boolean), 1: ("Int": non-null Int32), 2: ("Long": non-null Int64), 3: ("Float": non-null Float32), 4: ("Double": non-null Float64), 5: ("String": non-null Utf8), 6: ("Int128": non-null Utf8), 7: ("UInt128": non-null Utf8), 8: ("Binary": non-null List(non-null UInt8, field: 'element')), 9: ("Null": non-null Boolean)), field: 'element'), "record_count": non-null UInt64, "file_size_in_bytes": non-null UInt64, "column_sizes": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "value_counts": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "null_value_counts": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "nan_value_counts": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "lower_bounds_json": non-null Utf8, "upper_bounds_json": non-null Utf8, "split_offsets": non-null List(non-null Int64, field: 'element'), "equality_ids": non-null List(non-null Int32, field: 'element'), "sort_order_id": Int32, "first_row_id": Int64, "partition_spec_id": non-null Int32, "referenced_data_file": Utf8, "content_offset": Int64, "content_size_in_bytes": Int64)), 1: ("delete": non-null Struct("data_file": non-null Struct("content": non-null Utf8, "file_path": non-null Utf8, "file_format": non-null Utf8, "partition": non-null List(non-null Union(Dense, 0: ("Boolean": non-null Boolean), 1: ("Int": non-null Int32), 2: ("Long": non-null Int64), 3: ("Float": non-null Float32), 4: ("Double": non-null Float64), 5: ("String": non-null Utf8), 6: ("Int128": non-null Utf8), 7: ("UInt128": non-null Utf8), 8: ("Binary": non-null List(non-null UInt8, field: 'element')), 9: ("Null": non-null Boolean)), field: 'element'), "record_count": non-null UInt64, "file_size_in_bytes": non-null UInt64, "column_sizes": non-null Map("entries": non-null Struct("key": non-null Int32, "value": non-null UInt64), unsorted), "value_counts": non-null Map("entries": non-null Struct("key": non-null Int32, "value": non-null UInt64), unsorted), "null_value_counts": non-null Map("entries": non-null Struct("key": non-null Int32, "value": non-null UInt64), unsorted), "nan_value_counts": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "lower_bounds_json": non-null Utf8, "upper_bounds_json": non-null Utf8, "split_offsets": non-null List(non-null Int64, field: 'element'), "equality_ids": non-null List(non-null Int32, field: 'element'), "sort_order_id": Int32, "first_row_id": Int64, "partition_spec_id": non-null Int32, "referenced_data_file": Utf8, "content_offset": Int64, "content_size_in_bytes": Int64))), 2: ("remove_data_file": non-null Struct("file_path": non-null Utf8)), 3: ("commit_meta": non-null Struct("table_uri": non-null Utf8, "row_count": non-null UInt64, "requirements_json": non-null Utf8, "table_properties_json": non-null Utf8, "lakehouse_table_json": Utf8, "schema_json": Utf8, "partition_spec_json": Utf8)))]
+          IcebergWriterExec(table_path=file://<tmp>/distributed_iceberg_commit/), schema=[action:Union(Dense, 0: ("add": non-null Struct("content": non-null Utf8, "file_path": non-null Utf8, "file_format": non-null Utf8, "partition": non-null List(non-null Union(Dense, 0: ("Boolean": non-null Boolean), 1: ("Int": non-null Int32), 2: ("Long": non-null Int64), 3: ("Float": non-null Float32), 4: ("Double": non-null Float64), 5: ("String": non-null Utf8), 6: ("Int128": non-null Utf8), 7: ("UInt128": non-null Utf8), 8: ("Binary": non-null List(non-null UInt8, field: 'element')), 9: ("Null": non-null Boolean)), field: 'element'), "record_count": non-null UInt64, "file_size_in_bytes": non-null UInt64, "column_sizes": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "value_counts": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "null_value_counts": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "nan_value_counts": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "lower_bounds_json": non-null Utf8, "upper_bounds_json": non-null Utf8, "split_offsets": non-null List(non-null Int64, field: 'element'), "equality_ids": non-null List(non-null Int32, field: 'element'), "sort_order_id": Int32, "first_row_id": Int64, "partition_spec_id": non-null Int32, "referenced_data_file": Utf8, "content_offset": Int64, "content_size_in_bytes": Int64)), 1: ("delete": non-null Struct("data_file": non-null Struct("content": non-null Utf8, "file_path": non-null Utf8, "file_format": non-null Utf8, "partition": non-null List(non-null Union(Dense, 0: ("Boolean": non-null Boolean), 1: ("Int": non-null Int32), 2: ("Long": non-null Int64), 3: ("Float": non-null Float32), 4: ("Double": non-null Float64), 5: ("String": non-null Utf8), 6: ("Int128": non-null Utf8), 7: ("UInt128": non-null Utf8), 8: ("Binary": non-null List(non-null UInt8, field: 'element')), 9: ("Null": non-null Boolean)), field: 'element'), "record_count": non-null UInt64, "file_size_in_bytes": non-null UInt64, "column_sizes": non-null Map("entries": non-null Struct("key": non-null Int32, "value": non-null UInt64), unsorted), "value_counts": non-null Map("entries": non-null Struct("key": non-null Int32, "value": non-null UInt64), unsorted), "null_value_counts": non-null Map("entries": non-null Struct("key": non-null Int32, "value": non-null UInt64), unsorted), "nan_value_counts": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "lower_bounds_json": non-null Utf8, "upper_bounds_json": non-null Utf8, "split_offsets": non-null List(non-null Int64, field: 'element'), "equality_ids": non-null List(non-null Int32, field: 'element'), "sort_order_id": Int32, "first_row_id": Int64, "partition_spec_id": non-null Int32, "referenced_data_file": Utf8, "content_offset": Int64, "content_size_in_bytes": Int64))), 2: ("remove_data_file": non-null Struct("file_path": non-null Utf8)), 3: ("commit_meta": non-null Struct("table_uri": non-null Utf8, "row_count": non-null UInt64, "requirements_json": non-null Utf8, "table_properties_json": non-null Utf8, "lakehouse_table_json": Utf8, "schema_json": Utf8, "partition_spec_json": Utf8)))]
+            ProjectionExec: expr=[id@0 as id], schema=[id:Int64;N]
+              FilterExec: __sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8, schema=[id:Int64;N, __sail_file_path:Utf8, __sail_operation_type:Int32]
+                UnionExec, schema=[id:Int64;N, __sail_file_path:Utf8, __sail_operation_type:Int32]
+                  FilterExec: __sail_file_path@1 IS NULL, schema=[id:Int64;N, __sail_file_path:Utf8, __sail_operation_type:Int32]
+                    ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type], schema=[id:Int64;N, __sail_file_path:Utf8, __sail_operation_type:Int32]
+                      ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path], schema=[__common_expr_1:Boolean;N, id:Int64;N, __sail_file_path:Utf8]
+                        ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path], schema=[id:Int64;N, __sail_file_path:Utf8]
+                          IcebergMergeMetadataExec: data_file_column=__sail_file_path, schema=[id:Int64;N, __sail_file_path:Utf8, __sail_iceberg_partition_spec_id:Int32, __sail_iceberg_partition:Utf8]
+                            DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet, schema=[id:Int64;N, __sail_file_path:Utf8, __sail_iceberg_partition_spec_id:Int32, __sail_iceberg_partition:Utf8]
+                  ProjectionExec: expr=[id@1 as id, __sail_file_path@2 as __sail_file_path, __sail_operation_type@3 as __sail_operation_type], schema=[id:Int64;N, __sail_file_path:Utf8, __sail_operation_type:Int32]
+                    HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(__sail_file_path@0, __sail_file_path@1)], schema=[__sail_file_path:Utf8, id:Int64;N, __sail_file_path:Utf8, __sail_operation_type:Int32]
+                      ProjectionExec: expr=[__sail_file_path@0 as __sail_file_path], schema=[__sail_file_path:Utf8]
+                        AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[], schema=[__sail_file_path:Utf8]
+                          AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[], schema=[__sail_file_path:Utf8]
+                            ProjectionExec: expr=[__sail_file_path@1 as __sail_file_path], schema=[__sail_file_path:Utf8]
+                              FilterExec: id@0 < 10, schema=[id:Int64;N, __sail_file_path:Utf8]
+                                ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path], schema=[id:Int64;N, __sail_file_path:Utf8]
+                                  IcebergMergeMetadataExec: data_file_column=__sail_file_path, schema=[id:Int64;N, __sail_file_path:Utf8, __sail_iceberg_partition_spec_id:Int32, __sail_iceberg_partition:Utf8]
+                                    DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet, schema=[id:Int64;N, __sail_file_path:Utf8, __sail_iceberg_partition_spec_id:Int32, __sail_iceberg_partition:Utf8]
+                      ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type], schema=[id:Int64;N, __sail_file_path:Utf8, __sail_operation_type:Int32]
+                        ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path], schema=[__common_expr_1:Boolean;N, id:Int64;N, __sail_file_path:Utf8]
+                          ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path], schema=[id:Int64;N, __sail_file_path:Utf8]
+                            IcebergMergeMetadataExec: data_file_column=__sail_file_path, schema=[id:Int64;N, __sail_file_path:Utf8, __sail_iceberg_partition_spec_id:Int32, __sail_iceberg_partition:Utf8]
+                              DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet, schema=[id:Int64;N, __sail_file_path:Utf8, __sail_iceberg_partition_spec_id:Int32, __sail_iceberg_partition:Utf8]
+          IcebergRemoveDataFilesExec(file_path_column=__sail_file_path), schema=[action:Union(Dense, 0: ("add": non-null Struct("content": non-null Utf8, "file_path": non-null Utf8, "file_format": non-null Utf8, "partition": non-null List(non-null Union(Dense, 0: ("Boolean": non-null Boolean), 1: ("Int": non-null Int32), 2: ("Long": non-null Int64), 3: ("Float": non-null Float32), 4: ("Double": non-null Float64), 5: ("String": non-null Utf8), 6: ("Int128": non-null Utf8), 7: ("UInt128": non-null Utf8), 8: ("Binary": non-null List(non-null UInt8, field: 'element')), 9: ("Null": non-null Boolean)), field: 'element'), "record_count": non-null UInt64, "file_size_in_bytes": non-null UInt64, "column_sizes": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "value_counts": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "null_value_counts": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "nan_value_counts": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "lower_bounds_json": non-null Utf8, "upper_bounds_json": non-null Utf8, "split_offsets": non-null List(non-null Int64, field: 'element'), "equality_ids": non-null List(non-null Int32, field: 'element'), "sort_order_id": Int32, "first_row_id": Int64, "partition_spec_id": non-null Int32, "referenced_data_file": Utf8, "content_offset": Int64, "content_size_in_bytes": Int64)), 1: ("delete": non-null Struct("data_file": non-null Struct("content": non-null Utf8, "file_path": non-null Utf8, "file_format": non-null Utf8, "partition": non-null List(non-null Union(Dense, 0: ("Boolean": non-null Boolean), 1: ("Int": non-null Int32), 2: ("Long": non-null Int64), 3: ("Float": non-null Float32), 4: ("Double": non-null Float64), 5: ("String": non-null Utf8), 6: ("Int128": non-null Utf8), 7: ("UInt128": non-null Utf8), 8: ("Binary": non-null List(non-null UInt8, field: 'element')), 9: ("Null": non-null Boolean)), field: 'element'), "record_count": non-null UInt64, "file_size_in_bytes": non-null UInt64, "column_sizes": non-null Map("entries": non-null Struct("key": non-null Int32, "value": non-null UInt64), unsorted), "value_counts": non-null Map("entries": non-null Struct("key": non-null Int32, "value": non-null UInt64), unsorted), "null_value_counts": non-null Map("entries": non-null Struct("key": non-null Int32, "value": non-null UInt64), unsorted), "nan_value_counts": non-null Map("entries": non-null Struct("keys": non-null Int32, "values": non-null UInt64), unsorted), "lower_bounds_json": non-null Utf8, "upper_bounds_json": non-null Utf8, "split_offsets": non-null List(non-null Int64, field: 'element'), "equality_ids": non-null List(non-null Int32, field: 'element'), "sort_order_id": Int32, "first_row_id": Int64, "partition_spec_id": non-null Int32, "referenced_data_file": Utf8, "content_offset": Int64, "content_size_in_bytes": Int64))), 2: ("remove_data_file": non-null Struct("file_path": non-null Utf8)), 3: ("commit_meta": non-null Struct("table_uri": non-null Utf8, "row_count": non-null UInt64, "requirements_json": non-null Utf8, "table_properties_json": non-null Utf8, "lakehouse_table_json": Utf8, "schema_json": Utf8, "partition_spec_json": Utf8)))]
+            ProjectionExec: expr=[__sail_file_path@0 as __sail_file_path], schema=[__sail_file_path:Utf8]
+              AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[], schema=[__sail_file_path:Utf8]
+                AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[], schema=[__sail_file_path:Utf8]
+                  ProjectionExec: expr=[__sail_file_path@1 as __sail_file_path], schema=[__sail_file_path:Utf8]
+                    FilterExec: id@0 < 10, schema=[id:Int64;N, __sail_file_path:Utf8]
+                      ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path], schema=[id:Int64;N, __sail_file_path:Utf8]
+                        IcebergMergeMetadataExec: data_file_column=__sail_file_path, schema=[id:Int64;N, __sail_file_path:Utf8, __sail_iceberg_partition_spec_id:Int32, __sail_iceberg_partition:Utf8]
+                          DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet, schema=[id:Int64;N, __sail_file_path:Utf8, __sail_iceberg_partition_spec_id:Int32, __sail_iceberg_partition:Utf8]
+  
+  
+    physical_plan after OutputRequirements:
+    OutputRequirementExec: order_by=[], dist_by=Unspecified
+      IcebergCommitExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+        CoalescePartitionsExec
+          UnionExec
+            IcebergWriterExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+              ProjectionExec: expr=[id@0 as id]
+                FilterExec: __sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8
+                  UnionExec
+                    FilterExec: __sail_file_path@1 IS NULL
+                      ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+                        ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                          ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                            IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                              DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+                    ProjectionExec: expr=[id@1 as id, __sail_file_path@2 as __sail_file_path, __sail_operation_type@3 as __sail_operation_type]
+                      HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(__sail_file_path@0, __sail_file_path@1)]
+                        ProjectionExec: expr=[__sail_file_path@0 as __sail_file_path]
+                          AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                            AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                              ProjectionExec: expr=[__sail_file_path@1 as __sail_file_path]
+                                FilterExec: id@0 < 10
+                                  ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                                    IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                                      DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+                        ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+                          ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                            ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                              IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                                DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+            IcebergRemoveDataFilesExec(file_path_column=__sail_file_path)
+              ProjectionExec: expr=[__sail_file_path@0 as __sail_file_path]
+                AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                  AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                    ProjectionExec: expr=[__sail_file_path@1 as __sail_file_path]
+                      FilterExec: id@0 < 10
+                        ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                          IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                            DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+  
+  
+    physical_plan after aggregate_statistics:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after join_selection:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after LimitedDistinctAggregation:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after FilterPushdown:
+    OutputRequirementExec: order_by=[], dist_by=Unspecified
+      IcebergCommitExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+        CoalescePartitionsExec
+          UnionExec
+            IcebergWriterExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+              ProjectionExec: expr=[id@0 as id]
+                UnionExec
+                  FilterExec: (__sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8) AND __sail_file_path@1 IS NULL
+                    ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+                      ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                        ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                          IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                            DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+                  FilterExec: __sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8
+                    ProjectionExec: expr=[id@1 as id, __sail_file_path@2 as __sail_file_path, __sail_operation_type@3 as __sail_operation_type]
+                      HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(__sail_file_path@0, __sail_file_path@1)]
+                        ProjectionExec: expr=[__sail_file_path@0 as __sail_file_path]
+                          AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                            AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                              ProjectionExec: expr=[__sail_file_path@1 as __sail_file_path]
+                                FilterExec: id@0 < 10
+                                  ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                                    IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                                      DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+                        ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+                          ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                            ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                              IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                                DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+            IcebergRemoveDataFilesExec(file_path_column=__sail_file_path)
+              ProjectionExec: expr=[__sail_file_path@0 as __sail_file_path]
+                AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                  AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                    ProjectionExec: expr=[__sail_file_path@1 as __sail_file_path]
+                      FilterExec: id@0 < 10
+                        ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                          IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                            DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+  
+  
+    physical_plan after EnforceDistribution:
+    OutputRequirementExec: order_by=[], dist_by=Unspecified
+      IcebergCommitExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+        CoalescePartitionsExec
+          UnionExec
+            IcebergWriterExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+              ProjectionExec: expr=[id@0 as id]
+                UnionExec
+                  FilterExec: (__sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8) AND __sail_file_path@1 IS NULL
+                    ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+                      ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                        ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                          IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                            DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+                  FilterExec: __sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8
+                    ProjectionExec: expr=[id@1 as id, __sail_file_path@2 as __sail_file_path, __sail_operation_type@3 as __sail_operation_type]
+                      HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(__sail_file_path@0, __sail_file_path@1)]
+                        CoalescePartitionsExec
+                          ProjectionExec: expr=[__sail_file_path@0 as __sail_file_path]
+                            AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                              RepartitionExec: partitioning=Hash([__sail_file_path@0], 4), input_partitions=4
+                                AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                                  ProjectionExec: expr=[__sail_file_path@1 as __sail_file_path]
+                                    FilterExec: id@0 < 10
+                                      ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                                        IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                                          DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+                        ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+                          ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                            ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                              IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                                DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+            IcebergRemoveDataFilesExec(file_path_column=__sail_file_path)
+              ProjectionExec: expr=[__sail_file_path@0 as __sail_file_path]
+                AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                  RepartitionExec: partitioning=Hash([__sail_file_path@0], 4), input_partitions=4
+                    AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                      ProjectionExec: expr=[__sail_file_path@1 as __sail_file_path]
+                        FilterExec: id@0 < 10
+                          ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                            IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                              DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+  
+  
+    physical_plan after CombinePartialFinalAggregate:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EnforceSorting:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after OptimizeAggregateOrder:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after WindowTopN:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after ProjectionPushdown:
+    OutputRequirementExec: order_by=[], dist_by=Unspecified
+      IcebergCommitExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+        CoalescePartitionsExec
+          UnionExec
+            IcebergWriterExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+              UnionExec
+                FilterExec: (__sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8) AND __sail_file_path@1 IS NULL, projection=[id@0]
+                  ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+                    ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                      IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                        DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+                FilterExec: __sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8, projection=[id@0]
+                  HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(__sail_file_path@0, __sail_file_path@1)], projection=[id@1, __sail_file_path@2, __sail_operation_type@3]
+                    CoalescePartitionsExec
+                      AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                        RepartitionExec: partitioning=Hash([__sail_file_path@0], 4), input_partitions=4
+                          AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                            FilterExec: id@0 < 10, projection=[__sail_file_path@1]
+                              ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                                IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                                  DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+                    ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+                      ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                        IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                          DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+            IcebergRemoveDataFilesExec(file_path_column=__sail_file_path)
+              AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                RepartitionExec: partitioning=Hash([__sail_file_path@0], 4), input_partitions=4
+                  AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                    FilterExec: id@0 < 10, projection=[__sail_file_path@1]
+                      ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                        IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                          DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+  
+  
+    physical_plan after OutputRequirements:
+    IcebergCommitExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+      CoalescePartitionsExec
+        UnionExec
+          IcebergWriterExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+            UnionExec
+              FilterExec: (__sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8) AND __sail_file_path@1 IS NULL, projection=[id@0]
+                ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+                  ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                    IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                      DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+              FilterExec: __sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8, projection=[id@0]
+                HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(__sail_file_path@0, __sail_file_path@1)], projection=[id@1, __sail_file_path@2, __sail_operation_type@3]
+                  CoalescePartitionsExec
+                    AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                      RepartitionExec: partitioning=Hash([__sail_file_path@0], 4), input_partitions=4
+                        AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                          FilterExec: id@0 < 10, projection=[__sail_file_path@1]
+                            ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                              IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                                DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+                  ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+                    ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                      IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                        DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+          IcebergRemoveDataFilesExec(file_path_column=__sail_file_path)
+            AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+              RepartitionExec: partitioning=Hash([__sail_file_path@0], 4), input_partitions=4
+                AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                  FilterExec: id@0 < 10, projection=[__sail_file_path@1]
+                    ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                      IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                        DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+  
+  
+    physical_plan after LimitAggregation:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after LimitPushPastWindows:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after HashJoinBuffering:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after LimitPushdown:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after TopKRepartition:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after ProjectionPushdown:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after PushdownSort:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EnsureCooperative:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after FilterPushdown(Post):
+    SAME TEXT AS ABOVE
+  
+    physical_plan after RewriteExplicitRepartition:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after RewriteCollectLeftHashJoin:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after EnforceBarrierPartitioning:
+    SAME TEXT AS ABOVE
+  
+    physical_plan after SanityCheckPlan:
+    SAME TEXT AS ABOVE
+  
+    physical_plan:
+    IcebergCommitExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+      CoalescePartitionsExec
+        UnionExec
+          IcebergWriterExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+            UnionExec
+              FilterExec: (__sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8) AND __sail_file_path@1 IS NULL, projection=[id@0]
+                ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+                  ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                    IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                      DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+              FilterExec: __sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8, projection=[id@0]
+                HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(__sail_file_path@0, __sail_file_path@1)], projection=[id@1, __sail_file_path@2, __sail_operation_type@3]
+                  CoalescePartitionsExec
+                    AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                      RepartitionExec: partitioning=Hash([__sail_file_path@0], 4), input_partitions=4
+                        AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                          FilterExec: id@0 < 10, projection=[__sail_file_path@1]
+                            ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                              IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                                DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+                  ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+                    ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                      IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                        DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+          IcebergRemoveDataFilesExec(file_path_column=__sail_file_path)
+            AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+              RepartitionExec: partitioning=Hash([__sail_file_path@0], 4), input_partitions=4
+                AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                  FilterExec: id@0 < 10, projection=[__sail_file_path@1]
+                    ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                      IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                        DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+  
+  
+    == Physical Plan ==
+    IcebergCommitExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+      CoalescePartitionsExec
+        UnionExec
+          IcebergWriterExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+            UnionExec
+              FilterExec: (__sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8) AND __sail_file_path@1 IS NULL, projection=[id@0]
+                ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+                  ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                    IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                      DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+              FilterExec: __sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8, projection=[id@0]
+                HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(__sail_file_path@0, __sail_file_path@1)], projection=[id@1, __sail_file_path@2, __sail_operation_type@3]
+                  CoalescePartitionsExec
+                    AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                      RepartitionExec: partitioning=Hash([__sail_file_path@0], 4), input_partitions=4
+                        AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                          FilterExec: id@0 < 10, projection=[__sail_file_path@1]
+                            ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                              IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                                DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+                  ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+                    ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                      IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                        DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+          IcebergRemoveDataFilesExec(file_path_column=__sail_file_path)
+            AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+              RepartitionExec: partitioning=Hash([__sail_file_path@0], 4), input_partitions=4
+                AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+                  FilterExec: id@0 < 10, projection=[__sail_file_path@1]
+                    ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+                      IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                        DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+  
+  
+    == Distributed Plan ==
+    === stage 0 ===
+    inputs=[]
+    mode=Pipelined
+    partitions=4
+    distribution=Hash(keys=[__sail_file_path@0], channels=4)
+    placement=Worker
+    AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+      FilterExec: id@0 < 10, projection=[__sail_file_path@1]
+        ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+          IcebergMergeMetadataExec: data_file_column=__sail_file_path
+            DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+  
+    === stage 1 ===
+    inputs=[StageInput(stage=0, mode=Shuffle)]
+    mode=Pipelined
+    partitions=4
+    distribution=RoundRobinBatch(channels=1)
+    placement=Worker
+    AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+      StageInputExec: input=0, partitioning=Hash([__sail_file_path@0], 4)
+  
+    === stage 2 ===
+    inputs=[]
+    mode=Pipelined
+    partitions=4
+    distribution=Hash(keys=[__sail_file_path@0], channels=4)
+    placement=Worker
+    AggregateExec: mode=Partial, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+      FilterExec: id@0 < 10, projection=[__sail_file_path@1]
+        ProjectionExec: expr=[id@0 as id, __sail_file_path@1 as __sail_file_path]
+          IcebergMergeMetadataExec: data_file_column=__sail_file_path
+            DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+  
+    === stage 3 ===
+    inputs=[StageInput(stage=1, mode=Broadcast), StageInput(stage=2, mode=Shuffle)]
+    mode=Pipelined
+    partitions=12
+    distribution=RoundRobinBatch(channels=1)
+    placement=Worker
+    UnionExec
+      IcebergWriterExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+        UnionExec
+          FilterExec: (__sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8) AND __sail_file_path@1 IS NULL, projection=[id@0]
+            ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+              ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                  DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+          FilterExec: __sail_operation_type@2 = 0 OR __sail_operation_type@2 = 2 OR __sail_operation_type@2 = 3 OR __sail_operation_type@2 = 6 OR __sail_operation_type@2 = 8, projection=[id@0]
+            HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(__sail_file_path@0, __sail_file_path@1)], projection=[id@1, __sail_file_path@2, __sail_operation_type@3]
+              StageInputExec: input=0, partitioning=UnknownPartitioning(1)
+              ProjectionExec: expr=[CASE WHEN __common_expr_1@0 THEN id@1 + 1000 ELSE id@1 END as id, __sail_file_path@2 as __sail_file_path, CASE WHEN __common_expr_1@0 THEN 2 ELSE 0 END as __sail_operation_type]
+                ProjectionExec: expr=[id@0 < 10 as __common_expr_1, id@0 as id, __sail_file_path@1 as __sail_file_path]
+                  IcebergMergeMetadataExec: data_file_column=__sail_file_path
+                    DataSourceExec: file_groups={4 groups: [[<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000000.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000001.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000002.parquet], [<tmp>/distributed_iceberg_commit/data/part-<uuid>-00000000000000000003.parquet]]}, projection=[id, __sail_file_path, __sail_iceberg_partition_spec_id, __sail_iceberg_partition], file_type=parquet
+      IcebergRemoveDataFilesExec(file_path_column=__sail_file_path)
+        AggregateExec: mode=FinalPartitioned, gby=[__sail_file_path@0 as __sail_file_path], aggr=[]
+          StageInputExec: input=1, partitioning=Hash([__sail_file_path@0], 4)
+  
+    === stage 4 ===
+    inputs=[StageInput(stage=3, mode=Shuffle)]
+    mode=Pipelined
+    partitions=1
+    distribution=RoundRobinBatch(channels=1)
+    placement=Driver
+    IcebergCommitExec(table_path=file://<tmp>/distributed_iceberg_commit/)
+      StageInputExec: input=0, partitioning=UnknownPartitioning(1)
+  
+    === stage 5 ===
+    inputs=[StageInput(stage=4, mode=Forward)]
+    mode=Pipelined
+    partitions=1
+    distribution=RoundRobinBatch(channels=1)
+    placement=Worker
+    StageInputExec: input=0, partitioning=UnknownPartitioning(1)

--- a/python/pysail/tests/spark/execution/features/lakehouse_commit.feature
+++ b/python/pysail/tests/spark/execution/features/lakehouse_commit.feature
@@ -75,3 +75,34 @@ Feature: Lakehouse commits in distributed execution
       Then query result
         | count |
         | 400   |
+
+    Scenario: Iceberg copy-on-write keeps rewriting on workers and commit on the driver
+      Given statement
+        """
+        INSERT INTO distributed_iceberg_commit
+        SELECT id FROM range(0, 400, 1, 4)
+        """
+      When query
+        """
+        EXPLAIN CODEGEN
+        UPDATE distributed_iceberg_commit
+        SET id = id + 1000
+        WHERE id < 10
+        """
+      Then query plan matches snapshot
+      Given statement
+        """
+        UPDATE distributed_iceberg_commit
+        SET id = id + 1000
+        WHERE id < 10
+        """
+      When query
+        """
+        SELECT
+          COUNT(*) AS count,
+          SUM(CASE WHEN id >= 1000 THEN 1 ELSE 0 END) AS updated
+        FROM distributed_iceberg_commit
+        """
+      Then query result
+        | count | updated |
+        | 400   | 10      |

--- a/python/pysail/tests/spark/iceberg/__snapshots__/features/copy_on_write.yaml
+++ b/python/pysail/tests/spark/iceberg/__snapshots__/features/copy_on_write.yaml
@@ -1,0 +1,132 @@
+# serializer version: 1
+---
+name: "test_partial_update_snapshots_replacement_metadata"
+data:
+  current-schema-id: 0
+  current-snapshot-id: <snapshot-id>
+  default-sort-order-id: 0
+  default-spec-id: 0
+  format-version: 2
+  last-column-id: 3
+  last-partition-id: 999
+  last-sequence-number: 2
+  last-updated-ms: <timestamp>
+  location: file://<root>/iceberg_cow_metadata/
+  metadata-log:
+  - metadata-file: <tmp>/iceberg_cow_metadata/metadata/v1.metadata.json
+    timestamp-ms: <timestamp>
+  - metadata-file: <tmp>/iceberg_cow_metadata/metadata/v2.metadata.json
+    timestamp-ms: <timestamp>
+  partition-specs:
+  - fields: []
+    spec-id: 0
+  properties:
+    write.update.mode: copy-on-write
+  refs:
+    main:
+      snapshot-id: <snapshot-id>
+      type: branch
+  schemas:
+  - fields:
+    - id: 1
+      name: id
+      required: false
+      type: int
+    - id: 2
+      name: value
+      required: false
+      type: string
+    - id: 3
+      name: selected
+      required: false
+      type: boolean
+    schema-id: 0
+    type: struct
+  snapshot-log:
+  - snapshot-id: <snapshot-id>
+    timestamp-ms: <timestamp>
+  - snapshot-id: <snapshot-id>
+    timestamp-ms: <timestamp>
+  snapshots:
+  - manifest-list: file://<root>/metadata/snap-<id>.avro
+    schema-id: 0
+    sequence-number: 1
+    snapshot-id: <snapshot-id>
+    summary:
+      added-data-files: '1'
+      added-records: '3'
+      operation: append
+      total-data-files: '1'
+      total-delete-files: '0'
+      total-equality-deletes: '0'
+      total-position-deletes: '0'
+      total-records: '3'
+    timestamp-ms: <timestamp>
+  - manifest-list: file://<root>/metadata/snap-<id>.avro
+    parent-snapshot-id: <parent-snapshot-id>
+    schema-id: 0
+    sequence-number: 2
+    snapshot-id: <snapshot-id>
+    summary:
+      added-data-files: '1'
+      added-records: '3'
+      deleted-data-files: '1'
+      deleted-records: '3'
+      operation: overwrite
+      total-data-files: '1'
+      total-delete-files: '0'
+      total-equality-deletes: '0'
+      total-position-deletes: '0'
+      total-records: '3'
+    timestamp-ms: <timestamp>
+  sort-orders:
+  - fields: []
+    order-id: 0
+  table-uuid: <uuid>
+---
+name: "test_partial_update_snapshots_replacement_metadata.1"
+data:
+  manifests:
+  - added-files-count: 0
+    added-rows-count: 0
+    added-snapshot-id: <snapshot-id>
+    content: data
+    deleted-files-count: 1
+    deleted-rows-count: 3
+    existing-files-count: 0
+    existing-rows-count: 0
+    key-metadata: null
+    manifest-length: <bytes>
+    manifest-path: file://<root>/metadata/manifest-<uuid>.avro
+    min-sequence-number: 2
+    partition-spec-id: 0
+    partitions: null
+    sequence-number: 2
+  - added-files-count: 1
+    added-rows-count: 3
+    added-snapshot-id: <snapshot-id>
+    content: data
+    deleted-files-count: 0
+    deleted-rows-count: 0
+    existing-files-count: 0
+    existing-rows-count: 0
+    key-metadata: null
+    manifest-length: <bytes>
+    manifest-path: file://<root>/metadata/manifest-<uuid>.avro
+    min-sequence-number: 2
+    partition-spec-id: 0
+    partitions: null
+    sequence-number: 2
+---
+name: "test_partial_update_snapshots_replacement_metadata.2"
+data:
+  added-data-files: '1'
+  added-records: '3'
+  deleted-data-files: '1'
+  deleted-records: '3'
+  operation: overwrite
+  total-data-files: '1'
+  total-delete-files: '0'
+  total-equality-deletes: '0'
+  total-position-deletes: '0'
+  total-records: '3'

--- a/python/pysail/tests/spark/iceberg/features/copy_on_write.feature
+++ b/python/pysail/tests/spark/iceberg/features/copy_on_write.feature
@@ -1,0 +1,53 @@
+Feature: Iceberg copy-on-write row operations
+
+  Rule: Copy-on-write metadata
+    Background:
+      Given variable location for temporary directory iceberg_cow_metadata
+      Given final statement
+        """
+        DROP TABLE IF EXISTS iceberg_cow_metadata
+        """
+      Given statement template
+        """
+        CREATE TABLE iceberg_cow_metadata (
+          id INT,
+          value STRING,
+          selected BOOLEAN
+        )
+        USING iceberg
+        LOCATION {{ location.uri }}
+        TBLPROPERTIES (
+          'format-version' = '2',
+          'write.update.mode' = 'copy-on-write'
+        )
+        """
+      Given statement
+        """
+        INSERT INTO iceberg_cow_metadata VALUES
+          (1, 'change', true),
+          (2, 'keep', false),
+          (3, 'unknown', NULL)
+        """
+
+    Scenario: Partial UPDATE snapshots replacement metadata
+      Given statement
+        """
+        UPDATE iceberg_cow_metadata
+        SET value = concat(value, '-updated')
+        WHERE selected
+        """
+      Then iceberg metadata matches snapshot
+      Then iceberg current manifest list matches snapshot
+      Then iceberg current snapshot summary matches snapshot
+      Then iceberg snapshot count is 2
+      When query
+        """
+        SELECT id, value, selected
+        FROM iceberg_cow_metadata
+        ORDER BY id
+        """
+      Then query result ordered
+        | id | value          | selected |
+        | 1  | change-updated | true     |
+        | 2  | keep           | false    |
+        | 3  | unknown        | NULL     |

--- a/python/pysail/tests/spark/iceberg/test_iceberg_equality_delete.py
+++ b/python/pysail/tests/spark/iceberg/test_iceberg_equality_delete.py
@@ -1,3 +1,5 @@
+# ruff: noqa: S608
+
 import time
 import uuid
 from pathlib import Path
@@ -361,8 +363,8 @@ def test_iceberg_sql_delete_rejects_partitioned_equality_delete_without_metadata
 
 
 @pytest.mark.parametrize("delete_mode", [None, "copy-on-write"], ids=["default", "explicit-cow"])
-def test_iceberg_sql_delete_rejects_copy_on_write_before_scanning_empty_table(spark, tmp_path, delete_mode):
-    table_name = "iceberg_delete_copy_on_write_reject"
+def test_iceberg_sql_delete_copy_on_write_rewrites_only_touched_files(spark, tmp_path, delete_mode):
+    table_name = "iceberg_delete_copy_on_write"
     table_path = tmp_path / table_name
     mode_property = "" if delete_mode is None else f", 'write.delete.mode' = '{delete_mode}'"
 
@@ -372,22 +374,46 @@ def test_iceberg_sql_delete_rejects_copy_on_write_before_scanning_empty_table(sp
             f"""
             CREATE TABLE {table_name} (
               id BIGINT,
-              name STRING
+              name STRING,
+              selected BOOLEAN
             )
             USING iceberg
             LOCATION '{_uri_sql(table_path)}'
             TBLPROPERTIES ('format-version' = '2'{mode_property})
             """
         )
-        before_metadata_path = _latest_metadata_path(table_path)
-        before_parquet_files = _parquet_file_paths(table_path)
+        spark.sql(f"INSERT INTO {table_name} VALUES (1, 'drop', true), (2, 'keep', false), (3, 'unknown', NULL)")
+        spark.sql(f"INSERT INTO {table_name} VALUES (4, 'untouched', false)")
+        before_manifests = _current_manifest_list(_find_latest_metadata(table_path))["manifests"]
+        before_manifest_paths = {manifest["manifest-path"] for manifest in before_manifests}
+        before_noop_metadata_path = _latest_metadata_path(table_path)
 
-        with pytest.raises(Exception, match=r"write\.delete\.mode=copy-on-write|copy-on-write.*not supported"):
-            spark.sql("DELETE FROM iceberg_delete_copy_on_write_reject WHERE id = 1").collect()
+        spark.sql(f"DELETE FROM {table_name} WHERE id = 999").collect()
+        assert _latest_metadata_path(table_path) == before_noop_metadata_path
 
-        assert spark.sql("SELECT * FROM iceberg_delete_copy_on_write_reject").collect() == []
-        assert _latest_metadata_path(table_path) == before_metadata_path
-        assert _parquet_file_paths(table_path) == before_parquet_files
+        spark.sql(f"DELETE FROM {table_name} AS target WHERE target.selected").collect()
+
+        rows = [tuple(row) for row in spark.sql(f"SELECT id, name, selected FROM {table_name} ORDER BY id").collect()]
+        assert rows == [
+            (2, "keep", False),
+            (3, "unknown", None),
+            (4, "untouched", False),
+        ]
+        metadata = _find_latest_metadata(table_path)
+        snapshot = _current_snapshot(metadata)
+        assert snapshot["summary"]["operation"] == "delete"
+        assert snapshot["summary"]["deleted-data-files"] == "1"
+        assert snapshot["summary"]["deleted-records"] == "3"
+        assert snapshot["summary"]["added-records"] == "2"
+        manifests = _current_manifest_list(metadata)["manifests"]
+        assert all(manifest.get("content") == "data" for manifest in manifests)
+        assert before_manifest_paths & {manifest["manifest-path"] for manifest in manifests}
+
+        spark.sql(f"DELETE FROM {table_name}").collect()
+        assert spark.sql(f"SELECT * FROM {table_name}").collect() == []
+        final_snapshot = _current_snapshot(_find_latest_metadata(table_path))
+        assert final_snapshot["summary"]["operation"] == "delete"
+        assert final_snapshot["summary"]["total-records"] == "0"
     finally:
         _drop_table(spark, table_name)
 

--- a/python/pysail/tests/spark/iceberg/test_iceberg_equality_delete.py
+++ b/python/pysail/tests/spark/iceberg/test_iceberg_equality_delete.py
@@ -384,12 +384,22 @@ def test_iceberg_sql_delete_copy_on_write_rewrites_only_touched_files(spark, tmp
         )
         spark.sql(f"INSERT INTO {table_name} VALUES (1, 'drop', true), (2, 'keep', false), (3, 'unknown', NULL)")
         spark.sql(f"INSERT INTO {table_name} VALUES (4, 'untouched', false)")
-        before_manifests = _current_manifest_list(_find_latest_metadata(table_path))["manifests"]
+        before_noop_metadata = _find_latest_metadata(table_path)
+        before_manifests = _current_manifest_list(before_noop_metadata)["manifests"]
         before_manifest_paths = {manifest["manifest-path"] for manifest in before_manifests}
         before_noop_metadata_path = _latest_metadata_path(table_path)
+        before_manifest_files = set((table_path / "metadata").glob("manifest-*.avro"))
 
         spark.sql(f"DELETE FROM {table_name} WHERE id = 999").collect()
-        assert _latest_metadata_path(table_path) == before_noop_metadata_path
+        noop_metadata = _find_latest_metadata(table_path)
+        noop_snapshot = _current_snapshot(noop_metadata)
+        assert _latest_metadata_path(table_path) != before_noop_metadata_path
+        assert len(noop_metadata["snapshots"]) == len(before_noop_metadata["snapshots"]) + 1
+        assert noop_snapshot["summary"]["operation"] == "overwrite"
+        assert {
+            manifest["manifest-path"] for manifest in _current_manifest_list(noop_metadata)["manifests"]
+        } == before_manifest_paths
+        assert set((table_path / "metadata").glob("manifest-*.avro")) == before_manifest_files
 
         spark.sql(f"DELETE FROM {table_name} AS target WHERE target.selected").collect()
 
@@ -401,7 +411,7 @@ def test_iceberg_sql_delete_copy_on_write_rewrites_only_touched_files(spark, tmp
         ]
         metadata = _find_latest_metadata(table_path)
         snapshot = _current_snapshot(metadata)
-        assert snapshot["summary"]["operation"] == "delete"
+        assert snapshot["summary"]["operation"] == "overwrite"
         assert snapshot["summary"]["deleted-data-files"] == "1"
         assert snapshot["summary"]["deleted-records"] == "3"
         assert snapshot["summary"]["added-records"] == "2"

--- a/python/pysail/tests/spark/iceberg/test_iceberg_merge.py
+++ b/python/pysail/tests/spark/iceberg/test_iceberg_merge.py
@@ -484,6 +484,49 @@ def test_iceberg_merge_copy_on_write_runtime_insert_only_uses_append_snapshot(sp
         _drop_table(spark, table_name)
 
 
+def test_iceberg_merge_copy_on_write_empty_insert_only_uses_overwrite_snapshot(spark, tmp_path):
+    table_name = "iceberg_merge_copy_on_write_empty_insert"
+    table_path = tmp_path / table_name
+
+    _drop_table(spark, table_name)
+    try:
+        spark.sql(
+            f"""
+            CREATE TABLE {table_name} (id INT, value STRING)
+            USING iceberg
+            LOCATION '{_uri_sql(table_path)}'
+            TBLPROPERTIES ('format-version' = '2', 'write.merge.mode' = 'copy-on-write')
+            """
+        )
+        spark.sql(f"INSERT INTO {table_name} VALUES (1, 'keep')")
+        spark.sql(
+            """
+            CREATE OR REPLACE TEMP VIEW iceberg_merge_copy_on_write_empty_source AS
+            SELECT 2 AS id, 'missing' AS value WHERE false
+            """
+        )
+        before_metadata = _find_latest_metadata(table_path)
+        before_manifest_paths = {manifest["manifest-path"] for manifest in _current_manifests(table_path)}
+
+        spark.sql(
+            f"""
+            MERGE INTO {table_name} AS t
+            USING iceberg_merge_copy_on_write_empty_source AS s
+            ON t.id = s.id
+            WHEN NOT MATCHED THEN INSERT *
+            """
+        ).collect()
+
+        after_metadata = _find_latest_metadata(table_path)
+        after_snapshot = _current_snapshot(after_metadata)
+        assert len(after_metadata["snapshots"]) == len(before_metadata["snapshots"]) + 1
+        assert after_snapshot["summary"]["operation"] == "overwrite"
+        assert {manifest["manifest-path"] for manifest in _current_manifests(table_path)} == before_manifest_paths
+        assert [tuple(row) for row in spark.table(table_name).collect()] == [(1, "keep")]
+    finally:
+        _drop_table(spark, table_name)
+
+
 def test_iceberg_merge_rejects_position_deletes_on_v1_table(spark, tmp_path):
     table_name = "iceberg_merge_v1_position_delete"
     table_path = tmp_path / table_name
@@ -915,7 +958,8 @@ def test_iceberg_merge_row_delta_snapshot_operation_tracks_written_files(spark, 
         _drop_table(spark, table_name)
 
 
-def test_iceberg_noop_merge_reuses_parent_manifests_with_overwrite_snapshot(spark, tmp_path):
+@pytest.mark.parametrize("merge_mode", ["merge-on-read", "copy-on-write"], ids=["mor", "cow"])
+def test_iceberg_noop_merge_reuses_parent_manifests_with_overwrite_snapshot(spark, tmp_path, merge_mode):
     table_name = "iceberg_merge_noop_snapshot"
     table_path = tmp_path / table_name
 
@@ -931,7 +975,7 @@ def test_iceberg_noop_merge_reuses_parent_manifests_with_overwrite_snapshot(spar
             LOCATION '{_uri_sql(table_path)}'
             TBLPROPERTIES (
               'format-version' = '2',
-              'write.merge.mode' = 'merge-on-read'
+              'write.merge.mode' = '{merge_mode}'
             )
             """
         )

--- a/python/pysail/tests/spark/iceberg/test_iceberg_merge.py
+++ b/python/pysail/tests/spark/iceberg/test_iceberg_merge.py
@@ -1,3 +1,5 @@
+# ruff: noqa: S608
+
 from pathlib import Path
 from urllib.parse import urlparse
 from urllib.request import url2pathname
@@ -350,8 +352,8 @@ def test_iceberg_merge_rejects_multiple_source_rows_for_one_target_row(spark, tm
 
 
 @pytest.mark.parametrize("merge_mode", [None, "copy-on-write"], ids=["default", "explicit-cow"])
-def test_iceberg_merge_rejects_copy_on_write_before_writing_empty_table(spark, tmp_path, merge_mode):
-    table_name = "iceberg_merge_copy_on_write_reject"
+def test_iceberg_merge_copy_on_write_inserts_into_empty_table(spark, tmp_path, merge_mode):
+    table_name = "iceberg_merge_copy_on_write_insert"
     table_path = tmp_path / table_name
     mode_property = "" if merge_mode is None else f", 'write.merge.mode' = '{merge_mode}'"
 
@@ -374,22 +376,110 @@ def test_iceberg_merge_rejects_copy_on_write_before_writing_empty_table(spark, t
             SELECT * FROM VALUES (1, 'new') AS src(id, value)
             """
         )
-        before_metadata_path = _latest_metadata_path(table_path)
-        before_parquet_files = _parquet_file_paths(table_path)
+        spark.sql(
+            f"""
+            MERGE INTO {table_name} AS t
+            USING iceberg_merge_copy_on_write_source AS s
+            ON t.id = s.id
+            WHEN NOT MATCHED THEN INSERT *
+            """
+        ).collect()
 
-        with pytest.raises(Exception, match=r"write\.merge\.mode=copy-on-write|copy-on-write.*not supported"):
-            spark.sql(
-                f"""
-                MERGE INTO {table_name} AS t
-                USING iceberg_merge_copy_on_write_source AS s
-                ON t.id = s.id
-                WHEN NOT MATCHED THEN INSERT *
-                """
-            ).collect()
+        rows = [tuple(row) for row in spark.sql(f"SELECT id, value FROM {table_name}").collect()]
+        assert rows == [(1, "new")]
+        snapshot = _current_snapshot(_find_latest_metadata(table_path))
+        assert snapshot["summary"]["operation"] == "append"
+    finally:
+        _drop_table(spark, table_name)
 
-        assert spark.sql("SELECT * FROM iceberg_merge_copy_on_write_reject").collect() == []
-        assert _latest_metadata_path(table_path) == before_metadata_path
-        assert _parquet_file_paths(table_path) == before_parquet_files
+
+def test_iceberg_merge_copy_on_write_updates_deletes_inserts_and_copies_touched_rows(spark, tmp_path):
+    table_name = "iceberg_merge_copy_on_write_rows"
+    table_path = tmp_path / table_name
+
+    _drop_table(spark, table_name)
+    try:
+        spark.sql(
+            f"""
+            CREATE TABLE {table_name} (id INT, value STRING)
+            USING iceberg
+            LOCATION '{_uri_sql(table_path)}'
+            TBLPROPERTIES ('format-version' = '2', 'write.merge.mode' = 'copy-on-write')
+            """
+        )
+        spark.sql(f"INSERT INTO {table_name} VALUES (1, 'old'), (2, 'delete'), (3, 'copy')")
+        spark.sql(
+            """
+            CREATE OR REPLACE TEMP VIEW iceberg_merge_copy_on_write_rows_source AS
+            SELECT * FROM VALUES
+              (1, 'updated', 'update'),
+              (2, 'ignored', 'delete'),
+              (4, 'inserted', 'insert')
+            AS src(id, value, action)
+            """
+        )
+
+        spark.sql(
+            f"""
+            MERGE INTO {table_name} AS t
+            USING iceberg_merge_copy_on_write_rows_source AS s
+            ON t.id = s.id
+            WHEN MATCHED AND s.action = 'delete' THEN DELETE
+            WHEN MATCHED THEN UPDATE SET value = s.value
+            WHEN NOT MATCHED THEN INSERT (id, value) VALUES (s.id, s.value)
+            """
+        ).collect()
+
+        rows = [tuple(row) for row in spark.sql(f"SELECT id, value FROM {table_name} ORDER BY id").collect()]
+        assert rows == [(1, "updated"), (3, "copy"), (4, "inserted")]
+        metadata = _find_latest_metadata(table_path)
+        snapshot = _current_snapshot(metadata)
+        assert snapshot["summary"]["operation"] == "overwrite"
+        assert snapshot["summary"]["deleted-data-files"] == "1"
+        assert snapshot["summary"]["deleted-records"] == "3"
+        assert snapshot["summary"]["added-records"] == "3"
+        manifests = _current_manifest_list(metadata)["manifests"]
+        assert all(manifest.get("content") == "data" for manifest in manifests)
+    finally:
+        _drop_table(spark, table_name)
+
+
+def test_iceberg_merge_copy_on_write_runtime_insert_only_uses_append_snapshot(spark, tmp_path):
+    table_name = "iceberg_merge_copy_on_write_runtime_insert"
+    table_path = tmp_path / table_name
+
+    _drop_table(spark, table_name)
+    try:
+        spark.sql(
+            f"""
+            CREATE TABLE {table_name} (id INT, value STRING)
+            USING iceberg
+            LOCATION '{_uri_sql(table_path)}'
+            TBLPROPERTIES ('format-version' = '2')
+            """
+        )
+        spark.sql(f"INSERT INTO {table_name} VALUES (1, 'old')")
+        spark.sql(
+            """
+            CREATE OR REPLACE TEMP VIEW iceberg_merge_copy_on_write_runtime_source AS
+            SELECT 2 AS id, 'new' AS value
+            """
+        )
+
+        spark.sql(
+            f"""
+            MERGE INTO {table_name} AS t
+            USING iceberg_merge_copy_on_write_runtime_source AS s
+            ON t.id = s.id
+            WHEN MATCHED THEN UPDATE SET value = s.value
+            WHEN NOT MATCHED THEN INSERT *
+            """
+        ).collect()
+
+        rows = [tuple(row) for row in spark.sql(f"SELECT id, value FROM {table_name} ORDER BY id").collect()]
+        assert rows == [(1, "old"), (2, "new")]
+        snapshot = _current_snapshot(_find_latest_metadata(table_path))
+        assert snapshot["summary"]["operation"] == "append"
     finally:
         _drop_table(spark, table_name)
 
@@ -588,9 +678,7 @@ def test_iceberg_merge_updates_rows_beyond_the_first_input_batch(spark, tmp_path
 
         rows = [
             tuple(row)
-            for row in spark.sql(
-                f"SELECT id, value FROM iceberg_merge_multi_batch WHERE id = {target_id}"  # noqa: S608
-            ).collect()
+            for row in spark.sql(f"SELECT id, value FROM iceberg_merge_multi_batch WHERE id = {target_id}").collect()
         ]
         assert rows == [(target_id, "updated")]
     finally:
@@ -619,9 +707,7 @@ def test_iceberg_merge_uses_absolute_positions_for_large_multi_row_group_file(sp
             """
         )
         large_file_insert_sql = (
-            f"INSERT INTO {table_name} "  # noqa: S608
-            "SELECT id, sha2(CAST(id AS STRING), 256) AS value "
-            "FROM range(4400000)"
+            f"INSERT INTO {table_name} SELECT id, sha2(CAST(id AS STRING), 256) AS value FROM range(4400000)"
         )
         spark.sql(large_file_insert_sql)
 
@@ -646,7 +732,7 @@ def test_iceberg_merge_uses_absolute_positions_for_large_multi_row_group_file(sp
             """
         ).collect()
 
-        target_row_sql = f"SELECT id, value FROM {table_name} WHERE id = {target_id}"  # noqa: S608
+        target_row_sql = f"SELECT id, value FROM {table_name} WHERE id = {target_id}"
         rows = [tuple(row) for row in spark.sql(target_row_sql).collect()]
         assert rows == [(target_id, "updated")]
 
@@ -912,8 +998,8 @@ def test_iceberg_merge_partition_delete_granularity_groups_data_files(
             )
             """
         )
-        spark.sql(f"INSERT INTO {table_name} VALUES (1, 'one', 'same')")  # noqa: S608
-        spark.sql(f"INSERT INTO {table_name} VALUES (2, 'two', 'same')")  # noqa: S608
+        spark.sql(f"INSERT INTO {table_name} VALUES (1, 'one', 'same')")
+        spark.sql(f"INSERT INTO {table_name} VALUES (2, 'two', 'same')")
 
         before_data_entries = _current_manifest_entries(table_path, ManifestContent.DATA)
         before_data_paths = {entry.data_file.file_path for entry in before_data_entries}

--- a/python/pysail/tests/spark/iceberg/test_iceberg_update.py
+++ b/python/pysail/tests/spark/iceberg/test_iceberg_update.py
@@ -10,6 +10,7 @@ from pysail.testing.spark.steps.iceberg import (
     _current_manifest_list,
     _current_snapshot,
     _find_latest_metadata,
+    _latest_metadata_path,
     _pyarrow_input_file,
 )
 from pysail.testing.spark.utils.sql import escape_sql_string_literal
@@ -21,6 +22,10 @@ def _uri_sql(path: Path) -> str:
 
 def _drop_table(spark, name: str) -> None:
     spark.sql(f"DROP TABLE IF EXISTS {name}")
+
+
+def _parquet_file_paths(table_path: Path) -> set[Path]:
+    return {path.relative_to(table_path) for path in table_path.rglob("*.parquet")}
 
 
 @pytest.mark.parametrize("update_mode", [None, "copy-on-write"], ids=["default", "explicit-cow"])
@@ -166,7 +171,7 @@ def test_iceberg_copy_on_write_rewrites_live_rows_after_merge_on_read_delete(spa
         _drop_table(spark, table_name)
 
 
-@pytest.mark.parametrize("format_version", ["1", "2", "3"])
+@pytest.mark.parametrize("format_version", ["1", "2"])
 def test_iceberg_copy_on_write_operations_support_table_format_versions(spark, tmp_path, format_version):
     table_name = f"iceberg_cow_format_v{format_version}"
     table_path = tmp_path / table_name
@@ -199,6 +204,11 @@ def test_iceberg_copy_on_write_operations_support_table_format_versions(spark, t
         assert rows == [(1, "updated"), (3, "inserted")]
         metadata = _find_latest_metadata(table_path)
         snapshot = _current_snapshot(metadata)
+        if format_version == "1":
+            assert "last-sequence-number" not in metadata
+            assert all("sequence-number" not in item for item in metadata["snapshots"])
+        else:
+            assert metadata["last-sequence-number"] == snapshot["sequence-number"]
         io = PyArrowFileIO()
         entries = [
             entry
@@ -209,5 +219,57 @@ def test_iceberg_copy_on_write_operations_support_table_format_versions(spark, t
         assert sum(
             entry.data_file.record_count for entry in entries if entry.status != ManifestEntryStatus.DELETED
         ) == len(rows)
+        assert all(entry.snapshot_id for entry in entries)
+    finally:
+        _drop_table(spark, table_name)
+
+
+def test_iceberg_v3_copy_on_write_rejects_target_rewrites_without_side_effects(spark, tmp_path):
+    table_name = "iceberg_cow_v3_row_lineage_reject"
+    table_path = tmp_path / table_name
+
+    _drop_table(spark, table_name)
+    try:
+        spark.sql(
+            f"""
+            CREATE TABLE {table_name} (id INT, value STRING)
+            USING iceberg
+            LOCATION '{_uri_sql(table_path)}'
+            TBLPROPERTIES ('format-version' = '3')
+            """
+        )
+        spark.sql(f"INSERT INTO {table_name} VALUES (1, 'old')")
+        spark.sql("CREATE OR REPLACE TEMP VIEW iceberg_cow_v3_insert_source AS SELECT 2 AS id, 'inserted' AS value")
+        spark.sql(
+            f"""
+            MERGE INTO {table_name} AS target
+            USING iceberg_cow_v3_insert_source AS source
+            ON target.id = source.id
+            WHEN NOT MATCHED THEN INSERT *
+            """
+        ).collect()
+        assert _current_snapshot(_find_latest_metadata(table_path))["summary"]["operation"] == "append"
+
+        spark.sql("CREATE OR REPLACE TEMP VIEW iceberg_cow_v3_match_source AS SELECT 1 AS id, 'new' AS value")
+        before_metadata_path = _latest_metadata_path(table_path)
+        before_parquet_files = _parquet_file_paths(table_path)
+        statements = [
+            f"UPDATE {table_name} SET value = 'updated' WHERE id = 1",
+            f"DELETE FROM {table_name} WHERE id = 1",
+            f"""
+            MERGE INTO {table_name} AS target
+            USING iceberg_cow_v3_match_source AS source
+            ON target.id = source.id
+            WHEN MATCHED THEN UPDATE SET value = source.value
+            """,
+        ]
+        for statement in statements:
+            with pytest.raises(Exception, match=r"v3 copy-on-write.*row lineage"):
+                spark.sql(statement).collect()
+            assert _latest_metadata_path(table_path) == before_metadata_path
+            assert _parquet_file_paths(table_path) == before_parquet_files
+
+        rows = [tuple(row) for row in spark.sql(f"SELECT id, value FROM {table_name} ORDER BY id").collect()]
+        assert rows == [(1, "old"), (2, "inserted")]
     finally:
         _drop_table(spark, table_name)

--- a/python/pysail/tests/spark/iceberg/test_iceberg_update.py
+++ b/python/pysail/tests/spark/iceberg/test_iceberg_update.py
@@ -1,0 +1,213 @@
+# ruff: noqa: S608
+
+from pathlib import Path
+
+import pytest
+from pyiceberg.io.pyarrow import PyArrowFileIO
+from pyiceberg.manifest import ManifestContent, ManifestEntryStatus, read_manifest_list
+
+from pysail.testing.spark.steps.iceberg import (
+    _current_manifest_list,
+    _current_snapshot,
+    _find_latest_metadata,
+    _pyarrow_input_file,
+)
+from pysail.testing.spark.utils.sql import escape_sql_string_literal
+
+
+def _uri_sql(path: Path) -> str:
+    return escape_sql_string_literal(path.as_uri())
+
+
+def _drop_table(spark, name: str) -> None:
+    spark.sql(f"DROP TABLE IF EXISTS {name}")
+
+
+@pytest.mark.parametrize("update_mode", [None, "copy-on-write"], ids=["default", "explicit-cow"])
+def test_iceberg_update_copy_on_write_preserves_false_and_unknown_predicates(spark, tmp_path, update_mode):
+    table_name = "iceberg_update_copy_on_write"
+    table_path = tmp_path / table_name
+    mode_property = "" if update_mode is None else f", 'write.update.mode' = '{update_mode}'"
+
+    _drop_table(spark, table_name)
+    try:
+        spark.sql(
+            f"""
+            CREATE TABLE {table_name} (id INT, value STRING, selected BOOLEAN)
+            USING iceberg
+            LOCATION '{_uri_sql(table_path)}'
+            TBLPROPERTIES ('format-version' = '2'{mode_property})
+            """
+        )
+        spark.sql(f"INSERT INTO {table_name} VALUES (1, 'change', true), (2, 'keep', false), (3, 'unknown', NULL)")
+
+        spark.sql(
+            f"""
+            UPDATE {table_name} AS target
+            SET value = concat(target.value, '-updated')
+            WHERE target.selected
+            """
+        ).collect()
+
+        rows = [tuple(row) for row in spark.sql(f"SELECT id, value, selected FROM {table_name} ORDER BY id").collect()]
+        assert rows == [
+            (1, "change-updated", True),
+            (2, "keep", False),
+            (3, "unknown", None),
+        ]
+        metadata = _find_latest_metadata(table_path)
+        snapshot = _current_snapshot(metadata)
+        assert snapshot["summary"]["operation"] == "overwrite"
+        assert snapshot["summary"]["deleted-data-files"] == "1"
+        assert snapshot["summary"]["deleted-records"] == "3"
+        assert snapshot["summary"]["added-records"] == "3"
+        assert all(manifest.get("content") == "data" for manifest in _current_manifest_list(metadata)["manifests"])
+    finally:
+        _drop_table(spark, table_name)
+
+
+def test_iceberg_update_copy_on_write_without_predicate_accepts_path_target(spark, tmp_path):
+    table_name = "iceberg_update_copy_on_write_path"
+    table_path = tmp_path / table_name
+
+    _drop_table(spark, table_name)
+    try:
+        spark.sql(
+            f"""
+            CREATE TABLE {table_name} (id INT, value INT)
+            USING iceberg
+            LOCATION '{_uri_sql(table_path)}'
+            TBLPROPERTIES ('format-version' = '2')
+            """
+        )
+        spark.sql(f"INSERT INTO {table_name} VALUES (1, 10), (2, 20)")
+
+        spark.sql(
+            f"""
+            UPDATE iceberg.`{table_path.as_uri()}` AS target
+            SET value = target.value + 1
+            """
+        ).collect()
+
+        rows = [tuple(row) for row in spark.sql(f"SELECT id, value FROM {table_name} ORDER BY id").collect()]
+        assert rows == [(1, 11), (2, 21)]
+    finally:
+        _drop_table(spark, table_name)
+
+
+def test_iceberg_update_copy_on_write_can_move_rows_between_partitions(spark, tmp_path):
+    table_name = "iceberg_update_copy_on_write_partition"
+    table_path = tmp_path / table_name
+
+    _drop_table(spark, table_name)
+    try:
+        spark.sql(
+            f"""
+            CREATE TABLE {table_name} (id INT, value STRING, part STRING)
+            USING iceberg
+            PARTITIONED BY (part)
+            LOCATION '{_uri_sql(table_path)}'
+            TBLPROPERTIES ('format-version' = '2', 'write.update.mode' = 'copy-on-write')
+            """
+        )
+        spark.sql(f"INSERT INTO {table_name} VALUES (1, 'move', 'A'), (2, 'stay-a', 'A')")
+        spark.sql(f"INSERT INTO {table_name} VALUES (3, 'stay-b', 'B')")
+        before_manifest_paths = {
+            manifest["manifest-path"]
+            for manifest in _current_manifest_list(_find_latest_metadata(table_path))["manifests"]
+        }
+
+        spark.sql(f"UPDATE {table_name} SET part = 'B' WHERE id = 1").collect()
+
+        rows = [tuple(row) for row in spark.sql(f"SELECT id, value, part FROM {table_name} ORDER BY id").collect()]
+        assert rows == [(1, "move", "B"), (2, "stay-a", "A"), (3, "stay-b", "B")]
+        metadata = _find_latest_metadata(table_path)
+        snapshot = _current_snapshot(metadata)
+        assert snapshot["summary"]["operation"] == "overwrite"
+        assert snapshot["summary"]["deleted-data-files"] == "1"
+        after_manifest_paths = {manifest["manifest-path"] for manifest in _current_manifest_list(metadata)["manifests"]}
+        assert before_manifest_paths & after_manifest_paths
+    finally:
+        _drop_table(spark, table_name)
+
+
+def test_iceberg_copy_on_write_rewrites_live_rows_after_merge_on_read_delete(spark, tmp_path):
+    table_name = "iceberg_cow_after_mor_delete"
+    table_path = tmp_path / table_name
+
+    _drop_table(spark, table_name)
+    try:
+        spark.sql(
+            f"""
+            CREATE TABLE {table_name} (id BIGINT, value STRING)
+            USING iceberg
+            LOCATION '{_uri_sql(table_path)}'
+            TBLPROPERTIES (
+              'format-version' = '2',
+              'write.delete.mode' = 'merge-on-read',
+              'write.update.mode' = 'copy-on-write'
+            )
+            """
+        )
+        spark.sql(f"INSERT INTO {table_name} VALUES (1, 'update'), (2, 'mor-delete'), (3, 'keep')")
+        spark.sql(f"DELETE FROM {table_name} WHERE id = 2").collect()
+
+        spark.sql(f"UPDATE {table_name} SET value = 'updated' WHERE id = 1").collect()
+
+        rows = [tuple(row) for row in spark.sql(f"SELECT id, value FROM {table_name} ORDER BY id").collect()]
+        assert rows == [(1, "updated"), (3, "keep")]
+        metadata = _find_latest_metadata(table_path)
+        snapshot = _current_snapshot(metadata)
+        assert snapshot["summary"]["operation"] == "overwrite"
+        manifests = _current_manifest_list(metadata)["manifests"]
+        assert any(manifest.get("content") == "deletes" for manifest in manifests)
+        assert snapshot["summary"]["total-delete-files"] == "1"
+    finally:
+        _drop_table(spark, table_name)
+
+
+@pytest.mark.parametrize("format_version", ["1", "2", "3"])
+def test_iceberg_copy_on_write_operations_support_table_format_versions(spark, tmp_path, format_version):
+    table_name = f"iceberg_cow_format_v{format_version}"
+    table_path = tmp_path / table_name
+
+    _drop_table(spark, table_name)
+    try:
+        spark.sql(
+            f"""
+            CREATE TABLE {table_name} (id INT, value STRING)
+            USING iceberg
+            LOCATION '{_uri_sql(table_path)}'
+            TBLPROPERTIES ('format-version' = '{format_version}')
+            """
+        )
+        spark.sql(f"INSERT INTO {table_name} VALUES (1, 'old'), (2, 'delete')")
+        spark.sql(f"UPDATE {table_name} SET value = 'updated' WHERE id = 1").collect()
+        spark.sql("CREATE OR REPLACE TEMP VIEW iceberg_cow_format_source AS SELECT 3 AS id, 'inserted' AS value")
+        spark.sql(
+            f"""
+            MERGE INTO {table_name} AS target
+            USING iceberg_cow_format_source AS source
+            ON target.id = source.id
+            WHEN MATCHED THEN UPDATE SET value = source.value
+            WHEN NOT MATCHED THEN INSERT *
+            """
+        ).collect()
+        spark.sql(f"DELETE FROM {table_name} WHERE id = 2").collect()
+
+        rows = [tuple(row) for row in spark.sql(f"SELECT id, value FROM {table_name} ORDER BY id").collect()]
+        assert rows == [(1, "updated"), (3, "inserted")]
+        metadata = _find_latest_metadata(table_path)
+        snapshot = _current_snapshot(metadata)
+        io = PyArrowFileIO()
+        entries = [
+            entry
+            for manifest in read_manifest_list(_pyarrow_input_file(io, snapshot["manifest-list"]))
+            if manifest.content == ManifestContent.DATA
+            for entry in manifest.fetch_manifest_entry(io)
+        ]
+        assert sum(
+            entry.data_file.record_count for entry in entries if entry.status != ManifestEntryStatus.DELETED
+        ) == len(rows)
+    finally:
+        _drop_table(spark, table_name)


### PR DESCRIPTION
## Summary

Connect Iceberg DELETE, UPDATE, and MERGE to the shared row-level plans and targeted copy-on-write commit path.

- use copy-on-write by default and honor explicit `write.delete.mode`, `write.update.mode`, and `write.merge.mode` properties
- expand DELETE, UPDATE, and MERGE into write-row and touched-file effects
- restrict rewrites to rows from affected data files while retaining inserts
- project row-level operation metadata out before writing replacement data files
- support conditionless DELETE and UPDATE
- support aliases and path-based targets
- preserve SQL false and unknown predicate results
- support updates that move rows between partitions
- avoid advancing the snapshot for no-op operations
- commit insert-only MERGE operations as fast appends
- retain existing delete manifests when COW follows a merge-on-read delete
- support Iceberg table format versions 1, 2, and 3

Existing merge-on-read DELETE and MERGE paths remain available. UPDATE with `write.update.mode=merge-on-read` remains explicitly unsupported; this PR adds UPDATE through copy-on-write.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>