### PR TITLE
feat: implement `session_window` (gap-based sessionization)

### DIFF
--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -71,6 +71,8 @@ message ExtendedPhysicalPlanNode {
     IcebergMergeMetadataExecNode iceberg_merge_metadata = 56;
     IcebergEqualityDeleteWriterExecNode iceberg_equality_delete_writer = 57;
     PartitionedTopKExecNode partitioned_top_k = 58;
+    SessionWindowExecNode session_window = 59;
+    SessionAggregateExecNode session_aggregate = 60;
   }
 }
 
@@ -915,6 +917,38 @@ message MonotonicIdExecNode {
   bytes input = 1;
   string column_name = 2;
   bytes schema = 3;
+}
+
+message SessionWindowExecNode {
+  bytes input = 1;
+  repeated string partition_columns = 2;
+  string time_column = 3;
+  string end_column = 4;
+  string output_column = 5;
+  bytes schema = 6;
+}
+
+message SessionAggregateExecNode {
+  bytes input = 1;
+  repeated string partition_columns = 2;
+  string time_column = 3;
+  string end_column = 4;
+  repeated string group_columns = 5;
+  string session_output = 6;
+  repeated SessionAggregateFunctionNode aggregates = 7;
+  bytes schema = 8;
+}
+
+message SessionAggregateFunctionNode {
+  // The aggregate as an encoded datafusion `PhysicalExprNode` (an
+  // `AggregateExpr`), produced by `serialize_physical_aggr_expr`: it carries the
+  // UDAF definition, argument expressions, order-bys, distinct, and ignore-nulls.
+  bytes expr = 1;
+  // The aggregate's output alias (not carried inside the `AggregateExpr`).
+  string output_name = 2;
+  // Optional `FILTER (WHERE ...)` predicate, an encoded datafusion
+  // `PhysicalExprNode`. Empty when the aggregate has no filter.
+  optional bytes filter = 3;
 }
 
 message SparkPartitionIdExecNode {

--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -934,7 +934,7 @@ message SessionAggregateExecNode {
   string time_column = 3;
   string end_column = 4;
   repeated string group_columns = 5;
-  string session_output = 6;
+  string output_column = 6;
   repeated SessionAggregateFunctionNode aggregates = 7;
   bytes schema = 8;
 }

--- a/crates/sail-execution/src/job_graph/planner.rs
+++ b/crates/sail-execution/src/job_graph/planner.rs
@@ -33,6 +33,7 @@ use sail_physical_plan::catalog_command::CatalogCommandExec;
 use sail_physical_plan::coalesce::CoalesceExec;
 use sail_physical_plan::remote_checkpoint::RemoteCheckpointCommitExec;
 use sail_physical_plan::repartition::ExplicitRepartitionExec;
+use sail_physical_plan::session_aggregate::SessionAggregateExec;
 
 use crate::error::{ExecutionError, ExecutionResult};
 use crate::job_graph::{
@@ -649,6 +650,18 @@ fn plan_node_has_scalar_subquery_expr(plan: &Arc<dyn ExecutionPlan>) -> bool {
     }
     if let Some(aggregate) = plan.downcast_ref::<AggregateExec>() {
         return aggregate_has_scalar_subquery_expr(aggregate);
+    }
+    if let Some(session) = plan.downcast_ref::<SessionAggregateExec>() {
+        return session
+            .filters()
+            .iter()
+            .flatten()
+            .any(physical_expr_has_scalar_subquery)
+            || session.aggregates().iter().any(|agg| {
+                agg.expressions()
+                    .iter()
+                    .any(physical_expr_has_scalar_subquery)
+            });
     }
     if let Some(sort) = plan.downcast_ref::<SortExec>() {
         return sort

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -164,7 +164,7 @@ use sail_function::scalar::datetime::spark_date_part::SparkDatePart;
 use sail_function::scalar::datetime::spark_date_trunc::SparkDateTrunc;
 use sail_function::scalar::datetime::spark_interval::{
     SparkCalendarInterval, SparkDayTimeInterval, SparkDayTimeIntervalToCalendarInterval,
-    SparkYearMonthInterval,
+    SparkTryCalendarInterval, SparkYearMonthInterval,
 };
 use sail_function::scalar::datetime::spark_last_day::SparkLastDay;
 use sail_function::scalar::datetime::spark_make_time::SparkMakeTime;
@@ -3107,6 +3107,9 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             "spark_calendar_interval" => {
                 Ok(Arc::new(ScalarUDF::from(SparkCalendarInterval::new())))
             }
+            "spark_try_calendar_interval" => {
+                Ok(Arc::new(ScalarUDF::from(SparkTryCalendarInterval::new())))
+            }
             "spark_date_format" | "date_format" => {
                 // Use UTC as default timezone when creating from name only
                 Ok(Arc::new(ScalarUDF::from(SparkDateFormat::new(Arc::from(
@@ -3195,6 +3198,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node_inner.is::<SparkBitwiseNot>()
             || node_inner.is::<SparkBRound>()
             || node_inner.is::<SparkCalendarInterval>()
+            || node_inner.is::<SparkTryCalendarInterval>()
             || node_inner.is::<SparkConcat>()
             || node_inner.is::<SparkConv>()
             || node_inner.is::<SparkCrc32>()
@@ -6747,4 +6751,5 @@ mod tests {
 
         Ok(())
     }
+
 }

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -21,7 +21,7 @@ use datafusion::datasource::physical_plan::{
 };
 use datafusion::datasource::sink::DataSinkExec;
 use datafusion::datasource::source::{DataSource, DataSourceExec};
-use datafusion::execution::TaskContext;
+use datafusion::execution::{FunctionRegistry, TaskContext};
 use datafusion::functions::core::greatest::GreatestFunc;
 use datafusion::functions::core::least::LeastFunc;
 use datafusion::functions::string::overlay::OverlayFunc;
@@ -34,6 +34,7 @@ use datafusion::logical_expr::{
     AggregateUDF, AggregateUDFImpl, ScalarUDF, ScalarUDFImpl, WindowUDF,
 };
 use datafusion::parquet::arrow::PARQUET_FIELD_ID_META_KEY;
+use datafusion::physical_expr::aggregate::AggregateExprBuilder;
 use datafusion::physical_expr::equivalence::{EquivalenceClass, EquivalenceGroup};
 use datafusion::physical_expr::expressions::{Column, LambdaExpr, LambdaVariable};
 use datafusion::physical_expr::{
@@ -50,14 +51,19 @@ use datafusion::physical_plan::work_table::WorkTableExec;
 use datafusion::physical_plan::{ExecutionPlan, PlanProperties};
 use datafusion_proto::generated::datafusion_common as gen_datafusion_common;
 use datafusion_proto::physical_plan::from_proto::{
-    parse_physical_sort_exprs, parse_protobuf_file_scan_config, parse_protobuf_file_scan_schema,
-    parse_protobuf_partitioning, parse_table_schema_from_proto,
+    parse_physical_exprs, parse_physical_sort_exprs, parse_protobuf_file_scan_config,
+    parse_protobuf_file_scan_schema, parse_protobuf_partitioning, parse_table_schema_from_proto,
 };
 use datafusion_proto::physical_plan::to_proto::{
-    serialize_file_scan_config, serialize_partitioning, serialize_physical_sort_exprs,
+    serialize_file_scan_config, serialize_partitioning, serialize_physical_aggr_expr,
+    serialize_physical_sort_exprs,
 };
 use datafusion_proto::physical_plan::{PhysicalExtensionCodec, PhysicalPlanDecodeContext};
-use datafusion_proto::protobuf::{JoinType as ProtoJoinType, PhysicalSortExprNode};
+use datafusion_proto::protobuf::physical_aggregate_expr_node::AggregateFunction as ProtoAggregateFunction;
+use datafusion_proto::protobuf::physical_expr_node::ExprType as PhysicalExprType;
+use datafusion_proto::protobuf::{
+    JoinType as ProtoJoinType, PhysicalExprNode, PhysicalSortExprNode,
+};
 use datafusion_spark::function::aggregate::try_sum::SparkTrySum;
 use datafusion_spark::function::array::shuffle::SparkShuffle;
 use datafusion_spark::function::bitmap::bitmap_count::BitmapCount;
@@ -276,6 +282,8 @@ use sail_physical_plan::remote_checkpoint::{
     CheckpointDataSource, RemoteCheckpointCommitExec, RemoteCheckpointWriteExec,
 };
 use sail_physical_plan::schema_pivot::SchemaPivotExec;
+use sail_physical_plan::session_aggregate::SessionAggregateExec;
+use sail_physical_plan::session_window::SessionWindowExec;
 use sail_physical_plan::show_string::ShowStringExec;
 use sail_physical_plan::spark_partition_id::SparkPartitionIdExec;
 use sail_physical_plan::streaming::collector::StreamCollectorExec;
@@ -1288,6 +1296,107 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                     Arc::new(schema),
                 )?))
             }
+            NodeKind::SessionWindow(r#gen::SessionWindowExecNode {
+                input,
+                partition_columns,
+                time_column,
+                end_column,
+                output_column,
+                schema,
+            }) => {
+                let schema = try_decode_schema(&schema)?;
+                Ok(Arc::new(SessionWindowExec::try_new(
+                    try_decode_physical_plan(ctx, self, &input)?,
+                    partition_columns,
+                    time_column,
+                    end_column,
+                    output_column,
+                    Arc::new(schema),
+                )?))
+            }
+            NodeKind::SessionAggregate(r#gen::SessionAggregateExecNode {
+                input,
+                partition_columns,
+                time_column,
+                end_column,
+                group_columns,
+                session_output,
+                aggregates,
+                schema,
+            }) => {
+                let input = try_decode_physical_plan(ctx, self, &input)?;
+                let schema = Arc::new(try_decode_schema(&schema)?);
+                let input_schema = input.schema();
+                let decode_ctx = PhysicalPlanDecodeContext::new(ctx, self);
+                let converter = RemotePhysicalProtoConverter {};
+                // Each aggregate: a serialized `AggregateExpr`, its output
+                // alias, and an optional `FILTER (WHERE ...)` predicate applied
+                // by this operator.
+                let mut decoded_aggregates = Vec::with_capacity(aggregates.len());
+                let mut filters = Vec::with_capacity(aggregates.len());
+                for agg in aggregates {
+                    let node = try_decode_message::<PhysicalExprNode>(&agg.expr)?;
+                    let Some(PhysicalExprType::AggregateExpr(agg_node)) = node.expr_type else {
+                        return Err(plan_datafusion_err!(
+                            "SessionAggregate expected a serialized AggregateExpr"
+                        ));
+                    };
+                    let Some(ProtoAggregateFunction::UserDefinedAggrFunction(udaf_name)) =
+                        &agg_node.aggregate_function
+                    else {
+                        return Err(plan_datafusion_err!(
+                            "SessionAggregate expected a user-defined aggregate function"
+                        ));
+                    };
+                    let args = parse_physical_exprs(
+                        &agg_node.expr,
+                        &decode_ctx,
+                        input_schema.as_ref(),
+                        &converter,
+                    )?;
+                    let order_bys = parse_physical_sort_exprs(
+                        &agg_node.ordering_req,
+                        &decode_ctx,
+                        input_schema.as_ref(),
+                        &converter,
+                    )?;
+                    // Prefer the serialized UDAF definition, falling back to
+                    // the registry by name (as datafusion's decode does).
+                    let udaf = match &agg_node.fun_definition {
+                        Some(buf) => self.try_decode_udaf(udaf_name, buf)?,
+                        None => ctx
+                            .udaf(udaf_name)
+                            .or_else(|_| self.try_decode_udaf(udaf_name, &[]))?,
+                    };
+                    let aggregate = AggregateExprBuilder::new(udaf, args)
+                        .schema(input_schema.clone())
+                        .alias(agg.output_name)
+                        .with_ignore_nulls(agg_node.ignore_nulls)
+                        .with_distinct(agg_node.distinct)
+                        .order_by(order_bys)
+                        .build()?;
+                    let filter = agg
+                        .filter
+                        .as_ref()
+                        .map(|bytes| {
+                            try_decode_physical_expr(ctx, self, bytes, input_schema.as_ref())
+                        })
+                        .transpose()?;
+                    decoded_aggregates.push(Arc::new(aggregate));
+                    filters.push(filter);
+                }
+                Ok(Arc::new(SessionAggregateExec::try_new(
+                    input,
+                    partition_columns,
+                    time_column,
+                    end_column,
+                    group_columns,
+                    session_output,
+                    decoded_aggregates,
+                    filters,
+                    schema,
+                )?))
+            }
             NodeKind::Coalesce(r#gen::CoalesceExecNode {
                 input,
                 output_partitions,
@@ -2295,6 +2404,55 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             NodeKind::SparkPartitionId(r#gen::SparkPartitionIdExecNode {
                 input,
                 column_name: spark_partition_id.column_name().to_string(),
+                schema,
+            })
+        } else if let Some(session_window) = node.downcast_ref::<SessionWindowExec>() {
+            let input = try_encode_physical_plan(self, session_window.input().clone())?;
+            let schema = try_encode_schema(session_window.schema().as_ref())?;
+            NodeKind::SessionWindow(r#gen::SessionWindowExecNode {
+                input,
+                partition_columns: session_window.partition_columns().to_vec(),
+                time_column: session_window.time_column().to_string(),
+                end_column: session_window.end_column().to_string(),
+                output_column: session_window.output_column().to_string(),
+                schema,
+            })
+        } else if let Some(session_aggregate) = node.downcast_ref::<SessionAggregateExec>() {
+            let input = try_encode_physical_plan(self, session_aggregate.input().clone())?;
+            let schema = try_encode_schema(session_aggregate.schema().as_ref())?;
+            // Use datafusion's physical-aggregate round-trip so the full UDAF
+            // definition is carried; the alias and optional filter predicate
+            // live alongside it.
+            let aggregates = session_aggregate
+                .aggregates()
+                .iter()
+                .zip(session_aggregate.filters().iter())
+                .map(|(agg, filter)| {
+                    let expr = serialize_physical_aggr_expr(
+                        Arc::clone(agg),
+                        self,
+                        &RemotePhysicalProtoConverter {},
+                    )?
+                    .encode_to_vec();
+                    let filter = match filter {
+                        Some(f) => Some(try_encode_physical_expr(self, f)?),
+                        None => None,
+                    };
+                    Ok(r#gen::SessionAggregateFunctionNode {
+                        expr,
+                        output_name: agg.name().to_string(),
+                        filter,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            NodeKind::SessionAggregate(r#gen::SessionAggregateExecNode {
+                input,
+                partition_columns: session_aggregate.partition_columns().to_vec(),
+                time_column: session_aggregate.time_column().to_string(),
+                end_column: session_aggregate.end_column().to_string(),
+                group_columns: session_aggregate.group_columns().to_vec(),
+                session_output: session_aggregate.session_output().to_string(),
+                aggregates,
                 schema,
             })
         } else if let Some(coalesce) = node.downcast_ref::<CoalesceExec>() {
@@ -6489,6 +6647,103 @@ mod tests {
 
         assert!(decoded.inner().downcast_ref::<SparkDatePart>().is_some());
         assert_eq!(decoded.name(), "date_part");
+
+        Ok(())
+    }
+
+    /// Round-trips a `SessionAggregateExec` (plain + `FILTER (WHERE ...)`
+    /// aggregates) through the codec and checks every field survives.
+    #[test]
+    fn test_round_trip_session_aggregate_exec() -> Result<()> {
+        use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema, TimeUnit};
+        use datafusion::functions_aggregate::count::count_udaf;
+        use datafusion::functions_aggregate::sum::sum_udaf;
+        use datafusion::logical_expr::Operator;
+        use datafusion::physical_expr::expressions::{BinaryExpr, Column, lit};
+        use datafusion::physical_plan::empty::EmptyExec;
+        use datafusion::prelude::SessionContext;
+
+        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
+        // Input to the fused operator: the key, the projected time/end columns,
+        // and an aggregate input column.
+        let input_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Utf8, true),
+            Field::new("#t", ts.clone(), true),
+            Field::new("#e0", ts.clone(), true),
+            Field::new("v", DataType::Int64, true),
+        ]));
+        let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(input_schema.clone()));
+
+        // Output schema: group columns (key, then the `{start, end}` session
+        // struct), then the two aggregate outputs.
+        let struct_type = DataType::Struct(Fields::from(vec![
+            Field::new("start", ts.clone(), true),
+            Field::new("end", ts.clone(), true),
+        ]));
+        let output_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Utf8, true),
+            Field::new("#w", struct_type, true),
+            Field::new("total", DataType::Int64, true),
+            Field::new("cnt", DataType::Int64, true),
+        ]));
+
+        let v_col = || Arc::new(Column::new("v", 3)) as Arc<dyn PhysicalExpr>;
+        let total = AggregateExprBuilder::new(sum_udaf(), vec![v_col()])
+            .schema(input_schema.clone())
+            .alias("total")
+            .build()?;
+        let cnt = AggregateExprBuilder::new(count_udaf(), vec![v_col()])
+            .schema(input_schema.clone())
+            .alias("cnt")
+            .build()?;
+        // `count(v) FILTER (WHERE v > 0)` exercises the per-aggregate filter path.
+        let filter: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            v_col(),
+            Operator::Gt,
+            lit(ScalarValue::Int64(Some(0))),
+        ));
+
+        let exec = SessionAggregateExec::try_new(
+            input,
+            vec!["k".to_string()],
+            "#t".to_string(),
+            "#e0".to_string(),
+            vec!["k".to_string(), "#w".to_string()],
+            "#w".to_string(),
+            vec![Arc::new(total), Arc::new(cnt)],
+            vec![None, Some(filter.clone())],
+            output_schema.clone(),
+        )?;
+
+        let codec = RemoteExecutionCodec;
+        let mut buf = vec![];
+        codec.try_encode(Arc::new(exec) as Arc<dyn ExecutionPlan>, &mut buf)?;
+
+        let ctx = SessionContext::new().task_ctx();
+        let decoded = codec.try_decode(&buf, &[], &ctx)?;
+        let decoded = decoded
+            .downcast_ref::<SessionAggregateExec>()
+            .ok_or_else(|| plan_datafusion_err!("decoded plan should be a SessionAggregateExec"))?;
+
+        assert_eq!(decoded.partition_columns(), ["k".to_string()]);
+        assert_eq!(decoded.time_column(), "#t");
+        assert_eq!(decoded.end_column(), "#e0");
+        assert_eq!(decoded.group_columns(), ["k".to_string(), "#w".to_string()]);
+        assert_eq!(decoded.session_output(), "#w");
+        assert_eq!(decoded.schema(), output_schema);
+
+        assert_eq!(decoded.aggregates().len(), 2);
+        assert_eq!(decoded.aggregates()[0].name(), "total");
+        assert_eq!(decoded.aggregates()[0].fun().name(), "sum");
+        assert_eq!(decoded.aggregates()[1].name(), "cnt");
+        assert_eq!(decoded.aggregates()[1].fun().name(), "count");
+
+        assert_eq!(decoded.filters().len(), 2);
+        assert!(decoded.filters()[0].is_none());
+        assert_eq!(
+            decoded.filters()[1].as_ref().map(|f| f.to_string()),
+            Some(filter.to_string())
+        );
 
         Ok(())
     }

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -1368,6 +1368,15 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                             .udaf(udaf_name)
                             .or_else(|_| self.try_decode_udaf(udaf_name, &[]))?,
                     };
+                    // The fused operator feeds accumulators only the argument
+                    // expressions (no order-by columns appended, unlike
+                    // DataFusion's `AggregateExec`), so an ordering requirement
+                    // would be silently ignored — reject it instead.
+                    if !order_bys.is_empty() {
+                        return plan_err!(
+                            "SessionAggregateExec does not support ordered aggregates"
+                        );
+                    }
                     let aggregate = AggregateExprBuilder::new(udaf, args)
                         .schema(input_schema.clone())
                         .alias(agg.output_name)
@@ -6752,4 +6761,55 @@ mod tests {
         Ok(())
     }
 
+    /// Covers the unfused operator (no round-trip test existed), the keyless
+    /// (single-partition) shape, and a timezone-bearing session struct.
+    #[test]
+    fn test_round_trip_session_window_exec() -> Result<()> {
+        use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema, TimeUnit};
+        use datafusion::physical_plan::empty::EmptyExec;
+        use datafusion::prelude::SessionContext;
+        use sail_physical_plan::session_window::SessionWindowExec;
+
+        let tz: Arc<str> = Arc::from("America/New_York");
+        let ts = DataType::Timestamp(TimeUnit::Microsecond, Some(tz.clone()));
+        let input_schema = Arc::new(Schema::new(vec![
+            Field::new("#t", ts.clone(), true),
+            Field::new("#e0", ts.clone(), true),
+        ]));
+        let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(input_schema.clone()));
+        let struct_type = DataType::Struct(Fields::from(vec![
+            Field::new("start", ts.clone(), true),
+            Field::new("end", ts, true),
+        ]));
+        let output_schema = Arc::new(Schema::new(vec![
+            Field::new("#t", input_schema.field(0).data_type().clone(), true),
+            Field::new("#e0", input_schema.field(1).data_type().clone(), true),
+            Field::new("#w", struct_type, false),
+        ]));
+        let exec = SessionWindowExec::try_new(
+            input,
+            vec![],
+            "#t".to_string(),
+            "#e0".to_string(),
+            "#w".to_string(),
+            output_schema.clone(),
+        )?;
+
+        let codec = RemoteExecutionCodec;
+        let mut buf = vec![];
+        codec.try_encode(Arc::new(exec) as Arc<dyn ExecutionPlan>, &mut buf)?;
+
+        let ctx = SessionContext::new().task_ctx();
+        let decoded = codec.try_decode(&buf, &[], &ctx)?;
+        let decoded = decoded
+            .downcast_ref::<SessionWindowExec>()
+            .ok_or_else(|| plan_datafusion_err!("decoded plan should be a SessionWindowExec"))?;
+
+        assert!(decoded.partition_columns().is_empty());
+        assert_eq!(decoded.time_column(), "#t");
+        assert_eq!(decoded.end_column(), "#e0");
+        assert_eq!(decoded.output_column(), "#w");
+        assert_eq!(decoded.schema(), output_schema);
+        Ok(())
+    }
 }

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -1321,7 +1321,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 time_column,
                 end_column,
                 group_columns,
-                session_output,
+                output_column,
                 aggregates,
                 schema,
             }) => {
@@ -1330,9 +1330,6 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 let input_schema = input.schema();
                 let decode_ctx = PhysicalPlanDecodeContext::new(ctx, self);
                 let converter = RemotePhysicalProtoConverter {};
-                // Each aggregate: a serialized `AggregateExpr`, its output
-                // alias, and an optional `FILTER (WHERE ...)` predicate applied
-                // by this operator.
                 let mut decoded_aggregates = Vec::with_capacity(aggregates.len());
                 let mut filters = Vec::with_capacity(aggregates.len());
                 for agg in aggregates {
@@ -1355,12 +1352,15 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                         input_schema.as_ref(),
                         &converter,
                     )?;
-                    let order_bys = parse_physical_sort_exprs(
-                        &agg_node.ordering_req,
-                        &decode_ctx,
-                        input_schema.as_ref(),
-                        &converter,
-                    )?;
+                    // The fused operator feeds accumulators only the argument
+                    // expressions (no order-by columns appended, unlike
+                    // DataFusion's `AggregateExec`), so an ordering requirement
+                    // would be silently ignored — reject it instead.
+                    if !agg_node.ordering_req.is_empty() {
+                        return plan_err!(
+                            "SessionAggregateExec does not support ordered aggregates"
+                        );
+                    }
                     // Prefer the serialized UDAF definition, falling back to
                     // the registry by name (as datafusion's decode does).
                     let udaf = match &agg_node.fun_definition {
@@ -1369,21 +1369,11 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                             .udaf(udaf_name)
                             .or_else(|_| self.try_decode_udaf(udaf_name, &[]))?,
                     };
-                    // The fused operator feeds accumulators only the argument
-                    // expressions (no order-by columns appended, unlike
-                    // DataFusion's `AggregateExec`), so an ordering requirement
-                    // would be silently ignored — reject it instead.
-                    if !order_bys.is_empty() {
-                        return plan_err!(
-                            "SessionAggregateExec does not support ordered aggregates"
-                        );
-                    }
                     let aggregate = AggregateExprBuilder::new(udaf, args)
                         .schema(input_schema.clone())
                         .alias(agg.output_name)
                         .with_ignore_nulls(agg_node.ignore_nulls)
                         .with_distinct(agg_node.distinct)
-                        .order_by(order_bys)
                         .build()?;
                     let filter = agg
                         .filter
@@ -1401,7 +1391,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                     time_column,
                     end_column,
                     group_columns,
-                    session_output,
+                    output_column,
                     decoded_aggregates,
                     filters,
                     schema,
@@ -2461,7 +2451,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 time_column: session_aggregate.time_column().to_string(),
                 end_column: session_aggregate.end_column().to_string(),
                 group_columns: session_aggregate.group_columns().to_vec(),
-                session_output: session_aggregate.session_output().to_string(),
+                output_column: session_aggregate.output_column().to_string(),
                 aggregates,
                 schema,
             })
@@ -6735,6 +6725,8 @@ mod tests {
         let mut buf = vec![];
         codec.try_encode(Arc::new(exec) as Arc<dyn ExecutionPlan>, &mut buf)?;
 
+        // `SessionContext` (not the bare `TaskContext` other tests use) so the
+        // decode can resolve `sum`/`count` from the UDAF registry.
         let ctx = SessionContext::new().task_ctx();
         let decoded = codec.try_decode(&buf, &[], &ctx)?;
         let decoded = decoded
@@ -6745,7 +6737,7 @@ mod tests {
         assert_eq!(decoded.time_column(), "#t");
         assert_eq!(decoded.end_column(), "#e0");
         assert_eq!(decoded.group_columns(), ["k".to_string(), "#w".to_string()]);
-        assert_eq!(decoded.session_output(), "#w");
+        assert_eq!(decoded.output_column(), "#w");
         assert_eq!(decoded.schema(), output_schema);
 
         assert_eq!(decoded.aggregates().len(), 2);
@@ -6770,7 +6762,6 @@ mod tests {
     fn test_round_trip_session_window_exec() -> Result<()> {
         use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema, TimeUnit};
         use datafusion::physical_plan::empty::EmptyExec;
-        use datafusion::prelude::SessionContext;
         use sail_physical_plan::session_window::SessionWindowExec;
 
         let tz: Arc<str> = Arc::from("America/New_York");
@@ -6799,11 +6790,8 @@ mod tests {
         )?;
 
         let codec = RemoteExecutionCodec;
-        let mut buf = vec![];
-        codec.try_encode(Arc::new(exec) as Arc<dyn ExecutionPlan>, &mut buf)?;
-
-        let ctx = SessionContext::new().task_ctx();
-        let decoded = codec.try_decode(&buf, &[], &ctx)?;
+        let bytes = try_encode_physical_plan(&codec, Arc::new(exec))?;
+        let decoded = try_decode_physical_plan(&TaskContext::default(), &codec, &bytes)?;
         let decoded = decoded
             .downcast_ref::<SessionWindowExec>()
             .ok_or_else(|| plan_datafusion_err!("decoded plan should be a SessionWindowExec"))?;

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -171,6 +171,7 @@ use sail_function::scalar::datetime::spark_make_time::SparkMakeTime;
 use sail_function::scalar::datetime::spark_make_timestamp_ntz::SparkMakeTimestampNtz;
 use sail_function::scalar::datetime::spark_make_ym_interval::SparkMakeYmInterval;
 use sail_function::scalar::datetime::spark_next_day::SparkNextDay;
+use sail_function::scalar::datetime::spark_session_window::SparkSessionWindow;
 use sail_function::scalar::datetime::spark_time::SparkTime;
 use sail_function::scalar::datetime::spark_time_diff::SparkTimeDiff;
 use sail_function::scalar::datetime::spark_time_trunc::SparkTimeTrunc;
@@ -3119,6 +3120,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             "spark_try_calendar_interval" => {
                 Ok(Arc::new(ScalarUDF::from(SparkTryCalendarInterval::new())))
             }
+            "session_window" => Ok(Arc::new(ScalarUDF::from(SparkSessionWindow::new()))),
             "spark_date_format" | "date_format" => {
                 // Use UTC as default timezone when creating from name only
                 Ok(Arc::new(ScalarUDF::from(SparkDateFormat::new(Arc::from(
@@ -3208,6 +3210,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node_inner.is::<SparkBRound>()
             || node_inner.is::<SparkCalendarInterval>()
             || node_inner.is::<SparkTryCalendarInterval>()
+            || node_inner.is::<SparkSessionWindow>()
             || node_inner.is::<SparkConcat>()
             || node_inner.is::<SparkConv>()
             || node_inner.is::<SparkCrc32>()

--- a/crates/sail-function/src/scalar/datetime/mod.rs
+++ b/crates/sail-function/src/scalar/datetime/mod.rs
@@ -11,6 +11,7 @@ pub mod spark_make_time;
 pub mod spark_make_timestamp_ntz;
 pub mod spark_make_ym_interval;
 pub mod spark_next_day;
+pub mod spark_session_window;
 pub mod spark_time;
 pub mod spark_time_diff;
 pub mod spark_time_trunc;

--- a/crates/sail-function/src/scalar/datetime/spark_interval.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_interval.rs
@@ -1,9 +1,10 @@
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::{
-    DataType, DurationMicrosecondType, IntervalMonthDayNano, IntervalUnit, IntervalYearMonthType,
-    TimeUnit,
+    ArrowPrimitiveType, DataType, DurationMicrosecondType, IntervalMonthDayNano, IntervalUnit,
+    IntervalYearMonthType, TimeUnit,
 };
 use datafusion_common::arrow::array::{AsArray, PrimitiveArray};
 use datafusion_common::arrow::datatypes::IntervalMonthDayNanoType;
@@ -15,6 +16,39 @@ use datafusion_expr_common::signature::{Coercion, TypeSignatureClass};
 use sail_common_datafusion::utils::items::ItemTaker;
 use sail_sql_analyzer::literal::interval::IntervalValue;
 use sail_sql_analyzer::parser::parse_interval;
+
+/// Parses interval strings with per-batch memoization of distinct values.
+///
+/// `parse_interval` builds the full recursive SQL expression parser on every
+/// call, which costs on the order of a millisecond and a nontrivial amount of
+/// memory per call. Per-row interval columns (e.g. a dynamic `session_window`
+/// gap fed by a `CASE` expression) typically hold only a few distinct strings,
+/// so parsing each distinct value once per batch is the difference between a
+/// query finishing and it exhausting all memory.
+fn parse_memoized<'a, P, F>(
+    values: impl Iterator<Item = Option<&'a str>>,
+    parse: F,
+) -> Result<PrimitiveArray<P>>
+where
+    P: ArrowPrimitiveType,
+    F: Fn(&str) -> Result<P::Native>,
+{
+    let mut cache: HashMap<&'a str, P::Native> = HashMap::new();
+    values
+        .map(|value| {
+            value
+                .map(|s| match cache.get(s) {
+                    Some(v) => Ok(*v),
+                    None => {
+                        let v = parse(s)?;
+                        cache.insert(s, v);
+                        Ok(v)
+                    }
+                })
+                .transpose()
+        })
+        .collect()
+}
 
 macro_rules! define_interval_udf {
     ($udf:ident, $name:expr_2021, $return_type:expr_2021, $primitive_type:ty, $func:expr_2021, $scalar:expr_2021 $(,)?) => {
@@ -61,18 +95,15 @@ macro_rules! define_interval_udf {
                 match arg {
                     ColumnarValue::Array(array) => {
                         let array: PrimitiveArray<$primitive_type> = match array.data_type() {
-                            DataType::Utf8 => as_string_array(&array)?
-                                .iter()
-                                .map(|x| x.map(|x| $func(x)).transpose())
-                                .collect::<Result<_>>()?,
-                            DataType::LargeUtf8 => as_large_string_array(&array)?
-                                .iter()
-                                .map(|x| x.map(|x| $func(x)).transpose())
-                                .collect::<Result<_>>()?,
-                            DataType::Utf8View => as_string_view_array(&array)?
-                                .iter()
-                                .map(|x| x.map(|x| $func(x)).transpose())
-                                .collect::<Result<_>>()?,
+                            DataType::Utf8 => {
+                                parse_memoized(as_string_array(&array)?.iter(), $func)?
+                            }
+                            DataType::LargeUtf8 => {
+                                parse_memoized(as_large_string_array(&array)?.iter(), $func)?
+                            }
+                            DataType::Utf8View => {
+                                parse_memoized(as_string_view_array(&array)?.iter(), $func)?
+                            }
                             _ => return exec_err!("expected string array for intervals"),
                         };
                         Ok(ColumnarValue::Array(Arc::new(array)))
@@ -256,6 +287,43 @@ fn day_time_interval_to_calendar_interval(microseconds: i64) -> Result<IntervalM
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_memoized_computes_distinct_values_and_propagates_errors() -> Result<()> {
+        use datafusion_common::arrow::array::Array;
+
+        let values = [Some("5 minutes"), None, Some("5 minutes"), Some("1 month")];
+        let array: PrimitiveArray<IntervalMonthDayNanoType> =
+            parse_memoized(values.into_iter(), string_to_calendar_interval)?;
+        assert_eq!(array.len(), 4);
+        assert_eq!(
+            array.value(0),
+            IntervalMonthDayNano::new(0, 0, 300_000_000_000)
+        );
+        assert!(array.is_null(1));
+        assert_eq!(array.value(2), array.value(0));
+        assert_eq!(array.value(3), IntervalMonthDayNano::new(1, 0, 0));
+
+        let invalid: Result<PrimitiveArray<IntervalMonthDayNanoType>> = parse_memoized(
+            [Some("### nonsense")].into_iter(),
+            string_to_calendar_interval,
+        );
+        assert!(invalid.is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn string_parsers_map_interval_kinds() -> Result<()> {
+        assert_eq!(string_to_year_month_interval("2 years")?, 24);
+        assert!(string_to_year_month_interval("5 minutes").is_err());
+        assert_eq!(string_to_day_time_interval("5 minutes")?, 300_000_000);
+        assert!(string_to_day_time_interval("1 month").is_err());
+        assert_eq!(
+            string_to_calendar_interval("1 month 2 days")?,
+            IntervalMonthDayNano::new(1, 2, 0)
+        );
+        Ok(())
+    }
 
     #[test]
     fn day_time_interval_preserves_calendar_days_and_microsecond_remainder() -> Result<()> {

--- a/crates/sail-function/src/scalar/datetime/spark_interval.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_interval.rs
@@ -14,7 +14,7 @@ use datafusion_common::{Result, ScalarValue, exec_datafusion_err, exec_err};
 use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
 use datafusion_expr_common::signature::{Coercion, TypeSignatureClass};
 use sail_common_datafusion::utils::items::ItemTaker;
-use sail_sql_analyzer::literal::interval::IntervalValue;
+use sail_sql_analyzer::literal::interval::{IntervalValue, parse_calendar_interval_string};
 use sail_sql_analyzer::parser::parse_interval;
 
 /// Parses interval strings with per-batch memoization of distinct values.
@@ -148,6 +148,85 @@ define_interval_udf!(
     ScalarValue::IntervalMonthDayNano,
 );
 
+/// Lenient variant of [`SparkCalendarInterval`] for the `session_window` gap:
+/// Spark casts the gap with `safeStringToInterval`, which yields NULL for an
+/// invalid string (even under ANSI), and the desugar's `end > time` filter
+/// then drops the row — an invalid gap must not fail the query.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct SparkTryCalendarInterval {
+    signature: Signature,
+}
+
+impl Default for SparkTryCalendarInterval {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SparkTryCalendarInterval {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::coercible(
+                vec![Coercion::new_exact(TypeSignatureClass::Native(
+                    logical_string(),
+                ))],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for SparkTryCalendarInterval {
+    fn name(&self) -> &str {
+        "spark_try_calendar_interval"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> Result<DataType> {
+        Ok(DataType::Interval(IntervalUnit::MonthDayNano))
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        let ScalarFunctionArgs { args, .. } = args;
+        fn parse(s: &str) -> Option<IntervalMonthDayNano> {
+            string_to_calendar_interval(s).ok()
+        }
+        fn parse_all<'a>(
+            values: impl Iterator<Item = Option<&'a str>>,
+        ) -> PrimitiveArray<IntervalMonthDayNanoType> {
+            // NULL results are memoized too: an invalid string is
+            // deterministically NULL, unlike a transient error.
+            let mut cache: HashMap<&'a str, Option<IntervalMonthDayNano>> = HashMap::new();
+            values
+                .map(|value| value.and_then(|s| *cache.entry(s).or_insert_with(|| parse(s))))
+                .collect()
+        }
+        match args.one()? {
+            ColumnarValue::Array(array) => {
+                let array = match array.data_type() {
+                    DataType::Utf8 => parse_all(as_string_array(&array)?.iter()),
+                    DataType::LargeUtf8 => parse_all(as_large_string_array(&array)?.iter()),
+                    DataType::Utf8View => parse_all(as_string_view_array(&array)?.iter()),
+                    _ => return exec_err!("expected string array for intervals"),
+                };
+                Ok(ColumnarValue::Array(Arc::new(array)))
+            }
+            ColumnarValue::Scalar(scalar) => {
+                let value = match scalar.try_as_str() {
+                    Some(x) => x.and_then(parse),
+                    _ => return exec_err!("expected string scalar for intervals"),
+                };
+                Ok(ColumnarValue::Scalar(ScalarValue::IntervalMonthDayNano(
+                    value,
+                )))
+            }
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct SparkDayTimeIntervalToCalendarInterval {
     signature: Signature,
@@ -249,26 +328,15 @@ fn string_to_day_time_interval(value: &str) -> Result<i64> {
 }
 
 fn string_to_calendar_interval(value: &str) -> Result<IntervalMonthDayNano> {
-    let interval = parse_interval(value).map_err(|e| exec_datafusion_err!("{e}"))?;
-    match interval {
-        IntervalValue::YearMonth { months } => Ok(IntervalMonthDayNano {
-            months,
-            days: 0,
-            nanoseconds: 0,
-        }),
-        IntervalValue::Microsecond { microseconds } => {
-            day_time_interval_to_calendar_interval(microseconds)
-        }
-        IntervalValue::MonthDayNanosecond {
-            months,
-            days,
-            nanoseconds,
-        } => Ok(IntervalMonthDayNano {
-            months,
-            days,
-            nanoseconds,
-        }),
-    }
+    // Spark bucketing: the unit the user wrote decides the bucket; sub-day
+    // amounts stay absolute microseconds and are never rebucketed into days.
+    let interval =
+        parse_calendar_interval_string(value).map_err(|e| exec_datafusion_err!("{e}"))?;
+    Ok(IntervalMonthDayNano {
+        months: interval.months,
+        days: interval.days,
+        nanoseconds: interval.microseconds * 1_000,
+    })
 }
 
 fn day_time_interval_to_calendar_interval(microseconds: i64) -> Result<IntervalMonthDayNano> {

--- a/crates/sail-function/src/scalar/datetime/spark_interval.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_interval.rs
@@ -13,10 +13,10 @@ use datafusion_common::{Result, ScalarValue, exec_datafusion_err, exec_err};
 use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
 use datafusion_expr_common::signature::{Coercion, TypeSignatureClass};
 use sail_common_datafusion::utils::items::ItemTaker;
-
-use crate::functions_utils::StrMemo;
 use sail_sql_analyzer::literal::interval::{IntervalValue, parse_calendar_interval_string};
 use sail_sql_analyzer::parser::parse_interval;
+
+use crate::functions_utils::StrMemo;
 
 /// Parses interval strings with per-batch memoization of distinct values.
 ///
@@ -331,10 +331,14 @@ fn string_to_calendar_interval(value: &str) -> Result<IntervalMonthDayNano> {
     // amounts stay absolute microseconds and are never rebucketed into days.
     let interval =
         parse_calendar_interval_string(value).map_err(|e| exec_datafusion_err!("{e}"))?;
+    let nanoseconds = interval
+        .microseconds
+        .checked_mul(1_000)
+        .ok_or_else(|| exec_datafusion_err!("interval out of range: {value:?}"))?;
     Ok(IntervalMonthDayNano {
         months: interval.months,
         days: interval.days,
-        nanoseconds: interval.microseconds * 1_000,
+        nanoseconds,
     })
 }
 
@@ -377,6 +381,14 @@ mod tests {
         );
         assert!(invalid.is_err());
         Ok(())
+    }
+
+    /// A gap that fits i64 microseconds can still overflow the nanosecond
+    /// representation; the strict converter must error rather than wrap.
+    #[test]
+    fn calendar_interval_nanosecond_overflow_errors() {
+        assert!(string_to_calendar_interval("100000000000 hours").is_err());
+        assert!(string_to_calendar_interval("2000000 hours").is_ok());
     }
 
     #[test]

--- a/crates/sail-function/src/scalar/datetime/spark_interval.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_interval.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
@@ -14,6 +13,8 @@ use datafusion_common::{Result, ScalarValue, exec_datafusion_err, exec_err};
 use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
 use datafusion_expr_common::signature::{Coercion, TypeSignatureClass};
 use sail_common_datafusion::utils::items::ItemTaker;
+
+use crate::functions_utils::StrMemo;
 use sail_sql_analyzer::literal::interval::{IntervalValue, parse_calendar_interval_string};
 use sail_sql_analyzer::parser::parse_interval;
 
@@ -33,18 +34,11 @@ where
     P: ArrowPrimitiveType,
     F: Fn(&str) -> Result<P::Native>,
 {
-    let mut cache: HashMap<&'a str, P::Native> = HashMap::new();
+    let mut memo: StrMemo<'a, P::Native> = StrMemo::new();
     values
         .map(|value| {
             value
-                .map(|s| match cache.get(s) {
-                    Some(v) => Ok(*v),
-                    None => {
-                        let v = parse(s)?;
-                        cache.insert(s, v);
-                        Ok(v)
-                    }
-                })
+                .map(|s| memo.get_or_try_insert_ref(s, &parse).copied())
                 .transpose()
         })
         .collect()
@@ -199,9 +193,14 @@ impl ScalarUDFImpl for SparkTryCalendarInterval {
         ) -> PrimitiveArray<IntervalMonthDayNanoType> {
             // NULL results are memoized too: an invalid string is
             // deterministically NULL, unlike a transient error.
-            let mut cache: HashMap<&'a str, Option<IntervalMonthDayNano>> = HashMap::new();
+            let mut memo: StrMemo<'a, Option<IntervalMonthDayNano>> = StrMemo::new();
             values
-                .map(|value| value.and_then(|s| *cache.entry(s).or_insert_with(|| parse(s))))
+                .map(|value| {
+                    value.and_then(|s| {
+                        memo.get_or_try_insert_ref(s, |s| Ok(parse(s)))
+                            .map_or(None, |v| *v)
+                    })
+                })
                 .collect()
         }
         match args.one()? {

--- a/crates/sail-function/src/scalar/datetime/spark_interval.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_interval.rs
@@ -331,13 +331,12 @@ fn string_to_calendar_interval(value: &str) -> Result<IntervalMonthDayNano> {
     // amounts stay absolute microseconds and are never rebucketed into days.
     let interval =
         parse_calendar_interval_string(value).map_err(|e| exec_datafusion_err!("{e}"))?;
-    let nanoseconds = interval
-        .microseconds
-        .checked_mul(1_000)
+    let (days, nanoseconds) = interval
+        .days_and_nanoseconds()
         .ok_or_else(|| exec_datafusion_err!("interval out of range: {value:?}"))?;
     Ok(IntervalMonthDayNano {
         months: interval.months,
-        days: interval.days,
+        days,
         nanoseconds,
     })
 }
@@ -383,12 +382,21 @@ mod tests {
         Ok(())
     }
 
-    /// A gap that fits i64 microseconds can still overflow the nanosecond
-    /// representation; the strict converter must error rather than wrap.
+    /// A sub-day amount too large for i64 nanoseconds splits whole days out
+    /// (Spark's microsecond-based CalendarInterval still represents it);
+    /// below that bound the absolute bucket is preserved exactly.
     #[test]
-    fn calendar_interval_nanosecond_overflow_errors() {
-        assert!(string_to_calendar_interval("100000000000 hours").is_err());
-        assert!(string_to_calendar_interval("2000000 hours").is_ok());
+    fn calendar_interval_nanosecond_overflow_splits_days() -> Result<()> {
+        // 3000000 hours = 125000 days; fits i64 µs but not ns.
+        let v = string_to_calendar_interval("3000000 hours")?;
+        assert_eq!((v.months, v.days, v.nanoseconds), (0, 125_000, 0));
+        // 2000000 hours fits ns: stays absolute, no day splitting.
+        let v = string_to_calendar_interval("2000000 hours")?;
+        assert_eq!(
+            (v.months, v.days, v.nanoseconds),
+            (0, 0, 2_000_000i64 * 3_600 * 1_000_000_000)
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/sail-function/src/scalar/datetime/spark_session_window.rs
+++ b/crates/sail-function/src/scalar/datetime/spark_session_window.rs
@@ -1,0 +1,64 @@
+use datafusion::arrow::datatypes::{DataType, Field, Fields, TimeUnit};
+use datafusion_common::{Result, exec_err, plan_err};
+use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+
+/// Marker UDF for Spark `session_window(timeColumn, gapDuration)`. Sessions
+/// merge across rows, which a scalar UDF cannot express, so the aggregate
+/// resolver rewrites this marker into a `SessionWindowNode`. It only carries
+/// the `struct<start, end>` return type for analysis; `invoke` always errors.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct SparkSessionWindow {
+    signature: Signature,
+}
+
+impl Default for SparkSessionWindow {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SparkSessionWindow {
+    pub fn new() -> Self {
+        Self {
+            // `any(2)`: the resolver has already cast the arguments (time ->
+            // Timestamp(us), gap -> interval); no coercion is needed here.
+            signature: Signature::any(2, Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for SparkSessionWindow {
+    fn name(&self) -> &str {
+        "session_window"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        // Both struct fields carry the time argument's timezone so that
+        // `session_window(ts, ...).start` keeps `ts`'s timezone.
+        let tz = match arg_types.first() {
+            Some(DataType::Timestamp(TimeUnit::Microsecond, tz)) => tz.clone(),
+            other => {
+                return plan_err!(
+                    "session_window expects a Timestamp(Microsecond, *) first argument, got {other:?}"
+                );
+            }
+        };
+        let field_type = DataType::Timestamp(TimeUnit::Microsecond, tz);
+        // Fields are nullable: a group whose rows are all filtered out (null ts /
+        // non-positive gap) contributes no session, matching Spark.
+        Ok(DataType::Struct(Fields::from(vec![
+            Field::new("start", field_type.clone(), true),
+            Field::new("end", field_type, true),
+        ])))
+    }
+
+    fn invoke_with_args(&self, _args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        // Reaching here means the resolver rewrite did not fire (e.g. the
+        // marker was used outside a grouping position); fail loudly.
+        exec_err!("session_window can only be used as a grouping expression in an aggregation")
+    }
+}

--- a/crates/sail-logical-plan/src/lib.rs
+++ b/crates/sail-logical-plan/src/lib.rs
@@ -7,6 +7,8 @@ pub mod range;
 pub mod remote_checkpoint;
 pub mod repartition;
 pub mod schema_pivot;
+pub mod session_aggregate;
+pub mod session_window;
 pub mod show_string;
 pub mod sort;
 pub mod spark_partition_id;

--- a/crates/sail-logical-plan/src/session_aggregate.rs
+++ b/crates/sail-logical-plan/src/session_aggregate.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
@@ -134,8 +135,28 @@ impl UserDefinedLogicalNodeCore for SessionAggregateNode {
     }
 
     fn necessary_children_exprs(&self, _output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {
-        // Keep every input column: keys, time, end, and any aggregate inputs are all
-        // needed by the merge, so none can be pruned.
-        Some(vec![(0..self.input.schema().fields().len()).collect()])
+        // Only the keys, time/end, and aggregate inputs are needed; the rest of
+        // the desugar's `*` projection can be pruned before the repartition +
+        // sort below. The output schema does not depend on the input width, so
+        // the cloned schema in `with_exprs_and_inputs` stays valid.
+        let input_schema = self.input.schema();
+        let mut needed = BTreeSet::new();
+        for name in self
+            .partition_columns
+            .iter()
+            .chain([&self.time_column, &self.end_column])
+        {
+            let index = input_schema
+                .fields()
+                .iter()
+                .position(|field| field.name() == name)?;
+            needed.insert(index);
+        }
+        for expr in &self.aggregate_exprs {
+            for column in expr.column_refs() {
+                needed.insert(input_schema.maybe_index_of_column(column)?);
+            }
+        }
+        Some(vec![needed.into_iter().collect()])
     }
 }

--- a/crates/sail-logical-plan/src/session_aggregate.rs
+++ b/crates/sail-logical-plan/src/session_aggregate.rs
@@ -26,8 +26,8 @@ pub struct SessionAggregateNode {
     /// Per-row session end candidate (`time + gap`).
     end_column: String,
     /// Output column name of the `{start, end}` session struct.
-    session_output: String,
-    /// Output group columns in order. Exactly one equals `session_output` (the
+    output_column: String,
+    /// Output group columns in order. Exactly one equals `output_column` (the
     /// struct); the rest are the key columns. Drives output column order.
     group_columns: Vec<String>,
     /// User aggregate expressions, in output order, after the group columns.
@@ -42,7 +42,7 @@ impl SessionAggregateNode {
         partition_columns: Vec<String>,
         time_column: String,
         end_column: String,
-        session_output: String,
+        output_column: String,
         group_columns: Vec<String>,
         aggregate_exprs: Vec<Expr>,
         schema: DFSchemaRef,
@@ -52,7 +52,7 @@ impl SessionAggregateNode {
             partition_columns,
             time_column,
             end_column,
-            session_output,
+            output_column,
             group_columns,
             aggregate_exprs,
             schema,
@@ -75,8 +75,8 @@ impl SessionAggregateNode {
         &self.end_column
     }
 
-    pub fn session_output(&self) -> &str {
-        &self.session_output
+    pub fn output_column(&self) -> &str {
+        &self.output_column
     }
 
     pub fn group_columns(&self) -> &[String] {
@@ -115,7 +115,7 @@ impl UserDefinedLogicalNodeCore for SessionAggregateNode {
             self.partition_columns.join(", "),
             self.time_column,
             self.end_column,
-            self.session_output,
+            self.output_column,
             self.aggregate_exprs.len()
         )
     }
@@ -134,7 +134,7 @@ impl UserDefinedLogicalNodeCore for SessionAggregateNode {
             partition_columns: self.partition_columns.clone(),
             time_column: self.time_column.clone(),
             end_column: self.end_column.clone(),
-            session_output: self.session_output.clone(),
+            output_column: self.output_column.clone(),
             group_columns: self.group_columns.clone(),
             aggregate_exprs: exprs,
             schema: Arc::clone(&self.schema),

--- a/crates/sail-logical-plan/src/session_aggregate.rs
+++ b/crates/sail-logical-plan/src/session_aggregate.rs
@@ -1,0 +1,141 @@
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+use datafusion_common::{DFSchemaRef, Result};
+use datafusion_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
+use educe::Educe;
+use sail_common_datafusion::utils::items::ItemTaker;
+
+/// Fused logical node for Spark `session_window` aggregation (the
+/// `MergingSessionsExec`-equivalent): replaces an `Aggregate` over a
+/// [`SessionWindowNode`](crate::session_window::SessionWindowNode) when the
+/// aggregates allow it (no `DISTINCT`), merging sessions and driving the
+/// accumulators in one pass with O(1) state per open session. The output
+/// schema is identical to the `Aggregate` it replaces.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Educe)]
+#[educe(PartialOrd)]
+pub struct SessionAggregateNode {
+    /// The `SessionWindowNode`'s former child, already filtered of null time /
+    /// non-positive gap rows.
+    input: Arc<LogicalPlan>,
+    /// Session group keys (column names in `input`); the partition of the merge.
+    partition_columns: Vec<String>,
+    /// Per-row session start candidate (`Timestamp(us)`).
+    time_column: String,
+    /// Per-row session end candidate (`time + gap`).
+    end_column: String,
+    /// Output column name of the `{start, end}` session struct.
+    session_output: String,
+    /// Output group columns in order. Exactly one equals `session_output` (the
+    /// struct); the rest are the key columns. Drives output column order.
+    group_columns: Vec<String>,
+    /// User aggregate expressions, in output order, after the group columns.
+    aggregate_exprs: Vec<Expr>,
+    #[educe(PartialOrd(ignore))]
+    schema: DFSchemaRef,
+}
+
+impl SessionAggregateNode {
+    pub fn new(
+        input: Arc<LogicalPlan>,
+        partition_columns: Vec<String>,
+        time_column: String,
+        end_column: String,
+        session_output: String,
+        group_columns: Vec<String>,
+        aggregate_exprs: Vec<Expr>,
+        schema: DFSchemaRef,
+    ) -> Self {
+        Self {
+            input,
+            partition_columns,
+            time_column,
+            end_column,
+            session_output,
+            group_columns,
+            aggregate_exprs,
+            schema,
+        }
+    }
+
+    pub fn input(&self) -> &Arc<LogicalPlan> {
+        &self.input
+    }
+
+    pub fn partition_columns(&self) -> &[String] {
+        &self.partition_columns
+    }
+
+    pub fn time_column(&self) -> &str {
+        &self.time_column
+    }
+
+    pub fn end_column(&self) -> &str {
+        &self.end_column
+    }
+
+    pub fn session_output(&self) -> &str {
+        &self.session_output
+    }
+
+    pub fn group_columns(&self) -> &[String] {
+        &self.group_columns
+    }
+
+    pub fn aggregate_exprs(&self) -> &[Expr] {
+        &self.aggregate_exprs
+    }
+}
+
+impl UserDefinedLogicalNodeCore for SessionAggregateNode {
+    fn name(&self) -> &str {
+        "SessionAggregate"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![self.input.as_ref()]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        // The aggregate expressions reference input columns, so expose them for the
+        // optimizer to rewrite. Group/time/end columns are referenced by name (like
+        // `SessionWindowNode`) and are not listed here.
+        self.aggregate_exprs.clone()
+    }
+
+    fn fmt_for_explain(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "SessionAggregate: partition_by=[{}], time={}, end={}, session={}, aggs={}",
+            self.partition_columns.join(", "),
+            self.time_column,
+            self.end_column,
+            self.session_output,
+            self.aggregate_exprs.len()
+        )
+    }
+
+    fn with_exprs_and_inputs(&self, exprs: Vec<Expr>, inputs: Vec<LogicalPlan>) -> Result<Self> {
+        let input = Arc::new(inputs.one()?);
+        Ok(Self {
+            input,
+            partition_columns: self.partition_columns.clone(),
+            time_column: self.time_column.clone(),
+            end_column: self.end_column.clone(),
+            session_output: self.session_output.clone(),
+            group_columns: self.group_columns.clone(),
+            aggregate_exprs: exprs,
+            schema: Arc::clone(&self.schema),
+        })
+    }
+
+    fn necessary_children_exprs(&self, _output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {
+        // Keep every input column: keys, time, end, and any aggregate inputs are all
+        // needed by the merge, so none can be pruned.
+        Some(vec![(0..self.input.schema().fields().len()).collect()])
+    }
+}

--- a/crates/sail-logical-plan/src/session_aggregate.rs
+++ b/crates/sail-logical-plan/src/session_aggregate.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
-use datafusion_common::{DFSchemaRef, Result};
+use datafusion_common::{DFSchemaRef, Result, internal_err};
 use datafusion_expr::{Expr, LogicalPlan, UserDefinedLogicalNodeCore};
 use educe::Educe;
 use sail_common_datafusion::utils::items::ItemTaker;
@@ -121,6 +121,13 @@ impl UserDefinedLogicalNodeCore for SessionAggregateNode {
     }
 
     fn with_exprs_and_inputs(&self, exprs: Vec<Expr>, inputs: Vec<LogicalPlan>) -> Result<Self> {
+        if exprs.len() != self.aggregate_exprs.len() {
+            return internal_err!(
+                "SessionAggregateNode expects {} expressions, got {}",
+                self.aggregate_exprs.len(),
+                exprs.len()
+            );
+        }
         let input = Arc::new(inputs.one()?);
         Ok(Self {
             input,

--- a/crates/sail-logical-plan/src/session_window.rs
+++ b/crates/sail-logical-plan/src/session_window.rs
@@ -1,0 +1,147 @@
+use std::fmt::Formatter;
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::{DataType, Field, Fields};
+use datafusion_common::{DFSchema, DFSchemaRef, Result, plan_err};
+use datafusion_expr::{Expr, ExprSchemable, LogicalPlan, UserDefinedLogicalNodeCore};
+use educe::Educe;
+use sail_common_datafusion::utils::items::ItemTaker;
+
+/// Logical node for Spark `session_window`: appends a `{start, end}` struct
+/// column with the bounds of each row's session. Sessions merge per group of
+/// `partition_columns`, ordered by `time_column`, while the next row starts at
+/// or before the session's end (`end_column` = per-row `time + gap`). The
+/// physical operator requests the required hash partitioning and sort.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Educe)]
+#[educe(PartialOrd)]
+pub struct SessionWindowNode {
+    input: Arc<LogicalPlan>,
+    /// Group keys (column names in `input`). May be empty: then the whole input
+    /// is one group (a single session stream).
+    partition_columns: Vec<String>,
+    /// Per-row session start candidate: the time column cast to `Timestamp(us)`.
+    time_column: String,
+    /// Per-row session end candidate: `time_column + gap`, same timestamp type.
+    end_column: String,
+    /// Name of the appended `{start, end}` struct column.
+    output_column: String,
+    #[educe(PartialOrd(ignore))]
+    schema: DFSchemaRef,
+}
+
+impl SessionWindowNode {
+    pub fn try_new(
+        input: Arc<LogicalPlan>,
+        partition_columns: Vec<String>,
+        time_column: String,
+        end_column: String,
+        output_column: String,
+    ) -> Result<Self> {
+        // The struct's `start`/`end` fields carry exactly the time column's type
+        // (a `Timestamp(us, tz)`), so the session bounds keep `ts`'s timezone.
+        let time_type = Expr::Column(time_column.as_str().into()).get_type(input.schema())?;
+        if !matches!(time_type, DataType::Timestamp(_, _)) {
+            return plan_err!(
+                "session_window time column {time_column} must be a timestamp, got {time_type:?}"
+            );
+        }
+        let struct_type = DataType::Struct(Fields::from(vec![
+            Field::new("start", time_type.clone(), true),
+            Field::new("end", time_type, true),
+        ]));
+
+        // Output schema = every input column, then the new struct column.
+        let mut qualified_fields = input
+            .schema()
+            .iter()
+            .map(|(qualifier, field)| (qualifier.cloned(), Arc::clone(field)))
+            .collect::<Vec<_>>();
+        qualified_fields.push((
+            None,
+            // The struct column itself is non-nullable (matching Spark); its
+            // start/end fields stay nullable.
+            Arc::new(Field::new(output_column.clone(), struct_type, false)),
+        ));
+        let schema =
+            DFSchema::new_with_metadata(qualified_fields, input.schema().metadata().clone())?
+                .with_functional_dependencies(input.schema().functional_dependencies().clone())?;
+
+        Ok(Self {
+            input,
+            partition_columns,
+            time_column,
+            end_column,
+            output_column,
+            schema: Arc::new(schema),
+        })
+    }
+
+    pub fn input(&self) -> &Arc<LogicalPlan> {
+        &self.input
+    }
+
+    pub fn partition_columns(&self) -> &[String] {
+        &self.partition_columns
+    }
+
+    pub fn time_column(&self) -> &str {
+        &self.time_column
+    }
+
+    pub fn end_column(&self) -> &str {
+        &self.end_column
+    }
+
+    pub fn output_column(&self) -> &str {
+        &self.output_column
+    }
+}
+
+impl UserDefinedLogicalNodeCore for SessionWindowNode {
+    fn name(&self) -> &str {
+        "SessionWindow"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![self.input.as_ref()]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        // Group/time/end columns are referenced by name (like `MonotonicIdNode`),
+        // so there are no expressions for the optimizer to rewrite.
+        vec![]
+    }
+
+    fn fmt_for_explain(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "SessionWindow: partition_by=[{}], time={}, end={}, output={}",
+            self.partition_columns.join(", "),
+            self.time_column,
+            self.end_column,
+            self.output_column
+        )
+    }
+
+    fn with_exprs_and_inputs(&self, exprs: Vec<Expr>, inputs: Vec<LogicalPlan>) -> Result<Self> {
+        exprs.zero()?;
+        let input = Arc::new(inputs.one()?);
+        Self::try_new(
+            input,
+            self.partition_columns.clone(),
+            self.time_column.clone(),
+            self.end_column.clone(),
+            self.output_column.clone(),
+        )
+    }
+
+    fn necessary_children_exprs(&self, _output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {
+        // Keep every input column: the merge needs the group/time/end columns, and
+        // the appended struct is built from them, so none can be pruned away.
+        Some(vec![(0..self.input.schema().fields().len()).collect()])
+    }
+}

--- a/crates/sail-logical-plan/src/session_window.rs
+++ b/crates/sail-logical-plan/src/session_window.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fmt::Formatter;
 use std::sync::Arc;
 
@@ -139,9 +140,29 @@ impl UserDefinedLogicalNodeCore for SessionWindowNode {
         )
     }
 
-    fn necessary_children_exprs(&self, _output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {
-        // Keep every input column: the merge needs the group/time/end columns, and
-        // the appended struct is built from them, so none can be pruned away.
-        Some(vec![(0..self.input.schema().fields().len()).collect()])
+    fn necessary_children_exprs(&self, output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {
+        // The merge needs only the group/time/end columns, so input columns no
+        // parent asks for can be pruned — otherwise the desugar's `*` projection
+        // rides through the repartition + sort below this node.
+        // `with_exprs_and_inputs` recomputes the schema for the pruned input.
+        let input_schema = self.input.schema();
+        let num_input_fields = input_schema.fields().len();
+        let mut needed: BTreeSet<usize> = output_columns
+            .iter()
+            .copied()
+            .filter(|i| *i < num_input_fields)
+            .collect();
+        for name in self
+            .partition_columns
+            .iter()
+            .chain([&self.time_column, &self.end_column])
+        {
+            let index = input_schema
+                .fields()
+                .iter()
+                .position(|field| field.name() == name)?;
+            needed.insert(index);
+        }
+        Some(vec![needed.into_iter().collect()])
     }
 }

--- a/crates/sail-physical-plan/src/lib.rs
+++ b/crates/sail-physical-plan/src/lib.rs
@@ -9,6 +9,8 @@ pub mod range;
 pub mod remote_checkpoint;
 pub mod repartition;
 pub mod schema_pivot;
+pub mod session_aggregate;
+pub mod session_window;
 pub mod show_string;
 pub mod spark_partition_id;
 pub mod streaming;

--- a/crates/sail-physical-plan/src/session_aggregate.rs
+++ b/crates/sail-physical-plan/src/session_aggregate.rs
@@ -1,0 +1,815 @@
+use std::borrow::Cow;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use datafusion::arrow::array::{
+    Array, ArrayRef, BooleanArray, StructArray, TimestampMicrosecondArray,
+};
+use datafusion::arrow::compute::{SortOptions, filter_record_batch, partition};
+use datafusion::arrow::datatypes::{DataType, Fields, SchemaRef, TimeUnit};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::config::ConfigOptions;
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::functions::core::get_field;
+use datafusion::logical_expr::Accumulator;
+use datafusion::physical_expr::aggregate::AggregateFunctionExpr;
+use datafusion::physical_expr::expressions::{Column, lit};
+use datafusion::physical_expr::{
+    Distribution, EquivalenceProperties, LexOrdering, OrderingRequirements, PhysicalExpr,
+    PhysicalSortExpr, ScalarFunctionExpr,
+};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+    RecordBatchStream,
+};
+use datafusion_common::{Result, ScalarValue, Statistics, exec_err, internal_err};
+use futures::Stream;
+
+/// Fused physical operator for Spark `session_window` aggregation (phase 2, the
+/// `MergingSessionsExec`-equivalent).
+///
+/// Given input hash-partitioned on the group keys and locally sorted by
+/// `(keys, time)`, it merges sessions AND drives the user aggregates in a single
+/// pass, emitting one row per session. Only the open session's accumulator state is
+/// held (O(1) per session) — no per-session row buffering.
+#[derive(Debug)]
+pub struct SessionAggregateExec {
+    input: Arc<dyn ExecutionPlan>,
+    partition_columns: Vec<String>,
+    time_column: String,
+    end_column: String,
+    /// Output group columns in order; exactly one equals the session struct column.
+    group_columns: Vec<String>,
+    /// Name of the `{start, end}` struct column among `group_columns`.
+    session_output: String,
+    aggregates: Vec<Arc<AggregateFunctionExpr>>,
+    /// Optional `FILTER (WHERE ...)` predicate per aggregate, aligned with
+    /// `aggregates`. `None` means the aggregate consumes every session row.
+    filters: Vec<Option<Arc<dyn PhysicalExpr>>>,
+    schema: SchemaRef,
+    properties: Arc<PlanProperties>,
+    /// Required `(partition_columns..., time)` input ordering, resolved eagerly
+    /// so a missing column fails at construction instead of silently dropping
+    /// the sort requirement.
+    required_ordering: Option<OrderingRequirements>,
+}
+
+/// The emitted per-partition ordering: `(partition_columns..., session start)`
+/// — sessions close in scan order of the `(keys, time)`-sorted input. Note this
+/// follows `partition_columns` order, not `group_columns` order. Returns `None`
+/// (caller declares no ordering) if a column or the `get_field` expression
+/// cannot be built.
+fn output_ordering(
+    schema: &SchemaRef,
+    partition_columns: &[String],
+    session_output: &str,
+) -> Option<LexOrdering> {
+    let options = SortOptions {
+        descending: false,
+        nulls_first: false,
+    };
+    let mut sort_exprs: Vec<PhysicalSortExpr> = Vec::with_capacity(partition_columns.len() + 1);
+    for name in partition_columns {
+        let idx = schema.index_of(name).ok()?;
+        sort_exprs.push(PhysicalSortExpr {
+            expr: Arc::new(Column::new(name, idx)),
+            options,
+        });
+    }
+    let session_idx = schema.index_of(session_output).ok()?;
+    let args: Vec<Arc<dyn PhysicalExpr>> = vec![
+        Arc::new(Column::new(session_output, session_idx)),
+        lit("start"),
+    ];
+    let start = ScalarFunctionExpr::try_new(
+        get_field(),
+        args,
+        schema.as_ref(),
+        Arc::new(ConfigOptions::default()),
+    )
+    .ok()?;
+    sort_exprs.push(PhysicalSortExpr {
+        expr: Arc::new(start),
+        options,
+    });
+    LexOrdering::new(sort_exprs)
+}
+
+impl SessionAggregateExec {
+    #[expect(clippy::too_many_arguments)]
+    pub fn try_new(
+        input: Arc<dyn ExecutionPlan>,
+        partition_columns: Vec<String>,
+        time_column: String,
+        end_column: String,
+        group_columns: Vec<String>,
+        session_output: String,
+        aggregates: Vec<Arc<AggregateFunctionExpr>>,
+        filters: Vec<Option<Arc<dyn PhysicalExpr>>>,
+        schema: SchemaRef,
+    ) -> Result<Self> {
+        if filters.len() != aggregates.len() {
+            return internal_err!(
+                "SessionAggregateExec expects one filter slot per aggregate ({} vs {})",
+                filters.len(),
+                aggregates.len()
+            );
+        }
+        // Rows shrink to one per session but stay key-partitioned; report the
+        // input partitioning and the `(keys..., start)` ordering so parents can
+        // reuse both.
+        let eq_properties = match output_ordering(&schema, &partition_columns, &session_output) {
+            Some(ordering) => {
+                EquivalenceProperties::new_with_orderings(schema.clone(), vec![ordering])
+            }
+            None => EquivalenceProperties::new(schema.clone()),
+        };
+        let properties = Arc::new(PlanProperties::new(
+            eq_properties,
+            input.output_partitioning().clone(),
+            input.pipeline_behavior(),
+            input.boundedness(),
+        ));
+        // The merge relies on rows of the same group being adjacent and ordered
+        // by time, so require a local ordering by `(partition_columns..., time)`.
+        let input_schema = input.schema();
+        let mut sort_exprs = Vec::with_capacity(partition_columns.len() + 1);
+        for name in partition_columns
+            .iter()
+            .chain(std::iter::once(&time_column))
+        {
+            let idx = input_schema.index_of(name)?;
+            sort_exprs.push(PhysicalSortExpr {
+                expr: Arc::new(Column::new(name, idx)),
+                options: SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                },
+            });
+        }
+        let required_ordering = LexOrdering::new(sort_exprs).map(OrderingRequirements::from);
+        Ok(Self {
+            input,
+            partition_columns,
+            time_column,
+            end_column,
+            group_columns,
+            session_output,
+            aggregates,
+            filters,
+            schema,
+            properties,
+            required_ordering,
+        })
+    }
+
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
+    pub fn partition_columns(&self) -> &[String] {
+        &self.partition_columns
+    }
+
+    pub fn time_column(&self) -> &str {
+        &self.time_column
+    }
+
+    pub fn end_column(&self) -> &str {
+        &self.end_column
+    }
+
+    pub fn group_columns(&self) -> &[String] {
+        &self.group_columns
+    }
+
+    pub fn session_output(&self) -> &str {
+        &self.session_output
+    }
+
+    pub fn aggregates(&self) -> &[Arc<AggregateFunctionExpr>] {
+        &self.aggregates
+    }
+
+    pub fn filters(&self) -> &[Option<Arc<dyn PhysicalExpr>>] {
+        &self.filters
+    }
+
+    fn partition_exprs(&self) -> Result<Vec<Arc<dyn PhysicalExpr>>> {
+        let input_schema = self.input.schema();
+        self.partition_columns
+            .iter()
+            .map(|name| {
+                let idx = input_schema.index_of(name)?;
+                Ok(Arc::new(Column::new(name, idx)) as Arc<dyn PhysicalExpr>)
+            })
+            .collect()
+    }
+}
+
+impl DisplayAs for SessionAggregateExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "SessionAggregateExec: partition_by=[{}], time={}, end={}, aggs={}",
+            self.partition_columns.join(", "),
+            self.time_column,
+            self.end_column,
+            self.aggregates.len()
+        )
+    }
+}
+
+impl ExecutionPlan for SessionAggregateExec {
+    fn name(&self) -> &'static str {
+        "SessionAggregateExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        match self.partition_exprs() {
+            Ok(exprs) if !exprs.is_empty() => vec![Distribution::HashPartitioned(exprs)],
+            _ => vec![Distribution::SinglePartition],
+        }
+    }
+
+    fn required_input_ordering(&self) -> Vec<Option<OrderingRequirements>> {
+        vec![self.required_ordering.clone()]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let [input] = children.as_slice() else {
+            return internal_err!("SessionAggregateExec requires exactly one child");
+        };
+        Ok(Arc::new(SessionAggregateExec::try_new(
+            Arc::clone(input),
+            self.partition_columns.clone(),
+            self.time_column.clone(),
+            self.end_column.clone(),
+            self.group_columns.clone(),
+            self.session_output.clone(),
+            self.aggregates.clone(),
+            self.filters.clone(),
+            self.schema.clone(),
+        )?))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let input_schema = self.input.schema();
+        let partition_indices = self
+            .partition_columns
+            .iter()
+            .map(|name| input_schema.index_of(name))
+            .collect::<Result<Vec<_>, _>>()?;
+        let time_idx = input_schema.index_of(&self.time_column)?;
+        let end_idx = input_schema.index_of(&self.end_column)?;
+
+        // Locate the session struct field and its timezone in the output schema.
+        let session_idx = self.schema.index_of(&self.session_output)?;
+        let DataType::Struct(struct_fields) = self.schema.field(session_idx).data_type() else {
+            return exec_err!("SessionAggregateExec session column must be a struct");
+        };
+        let tz = match struct_fields.first().map(|f| f.data_type()) {
+            Some(DataType::Timestamp(TimeUnit::Microsecond, tz)) => tz.clone(),
+            _ => return exec_err!("SessionAggregateExec struct fields must be Timestamp(us, *)"),
+        };
+
+        // Non-session group columns line up 1:1 with the key tuple (both follow
+        // grouping order), so assign key positions sequentially.
+        let mut group_sources = Vec::with_capacity(self.group_columns.len());
+        let mut key_count = 0usize;
+        for name in &self.group_columns {
+            if name == &self.session_output {
+                group_sources.push(GroupSource::Session);
+            } else {
+                group_sources.push(GroupSource::Key(key_count));
+                key_count += 1;
+            }
+        }
+        if key_count != partition_indices.len() {
+            return exec_err!(
+                "SessionAggregateExec: {key_count} non-session group columns but \
+                 {} partition keys",
+                partition_indices.len()
+            );
+        }
+
+        let input = self.input.execute(partition, context)?;
+        Ok(Box::pin(SessionAggregateStream {
+            input,
+            output_schema: self.schema.clone(),
+            struct_fields: struct_fields.clone(),
+            tz,
+            partition_indices,
+            time_idx,
+            end_idx,
+            group_sources,
+            aggregates: self.aggregates.clone(),
+            filters: self.filters.clone(),
+            accumulators: Vec::new(),
+            cur_key: None,
+            cur_start: 0,
+            cur_end: 0,
+            finished: false,
+        }))
+    }
+
+    fn partition_statistics(&self, _partition: Option<usize>) -> Result<Arc<Statistics>> {
+        // Row count collapses to one-per-session, not known here.
+        Ok(Arc::new(Statistics::new_unknown(&self.schema)))
+    }
+}
+
+/// One finalized session: its key values, bounds, and aggregate results.
+struct SessionRow {
+    key: Vec<ScalarValue>,
+    start: i64,
+    end: i64,
+    aggs: Vec<ScalarValue>,
+}
+
+/// How `build_batch` materializes each output group column: the session struct
+/// or key-tuple position `i`. Precomputed once per stream.
+enum GroupSource {
+    Session,
+    Key(usize),
+}
+
+struct SessionAggregateStream {
+    input: SendableRecordBatchStream,
+    output_schema: SchemaRef,
+    struct_fields: Fields,
+    tz: Option<Arc<str>>,
+    partition_indices: Vec<usize>,
+    time_idx: usize,
+    end_idx: usize,
+    /// One entry per output group column, in schema order.
+    group_sources: Vec<GroupSource>,
+    aggregates: Vec<Arc<AggregateFunctionExpr>>,
+    /// Optional `FILTER (WHERE ...)` predicate per aggregate, aligned with
+    /// `aggregates`.
+    filters: Vec<Option<Arc<dyn PhysicalExpr>>>,
+    /// Accumulators for the currently-open session (one per aggregate).
+    accumulators: Vec<Box<dyn Accumulator>>,
+    cur_key: Option<Vec<ScalarValue>>,
+    cur_start: i64,
+    cur_end: i64,
+    finished: bool,
+}
+
+impl SessionAggregateStream {
+    fn row_key(&self, batch: &RecordBatch, i: usize) -> Result<Vec<ScalarValue>> {
+        self.partition_indices
+            .iter()
+            .map(|&idx| ScalarValue::try_from_array(batch.column(idx), i))
+            .collect()
+    }
+
+    /// Open a fresh session at row `i`, creating new accumulators.
+    fn start_session(&mut self, key: Vec<ScalarValue>, start: i64, end: i64) -> Result<()> {
+        self.accumulators = self
+            .aggregates
+            .iter()
+            .map(|a| a.create_accumulator())
+            .collect::<Result<Vec<_>>>()?;
+        self.cur_key = Some(key);
+        self.cur_start = start;
+        self.cur_end = end;
+        Ok(())
+    }
+
+    /// Feed a contiguous run of the open session's rows to every accumulator,
+    /// applying each aggregate's `FILTER (WHERE ...)` predicate if it has one.
+    fn update(&mut self, slice: &RecordBatch) -> Result<()> {
+        if slice.num_rows() == 0 {
+            return Ok(());
+        }
+        for ((agg, filter), acc) in self
+            .aggregates
+            .iter()
+            .zip(self.filters.iter())
+            .zip(self.accumulators.iter_mut())
+        {
+            // `FILTER (WHERE p)` masks rows out of this aggregate only; session
+            // boundaries come from the time/end columns and are unaffected.
+            let rows: Cow<RecordBatch> = match filter {
+                Some(predicate) => {
+                    let evaluated = predicate.evaluate(slice)?.into_array(slice.num_rows())?;
+                    let mask = evaluated
+                        .as_any()
+                        .downcast_ref::<BooleanArray>()
+                        .ok_or_else(|| {
+                            datafusion_common::DataFusionError::Internal(
+                                "session aggregate FILTER predicate must be boolean".to_string(),
+                            )
+                        })?;
+                    Cow::Owned(filter_record_batch(slice, &normalize_mask(mask))?)
+                }
+                None => Cow::Borrowed(slice),
+            };
+            if rows.num_rows() == 0 {
+                continue;
+            }
+            let args = agg
+                .expressions()
+                .iter()
+                .map(|e| e.evaluate(&rows)?.into_array(rows.num_rows()))
+                .collect::<Result<Vec<_>>>()?;
+            acc.update_batch(&args)?;
+        }
+        Ok(())
+    }
+
+    /// Finalize the open session into a [`SessionRow`].
+    fn finalize(&mut self) -> Result<Option<SessionRow>> {
+        let Some(key) = self.cur_key.take() else {
+            return Ok(None);
+        };
+        let aggs = self
+            .accumulators
+            .iter_mut()
+            .map(|acc| acc.evaluate())
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Some(SessionRow {
+            key,
+            start: self.cur_start,
+            end: self.cur_end,
+            aggs,
+        }))
+    }
+
+    /// Group-key runs come from arrow's vectorized `partition` kernel, so
+    /// per-row work is only the `i64` time comparisons.
+    fn process_batch(&mut self, batch: RecordBatch) -> Result<Option<RecordBatch>> {
+        let n = batch.num_rows();
+        if n == 0 {
+            return Ok(None);
+        }
+        let times = as_micros(batch.column(self.time_idx))?;
+        let ends = as_micros(batch.column(self.end_idx))?;
+        // Runs of equal group keys in this batch (the whole batch when there are
+        // no group keys).
+        let key_columns = self
+            .partition_indices
+            .iter()
+            .map(|&idx| Arc::clone(batch.column(idx)))
+            .collect::<Vec<_>>();
+        let ranges = if key_columns.is_empty() {
+            std::iter::once(0..n).collect()
+        } else {
+            partition(&key_columns)?.ranges()
+        };
+
+        let mut closed: Vec<SessionRow> = Vec::new();
+        let mut seg_start = 0usize;
+
+        for (range_idx, range) in ranges.iter().enumerate() {
+            // The open session can only continue into this batch's FIRST key run;
+            // every later run starts a different key by construction.
+            let continues_open = range_idx == 0
+                && match &self.cur_key {
+                    Some(k) => *k == self.row_key(&batch, range.start)?,
+                    None => false,
+                };
+            let merge_from = if continues_open {
+                range.start
+            } else {
+                // Close the open session: first feed its rows in this batch,
+                // then open a new session at the run's first row.
+                if self.cur_key.is_some() {
+                    if range.start > seg_start {
+                        self.update(&batch.slice(seg_start, range.start - seg_start))?;
+                    }
+                    if let Some(row) = self.finalize()? {
+                        closed.push(row);
+                    }
+                }
+                let key = self.row_key(&batch, range.start)?;
+                self.start_session(key, times.value(range.start), ends.value(range.start))?;
+                seg_start = range.start;
+                range.start + 1
+            };
+            for i in merge_from..range.end {
+                // Spark merges when `time <= cur_end` (a row exactly on the
+                // end still joins); only `time > cur_end` opens a new session.
+                if times.value(i) > self.cur_end {
+                    if i > seg_start {
+                        self.update(&batch.slice(seg_start, i - seg_start))?;
+                    }
+                    if let Some(row) = self.finalize()? {
+                        closed.push(row);
+                    }
+                    let key = self.row_key(&batch, i)?;
+                    self.start_session(key, times.value(i), ends.value(i))?;
+                    seg_start = i;
+                } else {
+                    self.cur_end = self.cur_end.max(ends.value(i));
+                }
+            }
+        }
+
+        // Feed the open session's trailing rows; it stays open across batches.
+        if n > seg_start {
+            self.update(&batch.slice(seg_start, n - seg_start))?;
+        }
+
+        if closed.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(self.build_batch(closed)?))
+        }
+    }
+
+    /// Build one output batch from finalized sessions, in output schema order:
+    /// the group columns (the session struct among them), then the aggregates.
+    fn build_batch(&self, rows: Vec<SessionRow>) -> Result<RecordBatch> {
+        let mut columns: Vec<ArrayRef> = Vec::with_capacity(self.output_schema.fields().len());
+
+        for source in &self.group_sources {
+            match source {
+                GroupSource::Session => {
+                    let starts = TimestampMicrosecondArray::from(
+                        rows.iter().map(|r| r.start).collect::<Vec<_>>(),
+                    )
+                    .with_timezone_opt(self.tz.clone());
+                    let ends = TimestampMicrosecondArray::from(
+                        rows.iter().map(|r| r.end).collect::<Vec<_>>(),
+                    )
+                    .with_timezone_opt(self.tz.clone());
+                    columns.push(Arc::new(StructArray::new(
+                        self.struct_fields.clone(),
+                        vec![Arc::new(starts) as ArrayRef, Arc::new(ends) as ArrayRef],
+                        None,
+                    )));
+                }
+                GroupSource::Key(pos) => {
+                    columns.push(ScalarValue::iter_to_array(
+                        rows.iter().map(|r| r.key[*pos].clone()),
+                    )?);
+                }
+            }
+        }
+
+        for j in 0..self.aggregates.len() {
+            columns.push(ScalarValue::iter_to_array(
+                rows.iter().map(|r| r.aggs[j].clone()),
+            )?);
+        }
+
+        Ok(RecordBatch::try_new(self.output_schema.clone(), columns)?)
+    }
+}
+
+/// Normalize a FILTER predicate mask so null entries are treated as `false`
+/// (SQL `FILTER (WHERE p)` keeps only rows where `p` is TRUE). Returns the mask
+/// unchanged when it has no nulls.
+fn normalize_mask(mask: &BooleanArray) -> BooleanArray {
+    if mask.null_count() == 0 {
+        mask.clone()
+    } else {
+        mask.iter().map(|v| Some(v.unwrap_or(false))).collect()
+    }
+}
+
+fn as_micros(array: &ArrayRef) -> Result<&TimestampMicrosecondArray> {
+    array
+        .as_any()
+        .downcast_ref::<TimestampMicrosecondArray>()
+        .ok_or_else(|| {
+            datafusion_common::DataFusionError::Internal(
+                "session_window expected a Timestamp(Microsecond) column".to_string(),
+            )
+        })
+}
+
+impl RecordBatchStream for SessionAggregateStream {
+    fn schema(&self) -> SchemaRef {
+        self.output_schema.clone()
+    }
+}
+
+impl Stream for SessionAggregateStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            match self.input.as_mut().poll_next(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Some(Err(e))) => return Poll::Ready(Some(Err(e))),
+                Poll::Ready(Some(Ok(batch))) => match self.process_batch(batch) {
+                    Ok(Some(out)) => return Poll::Ready(Some(Ok(out))),
+                    Ok(None) => continue,
+                    Err(e) => return Poll::Ready(Some(Err(e))),
+                },
+                Poll::Ready(None) => {
+                    if self.finished {
+                        return Poll::Ready(None);
+                    }
+                    self.finished = true;
+                    match self.finalize() {
+                        Ok(Some(row)) => match self.build_batch(vec![row]) {
+                            Ok(out) => return Poll::Ready(Some(Ok(out))),
+                            Err(e) => return Poll::Ready(Some(Err(e))),
+                        },
+                        Ok(None) => return Poll::Ready(None),
+                        Err(e) => return Poll::Ready(Some(Err(e))),
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used)]
+mod tests {
+    use datafusion::arrow::array::{Array, Int32Array, Int64Array, StructArray};
+    use datafusion::arrow::compute::concat_batches;
+    use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema, TimeUnit};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::functions_aggregate::count::count_udaf;
+    use datafusion::logical_expr::Operator;
+    use datafusion::physical_expr::aggregate::AggregateExprBuilder;
+    use datafusion::physical_expr::expressions::{BinaryExpr, Column, lit};
+    use datafusion::prelude::SessionContext;
+    use datafusion_common::ScalarValue;
+    use futures::StreamExt;
+
+    use super::*;
+
+    /// One row per (key, time, value); the end candidate is `time + 10`.
+    fn batch(schema: &SchemaRef, rows: &[(i32, i64, i64)]) -> RecordBatch {
+        let keys = Int32Array::from(rows.iter().map(|r| r.0).collect::<Vec<_>>());
+        let times = TimestampMicrosecondArray::from(rows.iter().map(|r| r.1).collect::<Vec<_>>());
+        let ends =
+            TimestampMicrosecondArray::from(rows.iter().map(|r| r.1 + 10).collect::<Vec<_>>());
+        let values = Int64Array::from(rows.iter().map(|r| r.2).collect::<Vec<_>>());
+        RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(keys),
+                Arc::new(times),
+                Arc::new(ends),
+                Arc::new(values),
+            ],
+        )
+        .expect("input batch")
+    }
+
+    /// The fused operator must produce one row per session with correct
+    /// accumulator state when session rows span input batches, including a
+    /// `FILTER (WHERE ...)` mask applied across the boundary.
+    #[tokio::test]
+    async fn fused_aggregation_survives_batch_boundaries() -> Result<()> {
+        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
+        let input_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, true),
+            Field::new("#t", ts.clone(), true),
+            Field::new("#e0", ts.clone(), true),
+            Field::new("v", DataType::Int64, true),
+        ]));
+        let struct_type = DataType::Struct(Fields::from(vec![
+            Field::new("start", ts.clone(), true),
+            Field::new("end", ts, true),
+        ]));
+        let output_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, true),
+            Field::new("#w", struct_type, false),
+            Field::new("cnt", DataType::Int64, true),
+            Field::new("cnt_pos", DataType::Int64, true),
+        ]));
+        let v_col = || Arc::new(Column::new("v", 3)) as Arc<dyn PhysicalExpr>;
+        let cnt = AggregateExprBuilder::new(count_udaf(), vec![v_col()])
+            .schema(input_schema.clone())
+            .alias("cnt")
+            .build()?;
+        let cnt_pos = AggregateExprBuilder::new(count_udaf(), vec![v_col()])
+            .schema(input_schema.clone())
+            .alias("cnt_pos")
+            .build()?;
+        let positive: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            v_col(),
+            Operator::Gt,
+            lit(ScalarValue::Int64(Some(0))),
+        ));
+        // Same session layout as the `SessionWindowExec` test: key 2's session
+        // spans the second batch boundary; its negative value lands in the
+        // second batch, so the filter mask must apply across the carry-over.
+        let batches = vec![
+            batch(&input_schema, &[(1, 0, 1), (1, 5, -1)]),
+            batch(&input_schema, &[(1, 30, 2), (2, 100, 3)]),
+            batch(&input_schema, &[(2, 105, -3), (3, 200, 5)]),
+        ];
+        let input = MemorySourceConfig::try_new_exec(&[batches], input_schema.clone(), None)?;
+        let exec = SessionAggregateExec::try_new(
+            input,
+            vec!["k".to_string()],
+            "#t".to_string(),
+            "#e0".to_string(),
+            vec!["k".to_string(), "#w".to_string()],
+            "#w".to_string(),
+            vec![Arc::new(cnt), Arc::new(cnt_pos)],
+            vec![None, Some(positive)],
+            output_schema.clone(),
+        )?;
+        let ctx = SessionContext::new().task_ctx();
+        let mut stream = exec.execute(0, ctx)?;
+        let mut batches = vec![];
+        while let Some(batch) = stream.next().await {
+            batches.push(batch?);
+        }
+        let output = concat_batches(&output_schema, &batches)?;
+        assert_eq!(output.num_rows(), 4);
+        let keys = output
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("key column");
+        let sessions = output
+            .column(1)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("session struct column");
+        let starts = as_micros(sessions.column(0))?;
+        let ends = as_micros(sessions.column(1))?;
+        let cnt = output
+            .column(2)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("cnt column");
+        let cnt_pos = output
+            .column(3)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("cnt_pos column");
+        let expected = [
+            (1, 0, 15, 2, 1),
+            (1, 30, 40, 1, 1),
+            (2, 100, 115, 2, 1),
+            (3, 200, 210, 1, 1),
+        ];
+        for (i, (key, start, end, count, count_pos)) in expected.iter().enumerate() {
+            assert_eq!(
+                (
+                    keys.value(i),
+                    starts.value(i),
+                    ends.value(i),
+                    cnt.value(i),
+                    cnt_pos.value(i)
+                ),
+                (*key, *start, *end, *count, *count_pos),
+                "session {i}"
+            );
+        }
+        Ok(())
+    }
+
+    /// A partition or time column missing from the input schema must fail at
+    /// construction, not silently drop the sort requirement later.
+    #[test]
+    fn try_new_rejects_missing_columns() -> Result<()> {
+        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
+        let input_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, true),
+            Field::new("#t", ts.clone(), true),
+            Field::new("#e0", ts, true),
+        ]));
+        let input = MemorySourceConfig::try_new_exec(&[vec![]], input_schema.clone(), None)?;
+        let result = SessionAggregateExec::try_new(
+            input,
+            vec!["#missing".to_string()],
+            "#t".to_string(),
+            "#e0".to_string(),
+            vec!["#w".to_string()],
+            "#w".to_string(),
+            vec![],
+            vec![],
+            input_schema,
+        );
+        match result {
+            Err(e) => assert!(e.to_string().contains("#missing"), "{e}"),
+            Ok(_) => return internal_err!("expected a missing-column error"),
+        }
+        Ok(())
+    }
+}

--- a/crates/sail-physical-plan/src/session_aggregate.rs
+++ b/crates/sail-physical-plan/src/session_aggregate.rs
@@ -24,7 +24,9 @@ use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
     RecordBatchStream,
 };
-use datafusion_common::{Result, ScalarValue, Statistics, exec_err, internal_err};
+use datafusion_common::{
+    Result, ScalarValue, Statistics, exec_err, internal_datafusion_err, internal_err,
+};
 use futures::Stream;
 
 /// Fused physical operator for Spark `session_window` aggregation (phase 2, the
@@ -43,28 +45,23 @@ pub struct SessionAggregateExec {
     /// Output group columns in order; exactly one equals the session struct column.
     group_columns: Vec<String>,
     /// Name of the `{start, end}` struct column among `group_columns`.
-    session_output: String,
+    output_column: String,
     aggregates: Vec<Arc<AggregateFunctionExpr>>,
-    /// Optional `FILTER (WHERE ...)` predicate per aggregate, aligned with
-    /// `aggregates`. `None` means the aggregate consumes every session row.
+    /// Optional `FILTER (WHERE ...)` predicate per aggregate, aligned with `aggregates`.
     filters: Vec<Option<Arc<dyn PhysicalExpr>>>,
     schema: SchemaRef,
     properties: Arc<PlanProperties>,
-    /// Required `(partition_columns..., time)` input ordering, resolved eagerly
-    /// so a missing column fails at construction instead of silently dropping
-    /// the sort requirement.
+    /// Required `(partition_columns..., time)` input ordering, resolved at
+    /// construction so a missing column fails early.
     required_ordering: Option<OrderingRequirements>,
     metrics: ExecutionPlanMetricsSet,
 }
 
-/// The emitted per-partition ordering: the `partition_columns` prefix —
-/// sessions close in scan order of the `(keys, time)`-sorted input. The output
-/// is also ordered by `session.start` within each key, but declaring that
-/// component needs a `get_field` expression built with the session's
-/// `ConfigOptions` (`ScalarFunctionExpr` equality compares config options, so
-/// one built from defaults never matches planner-built expressions and only
-/// adds comparison cost); threading the config here is a follow-up. Returns
-/// `None` when there are no keys.
+/// The `partition_columns` prefix of the emitted ordering (sessions close in
+/// scan order of the sorted input); `None` when there are no keys. The
+/// `session.start` component is omitted: declaring it needs a `get_field`
+/// expression built with the session's `ConfigOptions` (`ScalarFunctionExpr`
+/// equality compares them), which are not threaded here.
 fn output_ordering(schema: &SchemaRef, partition_columns: &[String]) -> Option<LexOrdering> {
     let options = SortOptions {
         descending: false,
@@ -89,7 +86,7 @@ impl SessionAggregateExec {
         time_column: String,
         end_column: String,
         group_columns: Vec<String>,
-        session_output: String,
+        output_column: String,
         aggregates: Vec<Arc<AggregateFunctionExpr>>,
         filters: Vec<Option<Arc<dyn PhysicalExpr>>>,
         schema: SchemaRef,
@@ -101,18 +98,16 @@ impl SessionAggregateExec {
                 aggregates.len()
             );
         }
-        if !group_columns.iter().any(|c| c == &session_output) {
+        if !group_columns.iter().any(|c| c == &output_column) {
             return internal_err!(
                 "SessionAggregateExec group columns {group_columns:?} must contain the session \
-                 output column {session_output:?}"
+                 output column {output_column:?}"
             );
         }
-        // Rows shrink to one per session but stay key-partitioned; report the
-        // input partitioning and the keys-prefix ordering so parents can reuse
-        // both. The input hash exprs are bound to input-schema indices,
-        // so rebind them to the output schema (columns move and most input
-        // columns disappear); anything that does not survive degrades to
-        // unknown partitioning instead of advertising dangling indices.
+        // Rows shrink to one per session but stay key-partitioned. The input
+        // hash exprs are bound to input-schema indices, so rebind them to the
+        // output schema; anything that does not survive degrades to unknown
+        // partitioning instead of advertising dangling indices.
         let eq_properties = match output_ordering(&schema, &partition_columns) {
             Some(ordering) => {
                 EquivalenceProperties::new_with_orderings(schema.clone(), vec![ordering])
@@ -168,7 +163,7 @@ impl SessionAggregateExec {
             time_column,
             end_column,
             group_columns,
-            session_output,
+            output_column,
             aggregates,
             filters,
             schema,
@@ -198,8 +193,8 @@ impl SessionAggregateExec {
         &self.group_columns
     }
 
-    pub fn session_output(&self) -> &str {
-        &self.session_output
+    pub fn output_column(&self) -> &str {
+        &self.output_column
     }
 
     pub fn aggregates(&self) -> &[Arc<AggregateFunctionExpr>] {
@@ -280,7 +275,7 @@ impl ExecutionPlan for SessionAggregateExec {
             self.time_column.clone(),
             self.end_column.clone(),
             self.group_columns.clone(),
-            self.session_output.clone(),
+            self.output_column.clone(),
             self.aggregates.clone(),
             self.filters.clone(),
             self.schema.clone(),
@@ -302,7 +297,7 @@ impl ExecutionPlan for SessionAggregateExec {
         let end_idx = input_schema.index_of(&self.end_column)?;
 
         // Locate the session struct field and its timezone in the output schema.
-        let session_idx = self.schema.index_of(&self.session_output)?;
+        let session_idx = self.schema.index_of(&self.output_column)?;
         let DataType::Struct(struct_fields) = self.schema.field(session_idx).data_type() else {
             return exec_err!("SessionAggregateExec session column must be a struct");
         };
@@ -316,7 +311,7 @@ impl ExecutionPlan for SessionAggregateExec {
         let mut group_sources = Vec::with_capacity(self.group_columns.len());
         let mut key_count = 0usize;
         for name in &self.group_columns {
-            if name == &self.session_output {
+            if name == &self.output_column {
                 group_sources.push(GroupSource::Session);
             } else {
                 group_sources.push(GroupSource::Key(key_count));
@@ -384,11 +379,8 @@ struct SessionAggregateStream {
     partition_indices: Vec<usize>,
     time_idx: usize,
     end_idx: usize,
-    /// One entry per output group column, in schema order.
     group_sources: Vec<GroupSource>,
     aggregates: Vec<Arc<AggregateFunctionExpr>>,
-    /// Optional `FILTER (WHERE ...)` predicate per aggregate, aligned with
-    /// `aggregates`.
     filters: Vec<Option<Arc<dyn PhysicalExpr>>>,
     /// Accumulators for the currently-open session (one per aggregate).
     accumulators: Vec<Box<dyn Accumulator>>,
@@ -396,7 +388,6 @@ struct SessionAggregateStream {
     cur_start: i64,
     cur_end: i64,
     baseline: BaselineMetrics,
-    /// Closed (emitted) sessions.
     num_sessions: Count,
     finished: bool,
 }
@@ -409,7 +400,6 @@ impl SessionAggregateStream {
             .collect()
     }
 
-    /// Open a fresh session at row `i`, creating new accumulators.
     fn start_session(&mut self, key: Vec<ScalarValue>, start: i64, end: i64) -> Result<()> {
         self.accumulators = self
             .aggregates
@@ -443,8 +433,8 @@ impl SessionAggregateStream {
                         .as_any()
                         .downcast_ref::<BooleanArray>()
                         .ok_or_else(|| {
-                            datafusion_common::DataFusionError::Internal(
-                                "session aggregate FILTER predicate must be boolean".to_string(),
+                            internal_datafusion_err!(
+                                "session aggregate FILTER predicate must be boolean"
                             )
                         })?;
                     Cow::Owned(filter_record_batch(slice, &normalize_mask(mask))?)
@@ -482,8 +472,6 @@ impl SessionAggregateStream {
         }))
     }
 
-    /// Group-key runs come from arrow's vectorized `partition` kernel, so
-    /// per-row work is only the `i64` time comparisons.
     fn process_batch(&mut self, batch: RecordBatch) -> Result<Option<RecordBatch>> {
         let n = batch.num_rows();
         if n == 0 {
@@ -508,8 +496,7 @@ impl SessionAggregateStream {
         let mut seg_start = 0usize;
 
         for (range_idx, range) in ranges.iter().enumerate() {
-            // The open session can only continue into this batch's FIRST key run;
-            // every later run starts a different key by construction.
+            // Only the batch's first key run can continue the open session.
             let continues_open = range_idx == 0
                 && match &self.cur_key {
                     Some(k) => *k == self.row_key(&batch, range.start)?,
@@ -564,8 +551,6 @@ impl SessionAggregateStream {
         }
     }
 
-    /// Build one output batch from finalized sessions, in output schema order:
-    /// the group columns (the session struct among them), then the aggregates.
     fn build_batch(&self, rows: Vec<SessionRow>) -> Result<RecordBatch> {
         self.num_sessions.add(rows.len());
         let mut columns: Vec<ArrayRef> = Vec::with_capacity(self.output_schema.fields().len());
@@ -605,9 +590,8 @@ impl SessionAggregateStream {
     }
 }
 
-/// Normalize a FILTER predicate mask so null entries are treated as `false`
-/// (SQL `FILTER (WHERE p)` keeps only rows where `p` is TRUE). Returns the mask
-/// unchanged when it has no nulls.
+/// Treats null mask entries as `false`: SQL `FILTER (WHERE p)` keeps only rows
+/// where `p` is TRUE.
 fn normalize_mask(mask: &BooleanArray) -> BooleanArray {
     if mask.null_count() == 0 {
         mask.clone()
@@ -621,9 +605,7 @@ fn as_micros(array: &ArrayRef) -> Result<&TimestampMicrosecondArray> {
         .as_any()
         .downcast_ref::<TimestampMicrosecondArray>()
         .ok_or_else(|| {
-            datafusion_common::DataFusionError::Internal(
-                "session_window expected a Timestamp(Microsecond) column".to_string(),
-            )
+            internal_datafusion_err!("session_window expected a Timestamp(Microsecond) column")
         })
 }
 
@@ -657,9 +639,6 @@ impl Stream for SessionAggregateStream {
                     }
                 }
                 Poll::Ready(None) => {
-                    if self.finished {
-                        return Poll::Ready(None);
-                    }
                     self.finished = true;
                     let _timer = baseline.elapsed_compute().timer();
                     match self.finalize() {
@@ -679,7 +658,7 @@ impl Stream for SessionAggregateStream {
 }
 
 #[cfg(test)]
-#[expect(clippy::expect_used)]
+#[expect(clippy::expect_used, clippy::panic)]
 mod tests {
     use datafusion::arrow::array::{Array, Int32Array, Int64Array, StructArray};
     use datafusion::arrow::compute::concat_batches;
@@ -690,21 +669,42 @@ mod tests {
     use datafusion::logical_expr::Operator;
     use datafusion::physical_expr::aggregate::AggregateExprBuilder;
     use datafusion::physical_expr::expressions::{BinaryExpr, Column, lit};
+    use datafusion::physical_plan::collect;
     use datafusion::prelude::SessionContext;
     use datafusion_common::ScalarValue;
-    use futures::StreamExt;
 
     use super::*;
 
+    fn micros_type() -> DataType {
+        DataType::Timestamp(TimeUnit::Microsecond, None)
+    }
+
+    fn session_field() -> Field {
+        let struct_type = DataType::Struct(Fields::from(vec![
+            Field::new("start", micros_type(), true),
+            Field::new("end", micros_type(), true),
+        ]));
+        Field::new("#w", struct_type, false)
+    }
+
+    fn input_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, true),
+            Field::new("#t", micros_type(), true),
+            Field::new("#e0", micros_type(), true),
+            Field::new("v", DataType::Int64, true),
+        ]))
+    }
+
     /// One row per (key, time, value); the end candidate is `time + 10`.
-    fn batch(schema: &SchemaRef, rows: &[(i32, i64, i64)]) -> RecordBatch {
+    fn batch(rows: &[(i32, i64, i64)]) -> RecordBatch {
         let keys = Int32Array::from(rows.iter().map(|r| r.0).collect::<Vec<_>>());
         let times = TimestampMicrosecondArray::from(rows.iter().map(|r| r.1).collect::<Vec<_>>());
         let ends =
             TimestampMicrosecondArray::from(rows.iter().map(|r| r.1 + 10).collect::<Vec<_>>());
         let values = Int64Array::from(rows.iter().map(|r| r.2).collect::<Vec<_>>());
         RecordBatch::try_new(
-            schema.clone(),
+            input_schema(),
             vec![
                 Arc::new(keys),
                 Arc::new(times),
@@ -715,111 +715,126 @@ mod tests {
         .expect("input batch")
     }
 
-    /// The fused operator must produce one row per session with correct
-    /// accumulator state when session rows span input batches, including a
-    /// `FILTER (WHERE ...)` mask applied across the boundary.
+    /// `count(v)` over the input schema, aliased.
+    fn count_agg(alias: &str) -> Result<Arc<AggregateFunctionExpr>> {
+        Ok(Arc::new(
+            AggregateExprBuilder::new(
+                count_udaf(),
+                vec![Arc::new(Column::new("v", 3)) as Arc<dyn PhysicalExpr>],
+            )
+            .schema(input_schema())
+            .alias(alias)
+            .build()?,
+        ))
+    }
+
+    fn fused_exec(
+        input: Arc<dyn ExecutionPlan>,
+        group_columns: &[&str],
+        aggregates: Vec<Arc<AggregateFunctionExpr>>,
+        filters: Vec<Option<Arc<dyn PhysicalExpr>>>,
+        output_schema: SchemaRef,
+    ) -> Result<Arc<SessionAggregateExec>> {
+        Ok(Arc::new(SessionAggregateExec::try_new(
+            input,
+            vec!["k".to_string()],
+            "#t".to_string(),
+            "#e0".to_string(),
+            group_columns.iter().map(|c| c.to_string()).collect(),
+            "#w".to_string(),
+            aggregates,
+            filters,
+            output_schema,
+        )?))
+    }
+
+    fn memory_input(batches: Vec<RecordBatch>) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(MemorySourceConfig::try_new_exec(
+            &[batches],
+            input_schema(),
+            None,
+        )?)
+    }
+
+    async fn run(exec: Arc<SessionAggregateExec>) -> Result<RecordBatch> {
+        let schema = exec.schema();
+        let ctx = SessionContext::new().task_ctx();
+        Ok(concat_batches(&schema, &collect(exec, ctx).await?)?)
+    }
+
+    /// The `(start, end)` pairs of the session struct column at index `i`.
+    fn session_bounds(output: &RecordBatch, i: usize) -> Result<Vec<(i64, i64)>> {
+        let sessions = output
+            .column(i)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("session struct column");
+        let starts = as_micros(sessions.column(0))?;
+        let ends = as_micros(sessions.column(1))?;
+        Ok(starts
+            .values()
+            .iter()
+            .zip(ends.values().iter())
+            .map(|(s, e)| (*s, *e))
+            .collect())
+    }
+
+    fn i32_values(output: &RecordBatch, i: usize) -> Vec<i32> {
+        output
+            .column(i)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("Int32 column")
+            .values()
+            .to_vec()
+    }
+
+    fn i64_values(output: &RecordBatch, i: usize) -> Vec<i64> {
+        output
+            .column(i)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("Int64 column")
+            .values()
+            .to_vec()
+    }
+
     #[tokio::test]
     async fn fused_aggregation_survives_batch_boundaries() -> Result<()> {
-        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
-        let input_schema = Arc::new(Schema::new(vec![
-            Field::new("k", DataType::Int32, true),
-            Field::new("#t", ts.clone(), true),
-            Field::new("#e0", ts.clone(), true),
-            Field::new("v", DataType::Int64, true),
-        ]));
-        let struct_type = DataType::Struct(Fields::from(vec![
-            Field::new("start", ts.clone(), true),
-            Field::new("end", ts, true),
-        ]));
         let output_schema = Arc::new(Schema::new(vec![
             Field::new("k", DataType::Int32, true),
-            Field::new("#w", struct_type, false),
+            session_field(),
             Field::new("cnt", DataType::Int64, true),
             Field::new("cnt_pos", DataType::Int64, true),
         ]));
-        let v_col = || Arc::new(Column::new("v", 3)) as Arc<dyn PhysicalExpr>;
-        let cnt = AggregateExprBuilder::new(count_udaf(), vec![v_col()])
-            .schema(input_schema.clone())
-            .alias("cnt")
-            .build()?;
-        let cnt_pos = AggregateExprBuilder::new(count_udaf(), vec![v_col()])
-            .schema(input_schema.clone())
-            .alias("cnt_pos")
-            .build()?;
         let positive: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
-            v_col(),
+            Arc::new(Column::new("v", 3)),
             Operator::Gt,
             lit(ScalarValue::Int64(Some(0))),
         ));
         // Same session layout as the `SessionWindowExec` test: key 2's session
         // spans the second batch boundary; its negative value lands in the
         // second batch, so the filter mask must apply across the carry-over.
-        let batches = vec![
-            batch(&input_schema, &[(1, 0, 1), (1, 5, -1)]),
-            batch(&input_schema, &[(1, 30, 2), (2, 100, 3)]),
-            batch(&input_schema, &[(2, 105, -3), (3, 200, 5)]),
-        ];
-        let input = MemorySourceConfig::try_new_exec(&[batches], input_schema.clone(), None)?;
-        let exec = SessionAggregateExec::try_new(
+        let input = memory_input(vec![
+            batch(&[(1, 0, 1), (1, 5, -1)]),
+            batch(&[(1, 30, 2), (2, 100, 3)]),
+            batch(&[(2, 105, -3), (3, 200, 5)]),
+        ])?;
+        let exec = fused_exec(
             input,
-            vec!["k".to_string()],
-            "#t".to_string(),
-            "#e0".to_string(),
-            vec!["k".to_string(), "#w".to_string()],
-            "#w".to_string(),
-            vec![Arc::new(cnt), Arc::new(cnt_pos)],
+            &["k", "#w"],
+            vec![count_agg("cnt")?, count_agg("cnt_pos")?],
             vec![None, Some(positive)],
-            output_schema.clone(),
+            output_schema,
         )?;
-        let ctx = SessionContext::new().task_ctx();
-        let mut stream = exec.execute(0, ctx)?;
-        let mut batches = vec![];
-        while let Some(batch) = stream.next().await {
-            batches.push(batch?);
-        }
-        let output = concat_batches(&output_schema, &batches)?;
-        assert_eq!(output.num_rows(), 4);
-        let keys = output
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int32Array>()
-            .expect("key column");
-        let sessions = output
-            .column(1)
-            .as_any()
-            .downcast_ref::<StructArray>()
-            .expect("session struct column");
-        let starts = as_micros(sessions.column(0))?;
-        let ends = as_micros(sessions.column(1))?;
-        let cnt = output
-            .column(2)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .expect("cnt column");
-        let cnt_pos = output
-            .column(3)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .expect("cnt_pos column");
-        let expected = [
-            (1, 0, 15, 2, 1),
-            (1, 30, 40, 1, 1),
-            (2, 100, 115, 2, 1),
-            (3, 200, 210, 1, 1),
-        ];
-        for (i, (key, start, end, count, count_pos)) in expected.iter().enumerate() {
-            assert_eq!(
-                (
-                    keys.value(i),
-                    starts.value(i),
-                    ends.value(i),
-                    cnt.value(i),
-                    cnt_pos.value(i)
-                ),
-                (*key, *start, *end, *count, *count_pos),
-                "session {i}"
-            );
-        }
+        let output = run(exec.clone()).await?;
+        assert_eq!(i32_values(&output, 0), [1, 1, 2, 3]);
+        assert_eq!(
+            session_bounds(&output, 1)?,
+            [(0, 15), (30, 40), (100, 115), (200, 210)]
+        );
+        assert_eq!(i64_values(&output, 2), [2, 1, 2, 1]);
+        assert_eq!(i64_values(&output, 3), [1, 1, 1, 1]);
         let metrics = exec.metrics().expect("metrics");
         assert_eq!(metrics.output_rows(), Some(4));
         assert_eq!(
@@ -829,127 +844,66 @@ mod tests {
         Ok(())
     }
 
-    /// Pins the fused merge rules: inclusive boundary, a key change at a
-    /// batch boundary within the carried gap, and multi-row segments at
-    /// nonzero offsets.
     #[tokio::test]
     async fn fused_merge_boundaries_and_segment_offsets() -> Result<()> {
-        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
-        let input_schema = Arc::new(Schema::new(vec![
-            Field::new("k", DataType::Int32, true),
-            Field::new("#t", ts.clone(), true),
-            Field::new("#e0", ts.clone(), true),
-            Field::new("v", DataType::Int64, true),
-        ]));
-        let struct_type = DataType::Struct(Fields::from(vec![
-            Field::new("start", ts.clone(), true),
-            Field::new("end", ts, true),
-        ]));
         let output_schema = Arc::new(Schema::new(vec![
             Field::new("k", DataType::Int32, true),
-            Field::new("#w", struct_type, false),
+            session_field(),
             Field::new("cnt", DataType::Int64, true),
         ]));
-        let cnt = AggregateExprBuilder::new(
-            count_udaf(),
-            vec![Arc::new(Column::new("v", 3)) as Arc<dyn PhysicalExpr>],
-        )
-        .schema(input_schema.clone())
-        .alias("cnt")
-        .build()?;
-        let batches = vec![
-            batch(
-                &input_schema,
-                &[
-                    (1, 0, 1),
-                    (1, 10, 1),
-                    (1, 25, 1),
-                    (1, 30, 1),
-                    (1, 50, 1),
-                    (2, 100, 1),
-                ],
-            ),
-            batch(&input_schema, &[(3, 104, 1), (3, 120, 1)]),
-        ];
-        let input = MemorySourceConfig::try_new_exec(&[batches], input_schema.clone(), None)?;
-        let exec = SessionAggregateExec::try_new(
+        // Batch 1: key 1 merges t=10 exactly on the session end (inclusive
+        // boundary), t=25 opens a second session extended by t=30, and t=50 a
+        // third (a mid-run close at a nonzero slice offset); key 2 changes
+        // mid-batch. Batch 2 starts with a key change at the batch boundary
+        // whose time (104) is within key 2's still-open gap.
+        let input = memory_input(vec![
+            batch(&[
+                (1, 0, 1),
+                (1, 10, 1),
+                (1, 25, 1),
+                (1, 30, 1),
+                (1, 50, 1),
+                (2, 100, 1),
+            ]),
+            batch(&[(3, 104, 1), (3, 120, 1)]),
+        ])?;
+        let exec = fused_exec(
             input,
-            vec!["k".to_string()],
-            "#t".to_string(),
-            "#e0".to_string(),
-            vec!["k".to_string(), "#w".to_string()],
-            "#w".to_string(),
-            vec![Arc::new(cnt)],
+            &["k", "#w"],
+            vec![count_agg("cnt")?],
             vec![None],
-            output_schema.clone(),
+            output_schema,
         )?;
-        let ctx = SessionContext::new().task_ctx();
-        let mut stream = exec.execute(0, ctx)?;
-        let mut batches = vec![];
-        while let Some(batch) = stream.next().await {
-            batches.push(batch?);
-        }
-        let output = concat_batches(&output_schema, &batches)?;
-        assert_eq!(output.num_rows(), 6);
-        let keys = output
-            .column(0)
-            .as_any()
-            .downcast_ref::<Int32Array>()
-            .expect("key column");
-        let sessions = output
-            .column(1)
-            .as_any()
-            .downcast_ref::<StructArray>()
-            .expect("session struct column");
-        let starts = as_micros(sessions.column(0))?;
-        let ends = as_micros(sessions.column(1))?;
-        let cnts = output
-            .column(2)
-            .as_any()
-            .downcast_ref::<Int64Array>()
-            .expect("count column");
-        let expected = [
-            (1, 0, 20, 2),
-            (1, 25, 40, 2),
-            (1, 50, 60, 1),
-            (2, 100, 110, 1),
-            (3, 104, 114, 1),
-            (3, 120, 130, 1),
-        ];
-        for (i, (key, start, end, count)) in expected.iter().enumerate() {
-            assert_eq!(
-                (keys.value(i), starts.value(i), ends.value(i), cnts.value(i)),
-                (*key, *start, *end, *count),
-                "session {i}"
-            );
-        }
+        let output = run(exec).await?;
+        assert_eq!(i32_values(&output, 0), [1, 1, 1, 2, 3, 3]);
+        assert_eq!(
+            session_bounds(&output, 1)?,
+            [
+                (0, 20),
+                (25, 40),
+                (50, 60),
+                (100, 110),
+                (104, 114),
+                (120, 130)
+            ]
+        );
+        assert_eq!(i64_values(&output, 2), [2, 2, 1, 1, 1, 1]);
         Ok(())
     }
 
-    /// The advertised output partitioning must be rebound to the output
-    /// schema: group columns move (the session struct is first here), so the
-    /// input's hash exprs carry stale indices.
+    /// The advertised output partitioning and ordering must be rebound to the
+    /// output schema: group columns move (the session struct is first here), so
+    /// the input's hash exprs carry stale indices.
     #[test]
     fn output_partitioning_rebinds_to_output_schema() -> Result<()> {
         use datafusion::physical_plan::repartition::RepartitionExec;
 
-        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
-        let input_schema = Arc::new(Schema::new(vec![
-            Field::new("k", DataType::Int32, true),
-            Field::new("#t", ts.clone(), true),
-            Field::new("#e0", ts.clone(), true),
-            Field::new("v", DataType::Int64, true),
-        ]));
-        let struct_type = DataType::Struct(Fields::from(vec![
-            Field::new("start", ts.clone(), true),
-            Field::new("end", ts, true),
-        ]));
         let output_schema = Arc::new(Schema::new(vec![
-            Field::new("#w", struct_type, false),
+            session_field(),
             Field::new("k", DataType::Int32, true),
             Field::new("cnt", DataType::Int64, true),
         ]));
-        let source = MemorySourceConfig::try_new_exec(&[vec![]], input_schema.clone(), None)?;
+        let source = MemorySourceConfig::try_new_exec(&[vec![]], input_schema(), None)?;
         let input = Arc::new(RepartitionExec::try_new(
             source,
             Partitioning::Hash(
@@ -957,54 +911,30 @@ mod tests {
                 4,
             ),
         )?);
-        let cnt = AggregateExprBuilder::new(
-            count_udaf(),
-            vec![Arc::new(Column::new("v", 3)) as Arc<dyn PhysicalExpr>],
-        )
-        .schema(input_schema.clone())
-        .alias("cnt")
-        .build()?;
-        let exec = SessionAggregateExec::try_new(
+        let exec = fused_exec(
             input,
-            vec!["k".to_string()],
-            "#t".to_string(),
-            "#e0".to_string(),
-            vec!["#w".to_string(), "k".to_string()],
-            "#w".to_string(),
-            vec![Arc::new(cnt)],
+            &["#w", "k"],
+            vec![count_agg("cnt")?],
             vec![None],
             output_schema,
         )?;
         let Partitioning::Hash(exprs, 4) = exec.properties().output_partitioning() else {
-            return internal_err!("expected hash output partitioning");
+            panic!("expected hash output partitioning");
         };
-        let column = exprs[0]
-            .downcast_ref::<Column>()
-            .ok_or_else(|| datafusion_common::DataFusionError::Internal("not a column".into()))?;
+        let column = exprs[0].downcast_ref::<Column>().expect("hash column");
         assert_eq!((column.name(), column.index()), ("k", 1));
-        let ordering = exec
-            .properties()
-            .output_ordering()
-            .ok_or_else(|| datafusion_common::DataFusionError::Internal("no ordering".into()))?;
+        let ordering = exec.properties().output_ordering().expect("ordering");
         let first = ordering[0]
             .expr
             .downcast_ref::<Column>()
-            .ok_or_else(|| datafusion_common::DataFusionError::Internal("not a column".into()))?;
+            .expect("ordering column");
         assert_eq!((first.name(), first.index()), ("k", 1));
         Ok(())
     }
 
-    /// A partition or time column missing from the input schema must fail at
-    /// construction, not silently drop the sort requirement later.
     #[test]
     fn try_new_rejects_missing_columns() -> Result<()> {
-        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
-        let input_schema = Arc::new(Schema::new(vec![
-            Field::new("k", DataType::Int32, true),
-            Field::new("#t", ts.clone(), true),
-            Field::new("#e0", ts, true),
-        ]));
-        let input = MemorySourceConfig::try_new_exec(&[vec![]], input_schema.clone(), None)?;
+        let input = MemorySourceConfig::try_new_exec(&[vec![]], input_schema(), None)?;
         let result = SessionAggregateExec::try_new(
             input,
             vec!["#missing".to_string()],
@@ -1014,12 +944,10 @@ mod tests {
             "#w".to_string(),
             vec![],
             vec![],
-            input_schema,
+            input_schema(),
         );
-        match result {
-            Err(e) => assert!(e.to_string().contains("#missing"), "{e}"),
-            Ok(_) => return internal_err!("expected a missing-column error"),
-        }
+        let err = result.expect_err("expected a missing-column error");
+        assert!(err.to_string().contains("#missing"), "{err}");
         Ok(())
     }
 }

--- a/crates/sail-physical-plan/src/session_aggregate.rs
+++ b/crates/sail-physical-plan/src/session_aggregate.rs
@@ -829,6 +829,103 @@ mod tests {
         Ok(())
     }
 
+    /// Pins the fused merge rules: inclusive boundary, a key change at a
+    /// batch boundary within the carried gap, and multi-row segments at
+    /// nonzero offsets.
+    #[tokio::test]
+    async fn fused_merge_boundaries_and_segment_offsets() -> Result<()> {
+        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
+        let input_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, true),
+            Field::new("#t", ts.clone(), true),
+            Field::new("#e0", ts.clone(), true),
+            Field::new("v", DataType::Int64, true),
+        ]));
+        let struct_type = DataType::Struct(Fields::from(vec![
+            Field::new("start", ts.clone(), true),
+            Field::new("end", ts, true),
+        ]));
+        let output_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, true),
+            Field::new("#w", struct_type, false),
+            Field::new("cnt", DataType::Int64, true),
+        ]));
+        let cnt = AggregateExprBuilder::new(
+            count_udaf(),
+            vec![Arc::new(Column::new("v", 3)) as Arc<dyn PhysicalExpr>],
+        )
+        .schema(input_schema.clone())
+        .alias("cnt")
+        .build()?;
+        let batches = vec![
+            batch(
+                &input_schema,
+                &[
+                    (1, 0, 1),
+                    (1, 10, 1),
+                    (1, 25, 1),
+                    (1, 30, 1),
+                    (1, 50, 1),
+                    (2, 100, 1),
+                ],
+            ),
+            batch(&input_schema, &[(3, 104, 1), (3, 120, 1)]),
+        ];
+        let input = MemorySourceConfig::try_new_exec(&[batches], input_schema.clone(), None)?;
+        let exec = SessionAggregateExec::try_new(
+            input,
+            vec!["k".to_string()],
+            "#t".to_string(),
+            "#e0".to_string(),
+            vec!["k".to_string(), "#w".to_string()],
+            "#w".to_string(),
+            vec![Arc::new(cnt)],
+            vec![None],
+            output_schema.clone(),
+        )?;
+        let ctx = SessionContext::new().task_ctx();
+        let mut stream = exec.execute(0, ctx)?;
+        let mut batches = vec![];
+        while let Some(batch) = stream.next().await {
+            batches.push(batch?);
+        }
+        let output = concat_batches(&output_schema, &batches)?;
+        assert_eq!(output.num_rows(), 6);
+        let keys = output
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .expect("key column");
+        let sessions = output
+            .column(1)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("session struct column");
+        let starts = as_micros(sessions.column(0))?;
+        let ends = as_micros(sessions.column(1))?;
+        let cnts = output
+            .column(2)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .expect("count column");
+        let expected = [
+            (1, 0, 20, 2),
+            (1, 25, 40, 2),
+            (1, 50, 60, 1),
+            (2, 100, 110, 1),
+            (3, 104, 114, 1),
+            (3, 120, 130, 1),
+        ];
+        for (i, (key, start, end, count)) in expected.iter().enumerate() {
+            assert_eq!(
+                (keys.value(i), starts.value(i), ends.value(i), cnts.value(i)),
+                (*key, *start, *end, *count),
+                "session {i}"
+            );
+        }
+        Ok(())
+    }
+
     /// The advertised output partitioning must be rebound to the output
     /// schema: group columns move (the session struct is first here), so the
     /// input's hash exprs carry stale indices.
@@ -885,6 +982,15 @@ mod tests {
             .downcast_ref::<Column>()
             .ok_or_else(|| datafusion_common::DataFusionError::Internal("not a column".into()))?;
         assert_eq!((column.name(), column.index()), ("k", 1));
+        let ordering = exec
+            .properties()
+            .output_ordering()
+            .ok_or_else(|| datafusion_common::DataFusionError::Internal("no ordering".into()))?;
+        let first = ordering[0]
+            .expr
+            .downcast_ref::<Column>()
+            .ok_or_else(|| datafusion_common::DataFusionError::Internal("not a column".into()))?;
+        assert_eq!((first.name(), first.index()), ("k", 1));
         Ok(())
     }
 

--- a/crates/sail-physical-plan/src/session_aggregate.rs
+++ b/crates/sail-physical-plan/src/session_aggregate.rs
@@ -9,15 +9,13 @@ use datafusion::arrow::array::{
 use datafusion::arrow::compute::{SortOptions, filter_record_batch, partition};
 use datafusion::arrow::datatypes::{DataType, Fields, SchemaRef, TimeUnit};
 use datafusion::arrow::record_batch::RecordBatch;
-use datafusion::config::ConfigOptions;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
-use datafusion::functions::core::get_field;
 use datafusion::logical_expr::Accumulator;
 use datafusion::physical_expr::aggregate::AggregateFunctionExpr;
-use datafusion::physical_expr::expressions::{Column, lit};
+use datafusion::physical_expr::expressions::Column;
 use datafusion::physical_expr::{
-    Distribution, EquivalenceProperties, LexOrdering, OrderingRequirements, PhysicalExpr,
-    PhysicalSortExpr, ScalarFunctionExpr,
+    Distribution, EquivalenceProperties, LexOrdering, OrderingRequirements, Partitioning,
+    PhysicalExpr, PhysicalSortExpr,
 };
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
@@ -55,21 +53,20 @@ pub struct SessionAggregateExec {
     required_ordering: Option<OrderingRequirements>,
 }
 
-/// The emitted per-partition ordering: `(partition_columns..., session start)`
-/// — sessions close in scan order of the `(keys, time)`-sorted input. Note this
-/// follows `partition_columns` order, not `group_columns` order. Returns `None`
-/// (caller declares no ordering) if a column or the `get_field` expression
-/// cannot be built.
-fn output_ordering(
-    schema: &SchemaRef,
-    partition_columns: &[String],
-    session_output: &str,
-) -> Option<LexOrdering> {
+/// The emitted per-partition ordering: the `partition_columns` prefix —
+/// sessions close in scan order of the `(keys, time)`-sorted input. The output
+/// is also ordered by `session.start` within each key, but declaring that
+/// component needs a `get_field` expression built with the session's
+/// `ConfigOptions` (`ScalarFunctionExpr` equality compares config options, so
+/// one built from defaults never matches planner-built expressions and only
+/// adds comparison cost); threading the config here is a follow-up. Returns
+/// `None` when there are no keys.
+fn output_ordering(schema: &SchemaRef, partition_columns: &[String]) -> Option<LexOrdering> {
     let options = SortOptions {
         descending: false,
         nulls_first: false,
     };
-    let mut sort_exprs: Vec<PhysicalSortExpr> = Vec::with_capacity(partition_columns.len() + 1);
+    let mut sort_exprs: Vec<PhysicalSortExpr> = Vec::with_capacity(partition_columns.len());
     for name in partition_columns {
         let idx = schema.index_of(name).ok()?;
         sort_exprs.push(PhysicalSortExpr {
@@ -77,22 +74,6 @@ fn output_ordering(
             options,
         });
     }
-    let session_idx = schema.index_of(session_output).ok()?;
-    let args: Vec<Arc<dyn PhysicalExpr>> = vec![
-        Arc::new(Column::new(session_output, session_idx)),
-        lit("start"),
-    ];
-    let start = ScalarFunctionExpr::try_new(
-        get_field(),
-        args,
-        schema.as_ref(),
-        Arc::new(ConfigOptions::default()),
-    )
-    .ok()?;
-    sort_exprs.push(PhysicalSortExpr {
-        expr: Arc::new(start),
-        options,
-    });
     LexOrdering::new(sort_exprs)
 }
 
@@ -116,18 +97,46 @@ impl SessionAggregateExec {
                 aggregates.len()
             );
         }
+        if !group_columns.iter().any(|c| c == &session_output) {
+            return internal_err!(
+                "SessionAggregateExec group columns {group_columns:?} must contain the session \
+                 output column {session_output:?}"
+            );
+        }
         // Rows shrink to one per session but stay key-partitioned; report the
-        // input partitioning and the `(keys..., start)` ordering so parents can
-        // reuse both.
-        let eq_properties = match output_ordering(&schema, &partition_columns, &session_output) {
+        // input partitioning and the keys-prefix ordering so parents can reuse
+        // both. The input hash exprs are bound to input-schema indices,
+        // so rebind them to the output schema (columns move and most input
+        // columns disappear); anything that does not survive degrades to
+        // unknown partitioning instead of advertising dangling indices.
+        let eq_properties = match output_ordering(&schema, &partition_columns) {
             Some(ordering) => {
                 EquivalenceProperties::new_with_orderings(schema.clone(), vec![ordering])
             }
             None => EquivalenceProperties::new(schema.clone()),
         };
+        let partitioning = match input.output_partitioning() {
+            Partitioning::Hash(exprs, n) => {
+                let remapped = exprs
+                    .iter()
+                    .map(|e| {
+                        e.downcast_ref::<Column>().and_then(|c| {
+                            schema.index_of(c.name()).ok().map(|idx| {
+                                Arc::new(Column::new(c.name(), idx)) as Arc<dyn PhysicalExpr>
+                            })
+                        })
+                    })
+                    .collect::<Option<Vec<_>>>();
+                match remapped {
+                    Some(exprs) => Partitioning::Hash(exprs, *n),
+                    None => Partitioning::UnknownPartitioning(*n),
+                }
+            }
+            other => other.clone(),
+        };
         let properties = Arc::new(PlanProperties::new(
             eq_properties,
-            input.output_partitioning().clone(),
+            partitioning,
             input.pipeline_behavior(),
             input.boundedness(),
         ));
@@ -611,6 +620,10 @@ impl Stream for SessionAggregateStream {
     type Item = Result<RecordBatch>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // Polling a terminated stream again is formally unspecified.
+        if self.finished {
+            return Poll::Ready(None);
+        }
         loop {
             match self.input.as_mut().poll_next(cx) {
                 Poll::Pending => return Poll::Pending,
@@ -781,6 +794,65 @@ mod tests {
                 "session {i}"
             );
         }
+        Ok(())
+    }
+
+    /// The advertised output partitioning must be rebound to the output
+    /// schema: group columns move (the session struct is first here), so the
+    /// input's hash exprs carry stale indices.
+    #[test]
+    fn output_partitioning_rebinds_to_output_schema() -> Result<()> {
+        use datafusion::physical_plan::repartition::RepartitionExec;
+
+        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
+        let input_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, true),
+            Field::new("#t", ts.clone(), true),
+            Field::new("#e0", ts.clone(), true),
+            Field::new("v", DataType::Int64, true),
+        ]));
+        let struct_type = DataType::Struct(Fields::from(vec![
+            Field::new("start", ts.clone(), true),
+            Field::new("end", ts, true),
+        ]));
+        let output_schema = Arc::new(Schema::new(vec![
+            Field::new("#w", struct_type, false),
+            Field::new("k", DataType::Int32, true),
+            Field::new("cnt", DataType::Int64, true),
+        ]));
+        let source = MemorySourceConfig::try_new_exec(&[vec![]], input_schema.clone(), None)?;
+        let input = Arc::new(RepartitionExec::try_new(
+            source,
+            Partitioning::Hash(
+                vec![Arc::new(Column::new("k", 0)) as Arc<dyn PhysicalExpr>],
+                4,
+            ),
+        )?);
+        let cnt = AggregateExprBuilder::new(
+            count_udaf(),
+            vec![Arc::new(Column::new("v", 3)) as Arc<dyn PhysicalExpr>],
+        )
+        .schema(input_schema.clone())
+        .alias("cnt")
+        .build()?;
+        let exec = SessionAggregateExec::try_new(
+            input,
+            vec!["k".to_string()],
+            "#t".to_string(),
+            "#e0".to_string(),
+            vec!["#w".to_string(), "k".to_string()],
+            "#w".to_string(),
+            vec![Arc::new(cnt)],
+            vec![None],
+            output_schema,
+        )?;
+        let Partitioning::Hash(exprs, 4) = exec.properties().output_partitioning() else {
+            return internal_err!("expected hash output partitioning");
+        };
+        let column = exprs[0]
+            .downcast_ref::<Column>()
+            .ok_or_else(|| datafusion_common::DataFusionError::Internal("not a column".into()))?;
+        assert_eq!((column.name(), column.index()), ("k", 1));
         Ok(())
     }
 

--- a/crates/sail-physical-plan/src/session_aggregate.rs
+++ b/crates/sail-physical-plan/src/session_aggregate.rs
@@ -17,6 +17,9 @@ use datafusion::physical_expr::{
     Distribution, EquivalenceProperties, LexOrdering, OrderingRequirements, Partitioning,
     PhysicalExpr, PhysicalSortExpr,
 };
+use datafusion::physical_plan::metrics::{
+    BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
+};
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
     RecordBatchStream,
@@ -51,6 +54,7 @@ pub struct SessionAggregateExec {
     /// so a missing column fails at construction instead of silently dropping
     /// the sort requirement.
     required_ordering: Option<OrderingRequirements>,
+    metrics: ExecutionPlanMetricsSet,
 }
 
 /// The emitted per-partition ordering: the `partition_columns` prefix —
@@ -170,6 +174,7 @@ impl SessionAggregateExec {
             schema,
             properties,
             required_ordering,
+            metrics: ExecutionPlanMetricsSet::new(),
         })
     }
 
@@ -247,6 +252,10 @@ impl ExecutionPlan for SessionAggregateExec {
         vec![&self.input]
     }
 
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
     fn required_input_distribution(&self) -> Vec<Distribution> {
         match self.partition_exprs() {
             Ok(exprs) if !exprs.is_empty() => vec![Distribution::HashPartitioned(exprs)],
@@ -322,9 +331,13 @@ impl ExecutionPlan for SessionAggregateExec {
             );
         }
 
+        let baseline = BaselineMetrics::new(&self.metrics, partition);
+        let num_sessions = MetricBuilder::new(&self.metrics).counter("num_sessions", partition);
         let input = self.input.execute(partition, context)?;
         Ok(Box::pin(SessionAggregateStream {
             input,
+            baseline,
+            num_sessions,
             output_schema: self.schema.clone(),
             struct_fields: struct_fields.clone(),
             tz,
@@ -382,6 +395,9 @@ struct SessionAggregateStream {
     cur_key: Option<Vec<ScalarValue>>,
     cur_start: i64,
     cur_end: i64,
+    baseline: BaselineMetrics,
+    /// Closed (emitted) sessions.
+    num_sessions: Count,
     finished: bool,
 }
 
@@ -551,6 +567,7 @@ impl SessionAggregateStream {
     /// Build one output batch from finalized sessions, in output schema order:
     /// the group columns (the session struct among them), then the aggregates.
     fn build_batch(&self, rows: Vec<SessionRow>) -> Result<RecordBatch> {
+        self.num_sessions.add(rows.len());
         let mut columns: Vec<ArrayRef> = Vec::with_capacity(self.output_schema.fields().len());
 
         for source in &self.group_sources {
@@ -624,23 +641,32 @@ impl Stream for SessionAggregateStream {
         if self.finished {
             return Poll::Ready(None);
         }
+        let baseline = self.baseline.clone();
         loop {
             match self.input.as_mut().poll_next(cx) {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(Some(Err(e))) => return Poll::Ready(Some(Err(e))),
-                Poll::Ready(Some(Ok(batch))) => match self.process_batch(batch) {
-                    Ok(Some(out)) => return Poll::Ready(Some(Ok(out))),
-                    Ok(None) => continue,
-                    Err(e) => return Poll::Ready(Some(Err(e))),
-                },
+                Poll::Ready(Some(Ok(batch))) => {
+                    let _timer = baseline.elapsed_compute().timer();
+                    match self.process_batch(batch) {
+                        Ok(Some(out)) => {
+                            return baseline.record_poll(Poll::Ready(Some(Ok(out))));
+                        }
+                        Ok(None) => continue,
+                        Err(e) => return Poll::Ready(Some(Err(e))),
+                    }
+                }
                 Poll::Ready(None) => {
                     if self.finished {
                         return Poll::Ready(None);
                     }
                     self.finished = true;
+                    let _timer = baseline.elapsed_compute().timer();
                     match self.finalize() {
                         Ok(Some(row)) => match self.build_batch(vec![row]) {
-                            Ok(out) => return Poll::Ready(Some(Ok(out))),
+                            Ok(out) => {
+                                return baseline.record_poll(Poll::Ready(Some(Ok(out))));
+                            }
                             Err(e) => return Poll::Ready(Some(Err(e))),
                         },
                         Ok(None) => return Poll::Ready(None),
@@ -794,6 +820,12 @@ mod tests {
                 "session {i}"
             );
         }
+        let metrics = exec.metrics().expect("metrics");
+        assert_eq!(metrics.output_rows(), Some(4));
+        assert_eq!(
+            metrics.sum_by_name("num_sessions").map(|m| m.as_usize()),
+            Some(4)
+        );
         Ok(())
     }
 

--- a/crates/sail-physical-plan/src/session_window.rs
+++ b/crates/sail-physical-plan/src/session_window.rs
@@ -1,0 +1,650 @@
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use datafusion::arrow::array::{Array, ArrayRef, StructArray, TimestampMicrosecondArray};
+use datafusion::arrow::compute::{SortOptions, concat_batches, partition};
+use datafusion::arrow::datatypes::{DataType, Fields, SchemaRef, TimeUnit};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::execution::memory_pool::{MemoryConsumer, MemoryReservation};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::{
+    Distribution, EquivalenceProperties, LexOrdering, OrderingRequirements, PhysicalExpr,
+    PhysicalSortExpr,
+};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+    RecordBatchStream,
+};
+use datafusion_common::{Result, ScalarValue, Statistics, exec_err, internal_err};
+use futures::Stream;
+
+/// Physical operator for Spark `session_window` (`UpdatingSessionsExec`-style):
+/// appends a `{start, end}` struct column to its input. Rows merge per group of
+/// `partition_columns` while the next row's time is at or before the session's
+/// end (`end_column` = `time + gap`, precomputed by the resolver). Requires the
+/// input hash-partitioned on the group keys and sorted by `(keys..., time)`;
+/// the one-pass merge buffers only the currently-open session's rows.
+#[derive(Debug)]
+pub struct SessionWindowExec {
+    input: Arc<dyn ExecutionPlan>,
+    partition_columns: Vec<String>,
+    time_column: String,
+    end_column: String,
+    output_column: String,
+    schema: SchemaRef,
+    properties: Arc<PlanProperties>,
+    /// Required `(partition_columns..., time)` input ordering, resolved eagerly
+    /// so a missing column fails at construction instead of silently dropping
+    /// the sort requirement.
+    required_ordering: Option<OrderingRequirements>,
+}
+
+impl SessionWindowExec {
+    pub fn try_new(
+        input: Arc<dyn ExecutionPlan>,
+        partition_columns: Vec<String>,
+        time_column: String,
+        end_column: String,
+        output_column: String,
+        schema: SchemaRef,
+    ) -> Result<Self> {
+        // Rows never move or reorder, so the child's partitioning passes
+        // through (the downstream aggregate on `(keys, struct)` reuses it) and
+        // its orderings stay valid and must be carried over to match
+        // `maintains_input_order`. Equivalence classes/constants are dropped.
+        let eq_properties = EquivalenceProperties::new_with_orderings(
+            schema.clone(),
+            input
+                .equivalence_properties()
+                .oeq_class()
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>(),
+        );
+        let properties = Arc::new(PlanProperties::new(
+            eq_properties,
+            input.output_partitioning().clone(),
+            input.pipeline_behavior(),
+            input.boundedness(),
+        ));
+        // The merge relies on rows of the same group being adjacent and ordered
+        // by time, so require a local ordering by `(partition_columns..., time)`.
+        let input_schema = input.schema();
+        let mut sort_exprs = Vec::with_capacity(partition_columns.len() + 1);
+        for name in partition_columns
+            .iter()
+            .chain(std::iter::once(&time_column))
+        {
+            let idx = input_schema.index_of(name)?;
+            sort_exprs.push(PhysicalSortExpr {
+                expr: Arc::new(Column::new(name, idx)),
+                options: SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                },
+            });
+        }
+        let required_ordering = LexOrdering::new(sort_exprs).map(OrderingRequirements::from);
+        Ok(Self {
+            input,
+            partition_columns,
+            time_column,
+            end_column,
+            output_column,
+            schema,
+            properties,
+            required_ordering,
+        })
+    }
+
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+
+    pub fn partition_columns(&self) -> &[String] {
+        &self.partition_columns
+    }
+
+    pub fn time_column(&self) -> &str {
+        &self.time_column
+    }
+
+    pub fn end_column(&self) -> &str {
+        &self.end_column
+    }
+
+    pub fn output_column(&self) -> &str {
+        &self.output_column
+    }
+
+    /// The hash-distribution columns as physical `Column` exprs (empty when there
+    /// are no group keys).
+    fn partition_exprs(&self) -> Result<Vec<Arc<dyn PhysicalExpr>>> {
+        let input_schema = self.input.schema();
+        self.partition_columns
+            .iter()
+            .map(|name| {
+                let idx = input_schema.index_of(name)?;
+                Ok(Arc::new(Column::new(name, idx)) as Arc<dyn PhysicalExpr>)
+            })
+            .collect()
+    }
+}
+
+impl DisplayAs for SessionWindowExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "SessionWindowExec: partition_by=[{}], time={}, end={}, output={}",
+            self.partition_columns.join(", "),
+            self.time_column,
+            self.end_column,
+            self.output_column
+        )
+    }
+}
+
+impl ExecutionPlan for SessionWindowExec {
+    fn name(&self) -> &'static str {
+        "SessionWindowExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn maintains_input_order(&self) -> Vec<bool> {
+        // One output row per input row, in input order.
+        vec![true]
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        // A session must never span partitions: hash-partition by the group
+        // keys, or a single partition when there are none.
+        match self.partition_exprs() {
+            Ok(exprs) if !exprs.is_empty() => vec![Distribution::HashPartitioned(exprs)],
+            _ => vec![Distribution::SinglePartition],
+        }
+    }
+
+    fn required_input_ordering(&self) -> Vec<Option<OrderingRequirements>> {
+        vec![self.required_ordering.clone()]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let [input] = children.as_slice() else {
+            return internal_err!("SessionWindowExec requires exactly one child");
+        };
+        Ok(Arc::new(SessionWindowExec::try_new(
+            Arc::clone(input),
+            self.partition_columns.clone(),
+            self.time_column.clone(),
+            self.end_column.clone(),
+            self.output_column.clone(),
+            self.schema.clone(),
+        )?))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        let input_schema = self.input.schema();
+
+        let partition_indices = self
+            .partition_columns
+            .iter()
+            .map(|name| input_schema.index_of(name))
+            .collect::<Result<Vec<_>, _>>()?;
+        let time_idx = input_schema.index_of(&self.time_column)?;
+        let end_idx = input_schema.index_of(&self.end_column)?;
+
+        // The appended struct field and its timestamp timezone.
+        let out_field = self.schema.field(self.schema.fields().len() - 1);
+        let DataType::Struct(struct_fields) = out_field.data_type() else {
+            return exec_err!("SessionWindowExec output column must be a struct");
+        };
+        let tz = match struct_fields.first().map(|f| f.data_type()) {
+            Some(DataType::Timestamp(TimeUnit::Microsecond, tz)) => tz.clone(),
+            _ => return exec_err!("SessionWindowExec struct fields must be Timestamp(us, *)"),
+        };
+
+        let reservation = MemoryConsumer::new(format!("SessionWindowStream[{partition}]"))
+            .register(context.memory_pool());
+        let input = self.input.execute(partition, context)?;
+        Ok(Box::pin(SessionWindowStream {
+            input,
+            input_schema,
+            output_schema: self.schema.clone(),
+            struct_fields: struct_fields.clone(),
+            tz,
+            partition_indices,
+            time_idx,
+            end_idx,
+            open_rows: Vec::new(),
+            reservation,
+            buffered_bytes: 0,
+            cur_key: None,
+            cur_start: 0,
+            cur_end: 0,
+            finished: false,
+        }))
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
+        // Row count is preserved; column stats shift due to the added column.
+        let stats = self.input.partition_statistics(partition)?;
+        Ok(Arc::new(
+            Statistics::new_unknown(&self.schema).with_num_rows(stats.num_rows),
+        ))
+    }
+}
+
+struct SessionWindowStream {
+    input: SendableRecordBatchStream,
+    /// Schema of the child (without the appended struct), used to concat buffers.
+    input_schema: SchemaRef,
+    /// Schema of this operator's output (child + struct column).
+    output_schema: SchemaRef,
+    struct_fields: Fields,
+    tz: Option<Arc<str>>,
+    partition_indices: Vec<usize>,
+    time_idx: usize,
+    end_idx: usize,
+    /// Rows of the currently-open session not yet emitted (may span batches).
+    open_rows: Vec<RecordBatch>,
+    /// Tracks `open_rows` against the task memory pool: a session spanning many
+    /// batches retains them all until it closes, so an oversized session must
+    /// fail with a resources error instead of aborting the process.
+    reservation: MemoryReservation,
+    /// Bytes currently held by `reservation` for `open_rows`.
+    buffered_bytes: usize,
+    /// Group key of the open session.
+    cur_key: Option<Vec<ScalarValue>>,
+    /// Open session start (micros) = time of its first row.
+    cur_start: i64,
+    /// Open session end (micros) = max(time + gap) over merged rows.
+    cur_end: i64,
+    finished: bool,
+}
+
+impl SessionWindowStream {
+    /// Buffers a slice of the open session that outlives its input batch,
+    /// charging the memory pool for the retained size (a slice keeps its
+    /// parent batch's buffers alive in full). Slices consumed within the same
+    /// `process_batch` call are pushed directly instead: their parent batch is
+    /// already resident and bounded, and per-slice accounting is measurable
+    /// overhead when sessions are small.
+    fn buffer_rows(&mut self, rows: RecordBatch) -> Result<()> {
+        let bytes = rows.get_array_memory_size();
+        self.reservation.try_grow(bytes)?;
+        self.buffered_bytes += bytes;
+        self.open_rows.push(rows);
+        Ok(())
+    }
+
+    /// The group key of row `i` as scalars (empty when there are no group keys).
+    fn row_key(&self, batch: &RecordBatch, i: usize) -> Result<Vec<ScalarValue>> {
+        self.partition_indices
+            .iter()
+            .map(|&idx| ScalarValue::try_from_array(batch.column(idx), i))
+            .collect()
+    }
+
+    /// Builds one output batch for a closed session: every buffered row gets the
+    /// same `{start, end}` struct. Returns `None` if the session held no rows.
+    fn build_output(&mut self) -> Result<Option<RecordBatch>> {
+        if self.open_rows.is_empty() {
+            return Ok(None);
+        }
+        let batches = std::mem::take(&mut self.open_rows);
+        self.reservation.shrink(self.buffered_bytes);
+        self.buffered_bytes = 0;
+        let input_batch = concat_batches(&self.input_schema, &batches)?;
+        let n = input_batch.num_rows();
+        if n == 0 {
+            return Ok(None);
+        }
+        // Same start/end for every row in the session.
+        let start = TimestampMicrosecondArray::from(vec![self.cur_start; n])
+            .with_timezone_opt(self.tz.clone());
+        let end = TimestampMicrosecondArray::from(vec![self.cur_end; n])
+            .with_timezone_opt(self.tz.clone());
+        let struct_arr = StructArray::new(
+            self.struct_fields.clone(),
+            vec![Arc::new(start) as ArrayRef, Arc::new(end) as ArrayRef],
+            None,
+        );
+        let mut cols = input_batch.columns().to_vec();
+        cols.push(Arc::new(struct_arr));
+        Ok(Some(RecordBatch::try_new(
+            self.output_schema.clone(),
+            cols,
+        )?))
+    }
+
+    /// Processes one input batch, returning the rows of sessions that closed in
+    /// it (`None` if nothing closed); the trailing open session is carried in
+    /// `open_rows`. Group-key runs come from arrow's vectorized `partition`
+    /// kernel, so per-row work is only the `i64` time comparisons.
+    fn process_batch(&mut self, batch: RecordBatch) -> Result<Option<RecordBatch>> {
+        let n = batch.num_rows();
+        if n == 0 {
+            return Ok(None);
+        }
+        let times = as_micros(batch.column(self.time_idx))?;
+        let ends = as_micros(batch.column(self.end_idx))?;
+        // Runs of equal group keys (the whole batch when there are no keys).
+        let key_columns = self
+            .partition_indices
+            .iter()
+            .map(|&idx| Arc::clone(batch.column(idx)))
+            .collect::<Vec<_>>();
+        let ranges = if key_columns.is_empty() {
+            std::iter::once(0..n).collect()
+        } else {
+            partition(&key_columns)?.ranges()
+        };
+
+        // Output batches for every session that closes during this input batch.
+        let mut closed: Vec<RecordBatch> = Vec::new();
+        // Start (in this batch) of the open session's rows; carried-over rows
+        // live in `open_rows`.
+        let mut seg_start = 0usize;
+
+        for (range_idx, range) in ranges.iter().enumerate() {
+            // Only the batch's first key run can continue the open session.
+            let continues_open = range_idx == 0
+                && match &self.cur_key {
+                    Some(k) => *k == self.row_key(&batch, range.start)?,
+                    None => false,
+                };
+            let merge_from = if continues_open {
+                range.start
+            } else {
+                // Close the open session and open a new one at this run's
+                // first row.
+                if range.start > seg_start {
+                    self.open_rows
+                        .push(batch.slice(seg_start, range.start - seg_start));
+                }
+                if let Some(out) = self.build_output()? {
+                    closed.push(out);
+                }
+                self.cur_key = Some(self.row_key(&batch, range.start)?);
+                self.cur_start = times.value(range.start);
+                self.cur_end = ends.value(range.start);
+                seg_start = range.start;
+                range.start + 1
+            };
+            for i in merge_from..range.end {
+                // Spark merges when `time <= cur_end` (a row exactly on the
+                // end still joins); only `time > cur_end` opens a new session.
+                if times.value(i) > self.cur_end {
+                    if i > seg_start {
+                        self.open_rows.push(batch.slice(seg_start, i - seg_start));
+                    }
+                    if let Some(out) = self.build_output()? {
+                        closed.push(out);
+                    }
+                    self.cur_start = times.value(i);
+                    self.cur_end = ends.value(i);
+                    seg_start = i;
+                } else {
+                    // Merge: extend the session end if this row reaches further.
+                    self.cur_end = self.cur_end.max(ends.value(i));
+                }
+            }
+        }
+
+        // Carry the open session's trailing rows over to the next batch.
+        if n > seg_start {
+            self.buffer_rows(batch.slice(seg_start, n - seg_start))?;
+        }
+
+        if closed.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(concat_batches(&self.output_schema, &closed)?))
+        }
+    }
+}
+
+/// Reads a `Timestamp(Microsecond, *)` column as raw `i64` micros; the
+/// resolver's filter guarantees non-null values.
+fn as_micros(array: &ArrayRef) -> Result<&TimestampMicrosecondArray> {
+    array
+        .as_any()
+        .downcast_ref::<TimestampMicrosecondArray>()
+        .ok_or_else(|| {
+            datafusion_common::DataFusionError::Internal(
+                "session_window expected a Timestamp(Microsecond) column".to_string(),
+            )
+        })
+}
+
+impl RecordBatchStream for SessionWindowStream {
+    fn schema(&self) -> SchemaRef {
+        self.output_schema.clone()
+    }
+}
+
+impl Stream for SessionWindowStream {
+    type Item = Result<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            match self.input.as_mut().poll_next(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(Some(Err(e))) => return Poll::Ready(Some(Err(e))),
+                Poll::Ready(Some(Ok(batch))) => match self.process_batch(batch) {
+                    Ok(Some(out)) => return Poll::Ready(Some(Ok(out))),
+                    // Whole batch merged into the still-open session; poll for more.
+                    Ok(None) => continue,
+                    Err(e) => return Poll::Ready(Some(Err(e))),
+                },
+                Poll::Ready(None) => {
+                    if self.finished {
+                        return Poll::Ready(None);
+                    }
+                    // Input exhausted: emit the final still-open session.
+                    self.finished = true;
+                    match self.build_output() {
+                        Ok(Some(out)) => return Poll::Ready(Some(Ok(out))),
+                        Ok(None) => return Poll::Ready(None),
+                        Err(e) => return Poll::Ready(Some(Err(e))),
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used)]
+mod tests {
+    use datafusion::arrow::array::{Array, Int32Array, StructArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema, TimeUnit};
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::prelude::SessionContext;
+    use futures::StreamExt;
+
+    use super::*;
+
+    /// One row per (key, time); the end candidate is `time + 10`.
+    fn batch(schema: &SchemaRef, rows: &[(i32, i64)]) -> RecordBatch {
+        let keys = Int32Array::from(rows.iter().map(|r| r.0).collect::<Vec<_>>());
+        let times = TimestampMicrosecondArray::from(rows.iter().map(|r| r.1).collect::<Vec<_>>());
+        let ends =
+            TimestampMicrosecondArray::from(rows.iter().map(|r| r.1 + 10).collect::<Vec<_>>());
+        RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(keys), Arc::new(times), Arc::new(ends)],
+        )
+        .expect("input batch")
+    }
+
+    /// Sessions must merge and close correctly when their rows are split
+    /// across input batches: an open session carried over a batch boundary, a
+    /// key change both inside a batch and at a boundary, and the final flush
+    /// at end of input.
+    #[tokio::test]
+    async fn sessions_survive_batch_boundaries() -> Result<()> {
+        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
+        let input_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, true),
+            Field::new("#t", ts.clone(), true),
+            Field::new("#e0", ts.clone(), true),
+        ]));
+        let struct_type = DataType::Struct(Fields::from(vec![
+            Field::new("start", ts.clone(), true),
+            Field::new("end", ts.clone(), true),
+        ]));
+        let output_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, true),
+            Field::new("#t", ts.clone(), true),
+            Field::new("#e0", ts, true),
+            Field::new("#w", struct_type, false),
+        ]));
+        // Sorted by (k, t), gap = 10: key 1 merges t=0 and t=5 across nothing,
+        // then t=30 opens a new session; key 2 merges t=100 and t=105 ACROSS
+        // the second batch boundary; key 3 is flushed at end of input. The
+        // first batch boundary splits key 1's open session from its closing
+        // row; the key 1 -> 2 change happens inside a batch and the 2 -> 3
+        // change at a boundary.
+        let batches = vec![
+            batch(&input_schema, &[(1, 0), (1, 5)]),
+            batch(&input_schema, &[(1, 30), (2, 100)]),
+            batch(&input_schema, &[(2, 105), (3, 200)]),
+        ];
+        let input = MemorySourceConfig::try_new_exec(&[batches], input_schema.clone(), None)?;
+        let exec = SessionWindowExec::try_new(
+            input,
+            vec!["k".to_string()],
+            "#t".to_string(),
+            "#e0".to_string(),
+            "#w".to_string(),
+            output_schema.clone(),
+        )?;
+        let ctx = SessionContext::new().task_ctx();
+        let mut stream = exec.execute(0, ctx)?;
+        let mut batches = vec![];
+        while let Some(batch) = stream.next().await {
+            batches.push(batch?);
+        }
+        let output = concat_batches(&output_schema, &batches)?;
+        assert_eq!(output.num_rows(), 6);
+        let sessions = output
+            .column(3)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("session struct column");
+        let starts = as_micros(sessions.column(0))?;
+        let ends = as_micros(sessions.column(1))?;
+        let expected = [
+            (0, 15),
+            (0, 15),
+            (30, 40),
+            (100, 115),
+            (100, 115),
+            (200, 210),
+        ];
+        for (i, (start, end)) in expected.iter().enumerate() {
+            assert_eq!((starts.value(i), ends.value(i)), (*start, *end), "row {i}");
+        }
+        Ok(())
+    }
+
+    /// A partition or time column missing from the input schema must fail at
+    /// construction, not silently drop the sort requirement later.
+    #[test]
+    fn try_new_rejects_missing_columns() -> Result<()> {
+        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
+        let input_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, true),
+            Field::new("#t", ts.clone(), true),
+            Field::new("#e0", ts.clone(), true),
+        ]));
+        let input = MemorySourceConfig::try_new_exec(&[vec![]], input_schema.clone(), None)?;
+        let result = SessionWindowExec::try_new(
+            input,
+            vec!["k".to_string()],
+            "#missing".to_string(),
+            "#e0".to_string(),
+            "#w".to_string(),
+            input_schema,
+        );
+        match result {
+            Err(e) => assert!(e.to_string().contains("#missing"), "{e}"),
+            Ok(_) => return internal_err!("expected a missing-column error"),
+        }
+        Ok(())
+    }
+
+    /// A session whose buffered rows exceed the task memory pool must fail
+    /// with a resources error instead of growing without bound.
+    #[tokio::test]
+    async fn oversized_session_fails_with_resources_error() -> Result<()> {
+        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
+        let input_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, true),
+            Field::new("#t", ts.clone(), true),
+            Field::new("#e0", ts.clone(), true),
+        ]));
+        let struct_type = DataType::Struct(Fields::from(vec![
+            Field::new("start", ts.clone(), true),
+            Field::new("end", ts, true),
+        ]));
+        let output_schema = Arc::new(Schema::new(
+            input_schema
+                .fields()
+                .iter()
+                .map(|f| f.as_ref().clone())
+                .chain(std::iter::once(Field::new("#w", struct_type, false)))
+                .collect::<Vec<_>>(),
+        ));
+        // One key, consecutive times within the gap: a single session spanning
+        // every batch, so `open_rows` retains them all.
+        let batches = (0..200)
+            .map(|i| batch(&input_schema, &[(1, i * 5), (1, i * 5 + 1)]))
+            .collect::<Vec<_>>();
+        let input = MemorySourceConfig::try_new_exec(&[batches], input_schema.clone(), None)?;
+        let exec = SessionWindowExec::try_new(
+            input,
+            vec!["k".to_string()],
+            "#t".to_string(),
+            "#e0".to_string(),
+            "#w".to_string(),
+            output_schema,
+        )?;
+        let runtime = datafusion::execution::runtime_env::RuntimeEnvBuilder::new()
+            .with_memory_limit(8 * 1024, 1.0)
+            .build_arc()?;
+        let ctx = SessionContext::new_with_config_rt(Default::default(), runtime).task_ctx();
+        let mut stream = exec.execute(0, ctx)?;
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(_) => continue,
+                Err(e) => {
+                    assert!(e.to_string().contains("Resources exhausted"), "{e}");
+                    return Ok(());
+                }
+            }
+        }
+        internal_err!("expected a resources-exhausted error")
+    }
+}

--- a/crates/sail-physical-plan/src/session_window.rs
+++ b/crates/sail-physical-plan/src/session_window.rs
@@ -607,6 +607,137 @@ mod tests {
         Ok(())
     }
 
+    /// Pins the merge rules a refactor could silently flip: the inclusive
+    /// boundary (a row at exactly the session end merges), a key change at a
+    /// batch boundary (must close the carried session even though its time is
+    /// within the gap), and multi-row segments at nonzero offsets (slice
+    /// arithmetic).
+    #[tokio::test]
+    async fn merge_boundaries_and_segment_offsets() -> Result<()> {
+        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
+        let input_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, true),
+            Field::new("#t", ts.clone(), true),
+            Field::new("#e0", ts.clone(), true),
+        ]));
+        let struct_type = DataType::Struct(Fields::from(vec![
+            Field::new("start", ts.clone(), true),
+            Field::new("end", ts, true),
+        ]));
+        let output_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, true),
+            Field::new("#t", input_schema.field(1).data_type().clone(), true),
+            Field::new("#e0", input_schema.field(2).data_type().clone(), true),
+            Field::new("#w", struct_type, false),
+        ]));
+        // Gap is 10 (the helper adds time + 10 as the end candidate).
+        // Batch 1: key 1 merges t=10 exactly on the session end (inclusive
+        // boundary), t=25 opens a second session extended by t=30; key 2
+        // changes mid-batch. Batch 2 starts with a key change at the batch
+        // boundary whose time (104) is within key 2's still-open gap.
+        let batches = vec![
+            batch(
+                &input_schema,
+                &[(1, 0), (1, 10), (1, 25), (1, 30), (1, 50), (2, 100)],
+            ),
+            batch(&input_schema, &[(3, 104), (3, 120)]),
+        ];
+        let input = MemorySourceConfig::try_new_exec(&[batches], input_schema.clone(), None)?;
+        let exec = SessionWindowExec::try_new(
+            input,
+            vec!["k".to_string()],
+            "#t".to_string(),
+            "#e0".to_string(),
+            "#w".to_string(),
+            output_schema.clone(),
+        )?;
+        let ctx = SessionContext::new().task_ctx();
+        let mut stream = exec.execute(0, ctx)?;
+        let mut batches = vec![];
+        while let Some(batch) = stream.next().await {
+            batches.push(batch?);
+        }
+        let output = concat_batches(&output_schema, &batches)?;
+        assert_eq!(output.num_rows(), 8);
+        let sessions = output
+            .column(3)
+            .as_any()
+            .downcast_ref::<StructArray>()
+            .expect("session struct column");
+        let starts = as_micros(sessions.column(0))?;
+        let ends = as_micros(sessions.column(1))?;
+        let expected = [
+            (0, 20),
+            (0, 20),
+            (25, 40),
+            (25, 40),
+            (50, 60),
+            (100, 110),
+            (104, 114),
+            (120, 130),
+        ];
+        for (i, (start, end)) in expected.iter().enumerate() {
+            assert_eq!((starts.value(i), ends.value(i)), (*start, *end), "row {i}");
+        }
+        let metrics = exec.metrics().expect("metrics");
+        assert_eq!(
+            metrics.sum_by_name("num_sessions").map(|m| m.as_usize()),
+            Some(6)
+        );
+        Ok(())
+    }
+
+    /// The memory reservation must be released when sessions close: many
+    /// carried-then-closed sessions stay within a modest pool (an accounting
+    /// leak would accumulate and trip it).
+    #[tokio::test]
+    async fn reservation_is_released_when_sessions_close() -> Result<()> {
+        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
+        let input_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, true),
+            Field::new("#t", ts.clone(), true),
+            Field::new("#e0", ts.clone(), true),
+        ]));
+        let struct_type = DataType::Struct(Fields::from(vec![
+            Field::new("start", ts.clone(), true),
+            Field::new("end", ts, true),
+        ]));
+        let output_schema = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, true),
+            Field::new("#t", input_schema.field(1).data_type().clone(), true),
+            Field::new("#e0", input_schema.field(2).data_type().clone(), true),
+            Field::new("#w", struct_type, false),
+        ]));
+        // Every session spans one batch boundary (one carried slice) and then
+        // closes; 300 sequential sessions never hold more than one carry, so
+        // the run must fit a modest pool unless accounting leaks.
+        let mut batches = Vec::new();
+        for i in 0..300i64 {
+            batches.push(batch(&input_schema, &[(1, i * 1000)]));
+            batches.push(batch(&input_schema, &[(1, i * 1000 + 5)]));
+        }
+        let input = MemorySourceConfig::try_new_exec(&[batches], input_schema.clone(), None)?;
+        let exec = SessionWindowExec::try_new(
+            input,
+            vec!["k".to_string()],
+            "#t".to_string(),
+            "#e0".to_string(),
+            "#w".to_string(),
+            output_schema,
+        )?;
+        let runtime = datafusion::execution::runtime_env::RuntimeEnvBuilder::new()
+            .with_memory_limit(32 * 1024, 1.0)
+            .build_arc()?;
+        let ctx = SessionContext::new_with_config_rt(Default::default(), runtime).task_ctx();
+        let mut stream = exec.execute(0, ctx)?;
+        let mut rows = 0;
+        while let Some(item) = stream.next().await {
+            rows += item?.num_rows();
+        }
+        assert_eq!(rows, 600);
+        Ok(())
+    }
+
     /// A partition or time column missing from the input schema must fail at
     /// construction, not silently drop the sort requirement later.
     #[test]

--- a/crates/sail-physical-plan/src/session_window.rs
+++ b/crates/sail-physical-plan/src/session_window.rs
@@ -214,7 +214,9 @@ impl ExecutionPlan for SessionWindowExec {
         let end_idx = input_schema.index_of(&self.end_column)?;
 
         // The appended struct field and its timestamp timezone.
-        let out_field = self.schema.field(self.schema.fields().len() - 1);
+        let out_field = self
+            .schema
+            .field(self.schema.index_of(&self.output_column)?);
         let DataType::Struct(struct_fields) = out_field.data_type() else {
             return exec_err!("SessionWindowExec output column must be a struct");
         };
@@ -447,6 +449,10 @@ impl Stream for SessionWindowStream {
     type Item = Result<RecordBatch>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // Polling a terminated stream again is formally unspecified.
+        if self.finished {
+            return Poll::Ready(None);
+        }
         loop {
             match self.input.as_mut().poll_next(cx) {
                 Poll::Pending => return Poll::Pending,

--- a/crates/sail-physical-plan/src/session_window.rs
+++ b/crates/sail-physical-plan/src/session_window.rs
@@ -13,6 +13,9 @@ use datafusion::physical_expr::{
     Distribution, EquivalenceProperties, LexOrdering, OrderingRequirements, PhysicalExpr,
     PhysicalSortExpr,
 };
+use datafusion::physical_plan::metrics::{
+    BaselineMetrics, Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
+};
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
     RecordBatchStream,
@@ -39,6 +42,7 @@ pub struct SessionWindowExec {
     /// so a missing column fails at construction instead of silently dropping
     /// the sort requirement.
     required_ordering: Option<OrderingRequirements>,
+    metrics: ExecutionPlanMetricsSet,
 }
 
 impl SessionWindowExec {
@@ -96,6 +100,7 @@ impl SessionWindowExec {
             schema,
             properties,
             required_ordering,
+            metrics: ExecutionPlanMetricsSet::new(),
         })
     }
 
@@ -168,6 +173,10 @@ impl ExecutionPlan for SessionWindowExec {
         vec![true]
     }
 
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
     fn required_input_distribution(&self) -> Vec<Distribution> {
         // A session must never span partitions: hash-partition by the group
         // keys, or a single partition when there are none.
@@ -225,6 +234,8 @@ impl ExecutionPlan for SessionWindowExec {
             _ => return exec_err!("SessionWindowExec struct fields must be Timestamp(us, *)"),
         };
 
+        let baseline = BaselineMetrics::new(&self.metrics, partition);
+        let num_sessions = MetricBuilder::new(&self.metrics).counter("num_sessions", partition);
         let reservation = MemoryConsumer::new(format!("SessionWindowStream[{partition}]"))
             .register(context.memory_pool());
         let input = self.input.execute(partition, context)?;
@@ -240,6 +251,8 @@ impl ExecutionPlan for SessionWindowExec {
             open_rows: Vec::new(),
             reservation,
             buffered_bytes: 0,
+            baseline,
+            num_sessions,
             cur_key: None,
             cur_start: 0,
             cur_end: 0,
@@ -275,6 +288,9 @@ struct SessionWindowStream {
     reservation: MemoryReservation,
     /// Bytes currently held by `reservation` for `open_rows`.
     buffered_bytes: usize,
+    baseline: BaselineMetrics,
+    /// Closed (emitted) sessions.
+    num_sessions: Count,
     /// Group key of the open session.
     cur_key: Option<Vec<ScalarValue>>,
     /// Open session start (micros) = time of its first row.
@@ -316,6 +332,7 @@ impl SessionWindowStream {
         let batches = std::mem::take(&mut self.open_rows);
         self.reservation.shrink(self.buffered_bytes);
         self.buffered_bytes = 0;
+        self.num_sessions.add(1);
         let input_batch = concat_batches(&self.input_schema, &batches)?;
         let n = input_batch.num_rows();
         if n == 0 {
@@ -453,24 +470,33 @@ impl Stream for SessionWindowStream {
         if self.finished {
             return Poll::Ready(None);
         }
+        let baseline = self.baseline.clone();
         loop {
             match self.input.as_mut().poll_next(cx) {
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(Some(Err(e))) => return Poll::Ready(Some(Err(e))),
-                Poll::Ready(Some(Ok(batch))) => match self.process_batch(batch) {
-                    Ok(Some(out)) => return Poll::Ready(Some(Ok(out))),
-                    // Whole batch merged into the still-open session; poll for more.
-                    Ok(None) => continue,
-                    Err(e) => return Poll::Ready(Some(Err(e))),
-                },
+                Poll::Ready(Some(Ok(batch))) => {
+                    let _timer = baseline.elapsed_compute().timer();
+                    match self.process_batch(batch) {
+                        Ok(Some(out)) => {
+                            return baseline.record_poll(Poll::Ready(Some(Ok(out))));
+                        }
+                        // Whole batch merged into the still-open session; poll for more.
+                        Ok(None) => continue,
+                        Err(e) => return Poll::Ready(Some(Err(e))),
+                    }
+                }
                 Poll::Ready(None) => {
                     if self.finished {
                         return Poll::Ready(None);
                     }
                     // Input exhausted: emit the final still-open session.
                     self.finished = true;
+                    let _timer = baseline.elapsed_compute().timer();
                     match self.build_output() {
-                        Ok(Some(out)) => return Poll::Ready(Some(Ok(out))),
+                        Ok(Some(out)) => {
+                            return baseline.record_poll(Poll::Ready(Some(Ok(out))));
+                        }
                         Ok(None) => return Poll::Ready(None),
                         Err(e) => return Poll::Ready(Some(Err(e))),
                     }
@@ -572,6 +598,12 @@ mod tests {
         for (i, (start, end)) in expected.iter().enumerate() {
             assert_eq!((starts.value(i), ends.value(i)), (*start, *end), "row {i}");
         }
+        let metrics = exec.metrics().expect("metrics");
+        assert_eq!(metrics.output_rows(), Some(6));
+        assert_eq!(
+            metrics.sum_by_name("num_sessions").map(|m| m.as_usize()),
+            Some(4)
+        );
         Ok(())
     }
 

--- a/crates/sail-physical-plan/src/session_window.rs
+++ b/crates/sail-physical-plan/src/session_window.rs
@@ -20,7 +20,9 @@ use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
     RecordBatchStream,
 };
-use datafusion_common::{Result, ScalarValue, Statistics, exec_err, internal_err};
+use datafusion_common::{
+    Result, ScalarValue, Statistics, exec_err, internal_datafusion_err, internal_err,
+};
 use futures::Stream;
 
 /// Physical operator for Spark `session_window` (`UpdatingSessionsExec`-style):
@@ -38,9 +40,8 @@ pub struct SessionWindowExec {
     output_column: String,
     schema: SchemaRef,
     properties: Arc<PlanProperties>,
-    /// Required `(partition_columns..., time)` input ordering, resolved eagerly
-    /// so a missing column fails at construction instead of silently dropping
-    /// the sort requirement.
+    /// Required `(partition_columns..., time)` input ordering, resolved at
+    /// construction so a missing column fails early.
     required_ordering: Option<OrderingRequirements>,
     metrics: ExecutionPlanMetricsSet,
 }
@@ -54,10 +55,8 @@ impl SessionWindowExec {
         output_column: String,
         schema: SchemaRef,
     ) -> Result<Self> {
-        // Rows never move or reorder, so the child's partitioning passes
-        // through (the downstream aggregate on `(keys, struct)` reuses it) and
-        // its orderings stay valid and must be carried over to match
-        // `maintains_input_order`. Equivalence classes/constants are dropped.
+        // Rows never move or reorder: the child's partitioning and orderings
+        // pass through (matching `maintains_input_order`).
         let eq_properties = EquivalenceProperties::new_with_orderings(
             schema.clone(),
             input
@@ -124,8 +123,6 @@ impl SessionWindowExec {
         &self.output_column
     }
 
-    /// The hash-distribution columns as physical `Column` exprs (empty when there
-    /// are no group keys).
     fn partition_exprs(&self) -> Result<Vec<Arc<dyn PhysicalExpr>>> {
         let input_schema = self.input.schema();
         self.partition_columns
@@ -271,42 +268,31 @@ impl ExecutionPlan for SessionWindowExec {
 
 struct SessionWindowStream {
     input: SendableRecordBatchStream,
-    /// Schema of the child (without the appended struct), used to concat buffers.
     input_schema: SchemaRef,
-    /// Schema of this operator's output (child + struct column).
     output_schema: SchemaRef,
     struct_fields: Fields,
     tz: Option<Arc<str>>,
     partition_indices: Vec<usize>,
     time_idx: usize,
     end_idx: usize,
-    /// Rows of the currently-open session not yet emitted (may span batches).
     open_rows: Vec<RecordBatch>,
     /// Tracks `open_rows` against the task memory pool: a session spanning many
     /// batches retains them all until it closes, so an oversized session must
     /// fail with a resources error instead of aborting the process.
     reservation: MemoryReservation,
-    /// Bytes currently held by `reservation` for `open_rows`.
     buffered_bytes: usize,
     baseline: BaselineMetrics,
-    /// Closed (emitted) sessions.
     num_sessions: Count,
-    /// Group key of the open session.
     cur_key: Option<Vec<ScalarValue>>,
-    /// Open session start (micros) = time of its first row.
     cur_start: i64,
-    /// Open session end (micros) = max(time + gap) over merged rows.
     cur_end: i64,
     finished: bool,
 }
 
 impl SessionWindowStream {
-    /// Buffers a slice of the open session that outlives its input batch,
-    /// charging the memory pool for the retained size (a slice keeps its
-    /// parent batch's buffers alive in full). Slices consumed within the same
-    /// `process_batch` call are pushed directly instead: their parent batch is
-    /// already resident and bounded, and per-slice accounting is measurable
-    /// overhead when sessions are small.
+    /// Buffers a slice that outlives its input batch, charging the memory pool
+    /// for the retained size (a slice keeps its parent batch's buffers alive in
+    /// full). Slices consumed within one `process_batch` call skip the pool.
     fn buffer_rows(&mut self, rows: RecordBatch) -> Result<()> {
         let bytes = rows.get_array_memory_size();
         self.reservation.try_grow(bytes)?;
@@ -315,7 +301,6 @@ impl SessionWindowStream {
         Ok(())
     }
 
-    /// The group key of row `i` as scalars (empty when there are no group keys).
     fn row_key(&self, batch: &RecordBatch, i: usize) -> Result<Vec<ScalarValue>> {
         self.partition_indices
             .iter()
@@ -358,8 +343,7 @@ impl SessionWindowStream {
 
     /// Processes one input batch, returning the rows of sessions that closed in
     /// it (`None` if nothing closed); the trailing open session is carried in
-    /// `open_rows`. Group-key runs come from arrow's vectorized `partition`
-    /// kernel, so per-row work is only the `i64` time comparisons.
+    /// `open_rows`.
     fn process_batch(&mut self, batch: RecordBatch) -> Result<Option<RecordBatch>> {
         let n = batch.num_rows();
         if n == 0 {
@@ -450,9 +434,7 @@ fn as_micros(array: &ArrayRef) -> Result<&TimestampMicrosecondArray> {
         .as_any()
         .downcast_ref::<TimestampMicrosecondArray>()
         .ok_or_else(|| {
-            datafusion_common::DataFusionError::Internal(
-                "session_window expected a Timestamp(Microsecond) column".to_string(),
-            )
+            internal_datafusion_err!("session_window expected a Timestamp(Microsecond) column")
         })
 }
 
@@ -487,9 +469,6 @@ impl Stream for SessionWindowStream {
                     }
                 }
                 Poll::Ready(None) => {
-                    if self.finished {
-                        return Poll::Ready(None);
-                    }
                     // Input exhausted: emit the final still-open session.
                     self.finished = true;
                     let _timer = baseline.elapsed_compute().timer();
@@ -512,74 +491,65 @@ mod tests {
     use datafusion::arrow::array::{Array, Int32Array, StructArray};
     use datafusion::arrow::datatypes::{DataType, Field, Fields, Schema, TimeUnit};
     use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+    use datafusion::physical_plan::collect;
     use datafusion::prelude::SessionContext;
-    use futures::StreamExt;
 
     use super::*;
 
-    /// One row per (key, time); the end candidate is `time + 10`.
-    fn batch(schema: &SchemaRef, rows: &[(i32, i64)]) -> RecordBatch {
-        let keys = Int32Array::from(rows.iter().map(|r| r.0).collect::<Vec<_>>());
-        let times = TimestampMicrosecondArray::from(rows.iter().map(|r| r.1).collect::<Vec<_>>());
-        let ends =
-            TimestampMicrosecondArray::from(rows.iter().map(|r| r.1 + 10).collect::<Vec<_>>());
-        RecordBatch::try_new(
-            schema.clone(),
-            vec![Arc::new(keys), Arc::new(times), Arc::new(ends)],
-        )
-        .expect("input batch")
-    }
-
-    /// Sessions must merge and close correctly when their rows are split
-    /// across input batches: an open session carried over a batch boundary, a
-    /// key change both inside a batch and at a boundary, and the final flush
-    /// at end of input.
-    #[tokio::test]
-    async fn sessions_survive_batch_boundaries() -> Result<()> {
+    fn schemas() -> (SchemaRef, SchemaRef) {
         let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
-        let input_schema = Arc::new(Schema::new(vec![
-            Field::new("k", DataType::Int32, true),
-            Field::new("#t", ts.clone(), true),
-            Field::new("#e0", ts.clone(), true),
-        ]));
         let struct_type = DataType::Struct(Fields::from(vec![
             Field::new("start", ts.clone(), true),
             Field::new("end", ts.clone(), true),
         ]));
-        let output_schema = Arc::new(Schema::new(vec![
+        let input = Arc::new(Schema::new(vec![
+            Field::new("k", DataType::Int32, true),
+            Field::new("#t", ts.clone(), true),
+            Field::new("#e0", ts.clone(), true),
+        ]));
+        let output = Arc::new(Schema::new(vec![
             Field::new("k", DataType::Int32, true),
             Field::new("#t", ts.clone(), true),
             Field::new("#e0", ts, true),
             Field::new("#w", struct_type, false),
         ]));
-        // Sorted by (k, t), gap = 10: key 1 merges t=0 and t=5 across nothing,
-        // then t=30 opens a new session; key 2 merges t=100 and t=105 ACROSS
-        // the second batch boundary; key 3 is flushed at end of input. The
-        // first batch boundary splits key 1's open session from its closing
-        // row; the key 1 -> 2 change happens inside a batch and the 2 -> 3
-        // change at a boundary.
-        let batches = vec![
-            batch(&input_schema, &[(1, 0), (1, 5)]),
-            batch(&input_schema, &[(1, 30), (2, 100)]),
-            batch(&input_schema, &[(2, 105), (3, 200)]),
-        ];
-        let input = MemorySourceConfig::try_new_exec(&[batches], input_schema.clone(), None)?;
-        let exec = SessionWindowExec::try_new(
+        (input, output)
+    }
+
+    /// One row per (key, time); the end candidate is `time + 10` (gap = 10).
+    fn batch(rows: &[(i32, i64)]) -> RecordBatch {
+        let keys = Int32Array::from(rows.iter().map(|r| r.0).collect::<Vec<_>>());
+        let times = TimestampMicrosecondArray::from(rows.iter().map(|r| r.1).collect::<Vec<_>>());
+        let ends =
+            TimestampMicrosecondArray::from(rows.iter().map(|r| r.1 + 10).collect::<Vec<_>>());
+        RecordBatch::try_new(
+            schemas().0,
+            vec![Arc::new(keys), Arc::new(times), Arc::new(ends)],
+        )
+        .expect("input batch")
+    }
+
+    fn session_exec(batches: Vec<RecordBatch>) -> Result<Arc<SessionWindowExec>> {
+        let (input_schema, output_schema) = schemas();
+        let input = MemorySourceConfig::try_new_exec(&[batches], input_schema, None)?;
+        Ok(Arc::new(SessionWindowExec::try_new(
             input,
             vec!["k".to_string()],
             "#t".to_string(),
             "#e0".to_string(),
             "#w".to_string(),
-            output_schema.clone(),
-        )?;
-        let ctx = SessionContext::new().task_ctx();
-        let mut stream = exec.execute(0, ctx)?;
-        let mut batches = vec![];
-        while let Some(batch) = stream.next().await {
-            batches.push(batch?);
-        }
-        let output = concat_batches(&output_schema, &batches)?;
-        assert_eq!(output.num_rows(), 6);
+            output_schema,
+        )?))
+    }
+
+    async fn run(exec: Arc<SessionWindowExec>, ctx: Arc<TaskContext>) -> Result<RecordBatch> {
+        let schema = exec.schema();
+        Ok(concat_batches(&schema, &collect(exec, ctx).await?)?)
+    }
+
+    /// The `(start, end)` pairs of the output's session struct column.
+    fn session_bounds(output: &RecordBatch) -> Result<Vec<(i64, i64)>> {
         let sessions = output
             .column(3)
             .as_any()
@@ -587,17 +557,38 @@ mod tests {
             .expect("session struct column");
         let starts = as_micros(sessions.column(0))?;
         let ends = as_micros(sessions.column(1))?;
-        let expected = [
-            (0, 15),
-            (0, 15),
-            (30, 40),
-            (100, 115),
-            (100, 115),
-            (200, 210),
-        ];
-        for (i, (start, end)) in expected.iter().enumerate() {
-            assert_eq!((starts.value(i), ends.value(i)), (*start, *end), "row {i}");
-        }
+        Ok(starts
+            .values()
+            .iter()
+            .zip(ends.values().iter())
+            .map(|(s, e)| (*s, *e))
+            .collect())
+    }
+
+    #[tokio::test]
+    async fn sessions_survive_batch_boundaries() -> Result<()> {
+        // Sorted by (k, t), gap = 10: key 1 merges t=0 and t=5, then t=30 opens
+        // a new session; key 2 merges t=100 and t=105 across the second batch
+        // boundary; key 3 is flushed at end of input. The first batch boundary
+        // splits key 1's open session from its closing row; the key 1 -> 2
+        // change happens inside a batch and the 2 -> 3 change at a boundary.
+        let exec = session_exec(vec![
+            batch(&[(1, 0), (1, 5)]),
+            batch(&[(1, 30), (2, 100)]),
+            batch(&[(2, 105), (3, 200)]),
+        ])?;
+        let output = run(exec.clone(), SessionContext::new().task_ctx()).await?;
+        assert_eq!(
+            session_bounds(&output)?,
+            [
+                (0, 15),
+                (0, 15),
+                (30, 40),
+                (100, 115),
+                (100, 115),
+                (200, 210)
+            ]
+        );
         let metrics = exec.metrics().expect("metrics");
         assert_eq!(metrics.output_rows(), Some(6));
         assert_eq!(
@@ -607,78 +598,31 @@ mod tests {
         Ok(())
     }
 
-    /// Pins the merge rules a refactor could silently flip: the inclusive
-    /// boundary (a row at exactly the session end merges), a key change at a
-    /// batch boundary (must close the carried session even though its time is
-    /// within the gap), and multi-row segments at nonzero offsets (slice
-    /// arithmetic).
     #[tokio::test]
     async fn merge_boundaries_and_segment_offsets() -> Result<()> {
-        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
-        let input_schema = Arc::new(Schema::new(vec![
-            Field::new("k", DataType::Int32, true),
-            Field::new("#t", ts.clone(), true),
-            Field::new("#e0", ts.clone(), true),
-        ]));
-        let struct_type = DataType::Struct(Fields::from(vec![
-            Field::new("start", ts.clone(), true),
-            Field::new("end", ts, true),
-        ]));
-        let output_schema = Arc::new(Schema::new(vec![
-            Field::new("k", DataType::Int32, true),
-            Field::new("#t", input_schema.field(1).data_type().clone(), true),
-            Field::new("#e0", input_schema.field(2).data_type().clone(), true),
-            Field::new("#w", struct_type, false),
-        ]));
-        // Gap is 10 (the helper adds time + 10 as the end candidate).
         // Batch 1: key 1 merges t=10 exactly on the session end (inclusive
-        // boundary), t=25 opens a second session extended by t=30; key 2
-        // changes mid-batch. Batch 2 starts with a key change at the batch
-        // boundary whose time (104) is within key 2's still-open gap.
-        let batches = vec![
-            batch(
-                &input_schema,
-                &[(1, 0), (1, 10), (1, 25), (1, 30), (1, 50), (2, 100)],
-            ),
-            batch(&input_schema, &[(3, 104), (3, 120)]),
-        ];
-        let input = MemorySourceConfig::try_new_exec(&[batches], input_schema.clone(), None)?;
-        let exec = SessionWindowExec::try_new(
-            input,
-            vec!["k".to_string()],
-            "#t".to_string(),
-            "#e0".to_string(),
-            "#w".to_string(),
-            output_schema.clone(),
-        )?;
-        let ctx = SessionContext::new().task_ctx();
-        let mut stream = exec.execute(0, ctx)?;
-        let mut batches = vec![];
-        while let Some(batch) = stream.next().await {
-            batches.push(batch?);
-        }
-        let output = concat_batches(&output_schema, &batches)?;
-        assert_eq!(output.num_rows(), 8);
-        let sessions = output
-            .column(3)
-            .as_any()
-            .downcast_ref::<StructArray>()
-            .expect("session struct column");
-        let starts = as_micros(sessions.column(0))?;
-        let ends = as_micros(sessions.column(1))?;
-        let expected = [
-            (0, 20),
-            (0, 20),
-            (25, 40),
-            (25, 40),
-            (50, 60),
-            (100, 110),
-            (104, 114),
-            (120, 130),
-        ];
-        for (i, (start, end)) in expected.iter().enumerate() {
-            assert_eq!((starts.value(i), ends.value(i)), (*start, *end), "row {i}");
-        }
+        // boundary), t=25 opens a second session extended by t=30, and t=50 a
+        // third (a mid-run close at a nonzero slice offset); key 2 changes
+        // mid-batch. Batch 2 starts with a key change at the batch boundary
+        // whose time (104) is within key 2's still-open gap.
+        let exec = session_exec(vec![
+            batch(&[(1, 0), (1, 10), (1, 25), (1, 30), (1, 50), (2, 100)]),
+            batch(&[(3, 104), (3, 120)]),
+        ])?;
+        let output = run(exec.clone(), SessionContext::new().task_ctx()).await?;
+        assert_eq!(
+            session_bounds(&output)?,
+            [
+                (0, 20),
+                (0, 20),
+                (25, 40),
+                (25, 40),
+                (50, 60),
+                (100, 110),
+                (104, 114),
+                (120, 130)
+            ]
+        );
         let metrics = exec.metrics().expect("metrics");
         assert_eq!(
             metrics.sum_by_name("num_sessions").map(|m| m.as_usize()),
@@ -687,67 +631,28 @@ mod tests {
         Ok(())
     }
 
-    /// The memory reservation must be released when sessions close: many
-    /// carried-then-closed sessions stay within a modest pool (an accounting
-    /// leak would accumulate and trip it).
     #[tokio::test]
     async fn reservation_is_released_when_sessions_close() -> Result<()> {
-        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
-        let input_schema = Arc::new(Schema::new(vec![
-            Field::new("k", DataType::Int32, true),
-            Field::new("#t", ts.clone(), true),
-            Field::new("#e0", ts.clone(), true),
-        ]));
-        let struct_type = DataType::Struct(Fields::from(vec![
-            Field::new("start", ts.clone(), true),
-            Field::new("end", ts, true),
-        ]));
-        let output_schema = Arc::new(Schema::new(vec![
-            Field::new("k", DataType::Int32, true),
-            Field::new("#t", input_schema.field(1).data_type().clone(), true),
-            Field::new("#e0", input_schema.field(2).data_type().clone(), true),
-            Field::new("#w", struct_type, false),
-        ]));
         // Every session spans one batch boundary (one carried slice) and then
         // closes; 300 sequential sessions never hold more than one carry, so
         // the run must fit a modest pool unless accounting leaks.
         let mut batches = Vec::new();
         for i in 0..300i64 {
-            batches.push(batch(&input_schema, &[(1, i * 1000)]));
-            batches.push(batch(&input_schema, &[(1, i * 1000 + 5)]));
+            batches.push(batch(&[(1, i * 1000)]));
+            batches.push(batch(&[(1, i * 1000 + 5)]));
         }
-        let input = MemorySourceConfig::try_new_exec(&[batches], input_schema.clone(), None)?;
-        let exec = SessionWindowExec::try_new(
-            input,
-            vec!["k".to_string()],
-            "#t".to_string(),
-            "#e0".to_string(),
-            "#w".to_string(),
-            output_schema,
-        )?;
-        let runtime = datafusion::execution::runtime_env::RuntimeEnvBuilder::new()
+        let exec = session_exec(batches)?;
+        let runtime = RuntimeEnvBuilder::new()
             .with_memory_limit(32 * 1024, 1.0)
             .build_arc()?;
         let ctx = SessionContext::new_with_config_rt(Default::default(), runtime).task_ctx();
-        let mut stream = exec.execute(0, ctx)?;
-        let mut rows = 0;
-        while let Some(item) = stream.next().await {
-            rows += item?.num_rows();
-        }
-        assert_eq!(rows, 600);
+        assert_eq!(run(exec, ctx).await?.num_rows(), 600);
         Ok(())
     }
 
-    /// A partition or time column missing from the input schema must fail at
-    /// construction, not silently drop the sort requirement later.
     #[test]
     fn try_new_rejects_missing_columns() -> Result<()> {
-        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
-        let input_schema = Arc::new(Schema::new(vec![
-            Field::new("k", DataType::Int32, true),
-            Field::new("#t", ts.clone(), true),
-            Field::new("#e0", ts.clone(), true),
-        ]));
+        let input_schema = schemas().0;
         let input = MemorySourceConfig::try_new_exec(&[vec![]], input_schema.clone(), None)?;
         let result = SessionWindowExec::try_new(
             input,
@@ -757,63 +662,27 @@ mod tests {
             "#w".to_string(),
             input_schema,
         );
-        match result {
-            Err(e) => assert!(e.to_string().contains("#missing"), "{e}"),
-            Ok(_) => return internal_err!("expected a missing-column error"),
-        }
+        let err = result.expect_err("expected a missing-column error");
+        assert!(err.to_string().contains("#missing"), "{err}");
         Ok(())
     }
 
-    /// A session whose buffered rows exceed the task memory pool must fail
-    /// with a resources error instead of growing without bound.
     #[tokio::test]
     async fn oversized_session_fails_with_resources_error() -> Result<()> {
-        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
-        let input_schema = Arc::new(Schema::new(vec![
-            Field::new("k", DataType::Int32, true),
-            Field::new("#t", ts.clone(), true),
-            Field::new("#e0", ts.clone(), true),
-        ]));
-        let struct_type = DataType::Struct(Fields::from(vec![
-            Field::new("start", ts.clone(), true),
-            Field::new("end", ts, true),
-        ]));
-        let output_schema = Arc::new(Schema::new(
-            input_schema
-                .fields()
-                .iter()
-                .map(|f| f.as_ref().clone())
-                .chain(std::iter::once(Field::new("#w", struct_type, false)))
-                .collect::<Vec<_>>(),
-        ));
         // One key, consecutive times within the gap: a single session spanning
         // every batch, so `open_rows` retains them all.
-        let batches = (0..200)
-            .map(|i| batch(&input_schema, &[(1, i * 5), (1, i * 5 + 1)]))
-            .collect::<Vec<_>>();
-        let input = MemorySourceConfig::try_new_exec(&[batches], input_schema.clone(), None)?;
-        let exec = SessionWindowExec::try_new(
-            input,
-            vec!["k".to_string()],
-            "#t".to_string(),
-            "#e0".to_string(),
-            "#w".to_string(),
-            output_schema,
-        )?;
-        let runtime = datafusion::execution::runtime_env::RuntimeEnvBuilder::new()
+        let batches = (0..200i64)
+            .map(|i| batch(&[(1, i * 5), (1, i * 5 + 1)]))
+            .collect();
+        let exec = session_exec(batches)?;
+        let runtime = RuntimeEnvBuilder::new()
             .with_memory_limit(8 * 1024, 1.0)
             .build_arc()?;
         let ctx = SessionContext::new_with_config_rt(Default::default(), runtime).task_ctx();
-        let mut stream = exec.execute(0, ctx)?;
-        while let Some(item) = stream.next().await {
-            match item {
-                Ok(_) => continue,
-                Err(e) => {
-                    assert!(e.to_string().contains("Resources exhausted"), "{e}");
-                    return Ok(());
-                }
-            }
-        }
-        internal_err!("expected a resources-exhausted error")
+        let err = run(exec, ctx)
+            .await
+            .expect_err("expected a resources-exhausted error");
+        assert!(err.to_string().contains("Resources exhausted"), "{err}");
+        Ok(())
     }
 }

--- a/crates/sail-plan/src/formatter.rs
+++ b/crates/sail-plan/src/formatter.rs
@@ -494,6 +494,9 @@ impl PlanFormatter for SparkPlanFormatter {
             "timestamp" | "date" => Ok(arguments.one()?.to_string()),
             // Spark always names the time window column `window`.
             "window" => Ok("window".to_string()),
+            // Likewise, the session window grouping column is always named
+            // `session_window`, so `session_window.start` / `.end` resolve.
+            "session_window" => Ok("session_window".to_string()),
             "to_unix_timestamp" => {
                 let mut argv = arguments.clone();
                 if argv.len() == 1 {

--- a/crates/sail-plan/src/function/scalar/datetime.rs
+++ b/crates/sail-plan/src/function/scalar/datetime.rs
@@ -18,7 +18,7 @@ use sail_function::scalar::datetime::spark_date::SparkDate;
 use sail_function::scalar::datetime::spark_date_format::SparkDateFormat;
 use sail_function::scalar::datetime::spark_date_part::SparkDatePart;
 use sail_function::scalar::datetime::spark_date_trunc::SparkDateTrunc;
-use sail_function::scalar::datetime::spark_interval::SparkCalendarInterval;
+use sail_function::scalar::datetime::spark_interval::SparkTryCalendarInterval;
 use sail_function::scalar::datetime::spark_last_day::SparkLastDay;
 use sail_function::scalar::datetime::spark_make_time::SparkMakeTime;
 use sail_function::scalar::datetime::spark_make_timestamp_ntz::SparkMakeTimestampNtz;
@@ -34,7 +34,7 @@ use sail_function::scalar::datetime::spark_window_buckets::SparkWindowBuckets;
 use sail_function::scalar::datetime::spark_year::SparkYear;
 use sail_function::scalar::datetime::timestamp_now::TimestampNow;
 use sail_function::scalar::explode::{Explode, ExplodeKind};
-use sail_sql_analyzer::literal::interval::IntervalValue;
+use sail_sql_analyzer::literal::interval::{IntervalValue, parse_calendar_interval_string};
 use sail_sql_analyzer::parser::parse_interval;
 
 use crate::config::DefaultTimestampType;
@@ -1169,19 +1169,18 @@ fn session_window_gap(gap: Expr, schema: &DFSchemaRef) -> PlanResult<Expr> {
     // filter then drops every row, matching Spark.
     if let Expr::Literal(value, _) = &gap {
         if let Some(s) = value.try_as_str().flatten() {
-            let (months, days, nanos) = match parse_interval(s)
-                .map_err(|e| PlanError::invalid(format!("invalid session_window gap {s:?}: {e}")))?
-            {
-                IntervalValue::YearMonth { months } => (months, 0, 0),
-                IntervalValue::Microsecond { microseconds } => (0, 0, microseconds * 1_000),
-                IntervalValue::MonthDayNanosecond {
-                    months,
-                    days,
-                    nanoseconds,
-                } => (months, days, nanoseconds),
-            };
+            // Spark bucketing: the unit the user wrote decides the bucket, so
+            // a `'1 day'` gap is a calendar day (25h across a DST fall-back)
+            // while `'25 hours'` is 25 absolute hours.
+            let interval = parse_calendar_interval_string(s).map_err(|e| {
+                PlanError::invalid(format!("invalid session_window gap {s:?}: {e}"))
+            })?;
             return Ok(lit(ScalarValue::IntervalMonthDayNano(Some(
-                IntervalMonthDayNano::new(months, days, nanos),
+                IntervalMonthDayNano::new(
+                    interval.months,
+                    interval.days,
+                    interval.microseconds * 1_000,
+                ),
             ))));
         }
         if let ScalarValue::IntervalYearMonth(_) = value {
@@ -1207,8 +1206,11 @@ fn session_window_gap(gap: Expr, schema: &DFSchemaRef) -> PlanResult<Expr> {
         // constant-fold to interval literals at plan time, so only non-literal
         // branches parse per row.
         DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
+            // Lenient parse (NULL on invalid input, like Spark's cast to
+            // CalendarInterval): a malformed gap drops the row via the
+            // `end > time` filter instead of failing the query.
             let parse =
-                |e: Expr| ScalarUDF::new_from_impl(SparkCalendarInterval::new()).call(vec![e]);
+                |e: Expr| ScalarUDF::new_from_impl(SparkTryCalendarInterval::new()).call(vec![e]);
             if let Expr::Case(case) = gap {
                 let when_then_expr = case
                     .when_then_expr

--- a/crates/sail-plan/src/function/scalar/datetime.rs
+++ b/crates/sail-plan/src/function/scalar/datetime.rs
@@ -1175,12 +1175,11 @@ fn session_window_gap(gap: Expr, schema: &DFSchemaRef) -> PlanResult<Expr> {
             let interval = parse_calendar_interval_string(s).map_err(|e| {
                 PlanError::invalid(format!("invalid session_window gap {s:?}: {e}"))
             })?;
+            let nanos = interval.microseconds.checked_mul(1_000).ok_or_else(|| {
+                PlanError::invalid(format!("session_window gap out of range: {s:?}"))
+            })?;
             return Ok(lit(ScalarValue::IntervalMonthDayNano(Some(
-                IntervalMonthDayNano::new(
-                    interval.months,
-                    interval.days,
-                    interval.microseconds * 1_000,
-                ),
+                IntervalMonthDayNano::new(interval.months, interval.days, nanos),
             ))));
         }
         if let ScalarValue::IntervalYearMonth(_) = value {
@@ -1193,8 +1192,13 @@ fn session_window_gap(gap: Expr, schema: &DFSchemaRef) -> PlanResult<Expr> {
             return Ok(lit(ScalarValue::IntervalMonthDayNano(Some(*v))));
         }
         let micros = window_interval_micros(&gap)?;
+        let nanos = micros.checked_mul(1_000).ok_or_else(|| {
+            PlanError::invalid(format!(
+                "session_window gap out of range: {micros} microseconds"
+            ))
+        })?;
         return Ok(lit(ScalarValue::IntervalMonthDayNano(Some(
-            IntervalMonthDayNano::new(0, 0, micros * 1_000),
+            IntervalMonthDayNano::new(0, 0, nanos),
         ))));
     }
     // Otherwise the gap is a per-row (dynamic) expression. Year-month *typed*

--- a/crates/sail-plan/src/function/scalar/datetime.rs
+++ b/crates/sail-plan/src/function/scalar/datetime.rs
@@ -1066,7 +1066,11 @@ fn parse_window_spec(args: &[Expr]) -> PlanResult<WindowSpec> {
             "The `abs(start_time)`({start_time}L) must be < the `slide_duration`({slide_duration}L)."
         )));
     }
-    let overlapping = (window_duration + slide_duration - 1) / slide_duration;
+    // Not `(a + b - 1) / b`: a gap past half of `i64` microseconds overflows
+    // the addition, and with release wrapping the negative ceiling passed this
+    // check and the query answered empty. Both operands are checked positive,
+    // so this form is the same ceiling with no addition to overflow.
+    let overlapping = (window_duration - 1) / slide_duration + 1;
     if overlapping > MAX_OVERLAPPING_WINDOWS {
         return Err(PlanError::invalid(format!(
             "window: ceil(windowDuration / slideDuration) = {overlapping} exceeds the limit of {MAX_OVERLAPPING_WINDOWS}"
@@ -1503,4 +1507,21 @@ pub(super) fn list_built_in_datetime_functions() -> Vec<(&'static str, ScalarFun
         ("year", F::udf(SparkYear::new())),
         ("years", F::unary(years)),
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A gap past half of `i64` microseconds used to overflow the overlap
+    /// ceiling; Spark answers such a window.
+    #[test]
+    fn window_spec_takes_a_huge_gap() -> PlanResult<()> {
+        let time = Expr::Literal(ScalarValue::TimestampMicrosecond(Some(0), None), None);
+        let gap = Expr::Literal(ScalarValue::Utf8(Some("106751991 day".to_string())), None);
+        let spec = parse_window_spec(&[time, gap])?;
+        assert_eq!(spec.window_duration, 106_751_991 * 86_400_000_000);
+        assert_eq!(spec.slide_duration, spec.window_duration);
+        Ok(())
+    }
 }

--- a/crates/sail-plan/src/function/scalar/datetime.rs
+++ b/crates/sail-plan/src/function/scalar/datetime.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::{
-    DataType, IntervalDayTimeType, IntervalUnit, IntervalYearMonthType, TimeUnit,
+    DataType, IntervalDayTimeType, IntervalMonthDayNano, IntervalUnit, IntervalYearMonthType,
+    TimeUnit,
 };
 use datafusion::functions::expr_fn;
 use datafusion_common::{DFSchemaRef, ScalarValue};
@@ -17,11 +18,13 @@ use sail_function::scalar::datetime::spark_date::SparkDate;
 use sail_function::scalar::datetime::spark_date_format::SparkDateFormat;
 use sail_function::scalar::datetime::spark_date_part::SparkDatePart;
 use sail_function::scalar::datetime::spark_date_trunc::SparkDateTrunc;
+use sail_function::scalar::datetime::spark_interval::SparkCalendarInterval;
 use sail_function::scalar::datetime::spark_last_day::SparkLastDay;
 use sail_function::scalar::datetime::spark_make_time::SparkMakeTime;
 use sail_function::scalar::datetime::spark_make_timestamp_ntz::SparkMakeTimestampNtz;
 use sail_function::scalar::datetime::spark_make_ym_interval::SparkMakeYmInterval;
 use sail_function::scalar::datetime::spark_next_day::SparkNextDay;
+use sail_function::scalar::datetime::spark_session_window::SparkSessionWindow;
 use sail_function::scalar::datetime::spark_time::SparkTime;
 use sail_function::scalar::datetime::spark_time_diff::SparkTimeDiff;
 use sail_function::scalar::datetime::spark_time_trunc::SparkTimeTrunc;
@@ -1156,6 +1159,97 @@ fn window_time(input: ScalarFunctionInput) -> PlanResult<Expr> {
     ))
 }
 
+/// Normalizes a `session_window` gap argument into an `Interval(MonthDayNano)`
+/// expression. The aggregate resolver later computes `end = ts + gap` per row, so
+/// the gap must end up as an interval the timestamp can be added to.
+fn session_window_gap(gap: Expr, schema: &DFSchemaRef) -> PlanResult<Expr> {
+    // A literal gap folds to a constant interval at plan time. Month-bearing
+    // strings are valid (like Spark); a year-month *typed* interval is rejected
+    // (like Spark); a non-positive literal is NOT an error — the `end > ts` row
+    // filter then drops every row, matching Spark.
+    if let Expr::Literal(value, _) = &gap {
+        if let Some(s) = value.try_as_str().flatten() {
+            let (months, days, nanos) = match parse_interval(s)
+                .map_err(|e| PlanError::invalid(format!("invalid session_window gap {s:?}: {e}")))?
+            {
+                IntervalValue::YearMonth { months } => (months, 0, 0),
+                IntervalValue::Microsecond { microseconds } => (0, 0, microseconds * 1_000),
+                IntervalValue::MonthDayNanosecond {
+                    months,
+                    days,
+                    nanoseconds,
+                } => (months, days, nanoseconds),
+            };
+            return Ok(lit(ScalarValue::IntervalMonthDayNano(Some(
+                IntervalMonthDayNano::new(months, days, nanos),
+            ))));
+        }
+        if let ScalarValue::IntervalYearMonth(_) = value {
+            return Err(PlanError::invalid(
+                "gap duration expression used in session window must be an interval string, \
+                 a calendar interval, or a day-time interval, but got a year-month interval",
+            ));
+        }
+        if let ScalarValue::IntervalMonthDayNano(Some(v)) = value {
+            return Ok(lit(ScalarValue::IntervalMonthDayNano(Some(*v))));
+        }
+        let micros = window_interval_micros(&gap)?;
+        return Ok(lit(ScalarValue::IntervalMonthDayNano(Some(
+            IntervalMonthDayNano::new(0, 0, micros * 1_000),
+        ))));
+    }
+    // Otherwise the gap is a per-row (dynamic) expression. Year-month *typed*
+    // intervals are rejected statically, matching Spark; day-time typed
+    // intervals are accepted (Spark rejects them, but they are unambiguous).
+    match gap.get_type(schema)? {
+        // Spark interval strings are parsed per row at run time by this UDF.
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
+            Ok(ScalarUDF::new_from_impl(SparkCalendarInterval::new()).call(vec![gap]))
+        }
+        DataType::Interval(IntervalUnit::YearMonth) => Err(PlanError::invalid(
+            "gap duration expression used in session window must be an interval string, \
+             a calendar interval, or a day-time interval, but got a year-month interval",
+        )),
+        // Already a calendar interval: nothing to do.
+        DataType::Interval(IntervalUnit::MonthDayNano) => Ok(gap),
+        // Day-time interval or a duration: purely time-based (no month component),
+        // so normalize to MonthDayNano for a single, predictable `ts + gap` type.
+        DataType::Interval(IntervalUnit::DayTime) | DataType::Duration(_) => {
+            Ok(cast(gap, DataType::Interval(IntervalUnit::MonthDayNano)))
+        }
+        other => Err(PlanError::invalid(format!(
+            "session_window gap must be an interval or interval-string expression, got {other:?}"
+        ))),
+    }
+}
+
+/// The Spark `session_window(timeColumn, gapDuration)` time function. Sessions
+/// merge across rows, so this cannot be a per-row expansion: it emits a
+/// `SparkSessionWindow` marker (cast time column + normalized gap) that the
+/// aggregate resolver rewrites into a `SessionWindowNode`.
+fn session_window(input: ScalarFunctionInput) -> PlanResult<Expr> {
+    let schema = input.function_context.schema;
+    let session_tz = input.function_context.plan_config.session_timezone.clone();
+    let args = input.arguments;
+    if args.len() != 2 {
+        return Err(PlanError::invalid(format!(
+            "session_window requires exactly 2 arguments (time column, gap duration), got {}",
+            args.len()
+        )));
+    }
+    let mut args = args.into_iter();
+    let (Some(time), Some(gap)) = (args.next(), args.next()) else {
+        return Err(PlanError::internal(
+            "session_window arguments missing after length check",
+        ));
+    };
+    // Cast the time column to a microsecond timestamp (same rule as `window`).
+    let field_type = window_field_type(&time.get_type(schema)?, &session_tz)?;
+    let time_ts = cast(time, field_type);
+    let gap_interval = session_window_gap(gap, schema)?;
+    Ok(ScalarUDF::new_from_impl(SparkSessionWindow::new()).call(vec![time_ts, gap_interval]))
+}
+
 pub(super) fn list_built_in_datetime_functions() -> Vec<(&'static str, ScalarFunction)> {
     use crate::function::common::ScalarFunctionBuilder as F;
 
@@ -1254,7 +1348,7 @@ pub(super) fn list_built_in_datetime_functions() -> Vec<(&'static str, ScalarFun
         ("now", F::custom(current_timestamp_microseconds)),
         ("quarter", F::unary(|arg| integer_part(arg, "QUARTER"))),
         ("second", F::unary(|arg| integer_part(arg, "SECOND"))),
-        ("session_window", F::unknown("session_window")),
+        ("session_window", F::custom(session_window)),
         ("time_bucket", F::unknown("time_bucket")),
         ("time_from_micros", F::unknown("time_from_micros")),
         ("time_from_millis", F::unknown("time_from_millis")),

--- a/crates/sail-plan/src/function/scalar/datetime.rs
+++ b/crates/sail-plan/src/function/scalar/datetime.rs
@@ -34,7 +34,9 @@ use sail_function::scalar::datetime::spark_window_buckets::SparkWindowBuckets;
 use sail_function::scalar::datetime::spark_year::SparkYear;
 use sail_function::scalar::datetime::timestamp_now::TimestampNow;
 use sail_function::scalar::explode::{Explode, ExplodeKind};
-use sail_sql_analyzer::literal::interval::{IntervalValue, parse_calendar_interval_string};
+use sail_sql_analyzer::literal::interval::{
+    CalendarInterval, IntervalValue, parse_calendar_interval_string,
+};
 use sail_sql_analyzer::parser::parse_interval;
 
 use crate::config::DefaultTimestampType;
@@ -1172,15 +1174,24 @@ fn session_window_gap(gap: Expr, schema: &DFSchemaRef) -> PlanResult<Expr> {
             // Spark bucketing: the unit the user wrote decides the bucket, so
             // a `'1 day'` gap is a calendar day (25h across a DST fall-back)
             // while `'25 hours'` is 25 absolute hours.
-            let interval = parse_calendar_interval_string(s).map_err(|e| {
-                PlanError::invalid(format!("invalid session_window gap {s:?}: {e}"))
-            })?;
-            let nanos = interval.microseconds.checked_mul(1_000).ok_or_else(|| {
-                PlanError::invalid(format!("session_window gap out of range: {s:?}"))
-            })?;
-            return Ok(lit(ScalarValue::IntervalMonthDayNano(Some(
-                IntervalMonthDayNano::new(interval.months, interval.days, nanos),
-            ))));
+            // Spark casts the gap with `safeStringToInterval`: an invalid or
+            // out-of-range literal becomes NULL, every row is dropped by the
+            // `end > time` filter, and the query returns an empty result.
+            let value = parse_calendar_interval_string(s).ok().and_then(|interval| {
+                interval
+                    .days_and_nanoseconds()
+                    .map(|(days, nanos)| IntervalMonthDayNano::new(interval.months, days, nanos))
+            });
+            return Ok(lit(ScalarValue::IntervalMonthDayNano(value)));
+        }
+        // Spark rejects integer gaps for session_window (unlike `window`,
+        // which Sail keeps interpreting as microseconds for parity with its
+        // own `window` implementation).
+        if let ScalarValue::Int32(_) | ScalarValue::Int64(_) = value {
+            return Err(PlanError::invalid(
+                "gap duration expression used in session window must be an interval string, \
+                 a calendar interval, or a day-time interval, but got an integer",
+            ));
         }
         if let ScalarValue::IntervalYearMonth(_) = value {
             return Err(PlanError::invalid(
@@ -1192,13 +1203,18 @@ fn session_window_gap(gap: Expr, schema: &DFSchemaRef) -> PlanResult<Expr> {
             return Ok(lit(ScalarValue::IntervalMonthDayNano(Some(*v))));
         }
         let micros = window_interval_micros(&gap)?;
-        let nanos = micros.checked_mul(1_000).ok_or_else(|| {
+        let interval = CalendarInterval {
+            months: 0,
+            days: 0,
+            microseconds: micros,
+        };
+        let (days, nanos) = interval.days_and_nanoseconds().ok_or_else(|| {
             PlanError::invalid(format!(
                 "session_window gap out of range: {micros} microseconds"
             ))
         })?;
         return Ok(lit(ScalarValue::IntervalMonthDayNano(Some(
-            IntervalMonthDayNano::new(0, 0, nanos),
+            IntervalMonthDayNano::new(0, days, nanos),
         ))));
     }
     // Otherwise the gap is a per-row (dynamic) expression. Year-month *typed*

--- a/crates/sail-plan/src/function/scalar/datetime.rs
+++ b/crates/sail-plan/src/function/scalar/datetime.rs
@@ -1202,9 +1202,28 @@ fn session_window_gap(gap: Expr, schema: &DFSchemaRef) -> PlanResult<Expr> {
     // intervals are rejected statically, matching Spark; day-time typed
     // intervals are accepted (Spark rejects them, but they are unambiguous).
     match gap.get_type(schema)? {
-        // Spark interval strings are parsed per row at run time by this UDF.
+        // Runtime interval-string parsing. For a CASE gap, push the parse into
+        // the branches (as Spark's implicit cast does): literal branches then
+        // constant-fold to interval literals at plan time, so only non-literal
+        // branches parse per row.
         DataType::Utf8 | DataType::LargeUtf8 | DataType::Utf8View => {
-            Ok(ScalarUDF::new_from_impl(SparkCalendarInterval::new()).call(vec![gap]))
+            let parse =
+                |e: Expr| ScalarUDF::new_from_impl(SparkCalendarInterval::new()).call(vec![e]);
+            if let Expr::Case(case) = gap {
+                let when_then_expr = case
+                    .when_then_expr
+                    .into_iter()
+                    .map(|(when, then)| (when, Box::new(parse(*then))))
+                    .collect();
+                let else_expr = case.else_expr.map(|e| Box::new(parse(*e)));
+                Ok(Expr::Case(expr::Case {
+                    expr: case.expr,
+                    when_then_expr,
+                    else_expr,
+                }))
+            } else {
+                Ok(parse(gap))
+            }
         }
         DataType::Interval(IntervalUnit::YearMonth) => Err(PlanError::invalid(
             "gap duration expression used in session window must be an interval string, \

--- a/crates/sail-plan/src/function/scalar/datetime.rs
+++ b/crates/sail-plan/src/function/scalar/datetime.rs
@@ -1171,12 +1171,10 @@ fn session_window_gap(gap: Expr, schema: &DFSchemaRef) -> PlanResult<Expr> {
     // filter then drops every row, matching Spark.
     if let Expr::Literal(value, _) = &gap {
         if let Some(s) = value.try_as_str().flatten() {
-            // Spark bucketing: the unit the user wrote decides the bucket, so
-            // a `'1 day'` gap is a calendar day (25h across a DST fall-back)
-            // while `'25 hours'` is 25 absolute hours.
-            // Spark casts the gap with `safeStringToInterval`: an invalid or
-            // out-of-range literal becomes NULL, every row is dropped by the
-            // `end > time` filter, and the query returns an empty result.
+            // The unit the user wrote decides the bucket (`'1 day'` is a
+            // calendar day across DST, `'25 hours'` is absolute); an invalid or
+            // out-of-range literal becomes NULL (`safeStringToInterval`), and
+            // the `end > time` filter then drops every row.
             let value = parse_calendar_interval_string(s).ok().and_then(|interval| {
                 interval
                     .days_and_nanoseconds()
@@ -1271,19 +1269,12 @@ fn session_window_gap(gap: Expr, schema: &DFSchemaRef) -> PlanResult<Expr> {
 fn session_window(input: ScalarFunctionInput) -> PlanResult<Expr> {
     let schema = input.function_context.schema;
     let session_tz = input.function_context.plan_config.session_timezone.clone();
-    let args = input.arguments;
-    if args.len() != 2 {
-        return Err(PlanError::invalid(format!(
+    let [time, gap]: [Expr; 2] = input.arguments.try_into().map_err(|args: Vec<Expr>| {
+        PlanError::invalid(format!(
             "session_window requires exactly 2 arguments (time column, gap duration), got {}",
             args.len()
-        )));
-    }
-    let mut args = args.into_iter();
-    let (Some(time), Some(gap)) = (args.next(), args.next()) else {
-        return Err(PlanError::internal(
-            "session_window arguments missing after length check",
-        ));
-    };
+        ))
+    })?;
     // Cast the time column to a microsecond timestamp (same rule as `window`).
     let field_type = window_field_type(&time.get_type(schema)?, &session_tz)?;
     let time_ts = cast(time, field_type);

--- a/crates/sail-plan/src/resolver/query/aggregate.rs
+++ b/crates/sail-plan/src/resolver/query/aggregate.rs
@@ -148,7 +148,7 @@ impl PlanResolver<'_> {
                 .collect::<Vec<_>>();
             for agg in find_aggregate_exprs(&all_exprs) {
                 let references_session = agg
-                    .exists(|e| Ok(session_columns.iter().any(|c| e == *c)))
+                    .exists(|e| Ok(session_columns.contains(&e)))
                     .unwrap_or(false);
                 if references_session {
                     return Err(PlanError::AnalysisError(

--- a/crates/sail-plan/src/resolver/query/aggregate.rs
+++ b/crates/sail-plan/src/resolver/query/aggregate.rs
@@ -111,7 +111,8 @@ impl PlanResolver<'_> {
         // unresolved ordinal literal would otherwise be materialized as a
         // constant grouping key by the session_window expander, and a marker
         // referenced only by ordinal would never desugar.
-        let grouping = self.resolve_grouping_positions_early(grouping, &resolved_projections)?;
+        let (grouping, resolved_positions) =
+            self.resolve_grouping_positions_early(grouping, &resolved_projections)?;
 
         // Expand any special grouping expressions into materialized grouping
         // columns; a no-op for ordinary aggregates.
@@ -131,34 +132,6 @@ impl PlanResolver<'_> {
                 state,
             )
             .await?;
-
-        // Spark evaluates `session_window` inside an aggregate function
-        // argument with per-row (pre-merge) semantics; Sail does not implement
-        // that path, so reject it instead of silently aggregating the merged
-        // struct.
-        let session_columns: Vec<&Expr> = generator_replacements
-            .iter()
-            .filter(|(from, _)| Self::contains_session_window(from))
-            .map(|(_, to)| to)
-            .collect();
-        if !session_columns.is_empty() {
-            let all_exprs = projections
-                .iter()
-                .map(|p| p.expr.clone())
-                .collect::<Vec<_>>();
-            for agg in find_aggregate_exprs(&all_exprs) {
-                let references_session = agg
-                    .exists(|e| Ok(session_columns.contains(&e)))
-                    .unwrap_or(false);
-                if references_session {
-                    return Err(PlanError::AnalysisError(
-                        "session_window inside an aggregate function has per-row semantics \
-                         and is not supported"
-                            .to_string(),
-                    ));
-                }
-            }
-        }
 
         // Spark CheckAnalysis: reject non-deterministic expressions in aggregate context
         for proj in &projections {
@@ -188,12 +161,42 @@ impl PlanResolver<'_> {
             }
         };
 
+        // Spark evaluates `session_window` inside an aggregate function
+        // argument with per-row (pre-merge) semantics; Sail does not implement
+        // that path, so reject it (in SELECT and HAVING alike) instead of
+        // silently aggregating the merged struct.
+        let session_columns: Vec<&Expr> = generator_replacements
+            .iter()
+            .filter(|(from, _)| Self::contains_session_window(from))
+            .map(|(_, to)| to)
+            .collect();
+        if !session_columns.is_empty() {
+            let all_exprs = projections
+                .iter()
+                .map(|p| p.expr.clone())
+                .chain(having.iter().cloned())
+                .collect::<Vec<_>>();
+            for agg in find_aggregate_exprs(&all_exprs) {
+                let references_session = agg
+                    .exists(|e| Ok(session_columns.contains(&e)))
+                    .unwrap_or(false);
+                if references_session {
+                    return Err(PlanError::AnalysisError(
+                        "session_window inside an aggregate function has per-row semantics \
+                         and is not supported"
+                            .to_string(),
+                    ));
+                }
+            }
+        }
+
         self.rewrite_aggregate(
             input,
             projections,
             grouping,
             having,
             with_grouping_expressions,
+            &resolved_positions,
             state,
         )
     }
@@ -201,15 +204,20 @@ impl PlanResolver<'_> {
     /// Resolves `GROUP BY <ordinal>` against the select list before grouping
     /// expansion. A deferred (not yet resolved) select item leaves the ordinal
     /// in place for [`Self::resolve_grouping_positions`] to finish later.
+    /// Returns the rewritten grouping plus a mask of positions it substituted,
+    /// so [`Self::resolve_grouping_positions`] does not re-read a substituted
+    /// integer literal (e.g. `SELECT 5 ... GROUP BY 1`) as another ordinal.
     fn resolve_grouping_positions_early(
         &self,
         exprs: Vec<NamedExpr>,
         projections: &[Option<NamedExpr>],
-    ) -> PlanResult<Vec<NamedExpr>> {
+    ) -> PlanResult<(Vec<NamedExpr>, Vec<bool>)> {
         let num_projections = projections.len() as i64;
-        exprs
+        let mut substituted = vec![false; exprs.len()];
+        let exprs = exprs
             .into_iter()
-            .map(|named_expr| {
+            .enumerate()
+            .map(|(i, named_expr)| {
                 let NamedExpr { expr, .. } = &named_expr;
                 let Expr::Literal(scalar_value, _) = expr else {
                     return Ok(named_expr);
@@ -221,7 +229,10 @@ impl PlanResolver<'_> {
                 };
                 if position > 0_i64 && position <= num_projections {
                     match &projections[(position - 1) as usize] {
-                        Some(resolved) => Ok(resolved.clone()),
+                        Some(resolved) => {
+                            substituted[i] = true;
+                            Ok(resolved.clone())
+                        }
                         None => Ok(named_expr),
                     }
                 } else {
@@ -230,18 +241,24 @@ impl PlanResolver<'_> {
                     )))
                 }
             })
-            .collect()
+            .collect::<PlanResult<Vec<_>>>()?;
+        Ok((exprs, substituted))
     }
 
     fn resolve_grouping_positions(
         &self,
         exprs: Vec<NamedExpr>,
         projections: &[NamedExpr],
+        resolved_positions: &[bool],
     ) -> PlanResult<Vec<NamedExpr>> {
         let num_projections = projections.len() as i64;
         exprs
             .into_iter()
-            .map(|named_expr| {
+            .enumerate()
+            .map(|(i, named_expr)| {
+                if resolved_positions.get(i).copied().unwrap_or(false) {
+                    return Ok(named_expr);
+                }
                 let NamedExpr { expr, .. } = &named_expr;
                 match expr {
                     Expr::Literal(scalar_value, _metadata) => {
@@ -271,9 +288,11 @@ impl PlanResolver<'_> {
         grouping: Vec<NamedExpr>,
         having: Option<Expr>,
         with_grouping_expressions: bool,
+        resolved_positions: &[bool],
         state: &mut PlanResolverState,
     ) -> PlanResult<LogicalPlan> {
-        let grouping = self.resolve_grouping_positions(grouping, &projections)?;
+        let grouping =
+            self.resolve_grouping_positions(grouping, &projections, resolved_positions)?;
         let group_exprs = grouping.iter().map(|x| x.expr.clone()).collect::<Vec<_>>();
         let has_grouping_set = Self::has_grouping_set(&group_exprs);
         let grouping_exprs = Self::distinct_grouping_expressions_from_exprs(&group_exprs);
@@ -1182,7 +1201,7 @@ impl PlanResolver<'_> {
     }
 
     /// Whether an expression contains a `session_window` marker anywhere.
-    fn contains_session_window(expr: &Expr) -> bool {
+    pub(super) fn contains_session_window(expr: &Expr) -> bool {
         expr.exists(|e| Ok(Self::is_session_window_marker(e)))
             .unwrap_or(false)
     }
@@ -1224,10 +1243,10 @@ impl PlanResolver<'_> {
 
         // Only one time-window expression per grouping; `session_window` cannot
         // be combined with `window` (its generator fills `replacements`).
-        let extra_window = grouping
-            .iter()
-            .enumerate()
-            .any(|(i, g)| i != marker_idx && Self::contains_session_window(&g.expr));
+        let marker_expr = grouping[marker_idx].expr.clone();
+        let extra_window = grouping.iter().enumerate().any(|(i, g)| {
+            i != marker_idx && g.expr != marker_expr && Self::contains_session_window(&g.expr)
+        });
         if extra_window || !replacements.is_empty() {
             return Err(PlanError::AnalysisError(
                 "only one session_window or window expression is allowed in a grouping".to_string(),
@@ -1240,8 +1259,16 @@ impl PlanResolver<'_> {
         // the downstream aggregate reuses the hash distribution (no reshuffle).
         let mut partition_columns = Vec::new();
         let mut key_projections: Vec<Expr> = Vec::new();
+        let mut duplicate_markers: Vec<usize> = Vec::new();
         for (i, g) in grouping.iter_mut().enumerate() {
             if i == marker_idx {
+                continue;
+            }
+            // Spark collapses duplicate identical session_window keys; point
+            // them at the same struct column instead of materializing (and
+            // executing) the marker as an expression key.
+            if g.expr == marker_expr {
+                duplicate_markers.push(i);
                 continue;
             }
             match &g.expr {
@@ -1343,6 +1370,18 @@ impl PlanResolver<'_> {
         }
         replacements.push((original_marker, w_col.clone()));
         grouping[marker_idx].expr = w_col;
+        // Drop the duplicate keys entirely (their SELECT/HAVING re-uses go
+        // through `replacements` like the primary's).
+        if !duplicate_markers.is_empty() {
+            let duplicates: std::collections::HashSet<usize> =
+                duplicate_markers.into_iter().collect();
+            grouping = grouping
+                .into_iter()
+                .enumerate()
+                .filter(|(i, _)| !duplicates.contains(i))
+                .map(|(_, g)| g)
+                .collect();
+        }
 
         Ok((plan, grouping, replacements))
     }

--- a/crates/sail-plan/src/resolver/query/aggregate.rs
+++ b/crates/sail-plan/src/resolver/query/aggregate.rs
@@ -107,6 +107,12 @@ impl PlanResolver<'_> {
                 .await?
         };
 
+        // GROUP BY ordinals must resolve before grouping expansion: an
+        // unresolved ordinal literal would otherwise be materialized as a
+        // constant grouping key by the session_window expander, and a marker
+        // referenced only by ordinal would never desugar.
+        let grouping = self.resolve_grouping_positions_early(grouping, &resolved_projections)?;
+
         // Expand any special grouping expressions into materialized grouping
         // columns; a no-op for ordinary aggregates.
         let (input, grouping, generator_replacements) =
@@ -125,6 +131,34 @@ impl PlanResolver<'_> {
                 state,
             )
             .await?;
+
+        // Spark evaluates `session_window` inside an aggregate function
+        // argument with per-row (pre-merge) semantics; Sail does not implement
+        // that path, so reject it instead of silently aggregating the merged
+        // struct.
+        let session_columns: Vec<&Expr> = generator_replacements
+            .iter()
+            .filter(|(from, _)| Self::contains_session_window(from))
+            .map(|(_, to)| to)
+            .collect();
+        if !session_columns.is_empty() {
+            let all_exprs = projections
+                .iter()
+                .map(|p| p.expr.clone())
+                .collect::<Vec<_>>();
+            for agg in find_aggregate_exprs(&all_exprs) {
+                let references_session = agg
+                    .exists(|e| Ok(session_columns.iter().any(|c| e == *c)))
+                    .unwrap_or(false);
+                if references_session {
+                    return Err(PlanError::AnalysisError(
+                        "session_window inside an aggregate function has per-row semantics \
+                         and is not supported"
+                            .to_string(),
+                    ));
+                }
+            }
+        }
 
         // Spark CheckAnalysis: reject non-deterministic expressions in aggregate context
         for proj in &projections {
@@ -162,6 +196,41 @@ impl PlanResolver<'_> {
             with_grouping_expressions,
             state,
         )
+    }
+
+    /// Resolves `GROUP BY <ordinal>` against the select list before grouping
+    /// expansion. A deferred (not yet resolved) select item leaves the ordinal
+    /// in place for [`Self::resolve_grouping_positions`] to finish later.
+    fn resolve_grouping_positions_early(
+        &self,
+        exprs: Vec<NamedExpr>,
+        projections: &[Option<NamedExpr>],
+    ) -> PlanResult<Vec<NamedExpr>> {
+        let num_projections = projections.len() as i64;
+        exprs
+            .into_iter()
+            .map(|named_expr| {
+                let NamedExpr { expr, .. } = &named_expr;
+                let Expr::Literal(scalar_value, _) = expr else {
+                    return Ok(named_expr);
+                };
+                let position = match scalar_value {
+                    ScalarValue::Int32(Some(position)) => *position as i64,
+                    ScalarValue::Int64(Some(position)) => *position,
+                    _ => return Ok(named_expr),
+                };
+                if position > 0_i64 && position <= num_projections {
+                    match &projections[(position - 1) as usize] {
+                        Some(resolved) => Ok(resolved.clone()),
+                        None => Ok(named_expr),
+                    }
+                } else {
+                    Err(PlanError::invalid(format!(
+                        "Cannot resolve column position {position}. Valid positions are 1 to {num_projections}."
+                    )))
+                }
+            })
+            .collect()
     }
 
     fn resolve_grouping_positions(
@@ -1034,6 +1103,24 @@ impl PlanResolver<'_> {
         if !Self::session_fusable(&agg.aggr_expr) {
             return plan;
         }
+        // The fused node's input is the SessionWindowNode's child, which lacks
+        // the session struct; an aggregate (or its FILTER) referencing it —
+        // e.g. `max(session_window(...).start)` — must stay on the baseline
+        // path where the struct exists.
+        let input_has = |name: &str| {
+            node.input()
+                .schema()
+                .field_with_unqualified_name(name)
+                .is_ok()
+        };
+        let references_missing_column = agg.aggr_expr.iter().any(|e| {
+            e.column_refs()
+                .iter()
+                .any(|c| c.name == node.output_column() || !input_has(&c.name))
+        });
+        if references_missing_column {
+            return plan;
+        }
         // The leading `group_expr.len()` output fields are the group columns (the
         // session struct among them), in order.
         let group_columns = agg
@@ -1084,7 +1171,13 @@ impl PlanResolver<'_> {
 
     /// Whether an expression is a top-level `session_window` marker call.
     fn is_session_window_marker(expr: &Expr) -> bool {
-        matches!(expr, Expr::ScalarFunction(f)
+        // Grouping by a projection alias (`GROUP BY sw`, `.alias("sw")`) keeps
+        // the `Expr::Alias` wrapper around the marker, so peel one layer.
+        let inner = match expr {
+            Expr::Alias(alias) => alias.expr.as_ref(),
+            other => other,
+        };
+        matches!(inner, Expr::ScalarFunction(f)
             if f.func.inner().downcast_ref::<SparkSessionWindow>().is_some())
     }
 
@@ -1153,6 +1246,15 @@ impl PlanResolver<'_> {
             }
             match &g.expr {
                 Expr::Column(col) => partition_columns.push(col.name().to_string()),
+                // A grouping-set sibling cannot be materialized as a key
+                // column; reject it cleanly instead of a downstream internal
+                // error (and silently destroyed CUBE/ROLLUP semantics).
+                Expr::GroupingSet(_) => {
+                    return Err(PlanError::AnalysisError(
+                        "session_window cannot be combined with GROUPING SETS, CUBE, or ROLLUP"
+                            .to_string(),
+                    ));
+                }
                 _ => {
                     let key_name = state.register_field_name("");
                     key_projections.push(g.expr.clone().alias(&key_name));
@@ -1165,8 +1267,12 @@ impl PlanResolver<'_> {
         }
 
         // Pull the (already cast) time column and normalized gap interval out of
-        // the marker call.
-        let (time_ts, gap_interval) = match &grouping[marker_idx].expr {
+        // the marker call (peeling a projection alias if present).
+        let marker = match &grouping[marker_idx].expr {
+            Expr::Alias(alias) => alias.expr.as_ref(),
+            other => other,
+        };
+        let (time_ts, gap_interval) = match marker {
             Expr::ScalarFunction(f) => {
                 let mut args = f.args.iter().cloned();
                 match (args.next(), args.next()) {
@@ -1230,6 +1336,11 @@ impl PlanResolver<'_> {
         }
         let w_col = ident(&w_name);
         let original_marker = grouping[marker_idx].expr.clone();
+        // Register both the grouping form and (when aliased) the bare marker,
+        // so SELECT/HAVING re-uses of either shape resolve to the struct.
+        if let Expr::Alias(alias) = &original_marker {
+            replacements.push((alias.expr.as_ref().clone(), w_col.clone()));
+        }
         replacements.push((original_marker, w_col.clone()));
         grouping[marker_idx].expr = w_col;
 

--- a/crates/sail-plan/src/resolver/query/aggregate.rs
+++ b/crates/sail-plan/src/resolver/query/aggregate.rs
@@ -43,19 +43,6 @@ type ResolvedProjections = (Vec<Option<NamedExpr>>, Vec<usize>);
 /// A map from a grouping generator expression to the column that materializes it.
 type GeneratorReplacements = Vec<(Expr, Expr)>;
 
-/// A grouping desugaring pass. Each one detects its own special expression in the
-/// grouping, rewrites the plan and grouping to materialize it as a column, and
-/// extends the replacement map; it is a no-op when its expression is absent. All
-/// passes share this signature so [`PlanResolver::expand_grouping`] can apply them
-/// uniformly as a list.
-type GroupingExpander<'a> = fn(
-    &PlanResolver<'a>,
-    LogicalPlan,
-    Vec<NamedExpr>,
-    GeneratorReplacements,
-    &mut PlanResolverState,
-) -> PlanResult<(LogicalPlan, Vec<NamedExpr>, GeneratorReplacements)>;
-
 /// Returns the name of a volatile (non-deterministic) scalar expression found
 /// in an aggregate context. Catches two Spark CheckAnalysis violations:
 /// 1. Volatile scalar UDF used directly in aggregate projections (outside any aggregate fn)
@@ -202,11 +189,9 @@ impl PlanResolver<'_> {
     }
 
     /// Resolves `GROUP BY <ordinal>` against the select list before grouping
-    /// expansion. A deferred (not yet resolved) select item leaves the ordinal
-    /// in place for [`Self::resolve_grouping_positions`] to finish later.
-    /// Returns the rewritten grouping plus a mask of positions it substituted,
-    /// so [`Self::resolve_grouping_positions`] does not re-read a substituted
-    /// integer literal (e.g. `SELECT 5 ... GROUP BY 1`) as another ordinal.
+    /// expansion; a deferred select item leaves the ordinal in place. Returns a
+    /// mask of substituted positions so [`Self::resolve_grouping_positions`]
+    /// does not re-read a substituted integer literal as another ordinal.
     fn resolve_grouping_positions_early(
         &self,
         exprs: Vec<NamedExpr>,
@@ -218,31 +203,40 @@ impl PlanResolver<'_> {
             .into_iter()
             .enumerate()
             .map(|(i, named_expr)| {
-                let NamedExpr { expr, .. } = &named_expr;
-                let Expr::Literal(scalar_value, _) = expr else {
-                    return Ok(named_expr);
-                };
-                let position = match scalar_value {
-                    ScalarValue::Int32(Some(position)) => *position as i64,
-                    ScalarValue::Int64(Some(position)) => *position,
-                    _ => return Ok(named_expr),
-                };
-                if position > 0_i64 && position <= num_projections {
-                    match &projections[(position - 1) as usize] {
+                match Self::grouping_position(&named_expr.expr, num_projections)? {
+                    Some(position) => match &projections[position] {
                         Some(resolved) => {
                             substituted[i] = true;
                             Ok(resolved.clone())
                         }
                         None => Ok(named_expr),
-                    }
-                } else {
-                    Err(PlanError::invalid(format!(
-                        "Cannot resolve column position {position}. Valid positions are 1 to {num_projections}."
-                    )))
+                    },
+                    None => Ok(named_expr),
                 }
             })
             .collect::<PlanResult<Vec<_>>>()?;
         Ok((exprs, substituted))
+    }
+
+    /// The zero-based select-list index of a `GROUP BY <ordinal>` integer
+    /// literal (`None` for non-ordinal expressions), erroring when it is out of
+    /// range.
+    fn grouping_position(expr: &Expr, num_projections: i64) -> PlanResult<Option<usize>> {
+        let Expr::Literal(scalar_value, _) = expr else {
+            return Ok(None);
+        };
+        let position = match scalar_value {
+            ScalarValue::Int32(Some(position)) => *position as i64,
+            ScalarValue::Int64(Some(position)) => *position,
+            _ => return Ok(None),
+        };
+        if position > 0_i64 && position <= num_projections {
+            Ok(Some((position - 1) as usize))
+        } else {
+            Err(PlanError::invalid(format!(
+                "Cannot resolve column position {position}. Valid positions are 1 to {num_projections}."
+            )))
+        }
     }
 
     fn resolve_grouping_positions(
@@ -259,23 +253,9 @@ impl PlanResolver<'_> {
                 if resolved_positions.get(i).copied().unwrap_or(false) {
                     return Ok(named_expr);
                 }
-                let NamedExpr { expr, .. } = &named_expr;
-                match expr {
-                    Expr::Literal(scalar_value, _metadata) => {
-                        let position = match scalar_value {
-                            ScalarValue::Int32(Some(position)) => *position as i64,
-                            ScalarValue::Int64(Some(position)) => *position,
-                            _ => return Ok(named_expr),
-                        };
-                        if position > 0_i64 && position <= num_projections {
-                            Ok(projections[(position - 1) as usize].clone())
-                        } else {
-                            Err(PlanError::invalid(format!(
-                                "Cannot resolve column position {position}. Valid positions are 1 to {num_projections}."
-                            )))
-                        }
-                    }
-                    _ => Ok(named_expr),
+                match Self::grouping_position(&named_expr.expr, num_projections)? {
+                    Some(position) => Ok(projections[position].clone()),
+                    None => Ok(named_expr),
                 }
             })
             .collect()
@@ -1032,16 +1012,10 @@ impl PlanResolver<'_> {
         state: &mut PlanResolverState,
     ) -> PlanResult<(LogicalPlan, Vec<NamedExpr>, GeneratorReplacements)> {
         // Generators run first so that combining `window` with `session_window`
-        // is caught downstream. New grouping functions append an expander here.
-        let expanders: &[GroupingExpander<'_>] = &[
-            Self::expand_grouping_generators,
-            Self::expand_session_window,
-        ];
-        let mut acc = (input, grouping, GeneratorReplacements::new());
-        for expand in expanders {
-            acc = expand(self, acc.0, acc.1, acc.2, state)?;
-        }
-        Ok(acc)
+        // is caught downstream.
+        let (input, grouping, replacements) =
+            self.expand_grouping_generators(input, grouping, GeneratorReplacements::new(), state)?;
+        self.expand_session_window(input, grouping, replacements, state)
     }
 
     /// Expands a generator in the grouping into rows, naming the unnested
@@ -1119,7 +1093,7 @@ impl PlanResolver<'_> {
         let Some(node) = ext.node.as_any().downcast_ref::<SessionWindowNode>() else {
             return plan;
         };
-        if !Self::session_fusable(&agg.aggr_expr) {
+        if !Self::is_session_fusable(&agg.aggr_expr) {
             return plan;
         }
         // The fused node's input is the SessionWindowNode's child, which lacks
@@ -1167,7 +1141,7 @@ impl PlanResolver<'_> {
     /// Whether every aggregate can run through the fused session operator.
     /// DISTINCT, ordered-set, and group UDAFs fall back to the baseline
     /// `SessionWindowNode` path (as Spark does); `FILTER (WHERE)` is fused.
-    fn session_fusable(aggr_exprs: &[Expr]) -> bool {
+    fn is_session_fusable(aggr_exprs: &[Expr]) -> bool {
         aggr_exprs.iter().all(|e| {
             let inner = match e {
                 Expr::Alias(alias) => alias.expr.as_ref(),
@@ -1206,15 +1180,10 @@ impl PlanResolver<'_> {
             .unwrap_or(false)
     }
 
-    /// Rewrites a `session_window` grouping marker into a `SessionWindowNode`
-    /// appending the `{start, end}` struct column. A no-op without a marker.
-    ///
-    /// ```text
-    /// SessionWindowNode partition_by=[K...] time=#t end=#e0 output=#w
-    ///   Filter: #t IS NOT NULL AND #e0 > #t        (drop null time / non-positive gap)
-    ///     Projection: *, ts AS #t, ts + gap AS #e0
-    /// ```
-    /// The marker grouping expression becomes a reference to `#w`.
+    /// Rewrites a `session_window` grouping marker into a `SessionWindowNode`:
+    /// project `#t = ts` and `#e0 = ts + gap`, filter out null times and
+    /// non-positive gaps, and append the `{start, end}` struct as a column that
+    /// the marker grouping expression then references. A no-op without a marker.
     fn expand_session_window(
         &self,
         input: LogicalPlan,
@@ -1299,24 +1268,17 @@ impl PlanResolver<'_> {
             Expr::Alias(alias) => alias.expr.as_ref(),
             other => other,
         };
-        let (time_ts, gap_interval) = match marker {
-            Expr::ScalarFunction(f) => {
-                let mut args = f.args.iter().cloned();
-                match (args.next(), args.next()) {
-                    (Some(t), Some(g)) => (t, g),
-                    _ => {
-                        return Err(PlanError::internal(
-                            "session_window marker is missing arguments",
-                        ));
-                    }
-                }
-            }
-            _ => {
-                return Err(PlanError::internal(
-                    "session_window marker is not a scalar function",
-                ));
-            }
+        let Expr::ScalarFunction(f) = marker else {
+            return Err(PlanError::internal(
+                "session_window marker is not a scalar function",
+            ));
         };
+        let [time_ts, gap_interval] = f.args.as_slice() else {
+            return Err(PlanError::internal(
+                "session_window marker is missing arguments",
+            ));
+        };
+        let (time_ts, gap_interval) = (time_ts.clone(), gap_interval.clone());
 
         // Project every input column through, then add `#t = ts` and the per-row
         // session-end candidate `#e0 = ts + gap`.

--- a/crates/sail-plan/src/resolver/query/aggregate.rs
+++ b/crates/sail-plan/src/resolver/query/aggregate.rs
@@ -11,14 +11,17 @@ use datafusion_expr::logical_plan::{FetchType, SkipType};
 use datafusion_expr::utils::find_aggregate_exprs;
 use datafusion_expr::{
     Aggregate, AggregateUDF, Expr, ExprSchemable, Extension, LogicalPlan, LogicalPlanBuilder,
-    Projection, SortExpr, Volatility, bitwise_and, bitwise_shift_right, cast,
+    Projection, SortExpr, Volatility, bitwise_and, bitwise_shift_right, cast, ident,
 };
 use datafusion_spark::function::aggregate::try_sum::SparkTrySum;
 use sail_common::spec;
 use sail_common_datafusion::utils::items::ItemTaker;
 use sail_function::aggregate::try_avg::TryAvgFunction;
+use sail_function::scalar::datetime::spark_session_window::SparkSessionWindow;
 use sail_function::scalar::explode::Explode;
 use sail_logical_plan::monotonic_id::MonotonicIdNode;
+use sail_logical_plan::session_aggregate::SessionAggregateNode;
+use sail_logical_plan::session_window::SessionWindowNode;
 use sail_logical_plan::sort::{RequiredSortNode, SortWithinPartitionsNode};
 use sail_logical_plan::spark_partition_id::SparkPartitionIdNode;
 use sail_python_udf::get_udf_display_name;
@@ -39,6 +42,19 @@ type ResolvedProjections = (Vec<Option<NamedExpr>>, Vec<usize>);
 
 /// A map from a grouping generator expression to the column that materializes it.
 type GeneratorReplacements = Vec<(Expr, Expr)>;
+
+/// A grouping desugaring pass. Each one detects its own special expression in the
+/// grouping, rewrites the plan and grouping to materialize it as a column, and
+/// extends the replacement map; it is a no-op when its expression is absent. All
+/// passes share this signature so [`PlanResolver::expand_grouping`] can apply them
+/// uniformly as a list.
+type GroupingExpander<'a> = fn(
+    &PlanResolver<'a>,
+    LogicalPlan,
+    Vec<NamedExpr>,
+    GeneratorReplacements,
+    &mut PlanResolverState,
+) -> PlanResult<(LogicalPlan, Vec<NamedExpr>, GeneratorReplacements)>;
 
 /// Returns the name of a volatile (non-deterministic) scalar expression found
 /// in an aggregate context. Catches two Spark CheckAnalysis violations:
@@ -91,10 +107,10 @@ impl PlanResolver<'_> {
                 .await?
         };
 
-        // Expand a generator (e.g. window's `explode`) in the grouping into a named
-        // column; a no-op for ordinary aggregates.
+        // Expand any special grouping expressions into materialized grouping
+        // columns; a no-op for ordinary aggregates.
         let (input, grouping, generator_replacements) =
-            self.expand_grouping_generators(input, grouping, state)?;
+            self.expand_grouping(input, grouping, state)?;
         let schema = input.schema();
 
         // Resolve the deferred projections (grouping columns are now in scope) and
@@ -210,6 +226,11 @@ impl PlanResolver<'_> {
         let plan = LogicalPlanBuilder::from(input)
             .aggregate(group_exprs, aggregate_exprs.clone())?
             .build()?;
+        // Phase 2: if this is a `session_window` aggregate with fusable aggregates,
+        // fuse the `Aggregate` + `SessionWindowNode` into one `SessionAggregateNode`
+        // (Spark's `MergingSessionsExec`). A no-op otherwise — including DISTINCT,
+        // which stays on the baseline `SessionWindowNode` path (Spark's fallback).
+        let plan = Self::maybe_fuse_session_aggregate(plan);
         let (grouping_exprs, aggregate_or_grouping_exprs) = {
             let mut grouping_exprs = vec![];
             let mut aggregate_or_grouping_exprs = aggregate_exprs;
@@ -912,22 +933,44 @@ impl PlanResolver<'_> {
         ))
     }
 
-    /// Expands a generator in the grouping into rows, naming the unnested column
-    /// after the grouping output. Returns a map from each generator to its column.
-    /// A no-op when the grouping has no generator.
-    fn expand_grouping_generators(
+    /// Single entry point for desugaring special grouping expressions into
+    /// materialized grouping columns. Each expander detects its own marker and
+    /// is a no-op otherwise. Returns the rewritten plan and grouping, plus the
+    /// map from each original expression to its column (for SELECT/HAVING).
+    fn expand_grouping(
         &self,
         input: LogicalPlan,
         grouping: Vec<NamedExpr>,
         state: &mut PlanResolverState,
     ) -> PlanResult<(LogicalPlan, Vec<NamedExpr>, GeneratorReplacements)> {
+        // Generators run first so that combining `window` with `session_window`
+        // is caught downstream. New grouping functions append an expander here.
+        let expanders: &[GroupingExpander<'_>] = &[
+            Self::expand_grouping_generators,
+            Self::expand_session_window,
+        ];
+        let mut acc = (input, grouping, GeneratorReplacements::new());
+        for expand in expanders {
+            acc = expand(self, acc.0, acc.1, acc.2, state)?;
+        }
+        Ok(acc)
+    }
+
+    /// Expands a generator in the grouping into rows, naming the unnested
+    /// column after the grouping output. A no-op without a generator.
+    fn expand_grouping_generators(
+        &self,
+        input: LogicalPlan,
+        grouping: Vec<NamedExpr>,
+        mut replacements: GeneratorReplacements,
+        state: &mut PlanResolverState,
+    ) -> PlanResult<(LogicalPlan, Vec<NamedExpr>, GeneratorReplacements)> {
         if !grouping.iter().any(Self::grouping_has_generator) {
-            return Ok((input, grouping, vec![]));
+            return Ok((input, grouping, replacements));
         }
         let generators = grouping.iter().map(|x| x.expr.clone()).collect::<Vec<_>>();
         let (input, mut grouping) =
             self.rewrite_projection::<ExplodeRewriter>(input, grouping, state)?;
-        let mut replacements = vec![];
         for (group, generator) in grouping.iter_mut().zip(generators) {
             // The rewriter returns the unnested column wrapped in an alias. Rename
             // that column to the grouping's output name and use it directly.
@@ -973,6 +1016,224 @@ impl PlanResolver<'_> {
                 None => Ok(Transformed::no(e)),
             })
             .data()?)
+    }
+
+    /// Fuses an `Aggregate` directly on a `SessionWindowNode` into a single
+    /// `SessionAggregateNode` (Spark's `MergingSessionsExec`) when the
+    /// aggregates allow it; otherwise returns the plan untouched.
+    fn maybe_fuse_session_aggregate(plan: LogicalPlan) -> LogicalPlan {
+        let LogicalPlan::Aggregate(agg) = &plan else {
+            return plan;
+        };
+        let LogicalPlan::Extension(ext) = agg.input.as_ref() else {
+            return plan;
+        };
+        let Some(node) = ext.node.as_any().downcast_ref::<SessionWindowNode>() else {
+            return plan;
+        };
+        if !Self::session_fusable(&agg.aggr_expr) {
+            return plan;
+        }
+        // The leading `group_expr.len()` output fields are the group columns (the
+        // session struct among them), in order.
+        let group_columns = agg
+            .schema
+            .fields()
+            .iter()
+            .take(agg.group_expr.len())
+            .map(|f| f.name().clone())
+            .collect::<Vec<_>>();
+        let fused = SessionAggregateNode::new(
+            Arc::clone(node.input()),
+            node.partition_columns().to_vec(),
+            node.time_column().to_string(),
+            node.end_column().to_string(),
+            node.output_column().to_string(),
+            group_columns,
+            agg.aggr_expr.clone(),
+            Arc::clone(&agg.schema),
+        );
+        LogicalPlan::Extension(Extension {
+            node: Arc::new(fused),
+        })
+    }
+
+    /// Whether every aggregate can run through the fused session operator.
+    /// DISTINCT, ordered-set, and group UDAFs fall back to the baseline
+    /// `SessionWindowNode` path (as Spark does); `FILTER (WHERE)` is fused.
+    fn session_fusable(aggr_exprs: &[Expr]) -> bool {
+        aggr_exprs.iter().all(|e| {
+            let inner = match e {
+                Expr::Alias(alias) => alias.expr.as_ref(),
+                other => other,
+            };
+            match inner {
+                Expr::AggregateFunction(af) => {
+                    !af.params.distinct
+                        && af.params.order_by.is_empty()
+                        && af
+                            .func
+                            .inner()
+                            .downcast_ref::<PySparkGroupAggregateUDF>()
+                            .is_none()
+                }
+                _ => false,
+            }
+        })
+    }
+
+    /// Whether an expression is a top-level `session_window` marker call.
+    fn is_session_window_marker(expr: &Expr) -> bool {
+        matches!(expr, Expr::ScalarFunction(f)
+            if f.func.inner().downcast_ref::<SparkSessionWindow>().is_some())
+    }
+
+    /// Whether an expression contains a `session_window` marker anywhere.
+    fn contains_session_window(expr: &Expr) -> bool {
+        expr.exists(|e| Ok(Self::is_session_window_marker(e)))
+            .unwrap_or(false)
+    }
+
+    /// Rewrites a `session_window` grouping marker into a `SessionWindowNode`
+    /// appending the `{start, end}` struct column. A no-op without a marker.
+    ///
+    /// ```text
+    /// SessionWindowNode partition_by=[K...] time=#t end=#e0 output=#w
+    ///   Filter: #t IS NOT NULL AND #e0 > #t        (drop null time / non-positive gap)
+    ///     Projection: *, ts AS #t, ts + gap AS #e0
+    /// ```
+    /// The marker grouping expression becomes a reference to `#w`.
+    fn expand_session_window(
+        &self,
+        input: LogicalPlan,
+        mut grouping: Vec<NamedExpr>,
+        mut replacements: GeneratorReplacements,
+        state: &mut PlanResolverState,
+    ) -> PlanResult<(LogicalPlan, Vec<NamedExpr>, GeneratorReplacements)> {
+        let Some(marker_idx) = grouping
+            .iter()
+            .position(|g| Self::is_session_window_marker(&g.expr))
+        else {
+            // A marker inside a larger grouping expression gets per-row
+            // semantics in Spark (no merge); Sail does not implement that path,
+            // so reject it at analysis time.
+            if grouping
+                .iter()
+                .any(|g| Self::contains_session_window(&g.expr))
+            {
+                return Err(PlanError::AnalysisError(
+                    "session_window is only supported as a top-level grouping expression"
+                        .to_string(),
+                ));
+            }
+            return Ok((input, grouping, replacements));
+        };
+
+        // Only one time-window expression per grouping; `session_window` cannot
+        // be combined with `window` (its generator fills `replacements`).
+        let extra_window = grouping
+            .iter()
+            .enumerate()
+            .any(|(i, g)| i != marker_idx && Self::contains_session_window(&g.expr));
+        if extra_window || !replacements.is_empty() {
+            return Err(PlanError::AnalysisError(
+                "only one session_window or window expression is allowed in a grouping".to_string(),
+            ));
+        }
+
+        // Non-marker grouping keys form the session partition. An expression key
+        // is projected to a fresh column so the operator can partition by it;
+        // the grouping and SELECT/HAVING re-uses point at that same column, so
+        // the downstream aggregate reuses the hash distribution (no reshuffle).
+        let mut partition_columns = Vec::new();
+        let mut key_projections: Vec<Expr> = Vec::new();
+        for (i, g) in grouping.iter_mut().enumerate() {
+            if i == marker_idx {
+                continue;
+            }
+            match &g.expr {
+                Expr::Column(col) => partition_columns.push(col.name().to_string()),
+                _ => {
+                    let key_name = state.register_field_name("");
+                    key_projections.push(g.expr.clone().alias(&key_name));
+                    partition_columns.push(key_name.clone());
+                    let key_col = ident(&key_name);
+                    replacements.push((g.expr.clone(), key_col.clone()));
+                    g.expr = key_col;
+                }
+            }
+        }
+
+        // Pull the (already cast) time column and normalized gap interval out of
+        // the marker call.
+        let (time_ts, gap_interval) = match &grouping[marker_idx].expr {
+            Expr::ScalarFunction(f) => {
+                let mut args = f.args.iter().cloned();
+                match (args.next(), args.next()) {
+                    (Some(t), Some(g)) => (t, g),
+                    _ => {
+                        return Err(PlanError::internal(
+                            "session_window marker is missing arguments",
+                        ));
+                    }
+                }
+            }
+            _ => {
+                return Err(PlanError::internal(
+                    "session_window marker is not a scalar function",
+                ));
+            }
+        };
+
+        // Project every input column through, then add `#t = ts` and the per-row
+        // session-end candidate `#e0 = ts + gap`.
+        let t_name = state.register_field_name("");
+        let e0_name = state.register_field_name("");
+        let mut proj: Vec<Expr> = input
+            .schema()
+            .columns()
+            .into_iter()
+            .map(Expr::Column)
+            .collect();
+        // Materialize any expression grouping keys as fresh columns alongside.
+        proj.extend(key_projections);
+        proj.push(time_ts.clone().alias(&t_name));
+        proj.push((time_ts + gap_interval).alias(&e0_name));
+        let projected = LogicalPlanBuilder::from(input).project(proj)?.build()?;
+
+        // Drop the rows Spark's `SessionWindowing` rule drops: null time, or a
+        // non-positive gap (`end <= time`).
+        let t_col = ident(&t_name);
+        let e0_col = ident(&e0_name);
+        let filtered = LogicalPlanBuilder::from(projected)
+            .filter(t_col.clone().is_not_null().and(e0_col.gt(t_col)))?
+            .build()?;
+
+        // Append the session `{start, end}` struct column.
+        let w_name = state.register_field_name("");
+        let node = SessionWindowNode::try_new(
+            Arc::new(filtered),
+            partition_columns,
+            t_name,
+            e0_name,
+            w_name.clone(),
+        )?;
+        let plan = LogicalPlan::Extension(Extension {
+            node: Arc::new(node),
+        });
+
+        // Name the struct column after the grouping output (`session_window`) so
+        // `session_window.start` / `.end` resolve, then point the grouping (and any
+        // re-use of the marker in SELECT/HAVING) at that column.
+        if let [display_name] = grouping[marker_idx].name.as_slice() {
+            state.set_field_name(&w_name, display_name);
+        }
+        let w_col = ident(&w_name);
+        let original_marker = grouping[marker_idx].expr.clone();
+        replacements.push((original_marker, w_col.clone()));
+        grouping[marker_idx].expr = w_col;
+
+        Ok((plan, grouping, replacements))
     }
 
     /// Reference: [datafusion_sql::utils::rebase_expr]

--- a/crates/sail-plan/src/resolver/query/pivoting.rs
+++ b/crates/sail-plan/src/resolver/query/pivoting.rs
@@ -195,7 +195,7 @@ impl PlanResolver<'_> {
             }
         }
 
-        self.rewrite_aggregate(input, projections, grouping, None, false, state)
+        self.rewrite_aggregate(input, projections, grouping, None, false, &[], state)
     }
 
     /// Infer pivot values by collecting the distinct values of the pivot column

--- a/crates/sail-plan/src/resolver/query/pivoting.rs
+++ b/crates/sail-plan/src/resolver/query/pivoting.rs
@@ -195,6 +195,17 @@ impl PlanResolver<'_> {
             }
         }
 
+        // Pivot builds its aggregate directly, bypassing the grouping
+        // expanders; reject the session_window marker cleanly instead of
+        // letting it reach execution with a misleading error.
+        if grouping
+            .iter()
+            .any(|g| Self::contains_session_window(&g.expr))
+        {
+            return Err(PlanError::AnalysisError(
+                "session_window is not supported in pivot grouping".to_string(),
+            ));
+        }
         self.rewrite_aggregate(input, projections, grouping, None, false, &[], state)
     }
 

--- a/crates/sail-plan/src/resolver/query/project.rs
+++ b/crates/sail-plan/src/resolver/query/project.rs
@@ -50,7 +50,7 @@ impl PlanResolver<'_> {
                 .unwrap_or(false)
         });
         if has_aggregate {
-            self.rewrite_aggregate(input, expr, vec![], None, false, state)
+            self.rewrite_aggregate(input, expr, vec![], None, false, &[], state)
         } else {
             let expr = self.rewrite_named_expressions(expr, state)?;
             Ok(LogicalPlan::Projection(Projection::try_new(

--- a/crates/sail-plan/src/resolver/query/sort.rs
+++ b/crates/sail-plan/src/resolver/query/sort.rs
@@ -9,6 +9,7 @@ use datafusion_expr::{
 };
 use sail_common::spec;
 use sail_common_datafusion::utils::items::ItemTaker;
+use sail_logical_plan::session_aggregate::SessionAggregateNode;
 use sail_logical_plan::sort::SortWithinPartitionsNode;
 
 use crate::error::{PlanError, PlanResult};
@@ -90,8 +91,31 @@ impl PlanResolver<'_> {
                 .into_iter()
                 .map(|x| Self::rebase_sort(x, &base, input.as_ref()))
                 .collect::<PlanResult<Vec<_>>>()
+        } else if let Some(node) = Self::input_session_aggregate(input.as_ref()) {
+            // The fused session aggregate is an extension node, not a
+            // `LogicalPlan::Aggregate`; rebase aggregate expressions in the
+            // sort onto its output columns the same way (group columns are
+            // already materialized columns and need no rebasing).
+            let base = node.aggregate_exprs().to_vec();
+            sorts
+                .into_iter()
+                .map(|x| Self::rebase_sort(x, &base, node.input().as_ref()))
+                .collect::<PlanResult<Vec<_>>>()
         } else {
             Ok(sorts)
+        }
+    }
+
+    fn input_session_aggregate(plan: &LogicalPlan) -> Option<&SessionAggregateNode> {
+        match plan {
+            LogicalPlan::Extension(ext) => ext.node.as_any().downcast_ref::<SessionAggregateNode>(),
+            LogicalPlan::Window(Window { input, .. }) => match input.as_ref() {
+                LogicalPlan::Extension(ext) => {
+                    ext.node.as_any().downcast_ref::<SessionAggregateNode>()
+                }
+                _ => None,
+            },
+            _ => None,
         }
     }
 

--- a/crates/sail-session/src/planner.rs
+++ b/crates/sail-session/src/planner.rs
@@ -25,6 +25,7 @@ use datafusion_datasource::file_scan_config::FileScanConfigBuilder;
 use datafusion_datasource::source::{DataSource, DataSourceExec};
 use datafusion_datasource::{PartitionedFile, TableSchema};
 use datafusion_expr::{Expr, LogicalPlan, UserDefinedLogicalNode};
+use datafusion_physical_expr::aggregate::AggregateExprBuilder;
 use datafusion_physical_expr::projection::{ProjectionExpr, ProjectionExprs};
 use datafusion_physical_expr::{Partitioning, create_physical_sort_exprs};
 use sail_cache::remote_checkpoint::RemoteCheckpointRegistry;
@@ -50,6 +51,8 @@ use sail_logical_plan::remote_checkpoint::{
 };
 use sail_logical_plan::repartition::{ExplicitRepartitionKind, ExplicitRepartitionNode};
 use sail_logical_plan::schema_pivot::SchemaPivotNode;
+use sail_logical_plan::session_aggregate::SessionAggregateNode;
+use sail_logical_plan::session_window::SessionWindowNode;
 use sail_logical_plan::show_string::ShowStringNode;
 use sail_logical_plan::sort::{RequiredSortNode, SortWithinPartitionsNode};
 use sail_logical_plan::spark_partition_id::SparkPartitionIdNode;
@@ -69,6 +72,8 @@ use sail_physical_plan::remote_checkpoint::{
 };
 use sail_physical_plan::repartition::ExplicitRepartitionExec;
 use sail_physical_plan::schema_pivot::SchemaPivotExec;
+use sail_physical_plan::session_aggregate::SessionAggregateExec;
+use sail_physical_plan::session_window::SessionWindowExec;
 use sail_physical_plan::show_string::ShowStringExec;
 use sail_physical_plan::spark_partition_id::SparkPartitionIdExec;
 use sail_physical_plan::streaming::collector::StreamCollectorExec;
@@ -404,6 +409,82 @@ impl ExtensionPlanner for ExtensionPhysicalPlanner {
             Arc::new(SparkPartitionIdExec::try_new(
                 input.clone(),
                 node.column_name().to_string(),
+                UserDefinedLogicalNode::schema(node).inner().clone(),
+            )?)
+        } else if let Some(node) = node.as_any().downcast_ref::<SessionWindowNode>() {
+            let [input] = physical_inputs else {
+                return internal_err!("SessionWindowExec requires exactly one physical input");
+            };
+            Arc::new(SessionWindowExec::try_new(
+                input.clone(),
+                node.partition_columns().to_vec(),
+                node.time_column().to_string(),
+                node.end_column().to_string(),
+                node.output_column().to_string(),
+                UserDefinedLogicalNode::schema(node).inner().clone(),
+            )?)
+        } else if let Some(node) = node.as_any().downcast_ref::<SessionAggregateNode>() {
+            let [input] = physical_inputs else {
+                return internal_err!("SessionAggregateExec requires exactly one physical input");
+            };
+            // Convert the logical aggregate expressions to physical ones, naming each
+            // after its output field (the fields after the group columns).
+            let input_dfschema = node.input().schema().as_ref();
+            let input_schema = input.schema();
+            let out_fields = UserDefinedLogicalNode::schema(node)
+                .inner()
+                .fields()
+                .clone();
+            let mut aggregates = Vec::with_capacity(node.aggregate_exprs().len());
+            let mut filters = Vec::with_capacity(node.aggregate_exprs().len());
+            for (expr, out_field) in node
+                .aggregate_exprs()
+                .iter()
+                .zip(out_fields.iter().skip(node.group_columns().len()))
+            {
+                let inner = match expr {
+                    Expr::Alias(alias) => alias.expr.as_ref(),
+                    other => other,
+                };
+                let Expr::AggregateFunction(af) = inner else {
+                    return internal_err!("SessionAggregate expected an aggregate function");
+                };
+                let args = af
+                    .params
+                    .args
+                    .iter()
+                    .map(|a| planner.create_physical_expr(a, input_dfschema, session_state))
+                    .collect::<datafusion_common::Result<Vec<_>>>()?;
+                // `FILTER (WHERE ...)` lives in `params.filter`, not in
+                // `AggregateFunctionExpr`; carry it alongside so the operator can
+                // apply the per-row mask (DataFusion's `AggregateExec` does the
+                // same). The fuse chooser only fuses aggregates without ORDER BY.
+                let filter = af
+                    .params
+                    .filter
+                    .as_ref()
+                    .map(|f| planner.create_physical_expr(f, input_dfschema, session_state))
+                    .transpose()?;
+                let ignore_nulls = af.params.null_treatment
+                    == Some(datafusion_expr::expr::NullTreatment::IgnoreNulls);
+                let agg = AggregateExprBuilder::new(af.func.clone(), args)
+                    .schema(input_schema.clone())
+                    .alias(out_field.name().clone())
+                    .with_ignore_nulls(ignore_nulls)
+                    .with_distinct(af.params.distinct)
+                    .build()?;
+                aggregates.push(Arc::new(agg));
+                filters.push(filter);
+            }
+            Arc::new(SessionAggregateExec::try_new(
+                input.clone(),
+                node.partition_columns().to_vec(),
+                node.time_column().to_string(),
+                node.end_column().to_string(),
+                node.group_columns().to_vec(),
+                node.session_output().to_string(),
+                aggregates,
+                filters,
                 UserDefinedLogicalNode::schema(node).inner().clone(),
             )?)
         } else if let Some(node) = node.as_any().downcast_ref::<SortWithinPartitionsNode>() {
@@ -1085,5 +1166,76 @@ mod tests {
         .unwrap();
 
         assert!(matches!(partitioning, Partitioning::UnknownPartitioning(2)));
+    }
+
+    /// The local planner must map `IGNORE NULLS` onto the physical aggregate,
+    /// mirroring the distributed codec's decode path.
+    #[tokio::test]
+    async fn session_aggregate_preserves_ignore_nulls() -> datafusion_common::Result<()> {
+        use datafusion::arrow::datatypes::{Fields, TimeUnit};
+        use datafusion::functions_aggregate::first_last::first_value_udaf;
+        use datafusion_expr::expr::{AggregateFunction, NullTreatment};
+        use datafusion_expr::{Expr, LogicalPlan};
+
+        let ts = DataType::Timestamp(TimeUnit::Microsecond, None);
+        let input_schema = Arc::new(Schema::new(vec![
+            Field::new("#t", ts.clone(), false),
+            Field::new("#e", ts.clone(), false),
+            Field::new("v", DataType::Int64, true),
+        ]));
+        let input = LogicalPlan::EmptyRelation(datafusion_expr::EmptyRelation {
+            produce_one_row: false,
+            schema: input_schema.to_dfschema_ref()?,
+        });
+        let struct_type = DataType::Struct(Fields::from(vec![
+            Field::new("start", ts.clone(), true),
+            Field::new("end", ts, true),
+        ]));
+        let output_schema = Arc::new(Schema::new(vec![
+            Field::new("session", struct_type, false),
+            Field::new("fv", DataType::Int64, true),
+        ]))
+        .to_dfschema_ref()?;
+        let agg = Expr::AggregateFunction(AggregateFunction::new_udf(
+            first_value_udaf(),
+            vec![col("v")],
+            false,
+            None,
+            vec![],
+            Some(NullTreatment::IgnoreNulls),
+        ))
+        .alias("fv");
+        let node = SessionAggregateNode::new(
+            Arc::new(input),
+            vec![],
+            "#t".to_string(),
+            "#e".to_string(),
+            "session".to_string(),
+            vec!["session".to_string()],
+            vec![agg],
+            output_schema,
+        );
+        let logical = LogicalPlan::Extension(datafusion_expr::Extension {
+            node: Arc::new(node),
+        });
+        let state = SessionStateBuilder::new()
+            .with_default_features()
+            .with_query_planner(new_query_planner())
+            .build();
+        let context = SessionContext::new_with_state(state);
+        let state = context.state();
+        let physical = state
+            .query_planner()
+            .create_physical_plan(&logical, &state)
+            .await?;
+
+        fn find_ignore_nulls(plan: &Arc<dyn ExecutionPlan>) -> Option<bool> {
+            if let Some(exec) = plan.downcast_ref::<SessionAggregateExec>() {
+                return Some(exec.aggregates()[0].ignore_nulls());
+            }
+            plan.children().into_iter().find_map(find_ignore_nulls)
+        }
+        assert_eq!(find_ignore_nulls(&physical), Some(true));
+        Ok(())
     }
 }

--- a/crates/sail-session/src/planner.rs
+++ b/crates/sail-session/src/planner.rs
@@ -482,7 +482,7 @@ impl ExtensionPlanner for ExtensionPhysicalPlanner {
                 node.time_column().to_string(),
                 node.end_column().to_string(),
                 node.group_columns().to_vec(),
-                node.session_output().to_string(),
+                node.output_column().to_string(),
                 aggregates,
                 filters,
                 UserDefinedLogicalNode::schema(node).inner().clone(),

--- a/crates/sail-spark-connect/tests/gold_data/function/datetime.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/datetime.json
@@ -39,7 +39,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: session_window"
+        "success": "ok"
       }
     },
     {
@@ -82,7 +82,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: session_window"
+        "success": "ok"
       }
     },
     {

--- a/crates/sail-sql-analyzer/src/literal/interval.rs
+++ b/crates/sail-sql-analyzer/src/literal/interval.rs
@@ -505,6 +505,25 @@ pub struct CalendarInterval {
     pub microseconds: i64,
 }
 
+impl CalendarInterval {
+    /// Splits the microsecond bucket for nanosecond-based consumers: whole
+    /// days move into the day bucket ONLY when the microseconds do not fit
+    /// i64 nanoseconds — an interval beyond ~106751 days of sub-day units,
+    /// which Spark's microsecond-based `CalendarInterval` still represents.
+    /// Below that bound the calendar/absolute distinction is preserved
+    /// exactly; above it the sub-day remainder stays absolute.
+    pub fn days_and_nanoseconds(&self) -> Option<(i32, i64)> {
+        if let Some(nanoseconds) = self.microseconds.checked_mul(1_000) {
+            return Some((self.days, nanoseconds));
+        }
+        const MICROSECONDS_PER_DAY: i64 = 24 * 60 * 60 * 1_000_000;
+        let extra_days = i32::try_from(self.microseconds / MICROSECONDS_PER_DAY).ok()?;
+        let days = self.days.checked_add(extra_days)?;
+        let nanoseconds = (self.microseconds % MICROSECONDS_PER_DAY).checked_mul(1_000)?;
+        Some((days, nanoseconds))
+    }
+}
+
 pub fn parse_calendar_interval_string(s: &str) -> SqlResult<CalendarInterval> {
     if let Some(value) = parse_calendar_interval_string_fast(s) {
         return Ok(value);

--- a/crates/sail-sql-analyzer/src/literal/interval.rs
+++ b/crates/sail-sql-analyzer/src/literal/interval.rs
@@ -493,11 +493,8 @@ fn parse_unqualified_interval_string_full(s: &str, negated: bool) -> SqlResult<I
 
 /// A calendar interval with Spark `stringToInterval` bucketing: the unit the
 /// user wrote decides the bucket (year/month → `months`, week/day → `days`,
-/// sub-day units → `microseconds`), and nothing is rebucketed across the day
-/// boundary. This is the semantics `session_window`/`window` gaps need — a
-/// `'1 day'` gap spans a calendar day across a DST transition while a
-/// `'25 hours'` gap spans 25 absolute hours. The typed SQL literal paths keep
-/// the legacy [IntervalValue] shapes from [parse_unqualified_interval_string].
+/// sub-day units → `microseconds`); nothing is rebucketed across the day
+/// boundary, so a `'1 day'` gap stays calendar and `'25 hours'` stays absolute.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CalendarInterval {
     pub months: i32,
@@ -506,12 +503,10 @@ pub struct CalendarInterval {
 }
 
 impl CalendarInterval {
-    /// Splits the microsecond bucket for nanosecond-based consumers: whole
-    /// days move into the day bucket ONLY when the microseconds do not fit
-    /// i64 nanoseconds — an interval beyond ~106751 days of sub-day units,
-    /// which Spark's microsecond-based `CalendarInterval` still represents.
-    /// Below that bound the calendar/absolute distinction is preserved
-    /// exactly; above it the sub-day remainder stays absolute.
+    /// Splits whole days out of the microsecond bucket only when the
+    /// microseconds do not fit `i64` nanoseconds (Spark's microsecond-based
+    /// `CalendarInterval` still represents such values); below that bound the
+    /// calendar/absolute distinction is preserved exactly.
     pub fn days_and_nanoseconds(&self) -> Option<(i32, i64)> {
         if let Some(nanoseconds) = self.microseconds.checked_mul(1_000) {
             return Some((self.days, nanoseconds));
@@ -563,9 +558,12 @@ pub fn parse_calendar_interval_string(s: &str) -> SqlResult<CalendarInterval> {
     }
 }
 
-/// Per-unit bucketing over the same term scanner as the fast interval parser;
-/// declines (`None`) anything the scanner does not recognize.
-fn parse_calendar_interval_string_fast(s: &str) -> Option<CalendarInterval> {
+/// A scanned interval term: (negated, integer digits, fraction digits, unit).
+type IntervalTerm<'a> = (bool, &'a str, Option<&'a str>, Unit);
+
+/// Scans `[interval] (value unit)+` into terms; `None` when any word is not a
+/// simple signed value or unit (the caller then falls back to the full parser).
+fn scan_interval_terms(s: &str) -> Option<Vec<IntervalTerm<'_>>> {
     let mut words = s.split_ascii_whitespace().peekable();
     if words
         .peek()
@@ -573,17 +571,29 @@ fn parse_calendar_interval_string_fast(s: &str) -> Option<CalendarInterval> {
     {
         words.next();
     }
-    let mut months: i32 = 0;
-    let mut days: i32 = 0;
-    let mut delta = TimeDelta::zero();
-    let mut seen = false;
+    let mut terms = Vec::new();
     while let Some(value_word) = words.next() {
         let (neg, int_part, fraction) = parse_value_word(value_word)?;
         let unit = parse_unit_word(words.next()?)?;
         if fraction.is_some() && unit != Unit::Second {
             return None;
         }
-        seen = true;
+        terms.push((neg, int_part, fraction, unit));
+    }
+    Some(terms)
+}
+
+/// Per-unit bucketing over [scan_interval_terms]; declines (`None`) anything
+/// the scanner does not recognize.
+fn parse_calendar_interval_string_fast(s: &str) -> Option<CalendarInterval> {
+    let terms = scan_interval_terms(s)?;
+    if terms.is_empty() {
+        return None;
+    }
+    let mut months: i32 = 0;
+    let mut days: i32 = 0;
+    let mut delta = TimeDelta::zero();
+    for (neg, int_part, fraction, unit) in terms {
         use Unit::*;
         match unit {
             Year | Month => {
@@ -627,9 +637,6 @@ fn parse_calendar_interval_string_fast(s: &str) -> Option<CalendarInterval> {
                 delta = delta.checked_add(&part)?;
             }
         }
-    }
-    if !seen {
-        return None;
     }
     Some(CalendarInterval {
         months,
@@ -782,30 +789,12 @@ fn fraction_microseconds(fraction: Option<&str>) -> Option<i64> {
     }
 }
 
-/// Fast parser for the common `[interval] (value unit)+` strings, e.g.
-/// `5 minutes`, `-2 days`, `1.5 seconds`. Anything else (quoted values, `+`,
-/// qualifiers like `day to second`) returns `None` and the caller falls back
-/// to the full parser. Accepted strings reproduce [from_ast_signed_interval]
-/// exactly, quirks included: a single year/month term is year-month even when
-/// zero, single-term seconds are `i64` but multi-term `u32`, and overflow is
-/// declined so the full parser reports the error.
+/// Fast parser for the common `[interval] (value unit)+` strings. Anything
+/// else (quoted values, `+`, qualifiers like `day to second`) returns `None`
+/// and the caller falls back to the full parser; accepted strings reproduce
+/// [from_ast_signed_interval] exactly, quirks and overflow-decline included.
 fn parse_unqualified_interval_string_fast(s: &str, negated: bool) -> Option<IntervalValue> {
-    let mut words = s.split_ascii_whitespace().peekable();
-    if words
-        .peek()
-        .is_some_and(|w| w.eq_ignore_ascii_case("interval"))
-    {
-        words.next();
-    }
-    let mut terms: Vec<(bool, &str, Option<&str>, Unit)> = Vec::new();
-    while let Some(value_word) = words.next() {
-        let (neg, int_part, fraction) = parse_value_word(value_word)?;
-        let unit = parse_unit_word(words.next()?)?;
-        if fraction.is_some() && unit != Unit::Second {
-            return None;
-        }
-        terms.push((neg, int_part, fraction, unit));
-    }
+    let terms = scan_interval_terms(s)?;
 
     // A single term follows the standard-interval path for its units;
     // everything else accumulates as multi-unit.

--- a/crates/sail-sql-analyzer/src/literal/interval.rs
+++ b/crates/sail-sql-analyzer/src/literal/interval.rs
@@ -491,6 +491,207 @@ fn parse_unqualified_interval_string_full(s: &str, negated: bool) -> SqlResult<I
     from_ast_signed_interval(value)
 }
 
+/// A calendar interval with Spark `stringToInterval` bucketing: the unit the
+/// user wrote decides the bucket (year/month → `months`, week/day → `days`,
+/// sub-day units → `microseconds`), and nothing is rebucketed across the day
+/// boundary. This is the semantics `session_window`/`window` gaps need — a
+/// `'1 day'` gap spans a calendar day across a DST transition while a
+/// `'25 hours'` gap spans 25 absolute hours. The typed SQL literal paths keep
+/// the legacy [IntervalValue] shapes from [parse_unqualified_interval_string].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CalendarInterval {
+    pub months: i32,
+    pub days: i32,
+    pub microseconds: i64,
+}
+
+pub fn parse_calendar_interval_string(s: &str) -> SqlResult<CalendarInterval> {
+    if let Some(value) = parse_calendar_interval_string_fast(s) {
+        return Ok(value);
+    }
+    let IntervalLiteral {
+        interval: _,
+        value: interval,
+    } = parse_interval_literal(s)?;
+    match interval {
+        IntervalExpr::MultiUnit { head, tail } => {
+            from_ast_multi_unit_calendar(std::iter::once(head).chain(tail))
+        }
+        // Shapes Spark's `stringToInterval` does not accept (qualified forms
+        // like `'1 2:03:04' day to second`); keep accepting them with the
+        // legacy conversion, whose day-time part is absolute microseconds.
+        other => match from_ast_signed_interval(Signed::Positive(other))? {
+            IntervalValue::YearMonth { months } => Ok(CalendarInterval {
+                months,
+                days: 0,
+                microseconds: 0,
+            }),
+            IntervalValue::Microsecond { microseconds } => Ok(CalendarInterval {
+                months: 0,
+                days: 0,
+                microseconds,
+            }),
+            IntervalValue::MonthDayNanosecond {
+                months,
+                days,
+                nanoseconds,
+            } => Ok(CalendarInterval {
+                months,
+                days,
+                microseconds: nanoseconds / 1_000,
+            }),
+        },
+    }
+}
+
+/// Per-unit bucketing over the same term scanner as the fast interval parser;
+/// declines (`None`) anything the scanner does not recognize.
+fn parse_calendar_interval_string_fast(s: &str) -> Option<CalendarInterval> {
+    let mut words = s.split_ascii_whitespace().peekable();
+    if words
+        .peek()
+        .is_some_and(|w| w.eq_ignore_ascii_case("interval"))
+    {
+        words.next();
+    }
+    let mut months: i32 = 0;
+    let mut days: i32 = 0;
+    let mut delta = TimeDelta::zero();
+    let mut seen = false;
+    while let Some(value_word) = words.next() {
+        let (neg, int_part, fraction) = parse_value_word(value_word)?;
+        let unit = parse_unit_word(words.next()?)?;
+        if fraction.is_some() && unit != Unit::Second {
+            return None;
+        }
+        seen = true;
+        use Unit::*;
+        match unit {
+            Year | Month => {
+                let mut value: i32 = int_part.parse().ok()?;
+                if neg {
+                    value = value.checked_neg()?;
+                }
+                if matches!(unit, Year) {
+                    value = value.checked_mul(12)?;
+                }
+                months = months.checked_add(value)?;
+            }
+            Week | Day => {
+                let mut value: i32 = int_part.parse().ok()?;
+                if neg {
+                    value = value.checked_neg()?;
+                }
+                if matches!(unit, Week) {
+                    value = value.checked_mul(7)?;
+                }
+                days = days.checked_add(value)?;
+            }
+            Hour | Minute | Second | Millisecond | Microsecond => {
+                let mut value: i64 = int_part.parse().ok()?;
+                if neg {
+                    value = value.checked_neg()?;
+                }
+                let part = match unit {
+                    Hour => TimeDelta::try_hours(value)?,
+                    Minute => TimeDelta::try_minutes(value)?,
+                    Second => TimeDelta::try_seconds(value)?.checked_add(
+                        &TimeDelta::microseconds(if neg {
+                            fraction_microseconds(fraction)?.checked_neg()?
+                        } else {
+                            fraction_microseconds(fraction)?
+                        }),
+                    )?,
+                    Millisecond => TimeDelta::try_milliseconds(value)?,
+                    _ => TimeDelta::microseconds(value),
+                };
+                delta = delta.checked_add(&part)?;
+            }
+        }
+    }
+    if !seen {
+        return None;
+    }
+    Some(CalendarInterval {
+        months,
+        days,
+        microseconds: delta.num_microseconds()?,
+    })
+}
+
+/// AST-side counterpart of [parse_calendar_interval_string_fast] for strings
+/// the fast scanner declines.
+fn from_ast_multi_unit_calendar(
+    values: impl Iterator<Item = IntervalValueWithUnit>,
+) -> SqlResult<CalendarInterval> {
+    let error = || SqlError::invalid("multi-unit interval");
+    let mut months = 0i32;
+    let mut days = 0i32;
+    let mut delta = TimeDelta::zero();
+    for value in values {
+        let IntervalValueWithUnit { value, unit } = value;
+        match unit {
+            IntervalUnit::Year(_) | IntervalUnit::Years(_) => {
+                let value: i32 = parse_signed_value(value)?;
+                let m = value.checked_mul(12).ok_or_else(error)?;
+                months = months.checked_add(m).ok_or_else(error)?;
+            }
+            IntervalUnit::Month(_) | IntervalUnit::Months(_) => {
+                let value: i32 = parse_signed_value(value)?;
+                months = months.checked_add(value).ok_or_else(error)?;
+            }
+            IntervalUnit::Week(_) | IntervalUnit::Weeks(_) => {
+                let value: i32 = parse_signed_value(value)?;
+                let d = value.checked_mul(7).ok_or_else(error)?;
+                days = days.checked_add(d).ok_or_else(error)?;
+            }
+            IntervalUnit::Day(_) | IntervalUnit::Days(_) => {
+                let value: i32 = parse_signed_value(value)?;
+                days = days.checked_add(value).ok_or_else(error)?;
+            }
+            IntervalUnit::Hour(_) | IntervalUnit::Hours(_) => {
+                let value: i64 = parse_signed_value(value)?;
+                let hours = TimeDelta::try_hours(value).ok_or_else(error)?;
+                delta = delta.checked_add(&hours).ok_or_else(error)?;
+            }
+            IntervalUnit::Minute(_) | IntervalUnit::Minutes(_) => {
+                let value: i64 = parse_signed_value(value)?;
+                let minutes = TimeDelta::try_minutes(value).ok_or_else(error)?;
+                delta = delta.checked_add(&minutes).ok_or_else(error)?;
+            }
+            IntervalUnit::Second(_) | IntervalUnit::Seconds(_) => {
+                let value: Signed<DecimalSecond> = parse_signed_value(value)?;
+                let negated = value.is_negative();
+                let value = value.into_inner();
+                let seconds = TimeDelta::seconds(value.seconds as i64);
+                let microseconds = TimeDelta::microseconds(value.microseconds as i64);
+                if negated {
+                    delta = delta.checked_sub(&seconds).ok_or_else(error)?;
+                    delta = delta.checked_sub(&microseconds).ok_or_else(error)?;
+                } else {
+                    delta = delta.checked_add(&seconds).ok_or_else(error)?;
+                    delta = delta.checked_add(&microseconds).ok_or_else(error)?;
+                }
+            }
+            IntervalUnit::Millisecond(_) | IntervalUnit::Milliseconds(_) => {
+                let value: i64 = parse_signed_value(value)?;
+                let milliseconds = TimeDelta::try_milliseconds(value).ok_or_else(error)?;
+                delta = delta.checked_add(&milliseconds).ok_or_else(error)?;
+            }
+            IntervalUnit::Microsecond(_) | IntervalUnit::Microseconds(_) => {
+                let value: i64 = parse_signed_value(value)?;
+                let microseconds = TimeDelta::microseconds(value);
+                delta = delta.checked_add(&microseconds).ok_or_else(error)?;
+            }
+        }
+    }
+    Ok(CalendarInterval {
+        months,
+        days,
+        microseconds: delta.num_microseconds().ok_or_else(error)?,
+    })
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Unit {
     Year,
@@ -860,6 +1061,46 @@ mod tests {
             parse_unqualified_interval_string("1 hour 2 seconds", false)?,
             parse_unqualified_interval_string("-1 hour -2 seconds", true)?
         );
+        Ok(())
+    }
+
+    /// Spark `stringToInterval` bucketing: the unit written decides the
+    /// bucket; sub-day amounts are never rebucketed into days (and days never
+    /// collapse into microseconds).
+    #[test]
+    fn test_calendar_interval_bucketing() -> SqlResult<()> {
+        const HOUR: i64 = 3_600_000_000;
+        for (s, months, days, micros) in [
+            ("1 day", 0, 1, 0),
+            ("interval 1 day", 0, 1, 0),
+            ("25 hours", 0, 0, 25 * HOUR),
+            ("1 day 2 hours", 0, 1, 2 * HOUR),
+            ("2 weeks", 0, 14, 0),
+            ("-2 days", 0, -2, 0),
+            ("1 month -30 days", 1, -30, 0),
+            ("1 month 25 hours", 1, 0, 25 * HOUR),
+            ("1.5 seconds", 0, 0, 1_500_000),
+            ("-1.5 seconds", 0, 0, -1_500_000),
+            ("1 year 1 microsecond", 12, 0, 1),
+        ] {
+            let v = parse_calendar_interval_string(s)?;
+            assert_eq!(
+                (v.months, v.days, v.microseconds),
+                (months, days, micros),
+                "{s}"
+            );
+        }
+        assert!(parse_calendar_interval_string("garbage").is_err());
+        Ok(())
+    }
+
+    /// The fast scanner and the AST fallback agree; exercise the fallback via
+    /// a quoted value the scanner declines.
+    #[test]
+    fn test_calendar_interval_fallback_matches_fast() -> SqlResult<()> {
+        let fast = parse_calendar_interval_string("1 day 2 hours")?;
+        let full = parse_calendar_interval_string("'1' day '2' hours")?;
+        assert_eq!(fast, full);
         Ok(())
     }
 }

--- a/crates/sail-sql-analyzer/src/literal/interval.rs
+++ b/crates/sail-sql-analyzer/src/literal/interval.rs
@@ -469,6 +469,16 @@ pub(crate) fn parse_unqualified_interval_string(
     s: &str,
     negated: bool,
 ) -> SqlResult<IntervalValue> {
+    // The full parser rebuilds its combinator graph on every call — too costly
+    // for per-row use. Common strings take the fast path; everything else falls
+    // through, so accepted syntax and errors are unchanged.
+    if let Some(value) = parse_unqualified_interval_string_fast(s, negated) {
+        return Ok(value);
+    }
+    parse_unqualified_interval_string_full(s, negated)
+}
+
+fn parse_unqualified_interval_string_full(s: &str, negated: bool) -> SqlResult<IntervalValue> {
     let IntervalLiteral {
         interval: _,
         value: interval,
@@ -479,6 +489,216 @@ pub(crate) fn parse_unqualified_interval_string(
         Signed::Positive(interval)
     };
     from_ast_signed_interval(value)
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Unit {
+    Year,
+    Month,
+    Week,
+    Day,
+    Hour,
+    Minute,
+    Second,
+    Millisecond,
+    Microsecond,
+}
+
+fn parse_unit_word(word: &str) -> Option<Unit> {
+    use Unit::*;
+    for (names, unit) in [
+        (["year", "years"], Year),
+        (["month", "months"], Month),
+        (["week", "weeks"], Week),
+        (["day", "days"], Day),
+        (["hour", "hours"], Hour),
+        (["minute", "minutes"], Minute),
+        (["second", "seconds"], Second),
+        (["millisecond", "milliseconds"], Millisecond),
+        (["microsecond", "microseconds"], Microsecond),
+    ] {
+        if names.iter().any(|n| word.eq_ignore_ascii_case(n)) {
+            return Some(unit);
+        }
+    }
+    None
+}
+
+/// Splits a value word into (negated, integer digits, fraction digits).
+/// Accepts only `-?digits(.digits)?`; anything else (`+`, a detached sign, a
+/// trailing dot) is declined so the full parser decides.
+fn parse_value_word(word: &str) -> Option<(bool, &str, Option<&str>)> {
+    let (negated, rest) = match word.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, word),
+    };
+    let (int_part, fraction) = match rest.split_once('.') {
+        Some((i, f)) => (i, Some(f)),
+        None => (rest, None),
+    };
+    if int_part.is_empty() || !int_part.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    if let Some(f) = fraction
+        && (f.is_empty() || !f.bytes().all(|b| b.is_ascii_digit()))
+    {
+        return None;
+    }
+    Some((negated, int_part, fraction))
+}
+
+/// Converts fraction digits of a second to microseconds the same way
+/// [extract_fraction_match] does: pad with zeros to 6 digits, ignore the rest.
+fn fraction_microseconds(fraction: Option<&str>) -> Option<i64> {
+    match fraction {
+        None => Some(0),
+        Some(f) => f
+            .chars()
+            .chain(std::iter::repeat('0'))
+            .take(6)
+            .collect::<String>()
+            .parse::<i64>()
+            .ok(),
+    }
+}
+
+/// Fast parser for the common `[interval] (value unit)+` strings, e.g.
+/// `5 minutes`, `-2 days`, `1.5 seconds`. Anything else (quoted values, `+`,
+/// qualifiers like `day to second`) returns `None` and the caller falls back
+/// to the full parser. Accepted strings reproduce [from_ast_signed_interval]
+/// exactly, quirks included: a single year/month term is year-month even when
+/// zero, single-term seconds are `i64` but multi-term `u32`, and overflow is
+/// declined so the full parser reports the error.
+fn parse_unqualified_interval_string_fast(s: &str, negated: bool) -> Option<IntervalValue> {
+    let mut words = s.split_ascii_whitespace().peekable();
+    if words
+        .peek()
+        .is_some_and(|w| w.eq_ignore_ascii_case("interval"))
+    {
+        words.next();
+    }
+    let mut terms: Vec<(bool, &str, Option<&str>, Unit)> = Vec::new();
+    while let Some(value_word) = words.next() {
+        let (neg, int_part, fraction) = parse_value_word(value_word)?;
+        let unit = parse_unit_word(words.next()?)?;
+        if fraction.is_some() && unit != Unit::Second {
+            return None;
+        }
+        terms.push((neg, int_part, fraction, unit));
+    }
+
+    // A single term follows the standard-interval path for its units;
+    // everything else accumulates as multi-unit.
+    if let [(neg, int_part, fraction, unit)] = terms[..] {
+        use Unit::*;
+        let negated = neg ^ negated;
+        match unit {
+            Year | Month => {
+                let value: i32 = int_part.parse().ok()?;
+                let mut months = match unit {
+                    Year => value.checked_mul(12)?,
+                    _ => value,
+                };
+                if negated {
+                    months = months.checked_neg()?;
+                }
+                return Some(IntervalValue::YearMonth { months });
+            }
+            Day | Hour | Minute | Second => {
+                let value: i64 = int_part.parse().ok()?;
+                let delta = match unit {
+                    Day => TimeDelta::try_days(value)?,
+                    Hour => TimeDelta::try_hours(value)?,
+                    Minute => TimeDelta::try_minutes(value)?,
+                    _ => TimeDelta::try_seconds(value)?
+                        .checked_add(&TimeDelta::microseconds(fraction_microseconds(fraction)?))?,
+                };
+                let mut microseconds = delta.num_microseconds()?;
+                if negated {
+                    microseconds = microseconds.checked_neg()?;
+                }
+                return Some(IntervalValue::Microsecond { microseconds });
+            }
+            Week | Millisecond | Microsecond => {}
+        }
+    } else if terms.is_empty() {
+        return None;
+    }
+
+    let mut months: i32 = 0;
+    let mut delta = TimeDelta::zero();
+    for (neg, int_part, fraction, unit) in &terms {
+        use Unit::*;
+        match unit {
+            Year | Month => {
+                let mut value: i32 = int_part.parse().ok()?;
+                if *neg {
+                    value = value.checked_neg()?;
+                }
+                if matches!(unit, Year) {
+                    value = value.checked_mul(12)?;
+                }
+                months = months.checked_add(value)?;
+            }
+            Second => {
+                // Multi-unit seconds are `u32` (`DecimalSecond`).
+                let seconds: u32 = int_part.parse().ok()?;
+                let seconds = TimeDelta::seconds(seconds as i64);
+                let microseconds = TimeDelta::microseconds(fraction_microseconds(*fraction)?);
+                if *neg {
+                    delta = delta.checked_sub(&seconds)?.checked_sub(&microseconds)?;
+                } else {
+                    delta = delta.checked_add(&seconds)?.checked_add(&microseconds)?;
+                }
+            }
+            _ => {
+                let mut value: i64 = int_part.parse().ok()?;
+                if *neg {
+                    value = value.checked_neg()?;
+                }
+                let part = match unit {
+                    Week => TimeDelta::try_weeks(value)?,
+                    Day => TimeDelta::try_days(value)?,
+                    Hour => TimeDelta::try_hours(value)?,
+                    Minute => TimeDelta::try_minutes(value)?,
+                    Millisecond => TimeDelta::try_milliseconds(value)?,
+                    _ => TimeDelta::microseconds(value),
+                };
+                delta = delta.checked_add(&part)?;
+            }
+        }
+    }
+    match (months != 0, delta != TimeDelta::zero()) {
+        (true, false) => {
+            if negated {
+                months = months.checked_neg()?;
+            }
+            Some(IntervalValue::YearMonth { months })
+        }
+        (true, true) => {
+            let mut days = delta.num_days();
+            let remainder = delta - chrono::Duration::days(days);
+            let mut microseconds = remainder.num_microseconds()?;
+            if negated {
+                months = months.checked_neg()?;
+                days = days.checked_neg()?;
+                microseconds = microseconds.checked_neg()?;
+            }
+            let days = i32::try_from(days).ok()?;
+            Some(IntervalValue::MonthDayNanosecond {
+                months,
+                days,
+                nanoseconds: microseconds * 1_000,
+            })
+        }
+        (false, _) => {
+            let mut microseconds = delta.num_microseconds()?;
+            if negated {
+                microseconds = microseconds.checked_neg()?;
+            }
+            Some(IntervalValue::Microsecond { microseconds })
+        }
+    }
 }
 
 #[cfg(test)]
@@ -554,6 +774,78 @@ mod tests {
             )?
         );
         Ok(())
+    }
+
+    #[test]
+    fn test_fast_path_matches_full_parser() {
+        // Fast-path values must equal the full parser's; declined strings
+        // reach the full parser anyway. The list covers accepted shapes plus
+        // ones that must decline (quotes, `+`, qualifiers, junk, overflow).
+        let cases = [
+            "5 minutes",
+            "2 minutes",
+            "1 second",
+            "1.5 seconds",
+            "-1.5 seconds",
+            "1. seconds",
+            "0.000001 seconds",
+            "1.1234567 seconds",
+            "1 month",
+            "0 month",
+            "-0 month",
+            "0 year",
+            "3 years",
+            "0 day",
+            "0 seconds",
+            "1 week",
+            "-2 weeks",
+            "10 milliseconds",
+            "7 microseconds",
+            "1 month 2 days",
+            "1 hour 2 seconds",
+            "-1 hour -2 seconds",
+            "1 year 2 months 3 days 4 hours 5 minutes 6.789 seconds",
+            "1 day -2 hours",
+            "interval 5 minutes",
+            "INTERVAL 3 HOURS",
+            "  5   MINUTES  ",
+            "007 days",
+            "2147483647 months",
+            "-2147483648 month",
+            "178956970 year 7 month",
+            "178956970 year 8 month",
+            "106751991 day 14454775807 microsecond",
+            "106751991 day 14454775808 microsecond",
+            "5000000000 seconds",
+            "1 day 5000000000 seconds",
+            "'5' minutes",
+            "+5 minutes",
+            "- 5 minutes",
+            "'1 1' day to hour",
+            "'178956970-7' year to month",
+            "5",
+            "minutes",
+            "5 fortnights",
+            "1e3 days",
+            "",
+        ];
+        for s in cases {
+            for negated in [false, true] {
+                let full = parse_unqualified_interval_string_full(s, negated);
+                if let Some(fast) = parse_unqualified_interval_string_fast(s, negated) {
+                    assert!(
+                        full.is_ok(),
+                        "fast path accepts {s:?} (negated={negated}) but the full parser errors: {full:?}"
+                    );
+                    if let Ok(full) = full {
+                        assert_eq!(
+                            fast, full,
+                            "fast path diverges for {s:?} (negated={negated})"
+                        );
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/python/pysail/tests/spark/function/features/session_window.feature
+++ b/python/pysail/tests/spark/function/features/session_window.feature
@@ -317,6 +317,22 @@ Feature: session_window() gap-based sessionization
         | 2021-01-01 00:00:00 | 2021-01-01 00:00:00 | 2   |
         | 2021-01-02 00:00:00 | 2021-01-01 00:00:00 | 1   |
 
+  Rule: Invalid dynamic gap values
+
+    Scenario: an invalid gap string in a column drops the row, not the query
+      When query
+        """
+        SELECT session_window.start, session_window.end, count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00', '5 minutes'),
+                    (TIMESTAMP '2021-01-01 00:00:10', 'garbage'),
+                    (TIMESTAMP '2021-01-01 00:04:30', '5 minutes') AS t(b, g)
+        GROUP BY session_window(b, g)
+        ORDER BY start
+        """
+      Then query result
+        | start               | end                 | cnt |
+        | 2021-01-01 00:00:00 | 2021-01-01 00:09:30 | 2   |
+
   Rule: Aggregates
 
     # Spark evaluates the marker inside an aggregate argument with per-row

--- a/python/pysail/tests/spark/function/features/session_window.feature
+++ b/python/pysail/tests/spark/function/features/session_window.feature
@@ -266,6 +266,38 @@ Feature: session_window() gap-based sessionization
         | X | 2021-01-01 00:00:00 | 2021-01-01 00:09:00 | 2   |
         | Y | 2021-01-01 00:02:00 | 2021-01-01 00:07:00 | 1   |
 
+    # Guards the two-pass ordinal resolution: the substituted literal must not
+    # be re-read as another ordinal position.
+    Scenario: an integer literal selected and grouped by ordinal
+      When query
+        """
+        SELECT 5, count(*) AS cnt FROM VALUES (1), (2) AS t(x) GROUP BY 1
+        """
+      Then query result
+        | 5 | cnt |
+        | 5 | 2   |
+
+    Scenario: duplicate identical session_window keys collapse
+      When query
+        """
+        SELECT session_window.start, count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00'),
+                    (TIMESTAMP '2021-01-01 00:04:30') AS t(b)
+        GROUP BY session_window(b, '5 minutes'), session_window(b, '5 minutes')
+        """
+      Then query result
+        | start               | cnt |
+        | 2021-01-01 00:00:00 | 2   |
+
+    Scenario: an aggregate over the session struct in HAVING is rejected
+      When query
+        """
+        SELECT count(*) FROM VALUES (TIMESTAMP '2021-01-01 00:00:00') AS t(b)
+        GROUP BY session_window(b, '5 minutes')
+        HAVING max(session_window(b, '5 minutes').start) > TIMESTAMP '2020-01-01 00:00:00'
+        """
+      Then query error .*(session_window inside an aggregate function|MISSING_ATTRIBUTES).*
+
     Scenario: session_window grouped by its SELECT-list alias
       When query
         """
@@ -340,6 +372,37 @@ Feature: session_window() gap-based sessionization
         | 2021-01-01 00:00:00 | 2021-01-01 00:00:00 | 2   |
         | 2021-01-02 00:00:00 | 2021-01-01 00:00:00 | 1   |
 
+  Rule: Gap literal edge cases
+
+    Scenario: an invalid literal gap yields an empty result, not an error
+      When query
+        """
+        SELECT session_window.start, count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00') AS t(b)
+        GROUP BY session_window(b, 'garbage')
+        """
+      Then query result
+        | start | cnt |
+
+    Scenario: an integer gap is rejected
+      When query
+        """
+        SELECT count(*) FROM VALUES (TIMESTAMP '2021-01-01 00:00:00') AS t(b)
+        GROUP BY session_window(b, 300)
+        """
+      Then query error .*ap duration expression used in session window must be.*
+
+    Scenario: a gap too large for nanoseconds still works via whole days
+      When query
+        """
+        SELECT session_window.start, session_window.end, count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00') AS t(b)
+        GROUP BY session_window(b, '3000000 hours')
+        """
+      Then query result
+        | start               | end                 | cnt |
+        | 2021-01-01 00:00:00 | 2363-03-30 00:00:00 | 1   |
+
   Rule: Invalid dynamic gap values
 
     Scenario: an invalid gap string in a column drops the row, not the query
@@ -373,6 +436,23 @@ Feature: session_window() gap-based sessionization
         ORDER BY m
         """
       Then query error .*session_window inside an aggregate function.*
+
+    # The fused node is an extension, not LogicalPlan::Aggregate; ORDER BY on
+    # a bare aggregate must still rebase onto its output.
+    Scenario: ORDER BY a bare aggregate over the fused path
+      When query
+        """
+        SELECT session_window.start, count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00'),
+                    (TIMESTAMP '2021-01-01 00:04:30'),
+                    (TIMESTAMP '2021-01-01 00:20:00') AS t(b)
+        GROUP BY session_window(b, '5 minutes')
+        ORDER BY count(*) DESC
+        """
+      Then query result
+        | start               | cnt |
+        | 2021-01-01 00:00:00 | 2   |
+        | 2021-01-01 00:20:00 | 1   |
 
     Scenario: multiple aggregates are computed per session (fused path)
       When query

--- a/python/pysail/tests/spark/function/features/session_window.feature
+++ b/python/pysail/tests/spark/function/features/session_window.feature
@@ -1,0 +1,362 @@
+Feature: session_window() gap-based sessionization
+
+  # Sessions merge consecutive rows (per group, ordered by time) while the next
+  # row starts at or before the current session's end (max of merged time + gap).
+
+  Rule: Static gap
+
+    Scenario: a 5-minute gap merges rows per key into sessions
+      When query
+        """
+        SELECT a, session_window.start, session_window.end, count(*) AS cnt
+        FROM VALUES ('A1', TIMESTAMP '2021-01-01 00:00:00'),
+                    ('A1', TIMESTAMP '2021-01-01 00:04:30'),
+                    ('A1', TIMESTAMP '2021-01-01 00:10:00'),
+                    ('A2', TIMESTAMP '2021-01-01 00:01:00') AS tab(a, b)
+        GROUP BY a, session_window(b, '5 minutes')
+        ORDER BY a, start
+        """
+      Then query result
+        | a  | start               | end                 | cnt |
+        | A1 | 2021-01-01 00:00:00 | 2021-01-01 00:09:30 | 2   |
+        | A1 | 2021-01-01 00:10:00 | 2021-01-01 00:15:00 | 1   |
+        | A2 | 2021-01-01 00:01:00 | 2021-01-01 00:06:00 | 1   |
+
+    Scenario: a row landing exactly on the session end merges (not a new session)
+      When query
+        """
+        SELECT session_window.start, session_window.end, count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00'),
+                    (TIMESTAMP '2021-01-01 00:05:00'),
+                    (TIMESTAMP '2021-01-01 00:10:00') AS t(b)
+        GROUP BY session_window(b, '5 minutes')
+        ORDER BY start
+        """
+      # Rows exactly on the running session end merge (start <= end), not split.
+      Then query result
+        | start               | end                 | cnt |
+        | 2021-01-01 00:00:00 | 2021-01-01 00:15:00 | 3   |
+
+  Rule: Dynamic gap
+
+    Scenario: a per-row CASE gap is applied independently per key
+      When query
+        """
+        SELECT a, session_window.start, session_window.end, count(*) AS cnt
+        FROM VALUES ('A1', TIMESTAMP '2021-01-01 00:00:00'),
+                    ('A1', TIMESTAMP '2021-01-01 00:04:30'),
+                    ('A1', TIMESTAMP '2021-01-01 00:10:00'),
+                    ('A2', TIMESTAMP '2021-01-01 00:01:00'),
+                    ('A2', TIMESTAMP '2021-01-01 00:04:30') AS tab(a, b)
+        GROUP BY a, session_window(b, CASE WHEN a = 'A1' THEN '5 minutes'
+                                           WHEN a = 'A2' THEN '1 minute'
+                                           ELSE '10 minutes' END)
+        ORDER BY a, start
+        """
+      Then query result
+        | a  | start               | end                 | cnt |
+        | A1 | 2021-01-01 00:00:00 | 2021-01-01 00:09:30 | 2   |
+        | A1 | 2021-01-01 00:10:00 | 2021-01-01 00:15:00 | 1   |
+        | A2 | 2021-01-01 00:01:00 | 2021-01-01 00:02:00 | 1   |
+        | A2 | 2021-01-01 00:04:30 | 2021-01-01 00:05:30 | 1   |
+
+  Rule: Month-bearing gap
+
+    # A month-bearing string gap is valid and uses per-row calendar arithmetic:
+    # Jan 31 + 1 month = Feb 28 (day clamped to month end).
+    Scenario: a month string gap uses calendar arithmetic and merges across months
+      When query
+        """
+        SELECT session_window.start, session_window.end, count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-31 00:00:00'),
+                    (TIMESTAMP '2021-02-27 00:00:00') AS t(b)
+        GROUP BY session_window(b, '1 month')
+        ORDER BY start
+        """
+      Then query result
+        | start               | end                 | cnt |
+        | 2021-01-31 00:00:00 | 2021-03-27 00:00:00 | 2   |
+
+    # Spark rejects a year-month *typed* interval gap; only strings and calendar
+    # intervals pass.
+    Scenario: a year-month typed interval gap is rejected
+      When query
+        """
+        SELECT count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00') AS t(b)
+        GROUP BY session_window(b, INTERVAL '1' MONTH)
+        """
+      Then query error .*ap duration expression used in session window must be.*
+
+  Rule: Interval literal gap
+
+    # Spark 4.2 rejects a day-time *typed* interval gap; Sail deliberately
+    # accepts it as unambiguous.
+    @sail-only
+    Scenario: a day-time interval literal is used as the gap (no other group keys)
+      When query
+        """
+        SELECT session_window.start, session_window.end, count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00'),
+                    (TIMESTAMP '2021-01-01 00:04:30'),
+                    (TIMESTAMP '2021-01-01 00:10:00') AS t(b)
+        GROUP BY session_window(b, INTERVAL '5' MINUTE)
+        ORDER BY start
+        """
+      Then query result
+        | start               | end                 | cnt |
+        | 2021-01-01 00:00:00 | 2021-01-01 00:09:30 | 2   |
+        | 2021-01-01 00:10:00 | 2021-01-01 00:15:00 | 1   |
+
+  Rule: Null time values
+
+    Scenario: rows with a null time value are dropped
+      When query
+        """
+        SELECT a, session_window.start, count(*) AS cnt
+        FROM VALUES ('A', TIMESTAMP '2021-01-01 00:00:00'),
+                    ('A', CAST(NULL AS TIMESTAMP)) AS tab(a, b)
+        GROUP BY a, session_window(b, '5 minutes')
+        ORDER BY start
+        """
+      Then query result
+        | a | start               | cnt |
+        | A | 2021-01-01 00:00:00 | 1   |
+
+  Rule: Non-positive gap
+
+    # A non-positive gap is not an analysis error: the `end > start` filter
+    # drops every row.
+    Scenario: a static gap of zero yields an empty result, not an error
+      When query
+        """
+        SELECT session_window.start, count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00') AS t(b)
+        GROUP BY session_window(b, '0 seconds')
+        """
+      Then query result
+        | start | cnt |
+
+    Scenario: a static negative gap yields an empty result, not an error
+      When query
+        """
+        SELECT session_window.start, count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00') AS t(b)
+        GROUP BY session_window(b, '-5 seconds')
+        """
+      Then query result
+        | start | cnt |
+
+    Scenario: a dynamic gap of zero drops only that key's rows
+      When query
+        """
+        SELECT a, session_window.start, count(*) AS cnt
+        FROM VALUES ('A1', TIMESTAMP '2021-01-01 00:00:00'),
+                    ('A2', TIMESTAMP '2021-01-01 00:01:00'),
+                    ('A2', TIMESTAMP '2021-01-01 00:02:00') AS tab(a, b)
+        GROUP BY a, session_window(b, CASE WHEN a = 'A1' THEN '5 minutes'
+                                           ELSE '0 seconds' END)
+        ORDER BY start
+        """
+      Then query result
+        | a  | start               | cnt |
+        | A1 | 2021-01-01 00:00:00 | 1   |
+
+  Rule: Unsorted input
+
+    Scenario: rows out of time order are sessionized after sorting
+      When query
+        """
+        SELECT session_window.start, session_window.end, count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-01 00:10:00'),
+                    (TIMESTAMP '2021-01-01 00:00:00'),
+                    (TIMESTAMP '2021-01-01 00:04:30') AS t(b)
+        GROUP BY session_window(b, '5 minutes')
+        ORDER BY start
+        """
+      Then query result
+        | start               | end                 | cnt |
+        | 2021-01-01 00:00:00 | 2021-01-01 00:09:30 | 2   |
+        | 2021-01-01 00:10:00 | 2021-01-01 00:15:00 | 1   |
+
+  Rule: Whole struct selection
+
+    Scenario: the session_window column is a struct of start/end timestamps
+      When query
+        """
+        SELECT session_window(b, '5 minutes') AS w
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00') AS t(b)
+        GROUP BY session_window(b, '5 minutes')
+        """
+      Then query schema
+        """
+        root
+         |-- w: struct (nullable = false)
+         |    |-- start: timestamp (nullable = true)
+         |    |-- end: timestamp (nullable = true)
+        """
+
+  Rule: Re-using the session window in SELECT and HAVING
+
+    Scenario: session_window re-used in SELECT resolves to the grouping column, and HAVING filters sessions
+      When query
+        """
+        SELECT session_window(b, '5 minutes').start AS s, count(*) AS cnt
+        FROM VALUES ('A1', TIMESTAMP '2021-01-01 00:00:00'),
+                    ('A1', TIMESTAMP '2021-01-01 00:04:30'),
+                    ('A1', TIMESTAMP '2021-01-01 00:10:00'),
+                    ('A2', TIMESTAMP '2021-01-01 00:01:00') AS tab(a, b)
+        GROUP BY a, session_window(b, '5 minutes')
+        HAVING count(*) > 1
+        ORDER BY s
+        """
+      Then query result
+        | s                   | cnt |
+        | 2021-01-01 00:00:00 | 2   |
+
+  Rule: Expression grouping keys
+
+    Scenario: a non-column grouping key (upper) partitions sessions and resolves in SELECT
+      When query
+        """
+        SELECT upper(a) AS k, session_window.start, session_window.end, count(*) AS cnt
+        FROM VALUES ('a1', TIMESTAMP '2021-01-01 00:00:00'),
+                    ('a1', TIMESTAMP '2021-01-01 00:04:30'),
+                    ('A1', TIMESTAMP '2021-01-01 00:10:00') AS tab(a, b)
+        GROUP BY session_window(b, '5 minutes'), upper(a)
+        ORDER BY start
+        """
+      Then query result
+        | k  | start               | end                 | cnt |
+        | A1 | 2021-01-01 00:00:00 | 2021-01-01 00:09:30 | 2   |
+        | A1 | 2021-01-01 00:10:00 | 2021-01-01 00:15:00 | 1   |
+
+    Scenario: an arithmetic grouping key partitions sessions
+      When query
+        """
+        SELECT id + 1 AS k, session_window.start, count(*) AS cnt
+        FROM VALUES (10, TIMESTAMP '2021-01-01 00:00:00'),
+                    (10, TIMESTAMP '2021-01-01 00:01:00'),
+                    (20, TIMESTAMP '2021-01-01 00:00:00') AS tab(id, b)
+        GROUP BY session_window(b, '5 minutes'), id + 1
+        ORDER BY k, start
+        """
+      Then query result
+        | k  | start               | cnt |
+        | 11 | 2021-01-01 00:00:00 | 2   |
+        | 21 | 2021-01-01 00:00:00 | 1   |
+
+    Scenario: a cast grouping key partitions sessions
+      When query
+        """
+        SELECT CAST(id AS STRING) AS k, session_window.start, count(*) AS cnt
+        FROM VALUES (1, TIMESTAMP '2021-01-01 00:00:00'),
+                    (1, TIMESTAMP '2021-01-01 00:01:00'),
+                    (2, TIMESTAMP '2021-01-01 00:00:00') AS tab(id, b)
+        GROUP BY session_window(b, '5 minutes'), CAST(id AS STRING)
+        ORDER BY k, start
+        """
+      Then query result
+        | k | start               | cnt |
+        | 1 | 2021-01-01 00:00:00 | 2   |
+        | 2 | 2021-01-01 00:00:00 | 1   |
+
+    Scenario: a date_trunc grouping key over a second timestamp partitions sessions
+      When query
+        """
+        SELECT date_trunc('day', c) AS day, session_window.start AS s, count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-01 10:00:00', TIMESTAMP '2021-01-01 00:00:00'),
+                    (TIMESTAMP '2021-01-01 23:00:00', TIMESTAMP '2021-01-01 00:01:00'),
+                    (TIMESTAMP '2021-01-02 05:00:00', TIMESTAMP '2021-01-01 00:00:00') AS tab(c, b)
+        GROUP BY session_window(b, '5 minutes'), date_trunc('day', c)
+        ORDER BY day, s
+        """
+      Then query result
+        | day                 | s                   | cnt |
+        | 2021-01-01 00:00:00 | 2021-01-01 00:00:00 | 2   |
+        | 2021-01-02 00:00:00 | 2021-01-01 00:00:00 | 1   |
+
+  Rule: Aggregates
+
+    Scenario: multiple aggregates are computed per session (fused path)
+      When query
+        """
+        SELECT session_window.start, count(*) AS cnt, sum(v) AS s, min(v) AS mn, max(v) AS mx
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00', 10),
+                    (TIMESTAMP '2021-01-01 00:04:30', 20),
+                    (TIMESTAMP '2021-01-01 00:10:00', 5) AS t(b, v)
+        GROUP BY session_window(b, '5 minutes')
+        ORDER BY start
+        """
+      Then query result
+        | start               | cnt | s  | mn | mx |
+        | 2021-01-01 00:00:00 | 2   | 30 | 10 | 20 |
+        | 2021-01-01 00:10:00 | 1   | 5  | 5  | 5  |
+
+    Scenario: a FILTER (WHERE) aggregate is computed per session (fused path)
+      When query
+        """
+        SELECT session_window.start,
+               count(*) FILTER (WHERE v > 10) AS cnt_big,
+               sum(v) AS total
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00', 5),
+                    (TIMESTAMP '2021-01-01 00:04:30', 20),
+                    (TIMESTAMP '2021-01-01 00:10:00', 30) AS t(b, v)
+        GROUP BY session_window(b, '5 minutes')
+        ORDER BY start
+        """
+      Then query result
+        | start               | cnt_big | total |
+        | 2021-01-01 00:00:00 | 1       | 25    |
+        | 2021-01-01 00:10:00 | 1       | 30    |
+
+    Scenario: a FILTER that excludes every row of a session yields zero, not a dropped session
+      When query
+        """
+        SELECT session_window.start,
+               count(*) FILTER (WHERE v > 100) AS cnt_big,
+               count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00', 5),
+                    (TIMESTAMP '2021-01-01 00:04:30', 20) AS t(b, v)
+        GROUP BY session_window(b, '5 minutes')
+        ORDER BY start
+        """
+      Then query result
+        | start               | cnt_big | cnt |
+        | 2021-01-01 00:00:00 | 0       | 2   |
+
+    Scenario: a DISTINCT aggregate over a session (fallback path)
+      When query
+        """
+        SELECT session_window.start, count(DISTINCT v) AS dc
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00', 10),
+                    (TIMESTAMP '2021-01-01 00:01:00', 10),
+                    (TIMESTAMP '2021-01-01 00:02:00', 20) AS t(b, v)
+        GROUP BY session_window(b, '5 minutes')
+        ORDER BY start
+        """
+      Then query result
+        | start               | dc |
+        | 2021-01-01 00:00:00 | 2  |
+
+  Rule: Argument validation
+
+    # Spark gives a nested session_window per-row semantics (no merge); Sail
+    # rejects it at analysis time instead of implementing that path.
+    @sail-only
+    Scenario: session_window nested in a grouping expression is rejected
+      When query
+        """
+        SELECT count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00') AS t(b)
+        GROUP BY struct(session_window(b, '5 minutes'))
+        """
+      Then query error .*session_window is only supported as a top-level grouping expression.*
+
+    Scenario: session_window rejects a single argument
+      When query
+        """
+        SELECT count(*) FROM VALUES (TIMESTAMP '2021-01-01 00:00:00') AS t(b)
+        GROUP BY session_window(b)
+        """
+      Then query error .*session_window.*requires (exactly 2 arguments|2 parameters).*

--- a/python/pysail/tests/spark/function/features/session_window.feature
+++ b/python/pysail/tests/spark/function/features/session_window.feature
@@ -214,6 +214,47 @@ Feature: session_window() gap-based sessionization
         | s                   | cnt |
         | 2021-01-01 00:00:00 | 2   |
 
+  Rule: Grouping forms
+
+    Scenario: session_window referenced by GROUP BY ordinal
+      When query
+        """
+        SELECT a, session_window.start, session_window.end, count(*) AS cnt
+        FROM VALUES ('A1', TIMESTAMP '2021-01-01 00:00:00'),
+                    ('A1', TIMESTAMP '2021-01-01 00:04:30'),
+                    ('A2', TIMESTAMP '2021-01-01 00:01:00') AS tab(a, b)
+        GROUP BY session_window(b, '5 minutes'), 1
+        ORDER BY a, start
+        """
+      Then query result
+        | a  | start               | end                 | cnt |
+        | A1 | 2021-01-01 00:00:00 | 2021-01-01 00:09:30 | 2   |
+        | A2 | 2021-01-01 00:01:00 | 2021-01-01 00:06:00 | 1   |
+
+    Scenario: session_window in the SELECT list referenced only by ordinal
+      When query
+        """
+        SELECT session_window(b, '5 minutes'), count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00'),
+                    (TIMESTAMP '2021-01-01 00:04:30') AS t(b)
+        GROUP BY 1
+        """
+      Then query result
+        | session_window                             | cnt |
+        | {2021-01-01 00:00:00, 2021-01-01 00:09:30} | 2   |
+
+    Scenario: session_window grouped by its SELECT-list alias
+      When query
+        """
+        SELECT session_window(b, '5 minutes') AS sw, count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00'),
+                    (TIMESTAMP '2021-01-01 00:04:30') AS t(b)
+        GROUP BY sw
+        """
+      Then query result
+        | sw                                         | cnt |
+        | {2021-01-01 00:00:00, 2021-01-01 00:09:30} | 2   |
+
   Rule: Expression grouping keys
 
     Scenario: a non-column grouping key (upper) partitions sessions and resolves in SELECT
@@ -277,6 +318,22 @@ Feature: session_window() gap-based sessionization
         | 2021-01-02 00:00:00 | 2021-01-01 00:00:00 | 1   |
 
   Rule: Aggregates
+
+    # Spark evaluates the marker inside an aggregate argument with per-row
+    # (pre-merge) semantics; Sail rejects that path instead of silently
+    # aggregating the merged struct.
+    @sail-only
+    Scenario: an aggregate over the session struct is rejected (per-row semantics)
+      When query
+        """
+        SELECT max(session_window(b, '5 minutes').start) AS m, count(*) AS cnt
+        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00'),
+                    (TIMESTAMP '2021-01-01 00:04:30'),
+                    (TIMESTAMP '2021-01-01 00:10:00') AS t(b)
+        GROUP BY session_window(b, '5 minutes')
+        ORDER BY m
+        """
+      Then query error .*session_window inside an aggregate function.*
 
     Scenario: multiple aggregates are computed per session (fused path)
       When query

--- a/python/pysail/tests/spark/function/features/session_window.feature
+++ b/python/pysail/tests/spark/function/features/session_window.feature
@@ -243,6 +243,29 @@ Feature: session_window() gap-based sessionization
         | session_window                             | cnt |
         | {2021-01-01 00:00:00, 2021-01-01 00:09:30} | 2   |
 
+    # Both tables deliberately share the column names `k` and `ts`, and the
+    # join is on a third column so the duplicated ones hold DIFFERENT values:
+    # `b.k` is one constant (a mis-bound key qualifier would merge the groups)
+    # and `b.ts` is decades away (a mis-bound time qualifier would move the
+    # sessions to 2030).
+    Scenario: qualified keys after a join with duplicate column names
+      When query
+        """
+        SELECT a.k AS k, session_window.start, session_window.end, count(*) AS cnt
+        FROM VALUES ('X', TIMESTAMP '2021-01-01 00:00:00'),
+                    ('X', TIMESTAMP '2021-01-01 00:04:00'),
+                    ('Y', TIMESTAMP '2021-01-01 00:02:00') AS a(k, ts)
+        JOIN VALUES ('SAME', TIMESTAMP '2030-01-01 00:00:00', 'X'),
+                    ('SAME', TIMESTAMP '2030-06-01 00:00:00', 'Y') AS b(k, ts, jk)
+          ON a.k = b.jk
+        GROUP BY a.k, session_window(a.ts, '5 minutes')
+        ORDER BY k, start
+        """
+      Then query result
+        | k | start               | end                 | cnt |
+        | X | 2021-01-01 00:00:00 | 2021-01-01 00:09:00 | 2   |
+        | Y | 2021-01-01 00:02:00 | 2021-01-01 00:07:00 | 1   |
+
     Scenario: session_window grouped by its SELECT-list alias
       When query
         """

--- a/python/pysail/tests/spark/function/features/session_window.feature
+++ b/python/pysail/tests/spark/function/features/session_window.feature
@@ -125,27 +125,24 @@ Feature: session_window() gap-based sessionization
 
   Rule: Non-positive gap
 
-    # A non-positive gap is not an analysis error: the `end > start` filter
-    # drops every row.
-    Scenario: a static gap of zero yields an empty result, not an error
+    # A non-positive or invalid literal gap is not an analysis error: it casts
+    # to NULL or a non-positive interval, and the `end > start` filter drops
+    # every row.
+    Scenario Outline: <case> yields an empty result, not an error
       When query
         """
         SELECT session_window.start, count(*) AS cnt
         FROM VALUES (TIMESTAMP '2021-01-01 00:00:00') AS t(b)
-        GROUP BY session_window(b, '0 seconds')
+        GROUP BY session_window(b, '<gap>')
         """
       Then query result
         | start | cnt |
 
-    Scenario: a static negative gap yields an empty result, not an error
-      When query
-        """
-        SELECT session_window.start, count(*) AS cnt
-        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00') AS t(b)
-        GROUP BY session_window(b, '-5 seconds')
-        """
-      Then query result
-        | start | cnt |
+      Examples:
+        | case                       | gap        |
+        | a static gap of zero       | 0 seconds  |
+        | a static negative gap      | -5 seconds |
+        | an invalid literal gap     | garbage    |
 
     Scenario: a dynamic gap of zero drops only that key's rows
       When query
@@ -327,36 +324,6 @@ Feature: session_window() gap-based sessionization
         | A1 | 2021-01-01 00:00:00 | 2021-01-01 00:09:30 | 2   |
         | A1 | 2021-01-01 00:10:00 | 2021-01-01 00:15:00 | 1   |
 
-    Scenario: an arithmetic grouping key partitions sessions
-      When query
-        """
-        SELECT id + 1 AS k, session_window.start, count(*) AS cnt
-        FROM VALUES (10, TIMESTAMP '2021-01-01 00:00:00'),
-                    (10, TIMESTAMP '2021-01-01 00:01:00'),
-                    (20, TIMESTAMP '2021-01-01 00:00:00') AS tab(id, b)
-        GROUP BY session_window(b, '5 minutes'), id + 1
-        ORDER BY k, start
-        """
-      Then query result
-        | k  | start               | cnt |
-        | 11 | 2021-01-01 00:00:00 | 2   |
-        | 21 | 2021-01-01 00:00:00 | 1   |
-
-    Scenario: a cast grouping key partitions sessions
-      When query
-        """
-        SELECT CAST(id AS STRING) AS k, session_window.start, count(*) AS cnt
-        FROM VALUES (1, TIMESTAMP '2021-01-01 00:00:00'),
-                    (1, TIMESTAMP '2021-01-01 00:01:00'),
-                    (2, TIMESTAMP '2021-01-01 00:00:00') AS tab(id, b)
-        GROUP BY session_window(b, '5 minutes'), CAST(id AS STRING)
-        ORDER BY k, start
-        """
-      Then query result
-        | k | start               | cnt |
-        | 1 | 2021-01-01 00:00:00 | 2   |
-        | 2 | 2021-01-01 00:00:00 | 1   |
-
     Scenario: a date_trunc grouping key over a second timestamp partitions sessions
       When query
         """
@@ -373,16 +340,6 @@ Feature: session_window() gap-based sessionization
         | 2021-01-02 00:00:00 | 2021-01-01 00:00:00 | 1   |
 
   Rule: Gap literal edge cases
-
-    Scenario: an invalid literal gap yields an empty result, not an error
-      When query
-        """
-        SELECT session_window.start, count(*) AS cnt
-        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00') AS t(b)
-        GROUP BY session_window(b, 'garbage')
-        """
-      Then query result
-        | start | cnt |
 
     Scenario: an integer gap is rejected
       When query
@@ -469,11 +426,13 @@ Feature: session_window() gap-based sessionization
         | 2021-01-01 00:00:00 | 2   | 30 | 10 | 20 |
         | 2021-01-01 00:10:00 | 1   | 5  | 5  | 5  |
 
-    Scenario: a FILTER (WHERE) aggregate is computed per session (fused path)
+    # `cnt_none` matches no rows: it must yield zero, not a dropped session.
+    Scenario: FILTER (WHERE) aggregates are computed per session (fused path)
       When query
         """
         SELECT session_window.start,
                count(*) FILTER (WHERE v > 10) AS cnt_big,
+               count(*) FILTER (WHERE v > 100) AS cnt_none,
                sum(v) AS total
         FROM VALUES (TIMESTAMP '2021-01-01 00:00:00', 5),
                     (TIMESTAMP '2021-01-01 00:04:30', 20),
@@ -482,24 +441,9 @@ Feature: session_window() gap-based sessionization
         ORDER BY start
         """
       Then query result
-        | start               | cnt_big | total |
-        | 2021-01-01 00:00:00 | 1       | 25    |
-        | 2021-01-01 00:10:00 | 1       | 30    |
-
-    Scenario: a FILTER that excludes every row of a session yields zero, not a dropped session
-      When query
-        """
-        SELECT session_window.start,
-               count(*) FILTER (WHERE v > 100) AS cnt_big,
-               count(*) AS cnt
-        FROM VALUES (TIMESTAMP '2021-01-01 00:00:00', 5),
-                    (TIMESTAMP '2021-01-01 00:04:30', 20) AS t(b, v)
-        GROUP BY session_window(b, '5 minutes')
-        ORDER BY start
-        """
-      Then query result
-        | start               | cnt_big | cnt |
-        | 2021-01-01 00:00:00 | 0       | 2   |
+        | start               | cnt_big | cnt_none | total |
+        | 2021-01-01 00:00:00 | 1       | 0        | 25    |
+        | 2021-01-01 00:10:00 | 1       | 0        | 30    |
 
     Scenario: a DISTINCT aggregate over a session (fallback path)
       When query


### PR DESCRIPTION
## Summary

- Implement Spark `session_window(timeColumn, gapDuration)` for batch queries:
  - a marker UDF is desugared by the resolver into a `SessionWindowNode` over a filter + time/end projection;
  - `SessionWindowExec` merges sessions in one pass over hash-partitioned, `(keys, time)`-sorted input;
  - when aggregates allow it, node and aggregate fuse into `SessionAggregateExec` (Spark's `MergingSessionsExec` equivalent) with O(1) state per open session; DISTINCT falls back to the unfused path, which charges session rows carried across batch boundaries against the task memory pool (an oversized session fails with a resources error instead of aborting the process);
  - semantics match Spark 4.2: merge while `time <= session end`, month-bearing literal gaps, dynamic per-row gaps, empty result for non-positive gaps, year-month typed gaps rejected, non-nullable session struct.
- Gap strings follow Spark's cast semantics: the unit written decides the interval bucket — `'1 day'` is a calendar day (across a DST fall-back, where a calendar day lasts 25 absolute hours, it ends at the same wall-clock time), while `'25 hours'` is always 25 absolute hours — and an invalid dynamic gap drops the row instead of failing the query. `GROUP BY` ordinals and aliases resolve to the marker; grouping sets and aggregates over the session struct are rejected with clear analysis errors.
- Prune unused input columns through the new custom nodes (`necessary_children_exprs`).
- Fold literal CASE gap branches into interval constants at plan time.
- Stop rebuilding the SQL parser per row for interval strings: a fast path with full-parser fallback, plus per-batch memoization of distinct values.
- Tests: a 28-scenario BDD suite validated against both Sail and JVM Spark 4.2 (`SPARK_REMOTE=local[4]`; 3 scenarios are `@sail-only`), the Spark gold queries, codec round-trip and operator/parser unit tests including batch-boundary and memory-limit cases.
- Benchmarks (NYC taxi, 41M rows): 1.8–4.5x faster than Spark 4.2 on all session queries, checksums matching exactly.

<details>
<summary><b>Approach and semantics</b></summary>

## Approach

Unlike tumbling/sliding `window()`, session windows merge across rows, so a scalar UDF + explode cannot express them. The implementation is a pipeline:

1. **Marker UDF** (`SparkSessionWindow`): `session_window(ts, gap)` resolves to a marker carrying the cast time column and the normalized gap; it only provides the `struct<start, end>` type for analysis and never executes.
2. **Resolver desugar**: the aggregate resolver detects the marker in the grouping and rewrites it to
   ```text
   SessionWindowNode partition_by=[K...] time=#t end=#e0 output=#w
     Filter: #t IS NOT NULL AND #e0 > #t        -- drop null time / non-positive gap
       Projection: *, ts AS #t, ts + gap AS #e0
   ```
   (`#t`/`#e0`/`#w` are fresh internal column names.) The marker grouping expression becomes a reference to `#w`, so the ordinary GROUP BY machinery takes over. Expression grouping keys are projected to fresh columns so the operator can partition by them and the downstream aggregate reuses the hash distribution.
3. **`SessionWindowExec`** (Spark's `UpdatingSessionsExec` equivalent): requires the input hash-partitioned on the keys and sorted by `(keys, time)`, merges sessions in one pass (Spark's rule: a row merges while `time <= current session end`), buffering only the open session's rows. Group-key runs are found with arrow's vectorized `partition` kernel. Rows carried across batch boundaries are charged against the task memory pool, so a session larger than the pool fails with a resources error instead of unbounded growth.
4. **Fusion** (`SessionAggregateNode/Exec`, Spark's `MergingSessionsExec` equivalent): when the aggregates allow it (no DISTINCT / ordered-set / group UDAFs), the `Aggregate` + `SessionWindowNode` pair is fused into one operator that merges sessions and drives the accumulators in the same pass, holding O(1) state per open session. `FILTER (WHERE ...)` is fused via a per-row mask. DISTINCT falls back to the baseline path.

### Semantics parity (verified empirically against Spark 4.2)

The non-obvious behaviors, each with a scenario: the session-end boundary is inclusive (a row landing exactly on it merges); month-bearing gaps use per-row calendar arithmetic; day-bearing string gaps are calendar days while sub-day units are absolute time (Spark `stringToInterval` bucketing; across a DST fall-back `'1 day'` spans 25 absolute hours and `'25 hours'` lands an hour past the wall-clock time — both verified against Spark); an invalid dynamic gap string yields NULL and drops the row, as Spark's non-throwing cast does; non-positive gaps and null times drop rows (a non-positive static gap yields an empty result, not an error); the session struct is `nullable = false`.

Deliberate deviations, tagged `@sail-only`: a day-time *typed* interval gap is accepted (Spark rejects it; it is unambiguous, and as a day-time interval it is an absolute duration — unlike day-bearing gap strings, which are calendar-bucketed); `session_window` nested in a larger grouping expression or inside an aggregate argument — per-row semantics in Spark — is rejected at analysis time rather than silently mis-merged; GROUPING SETS/CUBE/ROLLUP combinations are a clear analysis error.

</details>

<details>
<summary><b>The three optimizations, with measurements</b></summary>

## Optimizations

Context: plan-time work happens once per query, per-row work 41M times here, per-batch work ~5000 times (8192-row Arrow batches) — these optimizations move work across those boundaries. sail's SQL grammar is built on the chumsky parser-combinator library, which constructs its (large, recursive) combinator graph at runtime on every parser call.

### 1. Column pruning through the custom nodes (`perf: prune unused input columns...`)

The desugar projects `*`, and both custom logical nodes originally declared every input column necessary, so `OptimizeProjections` could not prune anything: all input columns rode through the repartition + sort below the node. On the 41M-row taxi benchmark that meant sorting 5.9 GB and spilling 6 GB under a 6 GB memory pool (the benchmark's cap). `necessary_children_exprs` now declares only the keys, time/end columns, aggregate inputs, and parent-requested columns. The sort payload drops to 1.1 GB, spilling drops from 6 GB to 0.45 GB, and `q1` goes from 8.8s to ~4s (vs Spark's 12.4s).

### 2. Plan-time folding of CASE gap branches (`perf: fold literal session_window gap CASE branches...`)

For a dynamic gap like `CASE WHEN ... THEN '5 minutes' ELSE '2 minutes' END`, the resolver pushes the interval parse into the CASE branches instead of wrapping the whole CASE — the equivalent of Spark's implicit cast to `CalendarIntervalType`. Expression simplification then folds each literal branch into an interval literal, so this (overwhelmingly common) class of dynamic gaps performs zero runtime string parsing. `q3_dynamic_gap`: 3.7s → 2.7s.

### 3. Fast interval-string parser (`perf: stop building the SQL parser per row...`)

`parse_interval` constructs the full chumsky lexer and the recursive expression combinator graph on every call. The CPU cost is tolerable (~25 µs/call measured); the killer is memory: ~22 KB per call is never reclaimed — the leak scales with the grammar graph being constructed, independent of the input (consistent with reference cycles in `recursive()` combinators), and a process dies after roughly 200k parses. That is the wall any per-row caller (a non-foldable dynamic gap, `CAST(<string column> AS INTERVAL)`) runs into.

The fix adds a hand-rolled parser for the common `[interval] (value unit)+` shape, and the interval UDFs memoize distinct string values per batch so even the fast parse runs once per distinct value, not per row. Anything the fast parser does not recognize falls through to the full parser, so accepted syntax and error behavior are unchanged; a test battery asserts fast-path/full-parser equivalence over ~50 strings (including the quirks: single-term year/month zero, u32 vs i64 seconds, 6-digit fraction truncation). This is the same boundary Postgres (`interval_in`) and Spark (`IntervalUtils.stringToInterval`) draw: the data path gets a cheap type-input parser and never calls the query grammar. It covers what plan-time folding (commit 2) cannot reach — gaps that are not literal at plan time (a data column, a non-foldable expression) and `CAST(<string column> AS INTERVAL)`; without it such queries parse per row and die within a few hundred thousand rows from the never-reclaimed allocations (measured: a non-foldable `concat` gap on one month of data goes from 12.75s, dying at ~200k rows, to 0.09s).

</details>

<details>
<summary><b>Benchmarks</b></summary>

NYC yellow taxi 2024, 12 months (~41M rows), one machine (16 cores / 32 GB), `local[16]`, median of 3 runs after warmup; queries are wrapped in a 1-row checksum aggregation so timing excludes result transfer, and every checksum matches Spark 4.2 exactly.

| query | sail | spark 4.2 | speedup |
|---|---|---|---|
| q1 static gap per key | 3.80s | 12.38s | 3.3x |
| q2 global sessions (no key) | 8.67s | 38.70s | 4.5x |
| q3 dynamic CASE gap | 3.38s | 13.06s | 3.9x |
| q4 multi-aggregate + FILTER | 6.85s | 12.67s | 1.8x |
| q5 COUNT(DISTINCT) fallback path | 4.84s | 10.31s | 2.1x |
| q6 expression key, high cardinality | 10.71s | 20.55s | 1.9x |

</details>

<details>
<summary><b>Proposed follow-ups</b></summary>

Items 1–3 replace interim fixes from this PR at the layer that owns the concern; items 4–5 are deferred semantics decisions.

1. **Take the string path off the grammar entirely.** Measuring showed a narrowed grammar cannot close the gap — the full parser stays about three orders of magnitude above a direct scan — so instead of deleting the fast path, the follow-up is the opposite: remove the grammar from the string path altogether and read a cast in the exact shape of its target qualifier.
2. **Generalize the CASE-branch folding into a simplifier rule** — any deterministic function over a CASE/COALESCE/IF of literals. DataFusion's simplifier has this only for `=`/`!=`; its `ConstEvaluator` already keeps unfoldable branches intact, so the error semantics are safe.
3. **Encoding-aware scalar evaluation** (dictionary/REE peeling, plus operators that emit encoded output, e.g. CASE over literals) is the engine-level replacement for the per-batch memoization; once it exists upstream, the shared `StrMemo` helper is deleted — each use is one explicit call.
4. **Nested `session_window` per-row semantics** (rejected at analysis time, including inside aggregate arguments) can be implemented later without affecting the top-level path.
5. **`window_time(session_window(...))`** currently works in Sail while Spark rejects it; decide whether to reject for parity or document as a deliberate extension.

</details>

