### PR TITLE
fix: validate max_by and min_by arguments and reject unsupported syntax

### DIFF
--- a/crates/sail-function/src/aggregate/max_min_by.rs
+++ b/crates/sail-function/src/aggregate/max_min_by.rs
@@ -1,21 +1,24 @@
 use std::cmp::Ordering;
 use std::fmt::Debug;
 use std::ops::Deref;
+use std::sync::Arc;
 
 /// [Credit]: <https://github.com/datafusion-contrib/datafusion-functions-extra/blob/5fa184df2589f09e90035c5e6a0d2c88c57c298a/src/max_min_by.rs>
 use datafusion::arrow::array::ArrayRef;
 use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion::common::ScalarValue;
 use datafusion::error::DataFusionError;
+use datafusion::functions_aggregate::array_agg::array_agg_udaf;
 use datafusion::functions_aggregate::first_last::last_value_udaf;
+use datafusion::functions_nested::expr_fn::array_slice;
 use datafusion::logical_expr::expr::{AggregateFunction, Sort};
 use datafusion::logical_expr::function::{AccumulatorArgs, StateFieldsArgs};
 use datafusion::logical_expr::simplify::SimplifyContext;
 use datafusion::logical_expr::utils::format_state_name;
 use datafusion::logical_expr::{Accumulator, AggregateUDFImpl, Signature, Volatility, function};
-use datafusion::prelude::Expr;
+use datafusion::prelude::{Expr, lit};
 
-use crate::error::invalid_arg_count_exec_err;
+use crate::error::{generic_exec_err, invalid_arg_count_exec_err};
 
 #[derive(Debug)]
 struct MaxMinByAccumulator {
@@ -110,15 +113,18 @@ impl MaxByFunction {
     }
 }
 
-/// The argument count this implementation accepts, which is what the arity error must
-/// describe -- deliberately narrower than Spark.
+/// The argument count Spark 4.2 accepts: `MaxByBuilder`/`MinByBuilder` route the
+/// 3-argument form to the top-k variant `MaxMinByK`, which returns `ARRAY<value type>`.
+const MAX_MIN_BY_ARG_COUNT: (i32, i32) = (2, 3);
+
+/// The argument count the hooks that build a real accumulator accept.
 ///
-/// Spark 4.2 accepts `[2, 3]`: `MaxByBuilder`/`MinByBuilder` route the 3-argument form to
-/// the top-k variant `MaxMinByK`, which returns `ARRAY<value type>`. That form is not
-/// implemented here, so `max_by(x, y, k)` is reported as an arity error even though the
-/// function catalog (`crates/sail-plan/data/functions/aggregate.yaml`) documents it as a
-/// Spark 4.2 signature. Widen this to `(2, 3)` in the same change that ports `MaxMinByK`.
-const MAX_MIN_BY_ARG_COUNT: (i32, i32) = (2, 2);
+/// The top-k form is implemented as a logical rewrite in [`max_min_by_simplify`], which the
+/// window path never runs, so an accumulator is only ever built for the 2-argument form.
+const MAX_MIN_BY_ACCUMULATOR_ARG_COUNT: (i32, i32) = (2, 2);
+
+/// `MaxMinByK.MAX_K`.
+const MAX_MIN_BY_MAX_K: i64 = 100_000;
 
 /// Splits the arguments into the value and the ordering one.
 ///
@@ -133,9 +139,81 @@ fn max_min_by_args<'a, T>(
         [value, ordering] => Ok((value, ordering)),
         _ => Err(invalid_arg_count_exec_err(
             function_name,
+            MAX_MIN_BY_ACCUMULATOR_ARG_COUNT,
+            args.len(),
+        )),
+    }
+}
+
+/// Splits the arguments of either form, returning the top-k argument when present.
+fn max_min_by_top_k_args<'a, T>(
+    function_name: &str,
+    args: &'a [T],
+) -> Result<(&'a T, &'a T, Option<&'a T>), DataFusionError> {
+    match args {
+        [value, ordering] => Ok((value, ordering, None)),
+        [value, ordering, k] => Ok((value, ordering, Some(k))),
+        _ => Err(invalid_arg_count_exec_err(
+            function_name,
             MAX_MIN_BY_ARG_COUNT,
             args.len(),
         )),
+    }
+}
+
+/// Reads the top-k argument, which Spark requires to be foldable and within `[1, MAX_K]`.
+///
+/// Spark's rule is foldability, not "is a literal", so a constant-folded expression such as
+/// `1 + 1` qualifies. This runs inside `simplify`, after constant folding, so those reach
+/// here already reduced to a literal. A `Cast` around the literal is looked through because
+/// the argument is coerced to an integer before this point.
+fn max_min_by_k(function_name: &str, k_expr: &Expr) -> Result<i64, DataFusionError> {
+    let scalar = match k_expr {
+        Expr::Literal(scalar, _) => Some(scalar),
+        Expr::Cast(cast) => match cast.expr.as_ref() {
+            Expr::Literal(scalar, _) => Some(scalar),
+            _ => None,
+        },
+        _ => None,
+    };
+    let k = match scalar {
+        Some(ScalarValue::Int8(Some(v))) => Some(i64::from(*v)),
+        Some(ScalarValue::Int16(Some(v))) => Some(i64::from(*v)),
+        Some(ScalarValue::Int32(Some(v))) => Some(i64::from(*v)),
+        Some(ScalarValue::Int64(Some(v))) => Some(*v),
+        _ => None,
+    };
+    let Some(k) = k else {
+        return Err(generic_exec_err(
+            function_name,
+            &format!("the input k should be a foldable int expression; however, got {k_expr}"),
+        ));
+    };
+    if !(1..=MAX_MIN_BY_MAX_K).contains(&k) {
+        return Err(generic_exec_err(
+            function_name,
+            &format!("The `k` must be between [1, {MAX_MIN_BY_MAX_K}] (current value = {k})"),
+        ));
+    }
+    Ok(k)
+}
+
+/// The output type: the value type for the 2-argument form, and `ARRAY<value type>` for the
+/// top-k form, matching `MaxMinByK.dataType`.
+///
+/// The element field is built the same way `array_agg` builds its own, because the top-k form
+/// is rewritten to `array_agg` and the optimizer rejects a rewrite that changes the schema.
+fn max_min_by_return_type(
+    function_name: &str,
+    arg_types: &[DataType],
+) -> Result<DataType, DataFusionError> {
+    let (value_type, _, k) = max_min_by_top_k_args(function_name, arg_types)?;
+    match k {
+        None => Ok(value_type.clone()),
+        Some(_) => Ok(DataType::List(Arc::new(Field::new_list_field(
+            value_type.clone(),
+            true,
+        )))),
     }
 }
 
