### PR TITLE
fix: propagate cluster task panics

### DIFF
--- a/crates/sail-execution/src/task_runner/actor/handler.rs
+++ b/crates/sail-execution/src/task_runner/actor/handler.rs
@@ -1,3 +1,4 @@
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::Schema;
@@ -28,7 +29,7 @@ use crate::stream::reader::TaskStreamSource;
 use crate::stream::writer::{TaskStreamChannelSink, TaskStreamSink};
 use crate::task::definition::{TaskDefinition, TaskInput, TaskOutput};
 use crate::task_runner::monitor::TaskMonitor;
-use crate::task_runner::{TaskRunnerActor, TaskRunnerMessage, TaskRunnerPlacement};
+use crate::task_runner::{TaskRunnerActor, TaskRunnerMessage, TaskRunnerPlacement, panic_message};
 use crate::worker::{WorkerLocation, WorkerMessage};
 
 impl TaskRunnerActor {
@@ -61,14 +62,28 @@ impl TaskRunnerActor {
                 }
             });
         }
-        let stream = match self.execute_plan(ctx, &key, definition, context) {
-            Ok(stream) => stream,
-            Err(error) => {
+        // The workspace uses panic=unwind. The task runner actor is single-threaded, and
+        // execute_plan does not mutate lock-protected state, so it can continue after a panic.
+        let stream = match catch_unwind(AssertUnwindSafe(|| {
+            self.execute_plan(ctx, &key, definition, context)
+        })) {
+            Ok(Ok(stream)) => stream,
+            Ok(Err(error)) => {
                 ctx.send(TaskRunnerMessage::ReportTaskStatus {
                     key,
                     status: TaskStatus::Failed,
                     message: Some(format!("failed to execute plan: {error}")),
                     cause: Some(CommonErrorCause::new::<PyErrExtractor>(&error)),
+                });
+                return ActorAction::Continue;
+            }
+            Err(payload) => {
+                let message = format!("task panicked: {}", panic_message(payload));
+                ctx.send(TaskRunnerMessage::ReportTaskStatus {
+                    key,
+                    status: TaskStatus::Failed,
+                    message: Some(message.clone()),
+                    cause: Some(CommonErrorCause::Internal(message)),
                 });
                 return ActorAction::Continue;
             }

--- a/crates/sail-execution/src/task_runner/mod.rs
+++ b/crates/sail-execution/src/task_runner/mod.rs
@@ -1,6 +1,33 @@
+use std::any::Any;
+
 mod actor;
 
 pub(crate) use actor::{TaskRunnerActor, TaskRunnerMessage};
 mod monitor;
 
 pub use actor::{TaskRunnerComponents, TaskRunnerExtensions, TaskRunnerPlacement};
+
+fn panic_message(payload: Box<dyn Any + Send>) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_panic_messages() {
+        assert_eq!(panic_message(Box::new("literal panic")), "literal panic");
+        assert_eq!(
+            panic_message(Box::new("owned panic".to_string())),
+            "owned panic"
+        );
+        assert_eq!(panic_message(Box::new(42)), "unknown panic");
+    }
+}

--- a/crates/sail-execution/src/task_runner/monitor.rs
+++ b/crates/sail-execution/src/task_runner/monitor.rs
@@ -1,5 +1,7 @@
+use std::panic::AssertUnwindSafe;
+
 use datafusion::execution::SendableRecordBatchStream;
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use sail_common::actor::ActorHandle;
 use sail_common_datafusion::error::CommonErrorCause;
 use sail_python_udf::error::PyErrExtractor;
@@ -7,7 +9,7 @@ use tokio::sync::oneshot;
 
 use crate::driver::TaskStatus;
 use crate::id::{TaskKey, TaskKeyDisplay};
-use crate::task_runner::{TaskRunnerActor, TaskRunnerMessage};
+use crate::task_runner::{TaskRunnerActor, TaskRunnerMessage, panic_message};
 
 pub struct TaskMonitor {
     handle: ActorHandle<TaskRunnerActor>,
@@ -39,11 +41,36 @@ impl TaskMonitor {
             signal,
         } = self;
         let _ = handle.send(Self::running(key.clone())).await;
-        let message = tokio::select! {
-            x = Self::execute(key.clone(), stream) => x,
-            x = Self::cancel(key.clone(), signal) => x,
-        };
+        let message = Self::monitor(key, stream, signal).await;
         let _ = handle.send(message).await;
+    }
+
+    async fn monitor(
+        key: TaskKey,
+        stream: SendableRecordBatchStream,
+        signal: oneshot::Receiver<()>,
+    ) -> TaskRunnerMessage {
+        let panic_key = key.clone();
+        let result = AssertUnwindSafe(async move {
+            tokio::select! {
+                x = Self::execute(key.clone(), stream) => x,
+                x = Self::cancel(key, signal) => x,
+            }
+        })
+        .catch_unwind()
+        .await;
+        match result {
+            Ok(message) => message,
+            Err(payload) => {
+                let message = format!("task panicked: {}", panic_message(payload));
+                Self::status(
+                    panic_key,
+                    TaskStatus::Failed,
+                    Some(message.clone()),
+                    Some(CommonErrorCause::Internal(message)),
+                )
+            }
+        }
     }
 
     /// Builds a "task is running" status message.
@@ -90,5 +117,85 @@ impl TaskMonitor {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::task::Poll;
+
+    use datafusion::arrow::datatypes::Schema;
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::common::Result;
+    use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+    use futures::stream;
+
+    use super::*;
+    use crate::id::JobId;
+
+    #[tokio::test]
+    async fn reports_stream_panic_as_task_failure() -> std::result::Result<(), String> {
+        let key = TaskKey {
+            job_id: JobId::from(1),
+            stage: 2,
+            partition: 3,
+            attempt: 4,
+        };
+        let stream = stream::poll_fn(|_| -> Poll<Option<Result<RecordBatch>>> {
+            std::panic::resume_unwind(Box::new("test stream panic"))
+        });
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::new(Schema::empty()),
+            stream,
+        ));
+        let (_signal, receiver) = oneshot::channel();
+
+        let message = TaskMonitor::monitor(key.clone(), stream, receiver).await;
+
+        let TaskRunnerMessage::ReportTaskStatus {
+            key: actual_key,
+            status: TaskStatus::Failed,
+            message: Some(message),
+            cause: Some(CommonErrorCause::Internal(cause)),
+        } = message
+        else {
+            return Err("expected a failed task status".to_string());
+        };
+        assert_eq!(actual_key, key);
+        assert_eq!(message, "task panicked: test stream panic");
+        assert_eq!(cause, message);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reports_task_cancellation() -> std::result::Result<(), String> {
+        let key = TaskKey {
+            job_id: JobId::from(1),
+            stage: 2,
+            partition: 3,
+            attempt: 4,
+        };
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            Arc::new(Schema::empty()),
+            stream::pending(),
+        ));
+        let (signal, receiver) = oneshot::channel();
+        assert!(signal.send(()).is_ok());
+
+        let message = TaskMonitor::monitor(key.clone(), stream, receiver).await;
+
+        let TaskRunnerMessage::ReportTaskStatus {
+            key: actual_key,
+            status: TaskStatus::Canceled,
+            message: Some(message),
+            cause: None,
+        } = message
+        else {
+            return Err("expected a canceled task status".to_string());
+        };
+        assert_eq!(actual_key, key);
+        assert_eq!(message, "job 1 stage 2 partition 3 attempt 4 canceled");
+        Ok(())
     }
 }


### PR DESCRIPTION
This prevents cluster-mode queries from hanging when a task panics.

Panics during plan execution or while polling the task stream are now reported as failed task statuses, allowing the error to propagate back to the client through the existing retry and scheduling flow.

Added tests for panic reporting, panic message extraction, and task cancellation.

Closes #2390