### PR TITLE
fix: parse PostgreSQL JDBC write targets

### DIFF
--- a/crates/sail-data-source/src/formats/python/adapter.rs
+++ b/crates/sail-data-source/src/formats/python/adapter.rs
@@ -12,7 +12,7 @@ use datafusion::logical_expr::physical_planning_context::PhysicalPlanningContext
 use datafusion::logical_expr::{Extension, LogicalPlan, TableSource, UserDefinedLogicalNode};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
-use datafusion_common::{DFSchema, DFSchemaRef, Result, internal_err};
+use datafusion_common::{DFSchema, DFSchemaRef, Result, internal_err, plan_err};
 use datafusion_expr::{Expr, UserDefinedLogicalNodeCore};
 use educe::Educe;
 use sail_common_datafusion::datasource::{
@@ -24,6 +24,13 @@ use super::datasource::PythonDataSource;
 use super::discovery::DATA_SOURCE_REGISTRY;
 use super::executor::InProcessExecutor;
 use super::table_provider::PythonTableProvider;
+
+fn validate_jdbc_write_mode(name: &str, mode: &SinkMode) -> Result<()> {
+    if name.eq_ignore_ascii_case("jdbc") && !matches!(mode, SinkMode::Append) {
+        return plan_err!("JDBC writes currently support only explicit append mode");
+    }
+    Ok(())
+}
 
 /// DataSource implementation for a Python data source.
 ///
@@ -221,6 +228,8 @@ impl DataSource for PythonDataSourceAdapter {
             ..
         } = info;
 
+        validate_jdbc_write_mode(&self.name, &mode)?;
+
         // Warn about unsupported partitionBy (PySpark compat: silently ignored)
         if !partition_by.is_empty() {
             log::warn!(
@@ -378,5 +387,13 @@ mod tests {
     fn test_python_data_source_adapter_name() {
         let source = PythonDataSourceAdapter::new("test_datasource".to_string());
         assert_eq!(source.name(), "test_datasource");
+    }
+
+    #[test]
+    fn test_jdbc_write_mode_accepts_only_append() {
+        assert!(validate_jdbc_write_mode("jdbc", &SinkMode::Append).is_ok());
+        assert!(validate_jdbc_write_mode("JDBC", &SinkMode::ErrorIfExists).is_err());
+        assert!(validate_jdbc_write_mode("jdbc", &SinkMode::Overwrite).is_err());
+        assert!(validate_jdbc_write_mode("other", &SinkMode::Overwrite).is_ok());
     }
 }

--- a/crates/sail-data-source/src/formats/python/adapter.rs
+++ b/crates/sail-data-source/src/formats/python/adapter.rs
@@ -12,7 +12,7 @@ use datafusion::logical_expr::physical_planning_context::PhysicalPlanningContext
 use datafusion::logical_expr::{Extension, LogicalPlan, TableSource, UserDefinedLogicalNode};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
-use datafusion_common::{DFSchema, DFSchemaRef, Result, internal_err, plan_err};
+use datafusion_common::{DFSchema, DFSchemaRef, Result, internal_err};
 use datafusion_expr::{Expr, UserDefinedLogicalNodeCore};
 use educe::Educe;
 use sail_common_datafusion::datasource::{
@@ -25,11 +25,15 @@ use super::discovery::DATA_SOURCE_REGISTRY;
 use super::executor::InProcessExecutor;
 use super::table_provider::PythonTableProvider;
 
-fn validate_jdbc_write_mode(name: &str, mode: &SinkMode) -> Result<()> {
-    if name.eq_ignore_ascii_case("jdbc") && !matches!(mode, SinkMode::Append) {
-        return plan_err!("JDBC writes currently support only explicit append mode");
+fn sink_mode_name(mode: &SinkMode) -> &'static str {
+    match mode {
+        SinkMode::ErrorIfExists => "errorifexists",
+        SinkMode::IgnoreIfExists => "ignore",
+        SinkMode::Append => "append",
+        SinkMode::Overwrite | SinkMode::OverwriteIf { .. } | SinkMode::OverwritePartitions => {
+            "overwrite"
+        }
     }
-    Ok(())
 }
 
 /// DataSource implementation for a Python data source.
@@ -228,8 +232,6 @@ impl DataSource for PythonDataSourceAdapter {
             ..
         } = info;
 
-        validate_jdbc_write_mode(&self.name, &mode)?;
-
         // Warn about unsupported partitionBy (PySpark compat: silently ignored)
         if !partition_by.is_empty() {
             log::warn!(
@@ -343,12 +345,16 @@ impl ExtensionPlanner for PythonPhysicalPlanner {
             node.mode,
             SinkMode::Overwrite | SinkMode::OverwriteIf { .. } | SinkMode::OverwritePartitions
         );
-        let opaque_options: Vec<HashMap<String, String>> = node
+        let mut opaque_options: Vec<HashMap<String, String>> = node
             .options
             .clone()
             .into_iter()
             .map(|l| l.into_opaque_options())
             .collect();
+        opaque_options.push(HashMap::from([(
+            "__sail_save_mode".to_string(),
+            sink_mode_name(&node.mode).to_string(),
+        )]));
         let adapter = PythonDataSourceAdapter {
             name: node.name.clone(),
             pickled_class: node.pickled_class.clone(),
@@ -390,10 +396,10 @@ mod tests {
     }
 
     #[test]
-    fn test_jdbc_write_mode_accepts_only_append() {
-        assert!(validate_jdbc_write_mode("jdbc", &SinkMode::Append).is_ok());
-        assert!(validate_jdbc_write_mode("JDBC", &SinkMode::ErrorIfExists).is_err());
-        assert!(validate_jdbc_write_mode("jdbc", &SinkMode::Overwrite).is_err());
-        assert!(validate_jdbc_write_mode("other", &SinkMode::Overwrite).is_ok());
+    fn test_sink_mode_name_preserves_all_v1_modes() {
+        assert_eq!(sink_mode_name(&SinkMode::ErrorIfExists), "errorifexists");
+        assert_eq!(sink_mode_name(&SinkMode::IgnoreIfExists), "ignore");
+        assert_eq!(sink_mode_name(&SinkMode::Append), "append");
+        assert_eq!(sink_mode_name(&SinkMode::Overwrite), "overwrite");
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,11 +53,13 @@ test = [
     "pyarrow>=24.0,<25",
     "adbc-driver-flightsql>=1.0,<2",
     "adbc-driver-manager>=1.0,<2",
+    "adbc-driver-postgresql>=1.0,<2",
 ]
 mcp = [
     "mcp>=1.0.0,<2",
 ]
 jdbc = [
+    "adbc-driver-postgresql>=1.0,<2",
     "connectorx>=0.3",
     "pyarrow>=10.0",
 ]
@@ -114,6 +116,7 @@ dependencies = [
     "pyarrow>=24.0,<25",
     "adbc-driver-flightsql>=1.0,<2",
     "adbc-driver-manager>=1.0,<2",
+    "adbc-driver-postgresql>=1.0,<2",
     "moto[glue]>=5,<6",
     "testcontainers>=4,<5",
     "connectorx>=0.3,<1",
@@ -169,6 +172,7 @@ dependencies = [
     "pyarrow>=24.0,<25",
     "adbc-driver-flightsql>=1.0,<2",
     "adbc-driver-manager>=1.0,<2",
+    "adbc-driver-postgresql>=1.0,<2",
     "moto[glue]>=5,<6",
     "testcontainers>=4,<5",
     "connectorx>=0.3,<1",

--- a/python/pysail/spark/datasource/jdbc.py
+++ b/python/pysail/spark/datasource/jdbc.py
@@ -262,20 +262,30 @@ def _build_where(filters: list[str]) -> str:
 
 
 class _PostgresJdbcWriter(DataSourceArrowWriter):
-    def __init__(self, conn_str: str, dbtable: str):
+    def __init__(self, conn_str: str, dbtable: str, input_schema: pa.Schema):
         schema, _, table = dbtable.rpartition(".")
         self.conn_str = conn_str
         self.schema = schema or None
         self.table = table
+        self.input_schema = input_schema
 
     def write(self, iterator: Iterator[pa.RecordBatch]):
         import adbc_driver_postgresql.dbapi as pg_dbapi  # noqa: PLC0415
 
         with pg_dbapi.connect(self.conn_str) as connection, connection.cursor() as cursor:
+            empty = True
             for batch in iterator:
+                empty = False
                 cursor.adbc_ingest(
                     self.table,
                     pa.Table.from_batches([batch]),
+                    mode="append",
+                    db_schema_name=self.schema,
+                )
+            if empty:
+                cursor.adbc_ingest(
+                    self.table,
+                    pa.Table.from_batches([], schema=self.input_schema),
                     mode="append",
                     db_schema_name=self.schema,
                 )
@@ -487,7 +497,7 @@ class JdbcDataSource(DataSource):
         resolved = self._resolve_options()
         return JdbcDataSourceReader(**resolved)
 
-    def writer(self, schema: pa.Schema, overwrite: bool) -> DataSourceArrowWriter:  # noqa: ARG002, FBT001
+    def writer(self, schema: pa.Schema, overwrite: bool) -> DataSourceArrowWriter:  # noqa: FBT001
         if overwrite:
             msg = "JDBC writes currently support only append mode"
             raise ValueError(msg)
@@ -502,7 +512,7 @@ class JdbcDataSource(DataSource):
             msg = "JDBC writes currently support only PostgreSQL"
             raise ValueError(msg)
 
-        return _PostgresJdbcWriter(conn_str, resolved["dbtable"])
+        return _PostgresJdbcWriter(conn_str, resolved["dbtable"], schema)
 
 
 # ============================================================================

--- a/python/pysail/spark/datasource/jdbc.py
+++ b/python/pysail/spark/datasource/jdbc.py
@@ -269,7 +269,7 @@ class _PostgresJdbcWriter(DataSourceArrowWriter):
         self.table = table
 
     def write(self, iterator: Iterator[pa.RecordBatch]):
-        import adbc_driver_postgresql.dbapi as pg_dbapi
+        import adbc_driver_postgresql.dbapi as pg_dbapi  # noqa: PLC0415
 
         with pg_dbapi.connect(self.conn_str) as connection, connection.cursor() as cursor:
             for batch in iterator:
@@ -487,7 +487,7 @@ class JdbcDataSource(DataSource):
         resolved = self._resolve_options()
         return JdbcDataSourceReader(**resolved)
 
-    def writer(self, schema: pa.Schema, overwrite: bool) -> DataSourceArrowWriter:  # noqa: ARG002
+    def writer(self, schema: pa.Schema, overwrite: bool) -> DataSourceArrowWriter:  # noqa: ARG002, FBT001
         if overwrite:
             msg = "JDBC writes currently support only append mode"
             raise ValueError(msg)

--- a/python/pysail/spark/datasource/jdbc.py
+++ b/python/pysail/spark/datasource/jdbc.py
@@ -11,6 +11,7 @@ Install the optional dependency before use::
 from __future__ import annotations
 
 import datetime
+import re
 from urllib.parse import quote
 
 try:
@@ -90,6 +91,22 @@ def _jdbc_url_to_dsn(url: str, user: str | None, password: str | None) -> str:
 def _quote_identifier(name: str) -> str:
     """Double-quote a SQL identifier, escaping any embedded double quotes."""
     return '"' + name.replace('"', '""') + '"'
+
+
+_POSTGRES_IDENTIFIER = r'"(?:[^"]|"")+"|[^\W\d][\w$]*'
+_POSTGRES_DBTABLE = re.compile(rf"\s*({_POSTGRES_IDENTIFIER})(?:\s*\.\s*({_POSTGRES_IDENTIFIER}))?\s*")
+
+
+def _parse_postgres_dbtable(dbtable: str) -> tuple[str | None, str]:
+    """Parse a PostgreSQL ``[schema.]table`` identifier for ADBC."""
+    match = _POSTGRES_DBTABLE.fullmatch(dbtable)
+    if match is None:
+        msg = f"JDBC writes require 'dbtable' to be a PostgreSQL identifier in [schema.]table form; got {dbtable!r}"
+        raise ValueError(msg)
+
+    parts = [part for part in match.groups() if part is not None]
+    names = [part[1:-1].replace('""', '"') if part.startswith('"') else part.lower() for part in parts]
+    return (None, names[0]) if len(names) == 1 else (names[0], names[1])
 
 
 # ============================================================================
@@ -263,9 +280,9 @@ def _build_where(filters: list[str]) -> str:
 
 class _PostgresJdbcWriter(DataSourceArrowWriter):
     def __init__(self, conn_str: str, dbtable: str, input_schema: pa.Schema):
-        schema, _, table = dbtable.rpartition(".")
+        schema, table = _parse_postgres_dbtable(dbtable)
         self.conn_str = conn_str
-        self.schema = schema or None
+        self.schema = schema
         self.table = table
         self.input_schema = input_schema
 

--- a/python/pysail/spark/datasource/jdbc.py
+++ b/python/pysail/spark/datasource/jdbc.py
@@ -1,4 +1,4 @@
-"""JDBC data source for Sail, backed by connectorX.
+"""JDBC data source for Sail, backed by connectorX and ADBC.
 
 Supports ``spark.read.format("jdbc")`` and ``spark.read.jdbc()`` with options
 consistent with the PySpark JDBC API.
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 try:
     from pyspark.sql.datasource import (
         DataSource,
+        DataSourceArrowWriter,
         DataSourceReader,
         EqualTo,
         Filter,
@@ -260,6 +261,27 @@ def _build_where(filters: list[str]) -> str:
 # ============================================================================
 
 
+class _PostgresJdbcWriter(DataSourceArrowWriter):
+    def __init__(self, conn_str: str, dbtable: str):
+        schema, _, table = dbtable.rpartition(".")
+        self.conn_str = conn_str
+        self.schema = schema or None
+        self.table = table
+
+    def write(self, iterator: Iterator[pa.RecordBatch]):
+        import adbc_driver_postgresql.dbapi as pg_dbapi
+
+        with pg_dbapi.connect(self.conn_str) as connection, connection.cursor() as cursor:
+            for batch in iterator:
+                cursor.adbc_ingest(
+                    self.table,
+                    pa.Table.from_batches([batch]),
+                    mode="append",
+                    db_schema_name=self.schema,
+                )
+            connection.commit()
+
+
 class JdbcDataSource(DataSource):
     """JDBC data source backed by connectorX.
 
@@ -318,7 +340,9 @@ class JdbcDataSource(DataSource):
 
     * Exactly one of ``dbtable`` or ``query`` is required.
 
-    Not supported: ``driver``, ``predicates`` list, write operations,
+    Writes support PostgreSQL existing-table append only.
+
+    Not supported: ``driver``, ``predicates`` list, overwrite, table creation,
     ``queryTimeout``, ``isolationLevel``, ``sessionInitStatement``, Kerberos.
     """
 
@@ -462,6 +486,23 @@ class JdbcDataSource(DataSource):
     def reader(self, schema: pa.Schema) -> JdbcDataSourceReader:  # noqa: ARG002
         resolved = self._resolve_options()
         return JdbcDataSourceReader(**resolved)
+
+    def writer(self, schema: pa.Schema, overwrite: bool) -> DataSourceArrowWriter:  # noqa: ARG002
+        if overwrite:
+            msg = "JDBC writes currently support only append mode"
+            raise ValueError(msg)
+
+        resolved = self._resolve_options()
+        if resolved["query"] is not None:
+            msg = "Option 'query' is not supported for JDBC writes; use 'dbtable'"
+            raise ValueError(msg)
+
+        conn_str = resolved["conn_str"]
+        if not conn_str.startswith("postgresql://"):
+            msg = "JDBC writes currently support only PostgreSQL"
+            raise ValueError(msg)
+
+        return _PostgresJdbcWriter(conn_str, resolved["dbtable"])
 
 
 # ============================================================================

--- a/python/pysail/spark/datasource/jdbc.py
+++ b/python/pysail/spark/datasource/jdbc.py
@@ -515,8 +515,9 @@ class JdbcDataSource(DataSource):
         return JdbcDataSourceReader(**resolved)
 
     def writer(self, schema: pa.Schema, overwrite: bool) -> DataSourceArrowWriter:  # noqa: FBT001
-        if overwrite:
-            msg = "JDBC writes currently support only append mode"
+        save_mode = self.options.get("__sail_save_mode", "overwrite" if overwrite else "append")
+        if save_mode != "append":
+            msg = "JDBC writes currently support only explicit append mode"
             raise ValueError(msg)
 
         resolved = self._resolve_options()

--- a/python/pysail/tests/spark/datasource/test_jdbc.py
+++ b/python/pysail/tests/spark/datasource/test_jdbc.py
@@ -244,10 +244,17 @@ def test_null_values_handling(spark, jdbc_opts):
 # ---------------------------------------------------------------------------
 
 
-def test_empty_table(spark, jdbc_opts):
+def test_empty_table_append(spark, jdbc_opts):
     df = spark.read.format("jdbc").option("dbtable", "empty_table").options(**jdbc_opts).load()
     assert df.count() == 0
     assert df.filter("id > 0").collect() == []
+
+    spark.createDataFrame([(1, "written by Sail")], "id int, name string").write.format("jdbc").mode("append").option(
+        "dbtable", "empty_table"
+    ).options(**jdbc_opts).save()
+
+    rows = spark.read.format("jdbc").option("dbtable", "empty_table").options(**jdbc_opts).load().collect()
+    assert [(row.id, row.name) for row in rows] == [(1, "written by Sail")]
 
 
 # ---------------------------------------------------------------------------

--- a/python/pysail/tests/spark/datasource/test_jdbc_writer.py
+++ b/python/pysail/tests/spark/datasource/test_jdbc_writer.py
@@ -2,6 +2,12 @@ import sys
 import types
 
 import pyarrow as pa
+import pytest
+
+from pysail.testing.spark.utils.common import pyspark_version
+
+if pyspark_version() < (4, 1):
+    pytest.skip("Python data source requires Spark 4.1+", allow_module_level=True)
 
 from pysail.spark.datasource.jdbc import JdbcDataSource
 

--- a/python/pysail/tests/spark/datasource/test_jdbc_writer.py
+++ b/python/pysail/tests/spark/datasource/test_jdbc_writer.py
@@ -61,3 +61,37 @@ def test_postgres_writer_streams_arrow_batches(monkeypatch):
         ("events", [], {"mode": "append", "db_schema_name": "analytics"}),
         "commit",
     ]
+
+
+@pytest.mark.parametrize(
+    ("dbtable", "expected"),
+    [
+        ("Events", (None, "events")),
+        ('"events.log"', (None, "events.log")),
+        ('"analytics.data"."events""log"', ("analytics.data", 'events"log')),
+    ],
+)
+def test_postgres_writer_parses_dbtable(dbtable, expected):
+    datasource = JdbcDataSource(
+        options={
+            "url": "jdbc:postgresql://localhost:5432/db",
+            "dbtable": dbtable,
+        }
+    )
+
+    writer = datasource.writer(pa.schema({"id": pa.int64()}), overwrite=False)
+
+    assert (writer.schema, writer.table) == expected
+
+
+@pytest.mark.parametrize("dbtable", ["analytics.events.extra", '"unterminated'])
+def test_postgres_writer_rejects_invalid_dbtable(dbtable):
+    datasource = JdbcDataSource(
+        options={
+            "url": "jdbc:postgresql://localhost:5432/db",
+            "dbtable": dbtable,
+        }
+    )
+
+    with pytest.raises(ValueError, match=r"PostgreSQL.*identifier"):
+        datasource.writer(pa.schema({"id": pa.int64()}), overwrite=False)

--- a/python/pysail/tests/spark/datasource/test_jdbc_writer.py
+++ b/python/pysail/tests/spark/datasource/test_jdbc_writer.py
@@ -12,6 +12,20 @@ if pyspark_version() < (4, 1):
 from pysail.spark.datasource.jdbc import JdbcDataSource
 
 
+@pytest.mark.parametrize("mode", ["errorifexists", "ignore"])
+def test_postgres_writer_requires_explicit_append(mode):
+    datasource = JdbcDataSource(
+        options={
+            "url": "jdbc:postgresql://localhost:5432/db",
+            "dbtable": "events",
+            "__sail_save_mode": mode,
+        }
+    )
+
+    with pytest.raises(ValueError, match="only explicit append mode"):
+        datasource.writer(pa.schema({"id": pa.int64()}), overwrite=False)
+
+
 def test_postgres_writer_streams_arrow_batches(monkeypatch):
     calls = []
 

--- a/python/pysail/tests/spark/datasource/test_jdbc_writer.py
+++ b/python/pysail/tests/spark/datasource/test_jdbc_writer.py
@@ -53,3 +53,11 @@ def test_postgres_writer_streams_arrow_batches(monkeypatch):
         ("events", [2], {"mode": "append", "db_schema_name": "analytics"}),
         "commit",
     ]
+
+    calls.clear()
+    assert writer.write(iter([])) is None
+    assert calls == [
+        ("connect", "postgresql://localhost:5432/db"),
+        ("events", [], {"mode": "append", "db_schema_name": "analytics"}),
+        "commit",
+    ]

--- a/python/pysail/tests/spark/datasource/test_jdbc_writer.py
+++ b/python/pysail/tests/spark/datasource/test_jdbc_writer.py
@@ -1,0 +1,49 @@
+import sys
+import types
+
+import pyarrow as pa
+
+from pysail.spark.datasource.jdbc import JdbcDataSource
+
+
+def test_postgres_writer_streams_arrow_batches(monkeypatch):
+    calls = []
+
+    class Resource:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def cursor(self):
+            return self
+
+        def adbc_ingest(self, table, values, **options):
+            calls.append((table, values.column("id").to_pylist(), options))
+
+        def commit(self):
+            calls.append("commit")
+
+    dbapi = types.ModuleType("adbc_driver_postgresql.dbapi")
+    dbapi.connect = lambda dsn: calls.append(("connect", dsn)) or Resource()
+    package = types.ModuleType("adbc_driver_postgresql")
+    package.dbapi = dbapi
+    monkeypatch.setitem(sys.modules, "adbc_driver_postgresql", package)
+    monkeypatch.setitem(sys.modules, "adbc_driver_postgresql.dbapi", dbapi)
+
+    datasource = JdbcDataSource(
+        options={
+            "url": "jdbc:postgresql://localhost:5432/db",
+            "dbtable": "analytics.events",
+        }
+    )
+    writer = datasource.writer(pa.schema({"id": pa.int64()}), overwrite=False)
+
+    assert writer.write(iter([pa.record_batch({"id": [1]}), pa.record_batch({"id": [2]})])) is None
+    assert calls == [
+        ("connect", "postgresql://localhost:5432/db"),
+        ("events", [1], {"mode": "append", "db_schema_name": "analytics"}),
+        ("events", [2], {"mode": "append", "db_schema_name": "analytics"}),
+        "commit",
+    ]


### PR DESCRIPTION
## Summary

- parse PostgreSQL [schema.]table identifiers before ADBC ingestion
- unquote identifiers, unescape doubled quotes, and preserve quoted dots
- fold unquoted identifiers and reject unsupported multipart or malformed targets

## Testing

- focused JDBC writer tests: 6 passed
- hatch fmt --check

## Stack

Depends on #2376. Review the top commit only: 5b4ffc8a.
After #2376 lands, rebase this branch onto main to remove the parent diff.

Addresses https://github.com/lakehq/sail/pull/2376#discussion_r3780697944