@@ -143,19 +221,79 @@ fn get_min_max_by_result_type(
     function_name: &str,
     input_types: &[DataType],
 ) -> Result<Vec<DataType>, DataFusionError> {
-    let (value_type, ordering_type) = max_min_by_args(function_name, input_types)?;
-    match value_type {
-        // The ordering type is carried over so that the coerced list keeps both arguments;
-        // returning the value type alone made `coerce_types` answer one type for a
-        // two-argument call, which DataFusion rejects with a `Failed to coerce arguments`
-        // planning error rather than reaching the hooks below.
-        // Not covered by a scenario because a `Dictionary` column cannot be built from SQL.
-        DataType::Dictionary(_, dict_value_type) => {
-            // TODO add checker, if the value type is complex data type
-            Ok(vec![dict_value_type.deref().clone(), ordering_type.clone()])
-        }
-        _ => Ok(input_types.to_vec()),
+    let (value_type, _, _) = max_min_by_top_k_args(function_name, input_types)?;
+    // Only the value type is rewritten; every other argument is carried over unchanged.
+    // Answering a shorter list than it was given makes DataFusion reject the call with a
+    // `Failed to coerce arguments` planning error before any hook below runs.
+    // Not covered by a scenario because a `Dictionary` column cannot be built from SQL.
+    let DataType::Dictionary(_, dict_value_type) = value_type else {
+        return Ok(input_types.to_vec());
+    };
+    // TODO add checker, if the value type is complex data type
+    let mut coerced = input_types.to_vec();
+    if let Some(first) = coerced.first_mut() {
+        *first = dict_value_type.deref().clone();
     }
+    Ok(coerced)
+}
+
+/// Rewrites both forms into existing aggregates.
+///
+/// The 2-argument form becomes `last_value` ordered by the ordering argument. The top-k form
+/// becomes `array_slice(array_agg(value ORDER BY ordering), 1, k)`, which reproduces
+/// `MaxMinByK`: NULL orderings are dropped by the filter, the extreme values come first, and
+/// an empty group yields NULL rather than an empty array because `array_agg` returns NULL.
+fn max_min_by_simplify(is_max: bool) -> function::AggregateFunctionSimplification {
+    Box::new(
+        move |mut aggr_func: AggregateFunction, _: &SimplifyContext| {
+            let function_name = aggr_func.func.name().to_string();
+            max_min_by_top_k_args(&function_name, &aggr_func.params.args)?;
+
+            let k = match aggr_func.params.args.len() {
+                3 => Some(max_min_by_k(
+                    &function_name,
+                    &aggr_func.params.args.remove(2),
+                )?),
+                _ => None,
+            };
+            let (ordering_arg, value_arg) = (
+                aggr_func.params.args.remove(1),
+                aggr_func.params.args.remove(0),
+            );
+
+            let null_filter = ordering_arg.clone().is_not_null();
+            let filter = match aggr_func.params.filter {
+                Some(existing) => Some(Box::new((*existing).and(null_filter))),
+                None => Some(Box::new(null_filter)),
+            };
+
+            let mut order_by = aggr_func.params.order_by;
+            match k {
+                // `last_value` takes the row at the END of the ordering, so `max_by` sorts
+                // ascending and `min_by` descending.
+                None => order_by.push(Sort::new(ordering_arg, is_max, true)),
+                // `array_agg` keeps every row, so the extreme must come FIRST instead.
+                Some(_) => order_by.push(Sort::new(ordering_arg, !is_max, true)),
+            }
+
+            let (func, args) = match k {
+                None => (last_value_udaf(), vec![value_arg]),
+                Some(_) => (array_agg_udaf(), vec![value_arg]),
+            };
+            let aggregate = Expr::AggregateFunction(AggregateFunction::new_udf(
+                func,
+                args,
+                aggr_func.params.distinct,
+                filter,
+                order_by,
+                aggr_func.params.null_treatment,
+            ));
+            match k {
+                None => Ok(aggregate),
+                Some(k) => Ok(array_slice(aggregate, lit(1i64), lit(k), None)),
+            }
+        },
+    )
 }
 
 impl AggregateUDFImpl for MaxByFunction {
@@ -168,8 +306,7 @@ impl AggregateUDFImpl for MaxByFunction {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType, DataFusionError> {
-        let (value_type, _) = max_min_by_args(self.name(), arg_types)?;
-        Ok(value_type.to_owned())
+        max_min_by_return_type(self.name(), arg_types)
     }
 
     fn accumulator(
@@ -202,35 +339,7 @@ impl AggregateUDFImpl for MaxByFunction {
     }
 
     fn simplify(&self) -> Option<function::AggregateFunctionSimplification> {
-        let simplify = |mut aggr_func: AggregateFunction, _: &SimplifyContext| {
-            // `coerce_types` already rejects any other arity during analysis, so this is
-            // belt-and-braces before the `remove` calls below; it goes through the same
-            // helper as the other hooks so that the two cannot drift apart.
-            max_min_by_args(aggr_func.func.name(), &aggr_func.params.args)?;
-            let mut order_by = aggr_func.params.order_by;
-            let (second_arg, first_arg) = (
-                aggr_func.params.args.remove(1),
-                aggr_func.params.args.remove(0),
-            );
-
-            let null_filter = second_arg.clone().is_not_null();
-            let filter = match aggr_func.params.filter {
-                Some(existing) => Some(Box::new((*existing).and(null_filter))),
-                None => Some(Box::new(null_filter)),
-            };
-
-            order_by.push(Sort::new(second_arg, true, true)); // ASC,  NULLS FIRST
-
-            Ok(Expr::AggregateFunction(AggregateFunction::new_udf(
-                last_value_udaf(),
-                vec![first_arg],
-                aggr_func.params.distinct,
-                filter,
-                order_by,
-                aggr_func.params.null_treatment,
-            )))
-        };
-        Some(Box::new(simplify))
+        Some(max_min_by_simplify(true))
     }
 
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>, DataFusionError> {
@@ -277,8 +386,7 @@ impl AggregateUDFImpl for MinByFunction {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType, DataFusionError> {
-        let (value_type, _) = max_min_by_args(self.name(), arg_types)?;
-        Ok(value_type.to_owned())
+        max_min_by_return_type(self.name(), arg_types)
     }
 
     fn accumulator(
@@ -311,35 +419,7 @@ impl AggregateUDFImpl for MinByFunction {
     }
 
     fn simplify(&self) -> Option<function::AggregateFunctionSimplification> {
-        let simplify = |mut aggr_func: AggregateFunction, _: &SimplifyContext| {
-            // `coerce_types` already rejects any other arity during analysis, so this is
-            // belt-and-braces before the `remove` calls below; it goes through the same
-            // helper as the other hooks so that the two cannot drift apart.
-            max_min_by_args(aggr_func.func.name(), &aggr_func.params.args)?;
-            let mut order_by = aggr_func.params.order_by;
-            let (second_arg, first_arg) = (
-                aggr_func.params.args.remove(1),
-                aggr_func.params.args.remove(0),
-            );
-
-            let null_filter = second_arg.clone().is_not_null();
-            let filter = match aggr_func.params.filter {
-                Some(existing) => Some(Box::new((*existing).and(null_filter))),
-                None => Some(Box::new(null_filter)),
-            };
-
-            order_by.push(Sort::new(second_arg, false, true)); // DESC, NULLS FIRST
-
-            Ok(Expr::AggregateFunction(AggregateFunction::new_udf(
-                last_value_udaf(),
-                vec![first_arg],
-                aggr_func.params.distinct,
-                filter,
-                order_by,
-                aggr_func.params.null_treatment,
-            )))
-        };
-        Some(Box::new(simplify))
+        Some(max_min_by_simplify(false))
     }
 
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>, DataFusionError> {

--- a/crates/sail-function/src/aggregate/max_min_by.rs
+++ b/crates/sail-function/src/aggregate/max_min_by.rs
@@ -15,6 +15,8 @@ use datafusion::logical_expr::utils::format_state_name;
 use datafusion::logical_expr::{Accumulator, AggregateUDFImpl, Signature, Volatility, function};
 use datafusion::prelude::Expr;
 
+use crate::error::invalid_arg_count_exec_err;
+
 #[derive(Debug)]
 struct MaxMinByAccumulator {
     value: ScalarValue,
@@ -108,11 +110,42 @@ impl MaxByFunction {
     }
 }
 
-fn get_min_max_by_result_type(input_types: &[DataType]) -> Result<Vec<DataType>, DataFusionError> {
-    match &input_types[0] {
+/// Spark 4.2 accepts `[2, 3]` arguments: the 3-argument form is the top-k variant
+/// (`MaxMinByK`), which returns an array and is not implemented here, so only the
+/// 2-argument form is accepted and `max_by(x, y, k)` is reported as an arity error.
+const MAX_MIN_BY_ARG_COUNT: (i32, i32) = (2, 2);
+
+/// Splits the arguments into the value and the ordering one.
+///
+/// The signature is `user_defined`, so DataFusion runs no arity check of its own. Every
+/// hook that reaches for the ordering argument must go through here, or it indexes a
+/// short slice and panics instead of reporting an error.
+fn max_min_by_args<'a, T>(
+    function_name: &str,
+    args: &'a [T],
+) -> Result<(&'a T, &'a T), DataFusionError> {
+    match args {
+        [value, ordering] => Ok((value, ordering)),
+        _ => Err(invalid_arg_count_exec_err(
+            function_name,
+            MAX_MIN_BY_ARG_COUNT,
+            args.len(),
+        )),
+    }
+}
+
+fn get_min_max_by_result_type(
+    function_name: &str,
+    input_types: &[DataType],
+) -> Result<Vec<DataType>, DataFusionError> {
+    let (value_type, ordering_type) = max_min_by_args(function_name, input_types)?;
+    match value_type {
+        // The ordering type is carried over so that the coerced list keeps both arguments;
+        // returning the value type alone left the hooks below indexing a one-element slice.
+        // Not covered by a scenario because a `Dictionary` column cannot be built from SQL.
         DataType::Dictionary(_, dict_value_type) => {
             // TODO add checker, if the value type is complex data type
-            Ok(vec![dict_value_type.deref().clone()])
+            Ok(vec![dict_value_type.deref().clone(), ordering_type.clone()])
         }
         _ => Ok(input_types.to_vec()),
     }
@@ -128,7 +161,8 @@ impl AggregateUDFImpl for MaxByFunction {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType, DataFusionError> {
-        Ok(arg_types[0].to_owned())
+        let (value_type, _) = max_min_by_args(self.name(), arg_types)?;
+        Ok(value_type.to_owned())
     }
 
     fn accumulator(
@@ -136,7 +170,8 @@ impl AggregateUDFImpl for MaxByFunction {
         acc_args: AccumulatorArgs,
     ) -> Result<Box<dyn Accumulator>, DataFusionError> {
         let value_type = acc_args.return_field.data_type().clone();
-        let ordering_type = acc_args.exprs[1].data_type(acc_args.schema)?;
+        let (_, ordering) = max_min_by_args(self.name(), acc_args.exprs)?;
+        let ordering_type = ordering.data_type(acc_args.schema)?;
         Ok(Box::new(MaxMinByAccumulator::new(
             &value_type,
             &ordering_type,
@@ -146,7 +181,8 @@ impl AggregateUDFImpl for MaxByFunction {
 
     fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<FieldRef>, DataFusionError> {
         let value_type = args.return_field.data_type().clone();
-        let ordering_type = args.input_fields[1].data_type().clone();
+        let (_, ordering) = max_min_by_args(self.name(), args.input_fields)?;
+        let ordering_type = ordering.data_type().clone();
         Ok(vec![
             Field::new(format_state_name(args.name, "value"), value_type, true).into(),
             Field::new(
@@ -160,6 +196,10 @@ impl AggregateUDFImpl for MaxByFunction {
 
     fn simplify(&self) -> Option<function::AggregateFunctionSimplification> {
         let simplify = |mut aggr_func: AggregateFunction, _: &SimplifyContext| {
+            // `coerce_types` already rejects any other arity during analysis, so this is
+            // belt-and-braces before the `remove` calls below; it goes through the same
+            // helper as the other hooks so that the two cannot drift apart.
+            max_min_by_args(aggr_func.func.name(), &aggr_func.params.args)?;
             let mut order_by = aggr_func.params.order_by;
             let (second_arg, first_arg) = (
                 aggr_func.params.args.remove(1),
@@ -187,7 +227,7 @@ impl AggregateUDFImpl for MaxByFunction {
     }
 
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>, DataFusionError> {
-        get_min_max_by_result_type(arg_types)
+        get_min_max_by_result_type(self.name(), arg_types)
     }
 }
 
@@ -230,7 +270,8 @@ impl AggregateUDFImpl for MinByFunction {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> Result<DataType, DataFusionError> {
-        Ok(arg_types[0].to_owned())
+        let (value_type, _) = max_min_by_args(self.name(), arg_types)?;
+        Ok(value_type.to_owned())
     }
 
     fn accumulator(
@@ -238,7 +279,8 @@ impl AggregateUDFImpl for MinByFunction {
         acc_args: AccumulatorArgs,
     ) -> Result<Box<dyn Accumulator>, DataFusionError> {
         let value_type = acc_args.return_field.data_type().clone();
-        let ordering_type = acc_args.exprs[1].data_type(acc_args.schema)?;
+        let (_, ordering) = max_min_by_args(self.name(), acc_args.exprs)?;
+        let ordering_type = ordering.data_type(acc_args.schema)?;
         Ok(Box::new(MaxMinByAccumulator::new(
             &value_type,
             &ordering_type,
@@ -248,7 +290,8 @@ impl AggregateUDFImpl for MinByFunction {
 
     fn state_fields(&self, args: StateFieldsArgs) -> Result<Vec<FieldRef>, DataFusionError> {
         let value_type = args.return_field.data_type().clone();
-        let ordering_type = args.input_fields[1].data_type().clone();
+        let (_, ordering) = max_min_by_args(self.name(), args.input_fields)?;
+        let ordering_type = ordering.data_type().clone();
         Ok(vec![
             Field::new(format_state_name(args.name, "value"), value_type, true).into(),
             Field::new(
@@ -262,6 +305,10 @@ impl AggregateUDFImpl for MinByFunction {
 
     fn simplify(&self) -> Option<function::AggregateFunctionSimplification> {
         let simplify = |mut aggr_func: AggregateFunction, _: &SimplifyContext| {
+            // `coerce_types` already rejects any other arity during analysis, so this is
+            // belt-and-braces before the `remove` calls below; it goes through the same
+            // helper as the other hooks so that the two cannot drift apart.
+            max_min_by_args(aggr_func.func.name(), &aggr_func.params.args)?;
             let mut order_by = aggr_func.params.order_by;
             let (second_arg, first_arg) = (
                 aggr_func.params.args.remove(1),
@@ -289,6 +336,6 @@ impl AggregateUDFImpl for MinByFunction {
     }
 
     fn coerce_types(&self, arg_types: &[DataType]) -> Result<Vec<DataType>, DataFusionError> {
-        get_min_max_by_result_type(arg_types)
+        get_min_max_by_result_type(self.name(), arg_types)
     }
 }

--- a/crates/sail-function/src/aggregate/max_min_by.rs
+++ b/crates/sail-function/src/aggregate/max_min_by.rs
@@ -40,14 +40,14 @@ impl MaxMinByAccumulator {
 
 impl Accumulator for MaxMinByAccumulator {
     fn update_batch(&mut self, values: &[ArrayRef]) -> Result<(), DataFusionError> {
-        let value_array = &values[0];
-        let ordering_array = &values[1];
+        let function_name = if self.is_max { "max_by" } else { "min_by" };
+        let (value_array, ordering_array) = max_min_by_args(function_name, values)?;
 
         for i in 0..ordering_array.len() {
             if ordering_array.is_null(i) {
                 continue;
             }
-            let ordering_val = ScalarValue::try_from_array(&values[1], i)?;
+            let ordering_val = ScalarValue::try_from_array(ordering_array, i)?;
             let should_update = if self.ordering.is_null() {
                 true
             } else {
@@ -110,9 +110,14 @@ impl MaxByFunction {
     }
 }
 
-/// Spark 4.2 accepts `[2, 3]` arguments: the 3-argument form is the top-k variant
-/// (`MaxMinByK`), which returns an array and is not implemented here, so only the
-/// 2-argument form is accepted and `max_by(x, y, k)` is reported as an arity error.
+/// The argument count this implementation accepts, which is what the arity error must
+/// describe -- deliberately narrower than Spark.
+///
+/// Spark 4.2 accepts `[2, 3]`: `MaxByBuilder`/`MinByBuilder` route the 3-argument form to
+/// the top-k variant `MaxMinByK`, which returns `ARRAY<value type>`. That form is not
+/// implemented here, so `max_by(x, y, k)` is reported as an arity error even though the
+/// function catalog (`crates/sail-plan/data/functions/aggregate.yaml`) documents it as a
+/// Spark 4.2 signature. Widen this to `(2, 3)` in the same change that ports `MaxMinByK`.
 const MAX_MIN_BY_ARG_COUNT: (i32, i32) = (2, 2);
 
 /// Splits the arguments into the value and the ordering one.
@@ -141,7 +146,9 @@ fn get_min_max_by_result_type(
     let (value_type, ordering_type) = max_min_by_args(function_name, input_types)?;
     match value_type {
         // The ordering type is carried over so that the coerced list keeps both arguments;
-        // returning the value type alone left the hooks below indexing a one-element slice.
+        // returning the value type alone made `coerce_types` answer one type for a
+        // two-argument call, which DataFusion rejects with a `Failed to coerce arguments`
+        // planning error rather than reaching the hooks below.
         // Not covered by a scenario because a `Dictionary` column cannot be built from SQL.
         DataType::Dictionary(_, dict_value_type) => {
             // TODO add checker, if the value type is complex data type

--- a/crates/sail-plan/src/function/aggregate.rs
+++ b/crates/sail-plan/src/function/aggregate.rs
@@ -262,7 +262,27 @@ fn product(input: AggFunctionInput) -> PlanResult<expr::Expr> {
     }))
 }
 
+/// Rejects `IGNORE NULLS`, which Spark does not accept for `max_by`/`min_by`.
+///
+/// `FunctionResolution.applyIgnoreNulls` has no case for `MaxBy`/`MinBy`, so it falls
+/// through to `functionWithUnsupportedSyntaxError`. Silently honoring the flag would also
+/// change the answer rather than merely skip an error: `MaxMinBy.updateExpressions` skips
+/// NULL orderings only and may legitimately return a NULL value, whereas `last_value`
+/// (which these functions are rewritten to) skips NULL values.
+pub(crate) fn reject_ignore_nulls(
+    function_name: &str,
+    ignore_nulls: Option<bool>,
+) -> PlanResult<()> {
+    if ignore_nulls == Some(true) {
+        return Err(PlanError::unsupported(format!(
+            "The function `{function_name}` does not support IGNORE NULLS"
+        )));
+    }
+    Ok(())
+}
+
 fn max_by(input: AggFunctionInput) -> PlanResult<expr::Expr> {
+    reject_ignore_nulls("max_by", input.ignore_nulls)?;
     Ok(expr::Expr::AggregateFunction(AggregateFunction {
         func: Arc::new(AggregateUDF::from(MaxByFunction::new())),
         params: AggregateFunctionParams {
@@ -276,6 +296,7 @@ fn max_by(input: AggFunctionInput) -> PlanResult<expr::Expr> {
 }
 
 fn min_by(input: AggFunctionInput) -> PlanResult<expr::Expr> {
+    reject_ignore_nulls("min_by", input.ignore_nulls)?;
     Ok(expr::Expr::AggregateFunction(AggregateFunction {
         func: Arc::new(AggregateUDF::from(MinByFunction::new())),
         params: AggregateFunctionParams {

--- a/crates/sail-plan/src/function/window.rs
+++ b/crates/sail-plan/src/function/window.rs
@@ -41,6 +41,7 @@ use sail_function::aggregate::try_avg::TryAvgFunction;
 use sail_function::window::{spark_first_value_udwf, spark_last_value_udwf, spark_ntile_udwf};
 
 use crate::error::{PlanError, PlanResult};
+use crate::function::aggregate::reject_ignore_nulls;
 use crate::function::common::{
     WinFunction, WinFunctionInput, count_min_sketch_args, get_arguments_and_null_treatment,
     get_null_treatment, hll_args_with_default_lg, hll_union_args_with_default_allow_different_lg,
@@ -237,6 +238,50 @@ fn aggregate_udf_window_expr(
             distinct,
         },
     }))
+}
+
+/// Spark rejects `IGNORE NULLS` on `max_by`/`min_by` in `FunctionResolution.applyIgnoreNulls`,
+/// which runs on the function itself, so wrapping it in a window expression does not exempt it.
+fn max_min_by_window(
+    function_name: &str,
+    func: Arc<AggregateUDF>,
+    input: WinFunctionInput,
+) -> PlanResult<expr::Expr> {
+    let WinFunctionInput {
+        arguments,
+        partition_by,
+        order_by,
+        window_frame,
+        ignore_nulls,
+        distinct,
+        function_context: _,
+    } = input;
+    reject_ignore_nulls(function_name, ignore_nulls)?;
+    Ok(aggregate_udf_window_expr(
+        func,
+        arguments,
+        partition_by,
+        order_by,
+        window_frame,
+        ignore_nulls,
+        distinct,
+    ))
+}
+
+fn max_by(input: WinFunctionInput) -> PlanResult<expr::Expr> {
+    max_min_by_window(
+        "max_by",
+        Arc::new(AggregateUDF::from(MaxByFunction::new())),
+        input,
+    )
+}
+
+fn min_by(input: WinFunctionInput) -> PlanResult<expr::Expr> {
+    max_min_by_window(
+        "min_by",
+        Arc::new(AggregateUDF::from(MinByFunction::new())),
+        input,
+    )
 }
 
 fn product(input: WinFunctionInput) -> PlanResult<expr::Expr> {
@@ -730,17 +775,11 @@ fn list_built_in_window_functions() -> Vec<(&'static str, WinFunction)> {
         ("last_value", F::custom(last_value)),
         ("listagg", F::custom(listagg)),
         ("max", F::aggregate(min_max::max_udaf)),
-        (
-            "max_by",
-            F::aggregate(|| Arc::new(AggregateUDF::from(MaxByFunction::new()))),
-        ),
+        ("max_by", F::custom(max_by)),
         ("mean", F::aggregate(average::avg_udaf)),
         ("median", F::custom(median)),
         ("min", F::aggregate(min_max::min_udaf)),
-        (
-            "min_by",
-            F::aggregate(|| Arc::new(AggregateUDF::from(MinByFunction::new()))),
-        ),
+        ("min_by", F::custom(min_by)),
         (
             "mode",
             F::aggregate(|| Arc::new(AggregateUDF::from(ModeFunction::new()))),

--- a/crates/sail-spark-connect/tests/gold_data/function/agg.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/agg.json
@@ -1917,7 +1917,7 @@
         }
       },
       "output": {
-        "success": "ok"
+        "failure": "error in DataFusion: Error during planning: Execution error: Function 'max_by' user-defined coercion failed with: Execution error: Spark `max_by` function requires 2 arguments, got 3. No function matches the given name and argument types 'max_by(Utf8, Int32, Int32)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tmax_by(UserDefined)"
       }
     },
     {
@@ -2075,7 +2075,7 @@
         }
       },
       "output": {
-        "success": "ok"
+        "failure": "error in DataFusion: Error during planning: Execution error: Function 'min_by' user-defined coercion failed with: Execution error: Spark `min_by` function requires 2 arguments, got 3. No function matches the given name and argument types 'min_by(Utf8, Int32, Int32)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tmin_by(UserDefined)"
       }
     },
     {

--- a/crates/sail-spark-connect/tests/gold_data/function/agg.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/agg.json
@@ -1917,7 +1917,7 @@
         }
       },
       "output": {
-        "failure": "error in DataFusion: Error during planning: Execution error: Function 'max_by' user-defined coercion failed with: Execution error: Spark `max_by` function requires 2 arguments, got 3. No function matches the given name and argument types 'max_by(Utf8, Int32, Int32)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tmax_by(UserDefined)"
+        "success": "ok"
       }
     },
     {
@@ -2075,7 +2075,7 @@
         }
       },
       "output": {
-        "failure": "error in DataFusion: Error during planning: Execution error: Function 'min_by' user-defined coercion failed with: Execution error: Spark `min_by` function requires 2 arguments, got 3. No function matches the given name and argument types 'min_by(Utf8, Int32, Int32)'. You might need to add explicit type casts.\n\tCandidate functions:\n\tmin_by(UserDefined)"
+        "success": "ok"
       }
     },
     {

--- a/python/pysail/tests/spark/function/features/aggregate/max_by.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/max_by.feature
@@ -47,3 +47,77 @@ Feature: max_by function
         | #2   | (SELECT CASE WHEN val_col = 80 THEN NULL ELSE val_col END AS val_col, by_col FROM t_base)                             | NULL   |
         | #3   | t_base WHERE int_col <> 8                                                                                             | 70     |
         | #4   | (SELECT CASE WHEN val_col = 70 THEN NULL ELSE val_col END AS val_col, by_col, int_col FROM t_base) WHERE int_col <> 8 | NULL   |
+
+  Rule: An argument count outside the accepted range is rejected
+
+    # `Signature::user_defined` means DataFusion runs no arity check of its own, so
+    # every hook reaching for the second argument used to index an empty/short slice
+    # and panic -- which kills the gRPC connection instead of reporting an error.
+    Scenario: max_by with no arguments is rejected
+      When query
+        """
+        SELECT max_by()
+        """
+      Then query error (?i)max_by.*requires
+
+    Scenario: max_by with a single argument is rejected
+      When query
+        """
+        SELECT max_by(1)
+        """
+      Then query error (?i)max_by.*requires
+
+    Scenario: max_by with four arguments is rejected
+      When query
+        """
+        SELECT max_by(x, y, 2, 1) FROM VALUES (1, 2), (3, 4) AS t(x, y)
+        """
+      Then query error (?i)max_by.*requires
+
+  Rule: The ordering argument must be of an orderable type
+
+    # `MaxMinBy.checkInputDataTypes` only checks the ORDERING argument, via
+    # `TypeUtils.checkForOrderingExpr` -> `OrderUtils.isOrderable`; the value argument
+    # has no type restriction at all. ARRAY and STRUCT are orderable and must be
+    # ACCEPTED -- the rule is orderability, not "complex type". MAP is not orderable.
+    @sail-bug
+    Scenario: max_by rejects a MAP ordering column
+      When query
+        """
+        SELECT max_by(v, o) AS result FROM VALUES ('lo', map('a', 1)), ('hi', map('b', 2)) AS t(v, o)
+        """
+      Then query error does not support ordering on type
+
+    Scenario: max_by accepts an ARRAY ordering column
+      When query
+        """
+        SELECT max_by(v, o) AS result FROM VALUES ('lo', array(1, 2)), ('hi', array(3, 4)) AS t(v, o)
+        """
+      Then query result
+        | result |
+        | hi     |
+
+    Scenario: max_by accepts a STRUCT ordering column
+      When query
+        """
+        SELECT max_by(v, o) AS result FROM VALUES ('lo', named_struct('a', 1)), ('hi', named_struct('a', 2)) AS t(v, o)
+        """
+      Then query result
+        | result |
+        | hi     |
+
+  Rule: The three-argument form returns the k values at the extreme of the ordering column
+
+    # Added in Spark 4.2 (`MaxMinByK.scala`, `MaxByBuilder` accepts [2, 3] arguments):
+    # returns an ARRAY of the k values, sorted descending by the ordering column.
+    # The array is joined so that the assertion stays plain SQL; the element order is
+    # part of what is asserted, and it is deterministic here because every `y` differs.
+    @spark-4.2 @sail-bug
+    Scenario: max_by returns the top k values as an array
+      When query
+        """
+        SELECT array_join(max_by(x, y, 2), ',') AS result FROM VALUES ('a', 10), ('b', 50), ('c', 20) AS t(x, y)
+        """
+      Then query result
+        | result |
+        | b,c    |

--- a/python/pysail/tests/spark/function/features/aggregate/max_by.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/max_by.feature
@@ -106,6 +106,194 @@ Feature: max_by function
         | result |
         | hi     |
 
+    # The check is `checkInputDataTypes`, so it fires at ANALYSIS regardless of the
+    # data: a folded MAP literal is rejected just like a MAP column.
+    @sail-bug
+    Scenario: max_by rejects a MAP ordering literal
+      When query
+        """
+        SELECT max_by(1, map('a', 1)) AS result
+        """
+      Then query error does not support ordering on type
+
+    # The window path never reaches `simplify`, so a missing orderability check is
+    # SILENT there rather than merely mis-messaged: Sail returns a value.
+    @sail-bug
+    Scenario: max_by rejects a MAP ordering column in a window frame
+      When query
+        """
+        SELECT max_by(v, o) OVER (ORDER BY i ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS result
+        FROM VALUES ('lo', map('a', 1), 1), ('hi', map('b', 2), 2) AS t(v, o, i)
+        """
+      Then query error does not support ordering on type
+
+  Rule: IGNORE NULLS is not supported
+
+    # `FunctionResolution.applyIgnoreNulls` has no case for MaxBy/MinBy, so it falls
+    # through to `functionWithUnsupportedSyntaxError`. This is not just a missing
+    # error: `MaxMinBy.updateExpressions` skips NULL ORDERINGS only and may legitimately
+    # return a NULL value, whereas Sail forwards the flag to `last_value`, which skips
+    # NULL VALUES and answered 'b' where the two-argument semantics say NULL.
+    Scenario: max_by rejects IGNORE NULLS
+      When query
+        """
+        SELECT max_by(v, o) IGNORE NULLS AS result
+        FROM VALUES (CAST(NULL AS STRING), 3), ('b', 2), ('c', 1) AS t(v, o)
+        """
+      Then query error does not support IGNORE NULLS
+
+    # `applyIgnoreNulls` runs on the function itself (the Spark stack goes through
+    # `WindowExpression.mapChildren`), so the window form is rejected as well.
+    Scenario: max_by rejects IGNORE NULLS in a window frame
+      When query
+        """
+        SELECT max_by(v, o) IGNORE NULLS OVER (ORDER BY o ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS result
+        FROM VALUES (CAST(NULL AS STRING), 3), ('b', 2), ('c', 1) AS t(v, o)
+        """
+      Then query error does not support IGNORE NULLS
+
+    Scenario: max_by returns a NULL value at the maximum ordering
+      When query
+        """
+        SELECT max_by(v, o) AS result
+        FROM VALUES (CAST(NULL AS STRING), 3), ('b', 2), ('c', 1) AS t(v, o)
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+  Rule: The output type is the value argument's type
+
+    # `MaxMinBy.dataType` is `valueExpr.dataType` and `nullable` is unconditionally
+    # true, so the value type must survive unwidened -- including decimal precision
+    # and the inner nullability of a nested value.
+    Scenario: max_by preserves a narrow integer value type
+      When query
+        """
+        SELECT max_by(CAST(1 AS TINYINT), 2) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: byte (nullable = true)
+        """
+      Then query result
+        | result |
+        | 1      |
+
+    Scenario: max_by preserves decimal precision and scale
+      When query
+        """
+        SELECT max_by(CAST(1.5 AS DECIMAL(20,3)), 2) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: decimal(20,3) (nullable = true)
+        """
+
+    Scenario: max_by preserves the inner nullability of an ARRAY value
+      When query
+        """
+        SELECT max_by(array(1, 2), 1) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: array (nullable = true)
+         |    |-- element: integer (containsNull = false)
+        """
+
+    Scenario: max_by is nullable even over a non-nullable value column
+      When query
+        """
+        SELECT max_by(id, id) AS result FROM range(3)
+        """
+      Then query schema
+        """
+        root
+         |-- result: long (nullable = true)
+        """
+
+    # Sail carries the Spark type identity of GEOMETRY/GEOGRAPHY/UDT in the FIELD
+    # METADATA, which `udaf_default_return_field` drops because neither UDAF
+    # implements `return_field`. The bare `st_geomfromwkb` call keeps the type, so
+    # the downgrade to `binary` is `max_by`'s own.
+    @spark-4.2 @sail-bug
+    Scenario: max_by preserves the geometry type of the value argument
+      When query
+        """
+        SELECT max_by(st_geomfromwkb(g), i) AS result
+        FROM VALUES (X'0101000000000000000000F03F0000000000000040', 1) AS t(g, i)
+        """
+      Then query schema
+        """
+        root
+         |-- result: geometry (nullable = true)
+        """
+
+  Rule: A star argument is expanded before the function is resolved
+
+    # Spark expands `*` into the table's columns first, so `max_by(*)` over a
+    # two-column table resolves to `max_by(x, y)`. Sail does not expand a star inside
+    # aggregate arguments and reports an arity error instead.
+    @sail-bug
+    Scenario: max_by expands a star argument
+      When query
+        """
+        SELECT max_by(*) AS result FROM VALUES (1, 2) AS t(x, y)
+        """
+      Then query result
+        | result |
+        | 1      |
+
+    # Expanding here yields `max_by(x, x, y)`, i.e. the three-argument top-k form with a
+    # non-foldable `k`, which Spark rejects at ANALYSIS. Sail leaks a DataFusion physical
+    # planning error ("Physical plan does not support logical expression Wildcard").
+    @spark-4.2 @sail-bug
+    Scenario: max_by rejects a non-foldable k from an expanded star
+      When query
+        """
+        SELECT max_by(x, *) AS result FROM VALUES (1, 2) AS t(x, y)
+        """
+      Then query error should be a foldable
+
+  Rule: Other aggregate clauses
+
+    Scenario: max_by composes with FILTER
+      When query
+        """
+        SELECT max_by(v, o) FILTER (WHERE v <> 'x') AS result FROM VALUES ('x', 9), ('b', 2) AS t(v, o)
+        """
+      Then query result
+        | result |
+        | b      |
+
+    # Spark de-duplicates the (value, ordering) pair, not the value alone.
+    Scenario: max_by with DISTINCT de-duplicates the argument pair
+      When query
+        """
+        SELECT max_by(DISTINCT v, o) AS result FROM VALUES ('a', 1), ('a', 5), ('b', 3) AS t(v, o)
+        """
+      Then query result
+        | result |
+        | a      |
+
+    # A sliding frame needs `retract_batch`, which `MaxMinByAccumulator` does not
+    # implement, so Sail fails to plan the query outright.
+    @sail-bug
+    Scenario: max_by supports a sliding window frame
+      When query
+        """
+        SELECT max_by(v, o) OVER (ORDER BY o ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS result
+        FROM VALUES ('a', 1), ('b', 2), ('c', 3) AS t(v, o)
+        """
+      Then query result ordered
+        | result |
+        | a      |
+        | b      |
+        | c      |
+
   Rule: The three-argument form returns the k values at the extreme of the ordering column
 
     # Added in Spark 4.2 (`MaxMinByK.scala`, `MaxByBuilder` accepts [2, 3] arguments):
@@ -121,3 +309,19 @@ Feature: max_by function
       Then query result
         | result |
         | b,c    |
+
+    # The scenario above joins the array, so it asserts a STRING and would stay green
+    # against a wrong element type. `MaxMinByK.dataType` is
+    # `ArrayType(valueExpr.dataType, containsNull = true)`; pin it separately.
+    @spark-4.2 @sail-bug
+    Scenario: max_by returns the top k values with an array output type
+      When query
+        """
+        SELECT max_by(x, y, 2) AS result FROM VALUES ('a', 10), ('b', 50), ('c', 20) AS t(x, y)
+        """
+      Then query schema
+        """
+        root
+         |-- result: array (nullable = true)
+         |    |-- element: string (containsNull = true)
+        """

--- a/python/pysail/tests/spark/function/features/aggregate/max_by.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/max_by.feature
@@ -300,7 +300,7 @@ Feature: max_by function
     # returns an ARRAY of the k values, sorted descending by the ordering column.
     # The array is joined so that the assertion stays plain SQL; the element order is
     # part of what is asserted, and it is deterministic here because every `y` differs.
-    @spark-4.2 @sail-bug
+    @spark-4.2
     Scenario: max_by returns the top k values as an array
       When query
         """
@@ -313,7 +313,7 @@ Feature: max_by function
     # The scenario above joins the array, so it asserts a STRING and would stay green
     # against a wrong element type. `MaxMinByK.dataType` is
     # `ArrayType(valueExpr.dataType, containsNull = true)`; pin it separately.
-    @spark-4.2 @sail-bug
+    @spark-4.2
     Scenario: max_by returns the top k values with an array output type
       When query
         """
@@ -325,3 +325,70 @@ Feature: max_by function
          |-- result: array (nullable = true)
          |    |-- element: string (containsNull = true)
         """
+
+    # Spark's rule for `k` is FOLDABILITY, not "is a literal", so a constant-folded
+    # expression qualifies and must behave exactly like the literal it folds to.
+    @spark-4.2
+    Scenario: max_by accepts a foldable expression as k
+      When query
+        """
+        SELECT array_join(max_by(x, y, 1 + 1), ',') AS result FROM VALUES ('a', 10), ('b', 50), ('c', 20) AS t(x, y)
+        """
+      Then query result
+        | result |
+        | b,c    |
+
+    @spark-4.2
+    Scenario: max_by rejects a non-foldable k
+      When query
+        """
+        SELECT max_by(x, y, y) AS result FROM VALUES ('a', 10), ('b', 50), ('c', 20) AS t(x, y)
+        """
+      Then query error should be a foldable
+
+    # `MaxMinByK.MAX_K` is 100000 and `k` must be at least 1.
+    @spark-4.2
+    Scenario Outline: max_by rejects k outside [1, 100000] (<case>)
+      When query
+        """
+        SELECT max_by(x, y, <k>) AS result FROM VALUES ('a', 10), ('b', 50), ('c', 20) AS t(x, y)
+        """
+      Then query error must be between \[1, 100000\]
+
+      Examples:
+        | case      | k      |
+        | too small | 0      |
+        | too large | 100001 |
+
+    # A `k` larger than the group returns every row, not a padded array.
+    @spark-4.2
+    Scenario: max_by returns every value when k exceeds the row count
+      When query
+        """
+        SELECT array_join(max_by(x, y, 10), ',') AS result FROM VALUES ('a', 10), ('b', 50), ('c', 20) AS t(x, y)
+        """
+      Then query result
+        | result |
+        | b,c,a  |
+
+    # An empty group yields NULL rather than an empty array (`eval` returns null when the
+    # heap is empty), and NULL orderings are skipped while NULL VALUES are kept.
+    @spark-4.2
+    Scenario: max_by returns NULL for an empty group
+      When query
+        """
+        SELECT max_by(x, y, 2) AS result FROM VALUES ('a', 10), ('b', 50) AS t(x, y) WHERE y > 999
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    @spark-4.2
+    Scenario: max_by skips NULL orderings but keeps NULL values
+      When query
+        """
+        SELECT max_by(x, y, 2) AS result FROM VALUES (CAST(NULL AS STRING), 9), ('b', 5), ('c', CAST(NULL AS INT)) AS t(x, y)
+        """
+      Then query result collected
+        | result      |
+        | [None, 'b'] |

--- a/python/pysail/tests/spark/function/features/aggregate/min_by.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/min_by.feature
@@ -73,3 +73,58 @@ Feature: min_by function
       Then query result
         | result |
         | NULL   |
+
+  Rule: An argument count outside the accepted range is rejected
+
+    # `Signature::user_defined` means DataFusion runs no arity check of its own, so
+    # every hook reaching for the second argument used to index an empty/short slice
+    # and panic -- which kills the gRPC connection instead of reporting an error.
+    Scenario: min_by with no arguments is rejected
+      When query
+        """
+        SELECT min_by()
+        """
+      Then query error (?i)min_by.*requires
+
+    Scenario: min_by with a single argument is rejected
+      When query
+        """
+        SELECT min_by(1)
+        """
+      Then query error (?i)min_by.*requires
+
+    Scenario: min_by with four arguments is rejected
+      When query
+        """
+        SELECT min_by(x, y, 2, 1) FROM VALUES (1, 2), (3, 4) AS t(x, y)
+        """
+      Then query error (?i)min_by.*requires
+
+  Rule: The ordering argument must be of an orderable type
+
+    # Same rule as `max_by` (shared `MaxMinBy.checkInputDataTypes`): only the ORDERING
+    # argument is type-checked, and MAP is not orderable. See `aggregate/max_by.feature`
+    # for the ARRAY/STRUCT cases that show the rule is orderability, not "complex type".
+    @sail-bug
+    Scenario: min_by rejects a MAP ordering column
+      When query
+        """
+        SELECT min_by(v, o) AS result FROM VALUES ('lo', map('a', 1)), ('hi', map('b', 2)) AS t(v, o)
+        """
+      Then query error does not support ordering on type
+
+  Rule: The three-argument form returns the k values at the extreme of the ordering column
+
+    # Added in Spark 4.2 (`MaxMinByK.scala`, `MinByBuilder` accepts [2, 3] arguments):
+    # returns an ARRAY of the k values, sorted ascending by the ordering column.
+    # The array is joined so that the assertion stays plain SQL; the element order is
+    # part of what is asserted, and it is deterministic here because every `y` differs.
+    @spark-4.2 @sail-bug
+    Scenario: min_by returns the bottom k values as an array
+      When query
+        """
+        SELECT array_join(min_by(x, y, 2), ',') AS result FROM VALUES ('a', 10), ('b', 50), ('c', 20) AS t(x, y)
+        """
+      Then query result
+        | result |
+        | a,c    |

--- a/python/pysail/tests/spark/function/features/aggregate/min_by.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/min_by.feature
@@ -231,7 +231,7 @@ Feature: min_by function
     # returns an ARRAY of the k values, sorted ascending by the ordering column.
     # The array is joined so that the assertion stays plain SQL; the element order is
     # part of what is asserted, and it is deterministic here because every `y` differs.
-    @spark-4.2 @sail-bug
+    @spark-4.2
     Scenario: min_by returns the bottom k values as an array
       When query
         """

--- a/python/pysail/tests/spark/function/features/aggregate/min_by.feature
+++ b/python/pysail/tests/spark/function/features/aggregate/min_by.feature
@@ -113,6 +113,118 @@ Feature: min_by function
         """
       Then query error does not support ordering on type
 
+    # The rule is shared, but the two implementations are separate copies of every
+    # hook (opposite sort direction), so the accepted cases are asserted here too
+    # rather than only in `aggregate/max_by.feature`.
+    Scenario: min_by accepts an ARRAY ordering column
+      When query
+        """
+        SELECT min_by(v, o) AS result FROM VALUES ('lo', array(1, 2)), ('hi', array(3, 4)) AS t(v, o)
+        """
+      Then query result
+        | result |
+        | lo     |
+
+    Scenario: min_by accepts a STRUCT ordering column
+      When query
+        """
+        SELECT min_by(v, o) AS result FROM VALUES ('lo', named_struct('a', 1)), ('hi', named_struct('a', 2)) AS t(v, o)
+        """
+      Then query result
+        | result |
+        | lo     |
+
+    @sail-bug
+    Scenario: min_by rejects a MAP ordering column in a window frame
+      When query
+        """
+        SELECT min_by(v, o) OVER (ORDER BY i ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS result
+        FROM VALUES ('lo', map('a', 1), 1), ('hi', map('b', 2), 2) AS t(v, o, i)
+        """
+      Then query error does not support ordering on type
+
+  Rule: IGNORE NULLS is not supported
+
+    # Same rule as `max_by`: `FunctionResolution.applyIgnoreNulls` has no case for
+    # MaxBy/MinBy. The flag used to reach `last_value`, which skips NULL VALUES,
+    # while the two-argument semantics skip NULL ORDERINGS only.
+    Scenario: min_by rejects IGNORE NULLS
+      When query
+        """
+        SELECT min_by(v, o) IGNORE NULLS AS result
+        FROM VALUES (CAST(NULL AS STRING), 1), ('b', 2), ('c', 3) AS t(v, o)
+        """
+      Then query error does not support IGNORE NULLS
+
+    Scenario: min_by rejects IGNORE NULLS in a window frame
+      When query
+        """
+        SELECT min_by(v, o) IGNORE NULLS OVER (ORDER BY o ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS result
+        FROM VALUES (CAST(NULL AS STRING), 1), ('b', 2), ('c', 3) AS t(v, o)
+        """
+      Then query error does not support IGNORE NULLS
+
+    Scenario: min_by returns a NULL value at the minimum ordering
+      When query
+        """
+        SELECT min_by(v, o) AS result
+        FROM VALUES (CAST(NULL AS STRING), 1), ('b', 2), ('c', 3) AS t(v, o)
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+  Rule: The output type is the value argument's type
+
+    Scenario: min_by preserves a narrow integer value type
+      When query
+        """
+        SELECT min_by(CAST(1 AS TINYINT), 2) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: byte (nullable = true)
+        """
+
+    Scenario: min_by is nullable even over a non-nullable value column
+      When query
+        """
+        SELECT min_by(id, id) AS result FROM range(3)
+        """
+      Then query schema
+        """
+        root
+         |-- result: long (nullable = true)
+        """
+
+  Rule: A star argument is expanded before the function is resolved
+
+    @sail-bug
+    Scenario: min_by expands a star argument
+      When query
+        """
+        SELECT min_by(*) AS result FROM VALUES (1, 2) AS t(x, y)
+        """
+      Then query result
+        | result |
+        | 1      |
+
+  Rule: Other aggregate clauses
+
+    @sail-bug
+    Scenario: min_by supports a sliding window frame
+      When query
+        """
+        SELECT min_by(v, o) OVER (ORDER BY o ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS result
+        FROM VALUES ('a', 1), ('b', 2), ('c', 3) AS t(v, o)
+        """
+      Then query result ordered
+        | result |
+        | a      |
+        | a      |
+        | b      |
+
   Rule: The three-argument form returns the k values at the extreme of the ordering column
 
     # Added in Spark 4.2 (`MaxMinByK.scala`, `MinByBuilder` accepts [2, 3] arguments):


### PR DESCRIPTION
needs https://github.com/lakehq/sail/pull/2433