### PR TITLE
fix: support three-argument dateadd

### DIFF
--- a/crates/sail-plan/src/formatter.rs
+++ b/crates/sail-plan/src/formatter.rs
@@ -515,8 +515,13 @@ impl PlanFormatter for SparkPlanFormatter {
                 name, arguments, 2, "12",
             )),
             "dateadd" => {
+                let name = if arguments.len() == 3 {
+                    "timestampadd"
+                } else {
+                    "date_add"
+                };
                 let arguments = arguments.join(", ");
-                Ok(format!("date_add({arguments})"))
+                Ok(format!("{name}({arguments})"))
             }
             "sum" => {
                 let mut args = arguments.join(", ");

--- a/crates/sail-plan/src/formatter.rs
+++ b/crates/sail-plan/src/formatter.rs
@@ -514,11 +514,11 @@ impl PlanFormatter for SparkPlanFormatter {
             "theta_union" => Ok(format_function_with_default_argument(
                 name, arguments, 2, "12",
             )),
-            "dateadd" => {
-                let name = if arguments.len() == 3 {
-                    "timestampadd"
-                } else {
-                    "date_add"
+            "date_add" | "dateadd" => {
+                let name = match arguments.len() {
+                    2 => "date_add",
+                    3 => "timestampadd",
+                    _ => name,
                 };
                 let arguments = arguments.join(", ");
                 Ok(format!("{name}({arguments})"))

--- a/crates/sail-plan/src/function/scalar/datetime.rs
+++ b/crates/sail-plan/src/function/scalar/datetime.rs
@@ -156,7 +156,7 @@ fn format_interval(interval: Expr, unit: &str) -> Expr {
     })
 }
 
-fn timestampadd_interval(unit: &str, quantity: Expr) -> PlanResult<Expr> {
+fn timestampadd_interval(function_name: &str, unit: &str, quantity: Expr) -> PlanResult<Expr> {
     let zero_i32 = || lit(0_i32);
     let zero_f64 = || lit(0_f64);
     let quantity_i32 = || cast(quantity.clone(), DataType::Int32);
@@ -215,24 +215,24 @@ fn timestampadd_interval(unit: &str, quantity: Expr) -> PlanResult<Expr> {
             quantity_f64() / lit(1_000_000_f64),
         ])),
         _ => Err(PlanError::invalid(format!(
-            "timestampadd does not support interval unit type '{unit}'"
+            "{function_name} does not support interval unit type '{unit}'"
         ))),
     }
 }
 
-fn timestampadd(input: ScalarFunctionInput) -> PlanResult<Expr> {
+fn timestampadd_with_name(input: ScalarFunctionInput, function_name: &str) -> PlanResult<Expr> {
     let (unit, quantity, timestamp) = input.arguments.three()?;
     let unit = match &unit {
         Expr::Literal(ScalarValue::Utf8(Some(s)), _)
         | Expr::Literal(ScalarValue::LargeUtf8(Some(s)), _) => s.clone(),
         Expr::Column(col) => col.name().to_string(),
         _ => {
-            return Err(PlanError::invalid(
-                "timestampadd unit must be a string literal or keyword",
-            ));
+            return Err(PlanError::invalid(format!(
+                "{function_name} unit must be a string literal or keyword"
+            )));
         }
     };
-    let interval = timestampadd_interval(&unit, quantity)?;
+    let interval = timestampadd_interval(function_name, &unit, quantity)?;
     Ok(cast(
         timestamp,
         DataType::Timestamp(
@@ -242,11 +242,17 @@ fn timestampadd(input: ScalarFunctionInput) -> PlanResult<Expr> {
     ) + interval)
 }
 
-fn dateadd(input: ScalarFunctionInput) -> PlanResult<Expr> {
+fn timestampadd(input: ScalarFunctionInput) -> PlanResult<Expr> {
+    timestampadd_with_name(input, "timestampadd")
+}
+
+fn dateadd(input: ScalarFunctionInput, function_name: &str) -> PlanResult<Expr> {
     match input.arguments.len() {
         2 => interval_arithmetic(input, "days", Operator::Plus),
-        3 => timestampadd(input),
-        _ => Err(PlanError::invalid("dateadd requires 2 or 3 arguments")),
+        3 => timestampadd_with_name(input, function_name),
+        _ => Err(PlanError::invalid(format!(
+            "{function_name} requires 2 or 3 arguments"
+        ))),
     }
 }
 
@@ -1168,10 +1174,7 @@ pub(super) fn list_built_in_datetime_functions() -> Vec<(&'static str, ScalarFun
             F::custom(current_timestamp_microseconds),
         ),
         ("current_timezone", F::custom(current_timezone)),
-        (
-            "date_add",
-            F::custom(|input| interval_arithmetic(input, "days", Operator::Plus)),
-        ),
+        ("date_add", F::custom(|input| dateadd(input, "date_add"))),
         ("date_diff", F::custom(datediff)),
         (
             "date_format",
@@ -1190,7 +1193,7 @@ pub(super) fn list_built_in_datetime_functions() -> Vec<(&'static str, ScalarFun
             F::custom(|input| interval_arithmetic(input, "days", Operator::Minus)),
         ),
         ("date_trunc", F::custom(date_trunc)),
-        ("dateadd", F::custom(dateadd)),
+        ("dateadd", F::custom(|input| dateadd(input, "dateadd"))),
         ("datediff", F::custom(datediff)),
         ("datepart", F::binary(date_part)),
         ("day", F::unary(|arg| integer_part(arg, "DAY"))),

--- a/crates/sail-plan/src/function/scalar/datetime.rs
+++ b/crates/sail-plan/src/function/scalar/datetime.rs
@@ -242,6 +242,14 @@ fn timestampadd(input: ScalarFunctionInput) -> PlanResult<Expr> {
     ) + interval)
 }
 
+fn dateadd(input: ScalarFunctionInput) -> PlanResult<Expr> {
+    match input.arguments.len() {
+        2 => interval_arithmetic(input, "days", Operator::Plus),
+        3 => timestampadd(input),
+        _ => Err(PlanError::invalid("dateadd requires 2 or 3 arguments")),
+    }
+}
+
 fn make_date(year: Expr, month: Expr, day: Expr) -> Expr {
     match (&year, &month, &day) {
         (Expr::Literal(ScalarValue::Null, metadata), _, _)
@@ -1182,10 +1190,7 @@ pub(super) fn list_built_in_datetime_functions() -> Vec<(&'static str, ScalarFun
             F::custom(|input| interval_arithmetic(input, "days", Operator::Minus)),
         ),
         ("date_trunc", F::custom(date_trunc)),
-        (
-            "dateadd",
-            F::custom(|input| interval_arithmetic(input, "days", Operator::Plus)),
-        ),
+        ("dateadd", F::custom(dateadd)),
         ("datediff", F::custom(datediff)),
         ("datepart", F::binary(date_part)),
         ("day", F::unary(|arg| integer_part(arg, "DAY"))),

--- a/crates/sail-plan/src/resolver/expression/function.rs
+++ b/crates/sail-plan/src/resolver/expression/function.rs
@@ -453,6 +453,7 @@ impl PlanResolver<'_> {
         mut arguments: Vec<spec::Expr>,
     ) -> Vec<spec::Expr> {
         const DATE_PART_FUNCTIONS: &[&str] = &[
+            "date_add",
             "dateadd",
             "datediff",
             "date_diff",

--- a/crates/sail-plan/src/resolver/expression/function.rs
+++ b/crates/sail-plan/src/resolver/expression/function.rs
@@ -453,6 +453,7 @@ impl PlanResolver<'_> {
         mut arguments: Vec<spec::Expr>,
     ) -> Vec<spec::Expr> {
         const DATE_PART_FUNCTIONS: &[&str] = &[
+            "dateadd",
             "datediff",
             "date_diff",
             "timestampadd",

--- a/python/pysail/tests/spark/function/features/datetime/dateadd.feature
+++ b/python/pysail/tests/spark/function/features/datetime/dateadd.feature
@@ -1,0 +1,61 @@
+Feature: dateadd function
+
+  Scenario Outline: three-argument dateadd: <case>
+    When query
+      """
+      SELECT dateadd(<unit>, <quantity>, <value>) AS result
+      """
+    Then query result
+      | result   |
+      | <result> |
+
+    Examples:
+      | case                     | unit | quantity | value                           | result              |
+      | lowercase unit           | week | 2        | DATE '2024-01-01'               | 2024-01-15 00:00:00 |
+      | uppercase negative unit  | WEEK | -1       | DATE '2024-01-15'               | 2024-01-08 00:00:00 |
+      | timestamp sub-day unit   | HOUR | 2        | TIMESTAMP '2024-01-15 10:00:00' | 2024-01-15 12:00:00 |
+
+  Scenario: three-argument dateadd supports column input
+    When query
+      """
+      SELECT dateadd(DAY, id, DATE '2024-01-15') AS result FROM range(3)
+      """
+    Then query result
+      | result              |
+      | 2024-01-15 00:00:00 |
+      | 2024-01-16 00:00:00 |
+      | 2024-01-17 00:00:00 |
+
+  Scenario: two-argument dateadd remains date arithmetic
+    When query
+      """
+      SELECT dateadd(DATE '2024-01-15', 2) AS result
+      """
+    Then query result
+      | result     |
+      | 2024-01-17 |
+
+  @function(nullability)
+  Rule: Output schema
+
+    Scenario: three-argument dateadd with a date returns a timestamp
+      When query
+        """
+        SELECT dateadd(WEEK, 1, DATE '2024-01-15')
+        """
+      Then query schema
+        """
+        root
+         |-- timestampadd(WEEK, 1, DATE '2024-01-15'): timestamp (nullable = false)
+        """
+
+    Scenario: two-argument dateadd returns a date
+      When query
+        """
+        SELECT dateadd(DATE '2024-01-15', 1) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: date (nullable = false)
+        """

--- a/python/pysail/tests/spark/function/features/datetime/dateadd.feature
+++ b/python/pysail/tests/spark/function/features/datetime/dateadd.feature
@@ -38,16 +38,21 @@ Feature: dateadd function
   @function(nullability)
   Rule: Output schema
 
-    Scenario: three-argument dateadd with a date returns a timestamp
+    Scenario Outline: three-argument <function> with a date returns a timestamp
       When query
         """
-        SELECT dateadd(WEEK, 1, DATE '2024-01-15')
+        SELECT <function>(WEEK, 1, DATE '2024-01-15')
         """
       Then query schema
         """
         root
          |-- timestampadd(WEEK, 1, DATE '2024-01-15'): timestamp (nullable = false)
         """
+
+      Examples:
+        | function |
+        | dateadd  |
+        | date_add |
 
     Scenario: two-argument dateadd returns a date
       When query


### PR DESCRIPTION
## What changes

- Support three-argument `DATEADD(unit, quantity, value)` using existing `TIMESTAMPADD` semantics.
- Resolve date-part keywords such as `WEEK` correctly.
- Preserve the existing two-argument `DATEADD(date, days)` behavior.

Closes #2385