### PR TITLE
fix: support Python data source filter pushdown on PySpark 4.0

### DIFF
--- a/crates/sail-data-source/src/formats/python/executor.rs
+++ b/crates/sail-data-source/src/formats/python/executor.rs
@@ -10,6 +10,7 @@ use arrow_schema::SchemaRef;
 use async_trait::async_trait;
 use datafusion_common::Result;
 use futures::stream::BoxStream;
+use pyo3::exceptions::PyAttributeError;
 use pyo3::prelude::*;
 use pyo3::types::PyAnyMethods;
 
@@ -292,33 +293,63 @@ impl PythonExecutor for InProcessExecutor {
                     .call_method1("reader", (schema_obj,))
                     .map_err(|e| ctx.wrap_py_error(e))?;
 
-                // Push filters to reader if any were provided
+                // Push filters to reader if any were provided.
+                //
+                // `DataSourceReader.pushFilters` was added in PySpark 4.1; on 4.0
+                // the base class has no such method. Calling it unconditionally
+                // would fail every filtered scan against every Python data source
+                // on 4.0, so skip the push when the reader does not implement it
+                // and let the filters be applied above the scan instead. This is
+                // exactly what happens on 4.1 when a reader declines to push
+                // anything, so no rows are lost either way.
                 if !filters.is_empty() {
                     let filter_ctx = PythonDataSourceContext::new(&ds_name, "pushFilters");
 
-                    // Convert Rust filters to Python filter objects
-                    let py_filters = filters_to_python(py, &filters).map_err(|e| {
-                        filter_ctx.wrap_error(format!("Failed to convert filters: {}", e))
-                    })?;
+                    // A missing attribute is the PySpark 4.0 case, and a present
+                    // but non-callable one is a duck-typed reader that would fail
+                    // at the call site — both mean "cannot push", not an error.
+                    // Anything else is a genuine failure in the reader's
+                    // attribute lookup, reported against `pushFilters` so it is
+                    // not mis-attributed to `partitions`.
+                    let push_filters = match reader.getattr("pushFilters") {
+                        Ok(attr) => Ok(attr.is_callable().then_some(attr)),
+                        Err(e) if e.is_instance_of::<PyAttributeError>(py) => Ok(None),
+                        Err(e) => Err(filter_ctx.wrap_py_error(e)),
+                    }?;
 
-                    // Call pushFilters on the reader
-                    let rejected = reader
-                        .call_method1("pushFilters", (py_filters,))
-                        .map_err(|e| filter_ctx.wrap_py_error(e))?;
+                    if let Some(push_filters) = push_filters {
+                        // Convert Rust filters to Python filter objects
+                        let py_filters = filters_to_python(py, &filters).map_err(|e| {
+                            filter_ctx.wrap_error(format!("Failed to convert filters: {}", e))
+                        })?;
 
-                    // Count rejected filters for logging
-                    use pyo3::types::PyIterator;
-                    let rejected_list = PyIterator::from_object(&rejected).map_err(|e| {
-                        filter_ctx.wrap_error(format!("pushFilters must return an iterator: {}", e))
-                    })?;
-                    let rejected_count = rejected_list.count();
+                        // Call pushFilters on the reader
+                        let rejected = push_filters
+                            .call1((py_filters,))
+                            .map_err(|e| filter_ctx.wrap_py_error(e))?;
 
-                    log::debug!(
-                        "[{}::pushFilters] Pushed {} filters, {} rejected",
-                        ds_name,
-                        filters.len(),
-                        rejected_count
-                    );
+                        // Count rejected filters for logging
+                        use pyo3::types::PyIterator;
+                        let rejected_list = PyIterator::from_object(&rejected).map_err(|e| {
+                            filter_ctx
+                                .wrap_error(format!("pushFilters must return an iterator: {}", e))
+                        })?;
+                        let rejected_count = rejected_list.count();
+
+                        log::debug!(
+                            "[{}::pushFilters] Pushed {} filters, {} rejected",
+                            ds_name,
+                            filters.len(),
+                            rejected_count
+                        );
+                    } else {
+                        log::debug!(
+                            "[{}] Reader does not provide a callable pushFilters \
+                             (requires PySpark 4.1+); applying {} filter(s) above the scan",
+                            ds_name,
+                            filters.len()
+                        );
+                    }
                 }
 
                 // Now call partitions() on the same reader that has the filters

--- a/python/pysail/tests/spark/datasource/test_python.py
+++ b/python/pysail/tests/spark/datasource/test_python.py
@@ -725,6 +725,107 @@ def test_python_filter_pushdown_equality(spark):
     assert filtered_rows[0].id == 3  # noqa: PLR2004
 
 
+def test_python_filter_pushdown_reader_without_push_filters(spark):
+    """A reader that does not implement pushFilters must still filter correctly.
+
+    `DataSourceReader.pushFilters` was added in PySpark 4.1, so on 4.0 no reader
+    has one and calling it unconditionally fails every filtered scan. The reader
+    below omits the method entirely to stand in for that, which also covers any
+    duck-typed reader that is not a `DataSourceReader` subclass.
+
+    Filters are reported to DataFusion as `Inexact`, so the predicate stays in
+    the plan and is applied above the scan; the rows must come back filtered
+    even though nothing was pushed.
+    """
+    import pyarrow as pa
+    from pyspark.sql.datasource import DataSource, InputPartition
+
+    table_schema = pa.schema([("id", pa.int64()), ("value", pa.string())])
+
+    class NoPushFiltersReader:
+        """Deliberately not a DataSourceReader, so it has no pushFilters."""
+
+        def partitions(self):
+            return [InputPartition(0)]
+
+        def read(self, partition):  # noqa: ARG002
+            yield pa.RecordBatch.from_pydict(
+                {"id": [1, 2, 3, 4, 5], "value": ["a", "b", "c", "d", "e"]}, schema=table_schema
+            )
+
+    class NoPushFiltersDataSource(DataSource):
+        @classmethod
+        def name(cls) -> str:
+            return "no_push_filters_test"
+
+        def schema(self):
+            return table_schema
+
+        def reader(self, schema):  # noqa: ARG002
+            return NoPushFiltersReader()
+
+    assert not hasattr(NoPushFiltersReader, "pushFilters")
+
+    spark.dataSource.register(NoPushFiltersDataSource)
+    df = spark.read.format("no_push_filters_test").load()
+
+    expected_all_rows = 5
+    assert len(df.collect()) == expected_all_rows
+
+    filtered_rows = df.filter("id = 3").collect()
+    assert len(filtered_rows) == 1
+    assert filtered_rows[0].id == 3  # noqa: PLR2004
+
+
+def test_python_filter_pushdown_reader_with_non_callable_push_filters(spark):
+    """A non-callable `pushFilters` attribute must not break a filtered scan.
+
+    `hasattr` alone would report the attribute as present and then fail at the
+    call site, reintroducing the very failure this guard prevents. Treat a
+    non-callable the same as an absent one and filter above the scan.
+    """
+    import pyarrow as pa
+    from pyspark.sql.datasource import DataSource, InputPartition
+
+    table_schema = pa.schema([("id", pa.int64()), ("value", pa.string())])
+
+    class NonCallablePushFiltersReader:
+        # Present, but not a method — e.g. a stub someone left behind.
+        pushFilters = None  # noqa: N815
+
+        def partitions(self):
+            return [InputPartition(0)]
+
+        def read(self, partition):  # noqa: ARG002
+            yield pa.RecordBatch.from_pydict(
+                {"id": [1, 2, 3, 4, 5], "value": ["a", "b", "c", "d", "e"]}, schema=table_schema
+            )
+
+    class NonCallablePushFiltersDataSource(DataSource):
+        @classmethod
+        def name(cls) -> str:
+            return "non_callable_push_filters_test"
+
+        def schema(self):
+            return table_schema
+
+        def reader(self, schema):  # noqa: ARG002
+            return NonCallablePushFiltersReader()
+
+    assert hasattr(NonCallablePushFiltersReader, "pushFilters")
+    assert not callable(NonCallablePushFiltersReader.pushFilters)
+
+    spark.dataSource.register(NonCallablePushFiltersDataSource)
+    df = spark.read.format("non_callable_push_filters_test").load()
+
+    expected_all_rows = 5
+    assert len(df.collect()) == expected_all_rows
+
+    filtered_rows = df.filter("id = 3").collect()
+    assert len(filtered_rows) == 1
+    assert filtered_rows[0].id == 3  # noqa: PLR2004
+
+
 def test_python_ddl_schema_fallback(spark):
     """Test that DDL string schema is correctly parsed and used."""
     spark.dataSource.register(RangeDataSource)


### PR DESCRIPTION
## Problem

`DataSourceReader.pushFilters` was added in PySpark 4.1, but `InProcessExecutor` invokes it unconditionally whenever a scan carries filters. On PySpark 4.0 the base class has no such method, so **every filtered scan against every Python data source** fails at planning:

```
AttributeError: '<Reader>' object has no attribute 'pushFilters'
```

This affects the built-in `jdbc` and `vortex` sources as well as any user-defined one.

## Fix

Probe with `hasattr` and skip the push when the reader does not implement it.

This is safe because `supports_filters_pushdown` reports `TableProviderFilterPushDown::Inexact`, so DataFusion keeps the predicate in the plan and applies it above the scan. That is the same outcome as a 4.1 reader that declines to push anything — no rows are lost either way.

The probe only runs when there are filters to push, so unfiltered scans keep their existing FFI cost.

## Testing

Adds `test_python_filter_pushdown_reader_without_push_filters`, using a duck-typed reader with no `pushFilters` attribute to stand in for the 4.0 situation. It also covers readers that are not `DataSourceReader` subclasses.

Verified load-bearing: against the pre-fix binary the test reproduces the exact error above; after the fix it passes and the filter is still applied correctly (`id = 3` returns exactly one row).

Full `python/pysail/tests/spark/datasource/` suite: 201 passed, 8 skipped.

---

Split out of #2267, where this was found. It is independent of the Kafka work and can merge on its own.