### PR TITLE
perf: compile column regex patterns once per batch, not per row

### DIFF
--- a/crates/sail-function/src/functions_utils.rs
+++ b/crates/sail-function/src/functions_utils.rs
@@ -65,30 +65,36 @@ const MAX_DISTINCT: usize = 128;
 /// pay overhead.
 pub(crate) struct StrMemo<'a, T> {
     cache: std::collections::HashMap<&'a str, T>,
+    /// Value computed for a key seen once the cache is full, so
+    /// `get_or_try_insert_ref` can still hand out a reference.
+    overflow: Option<T>,
 }
 
-impl<'a, T: Clone> StrMemo<'a, T> {
+impl<'a, T> StrMemo<'a, T> {
     pub(crate) fn new() -> Self {
         Self {
             cache: std::collections::HashMap::new(),
+            overflow: None,
         }
     }
 
-    /// Returns the memoized value for `key`, computing it on first sight.
-    /// Errors are not cached and surface unchanged.
-    pub(crate) fn get_or_try_insert(
+    /// Returns a reference to the memoized value for `key`, computing it on
+    /// first sight. Errors are not cached and surface unchanged. Returning a
+    /// reference matters for values whose clone is not free — cloning a
+    /// `Regex` per row discards its internal lazy-DFA cache and forces the
+    /// automaton to be rebuilt on every match.
+    pub(crate) fn get_or_try_insert_ref(
         &mut self,
         key: &'a str,
         compute: impl FnOnce(&str) -> Result<T>,
-    ) -> Result<T> {
-        match self.cache.get(key) {
-            Some(value) => Ok(value.clone()),
-            None if self.cache.len() >= MAX_DISTINCT => compute(key),
-            None => {
-                let value = compute(key)?;
-                self.cache.insert(key, value.clone());
-                Ok(value)
-            }
+    ) -> Result<&T> {
+        use std::collections::hash_map::Entry;
+        if self.cache.len() >= MAX_DISTINCT && !self.cache.contains_key(key) {
+            return Ok(self.overflow.insert(compute(key)?));
+        }
+        match self.cache.entry(key) {
+            Entry::Occupied(entry) => Ok(entry.into_mut()),
+            Entry::Vacant(entry) => Ok(entry.insert(compute(key)?)),
         }
     }
 }
@@ -112,12 +118,12 @@ mod tests {
             }
             Ok(s.len())
         };
-        assert_eq!(memo.get_or_try_insert("ab", compute)?, 2);
-        assert_eq!(memo.get_or_try_insert("ab", compute)?, 2);
-        assert_eq!(memo.get_or_try_insert("xyz", compute)?, 3);
+        assert_eq!(*memo.get_or_try_insert_ref("ab", compute)?, 2);
+        assert_eq!(*memo.get_or_try_insert_ref("ab", compute)?, 2);
+        assert_eq!(*memo.get_or_try_insert_ref("xyz", compute)?, 3);
         assert_eq!(calls.get(), 2);
-        assert!(memo.get_or_try_insert("", compute).is_err());
-        assert!(memo.get_or_try_insert("", compute).is_err());
+        assert!(memo.get_or_try_insert_ref("", compute).is_err());
+        assert!(memo.get_or_try_insert_ref("", compute).is_err());
         assert_eq!(calls.get(), 4);
         Ok(())
     }
@@ -132,15 +138,15 @@ mod tests {
             Ok(s.len())
         };
         for key in &keys {
-            memo.get_or_try_insert(key, compute)?;
+            memo.get_or_try_insert_ref(key, compute)?;
         }
         assert_eq!(calls.get(), MAX_DISTINCT);
         // A cached key is still served without recomputing.
-        memo.get_or_try_insert(&keys[0], compute)?;
+        memo.get_or_try_insert_ref(&keys[0], compute)?;
         assert_eq!(calls.get(), MAX_DISTINCT);
         // Past the cap, values are computed per call and never cached.
-        assert_eq!(memo.get_or_try_insert("overflow", compute)?, 8);
-        assert_eq!(memo.get_or_try_insert("overflow", compute)?, 8);
+        assert_eq!(*memo.get_or_try_insert_ref("overflow", compute)?, 8);
+        assert_eq!(*memo.get_or_try_insert_ref("overflow", compute)?, 8);
         assert_eq!(calls.get(), MAX_DISTINCT + 2);
         Ok(())
     }

--- a/crates/sail-function/src/functions_utils.rs
+++ b/crates/sail-function/src/functions_utils.rs
@@ -1,4 +1,6 @@
 /// [Credit]: <https://github.com/apache/datafusion/blob/e6e1eb229440591263c82bb2b913a4d5a16f9b70/datafusion/functions/src/utils.rs>
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::sync::Arc;
 
 use datafusion::arrow::array::ArrayRef;
@@ -64,7 +66,7 @@ const MAX_DISTINCT: usize = 128;
 /// for low-cardinality inputs (patterns, formats); per-row-unique inputs just
 /// pay overhead.
 pub(crate) struct StrMemo<'a, T> {
-    cache: std::collections::HashMap<&'a str, T>,
+    cache: HashMap<&'a str, T>,
     /// Value computed for a key seen once the cache is full, so
     /// `get_or_try_insert_ref` can still hand out a reference.
     overflow: Option<T>,
@@ -73,7 +75,7 @@ pub(crate) struct StrMemo<'a, T> {
 impl<'a, T> StrMemo<'a, T> {
     pub(crate) fn new() -> Self {
         Self {
-            cache: std::collections::HashMap::new(),
+            cache: HashMap::new(),
             overflow: None,
         }
     }
@@ -88,13 +90,30 @@ impl<'a, T> StrMemo<'a, T> {
         key: &'a str,
         compute: impl FnOnce(&str) -> Result<T>,
     ) -> Result<&T> {
-        use std::collections::hash_map::Entry;
         if self.cache.len() >= MAX_DISTINCT && !self.cache.contains_key(key) {
             return Ok(self.overflow.insert(compute(key)?));
         }
         match self.cache.entry(key) {
             Entry::Occupied(entry) => Ok(entry.into_mut()),
             Entry::Vacant(entry) => Ok(entry.insert(compute(key)?)),
+        }
+    }
+
+    /// Resolves the value for one row: a pre-compiled scalar if there is one,
+    /// otherwise the per-batch memoized value for the row's key. `key` is
+    /// evaluated only on the memoized path, so scalar inputs may be length-1
+    /// arrays while the row index ranges over the whole batch. The value is
+    /// returned by reference: cloning a `Regex` per row would discard its
+    /// internal lazy-DFA cache and rebuild the automaton on every match.
+    pub(crate) fn resolve<'m>(
+        &'m mut self,
+        scalar: Option<&'m T>,
+        key: impl FnOnce() -> &'a str,
+        compute: impl FnOnce(&str) -> Result<T>,
+    ) -> Result<&'m T> {
+        match scalar {
+            Some(value) => Ok(value),
+            None => self.get_or_try_insert_ref(key(), compute),
         }
     }
 }

--- a/crates/sail-function/src/functions_utils.rs
+++ b/crates/sail-function/src/functions_utils.rs
@@ -50,3 +50,98 @@ where
         }
     })
 }
+
+/// Cap on memoized entries. A compiled `Regex` holds roughly 75 KiB once
+/// used, so memoizing a whole batch of unique patterns would pin hundreds of
+/// MiB until the batch ends; past the cap, values are computed per call. The
+/// design target (a handful of distinct patterns per batch) stays far below
+/// this.
+const MAX_DISTINCT: usize = 128;
+
+/// Per-batch memoization of an expensive `&str -> T` computation (a compiled
+/// regex, a parsed interval). Keys borrow from the input, so a cache lives one
+/// kernel invocation and holds at most [`MAX_DISTINCT`] entries. Only worth it
+/// for low-cardinality inputs (patterns, formats); per-row-unique inputs just
+/// pay overhead.
+pub(crate) struct StrMemo<'a, T> {
+    cache: std::collections::HashMap<&'a str, T>,
+}
+
+impl<'a, T: Clone> StrMemo<'a, T> {
+    pub(crate) fn new() -> Self {
+        Self {
+            cache: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Returns the memoized value for `key`, computing it on first sight.
+    /// Errors are not cached and surface unchanged.
+    pub(crate) fn get_or_try_insert(
+        &mut self,
+        key: &'a str,
+        compute: impl FnOnce(&str) -> Result<T>,
+    ) -> Result<T> {
+        match self.cache.get(key) {
+            Some(value) => Ok(value.clone()),
+            None if self.cache.len() >= MAX_DISTINCT => compute(key),
+            None => {
+                let value = compute(key)?;
+                self.cache.insert(key, value.clone());
+                Ok(value)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use datafusion_common::exec_err;
+
+    use super::*;
+
+    #[test]
+    fn str_memo_computes_each_distinct_key_once_and_does_not_cache_errors() -> Result<()> {
+        let calls = Cell::new(0);
+        let mut memo: StrMemo<'_, usize> = StrMemo::new();
+        let compute = |s: &str| {
+            calls.set(calls.get() + 1);
+            if s.is_empty() {
+                return exec_err!("empty");
+            }
+            Ok(s.len())
+        };
+        assert_eq!(memo.get_or_try_insert("ab", compute)?, 2);
+        assert_eq!(memo.get_or_try_insert("ab", compute)?, 2);
+        assert_eq!(memo.get_or_try_insert("xyz", compute)?, 3);
+        assert_eq!(calls.get(), 2);
+        assert!(memo.get_or_try_insert("", compute).is_err());
+        assert!(memo.get_or_try_insert("", compute).is_err());
+        assert_eq!(calls.get(), 4);
+        Ok(())
+    }
+
+    #[test]
+    fn str_memo_caps_distinct_entries() -> Result<()> {
+        let calls = Cell::new(0);
+        let keys: Vec<String> = (0..MAX_DISTINCT).map(|i| i.to_string()).collect();
+        let mut memo: StrMemo<'_, usize> = StrMemo::new();
+        let compute = |s: &str| {
+            calls.set(calls.get() + 1);
+            Ok(s.len())
+        };
+        for key in &keys {
+            memo.get_or_try_insert(key, compute)?;
+        }
+        assert_eq!(calls.get(), MAX_DISTINCT);
+        // A cached key is still served without recomputing.
+        memo.get_or_try_insert(&keys[0], compute)?;
+        assert_eq!(calls.get(), MAX_DISTINCT);
+        // Past the cap, values are computed per call and never cached.
+        assert_eq!(memo.get_or_try_insert("overflow", compute)?, 8);
+        assert_eq!(memo.get_or_try_insert("overflow", compute)?, 8);
+        assert_eq!(calls.get(), MAX_DISTINCT + 2);
+        Ok(())
+    }
+}

--- a/crates/sail-function/src/scalar/string/spark_regexp_extract_all.rs
+++ b/crates/sail-function/src/scalar/string/spark_regexp_extract_all.rs
@@ -15,7 +15,7 @@ use regex::Regex;
 
 use crate::error::{generic_exec_err, generic_internal_err, unsupported_data_types_exec_err};
 use crate::functions_nested_utils::opt_downcast_arg;
-use crate::functions_utils::make_scalar_function;
+use crate::functions_utils::{StrMemo, make_scalar_function};
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct SparkRegexpExtract {
@@ -146,6 +146,8 @@ fn regexp_extract_downcast<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<Arra
             let is_idx_null = idx_len == 1 && idx.is_null(0);
 
             let mut builder = StringBuilder::new();
+            // Compile each distinct column pattern once per batch, not per row.
+            let mut regex_memo = StrMemo::new();
             for i in 0..args[0].len() {
                 let pattern_is_null = if pattern_len == 1 {
                     is_pattern_null
@@ -161,10 +163,12 @@ fn regexp_extract_downcast<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<Arra
                 if pattern_is_null || idx_is_null || values.is_null(i) {
                     builder.append_null();
                 } else {
-                    let re = pattern_scalar_opt.as_ref().map_or_else(
-                        || parse_regex(SparkRegexpExtract::NAME, pattern.value_(i)),
-                        |re| Ok(re.clone()),
-                    )?;
+                    let re = match pattern_scalar_opt.as_ref() {
+                        Some(re) => re.clone(),
+                        None => regex_memo.get_or_try_insert(pattern.value_(i), |p| {
+                            parse_regex(SparkRegexpExtract::NAME, p)
+                        })?,
+                    };
                     let group_idx = idx_scalar_opt.unwrap_or_else(|| idx.value(i));
                     builder.append_value(extract_first_match(
                         SparkRegexpExtract::NAME,
@@ -209,6 +213,8 @@ fn regexp_extract_all_downcast<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<
             let is_idx_null = idx_len == 1 && idx.is_null(0);
 
             let mut builder = ListBuilder::new(StringBuilder::new());
+            // Compile each distinct column pattern once per batch, not per row.
+            let mut regex_memo = StrMemo::new();
             for i in 0..args[0].len() {
                 let pattern_is_null = if pattern_len == 1 {
                     is_pattern_null
@@ -224,10 +230,12 @@ fn regexp_extract_all_downcast<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<
                 if pattern_is_null || idx_is_null || values.is_null(i) {
                     builder.append_null();
                 } else {
-                    let re = pattern_scalar_opt.as_ref().map_or_else(
-                        || parse_regex(SparkRegexpExtractAll::NAME, pattern.value_(i)),
-                        |re| Ok(re.clone()),
-                    )?;
+                    let re = match pattern_scalar_opt.as_ref() {
+                        Some(re) => re.clone(),
+                        None => regex_memo.get_or_try_insert(pattern.value_(i), |p| {
+                            parse_regex(SparkRegexpExtractAll::NAME, p)
+                        })?,
+                    };
                     let group_idx = idx_scalar_opt.unwrap_or_else(|| idx.value(i));
                     let matches = extract_all_matches(
                         SparkRegexpExtractAll::NAME,
@@ -395,4 +403,71 @@ fn extract_all_matches(
         results.push(Some(extract_capture(function_name, &caps, group_idx)?));
     }
     Ok(results)
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used)]
+mod tests {
+    use datafusion::arrow::array::{Int64Array, ListArray, StringArray};
+
+    use super::*;
+
+    fn strings(values: Vec<Option<&str>>) -> ArrayRef {
+        Arc::new(StringArray::from(values))
+    }
+
+    /// A pattern supplied as a column selects the regex per row; null patterns
+    /// yield null outputs and an invalid pattern in the column errors.
+    #[test]
+    fn extract_with_column_pattern() -> Result<()> {
+        let values = strings(vec![Some("a11b"), Some("a22b"), Some("xyz"), Some("a33b")]);
+        let patterns = strings(vec![
+            Some("([0-9]+)"),
+            Some("([0-9]+)"),
+            None,
+            Some("([a-z]+)"),
+        ]);
+        let idx: ArrayRef = Arc::new(Int64Array::from(vec![1i64, 1, 1, 1]));
+        let output = regexp_extract_inner(&[values.clone(), patterns, idx.clone()])?;
+        let output = output
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("string output");
+        assert_eq!(output.value(0), "11");
+        assert_eq!(output.value(1), "22");
+        assert!(output.is_null(2));
+        assert_eq!(output.value(3), "a");
+
+        let invalid = strings(vec![Some("("), Some("("), Some("("), Some("(")]);
+        assert!(regexp_extract_inner(&[values, invalid, idx]).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn extract_all_with_column_pattern() -> Result<()> {
+        let values = strings(vec![Some("1a2"), Some("3b4")]);
+        let patterns = strings(vec![Some("[0-9]"), Some("[a-z]")]);
+        let idx: ArrayRef = Arc::new(Int64Array::from(vec![0i64, 0]));
+        let output = regexp_extract_all_inner(&[values, patterns, idx])?;
+        let output = output
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("list output");
+        let digits = output.value(0);
+        let digits = digits
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("string matches");
+        assert_eq!(
+            (digits.len(), digits.value(0), digits.value(1)),
+            (2, "1", "2")
+        );
+        let letters = output.value(1);
+        let letters = letters
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("string matches");
+        assert_eq!((letters.len(), letters.value(0)), (1, "b"));
+        Ok(())
+    }
 }

--- a/crates/sail-function/src/scalar/string/spark_regexp_extract_all.rs
+++ b/crates/sail-function/src/scalar/string/spark_regexp_extract_all.rs
@@ -163,9 +163,11 @@ fn regexp_extract_downcast<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<Arra
                 if pattern_is_null || idx_is_null || values.is_null(i) {
                     builder.append_null();
                 } else {
+                    // By reference: cloning a Regex per row would discard its
+                    // lazy-DFA cache and rebuild the automaton on every match.
                     let re = match pattern_scalar_opt.as_ref() {
-                        Some(re) => re.clone(),
-                        None => regex_memo.get_or_try_insert(pattern.value_(i), |p| {
+                        Some(re) => re,
+                        None => regex_memo.get_or_try_insert_ref(pattern.value_(i), |p| {
                             parse_regex(SparkRegexpExtract::NAME, p)
                         })?,
                     };
@@ -173,7 +175,7 @@ fn regexp_extract_downcast<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<Arra
                     builder.append_value(extract_first_match(
                         SparkRegexpExtract::NAME,
                         values.value(i),
-                        &re,
+                        re,
                         group_idx,
                     )?);
                 }
@@ -230,9 +232,11 @@ fn regexp_extract_all_downcast<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<
                 if pattern_is_null || idx_is_null || values.is_null(i) {
                     builder.append_null();
                 } else {
+                    // By reference: cloning a Regex per row would discard its
+                    // lazy-DFA cache and rebuild the automaton on every match.
                     let re = match pattern_scalar_opt.as_ref() {
-                        Some(re) => re.clone(),
-                        None => regex_memo.get_or_try_insert(pattern.value_(i), |p| {
+                        Some(re) => re,
+                        None => regex_memo.get_or_try_insert_ref(pattern.value_(i), |p| {
                             parse_regex(SparkRegexpExtractAll::NAME, p)
                         })?,
                     };
@@ -240,7 +244,7 @@ fn regexp_extract_all_downcast<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<
                     let matches = extract_all_matches(
                         SparkRegexpExtractAll::NAME,
                         values.value(i),
-                        &re,
+                        re,
                         group_idx,
                     )?;
                     builder.append_value(matches);

--- a/crates/sail-function/src/scalar/string/spark_regexp_extract_all.rs
+++ b/crates/sail-function/src/scalar/string/spark_regexp_extract_all.rs
@@ -163,14 +163,11 @@ fn regexp_extract_downcast<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<Arra
                 if pattern_is_null || idx_is_null || values.is_null(i) {
                     builder.append_null();
                 } else {
-                    // By reference: cloning a Regex per row would discard its
-                    // lazy-DFA cache and rebuild the automaton on every match.
-                    let re = match pattern_scalar_opt.as_ref() {
-                        Some(re) => re,
-                        None => regex_memo.get_or_try_insert_ref(pattern.value_(i), |p| {
-                            parse_regex(SparkRegexpExtract::NAME, p)
-                        })?,
-                    };
+                    let re = regex_memo.resolve(
+                        pattern_scalar_opt.as_ref(),
+                        || pattern.value_(i),
+                        |p| parse_regex(SparkRegexpExtract::NAME, p),
+                    )?;
                     let group_idx = idx_scalar_opt.unwrap_or_else(|| idx.value(i));
                     builder.append_value(extract_first_match(
                         SparkRegexpExtract::NAME,
@@ -232,14 +229,11 @@ fn regexp_extract_all_downcast<O: OffsetSizeTrait>(args: &[ArrayRef]) -> Result<
                 if pattern_is_null || idx_is_null || values.is_null(i) {
                     builder.append_null();
                 } else {
-                    // By reference: cloning a Regex per row would discard its
-                    // lazy-DFA cache and rebuild the automaton on every match.
-                    let re = match pattern_scalar_opt.as_ref() {
-                        Some(re) => re,
-                        None => regex_memo.get_or_try_insert_ref(pattern.value_(i), |p| {
-                            parse_regex(SparkRegexpExtractAll::NAME, p)
-                        })?,
-                    };
+                    let re = regex_memo.resolve(
+                        pattern_scalar_opt.as_ref(),
+                        || pattern.value_(i),
+                        |p| parse_regex(SparkRegexpExtractAll::NAME, p),
+                    )?;
                     let group_idx = idx_scalar_opt.unwrap_or_else(|| idx.value(i));
                     let matches = extract_all_matches(
                         SparkRegexpExtractAll::NAME,

--- a/crates/sail-function/src/scalar/string/spark_regexp_extract_all.rs
+++ b/crates/sail-function/src/scalar/string/spark_regexp_extract_all.rs
@@ -443,9 +443,9 @@ mod tests {
 
     #[test]
     fn extract_all_with_column_pattern() -> Result<()> {
-        let values = strings(vec![Some("1a2"), Some("3b4")]);
-        let patterns = strings(vec![Some("[0-9]"), Some("[a-z]")]);
-        let idx: ArrayRef = Arc::new(Int64Array::from(vec![0i64, 0]));
+        let values = strings(vec![Some("1a2"), Some("3b4"), Some("5c6")]);
+        let patterns = strings(vec![Some("[0-9]"), Some("[a-z]"), Some("[0-9]")]);
+        let idx: ArrayRef = Arc::new(Int64Array::from(vec![0i64, 0, 0]));
         let output = regexp_extract_all_inner(&[values, patterns, idx])?;
         let output = output
             .as_any()
@@ -466,6 +466,17 @@ mod tests {
             .downcast_ref::<StringArray>()
             .expect("string matches");
         assert_eq!((letters.len(), letters.value(0)), (1, "b"));
+        // Row 2 reuses "[0-9]" after row 0 compiled it: the memoized regex
+        // must extract exactly as a fresh compile would.
+        let reused = output.value(2);
+        let reused = reused
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("string matches");
+        assert_eq!(
+            (reused.len(), reused.value(0), reused.value(1)),
+            (2, "5", "6")
+        );
         Ok(())
     }
 }

--- a/crates/sail-function/src/scalar/string/spark_split.rs
+++ b/crates/sail-function/src/scalar/string/spark_split.rs
@@ -15,7 +15,7 @@ use regex::Regex;
 
 use crate::error::{generic_exec_err, generic_internal_err, unsupported_data_types_exec_err};
 use crate::functions_nested_utils::opt_downcast_arg;
-use crate::functions_utils::make_scalar_function;
+use crate::functions_utils::{StrMemo, make_scalar_function};
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub struct SparkSplit {
@@ -130,6 +130,8 @@ where
             let is_limit_null = limit.len() == 1 && limit.is_null(0);
 
             let mut builder = ListBuilder::new(StringBuilder::new());
+            // Compile each distinct column pattern once per batch, not per row.
+            let mut regex_memo = StrMemo::new();
             for i in 0..args[0].len() {
                 if is_format_null
                     || is_limit_null
@@ -139,10 +141,10 @@ where
                 {
                     builder.append_null();
                 } else {
-                    let format_regex = format_scalar_opt.as_ref().map_or_else(
-                        || parse_regex(format.value(i)),
-                        |format_regex| Ok(format_regex.clone()),
-                    )?;
+                    let format_regex = match format_scalar_opt.as_ref() {
+                        Some(format_regex) => format_regex.clone(),
+                        None => regex_memo.get_or_try_insert(format.value(i), parse_regex)?,
+                    };
                     let limit = limit_scalar_opt.unwrap_or_else(|| limit.value(i));
 
                     let values_format: Vec<Option<String>> =
@@ -174,4 +176,44 @@ pub fn split_to_array(value: &str, format: &Regex, limit: i32) -> Result<Vec<Opt
         .iter()
         .map(|value| Some(value.to_string()))
         .collect::<Vec<Option<String>>>())
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used)]
+mod tests {
+    use datafusion::arrow::array::{Int32Array, ListArray, StringArray};
+
+    use super::*;
+
+    /// A delimiter supplied as a column selects the split pattern per row;
+    /// null inputs yield null outputs.
+    #[test]
+    fn split_with_column_pattern() -> Result<()> {
+        let values: ArrayRef = Arc::new(StringArray::from(vec![Some("a-b-c"), Some("a:b"), None]));
+        let formats: ArrayRef = Arc::new(StringArray::from(vec![Some("-"), Some(":"), Some("-")]));
+        let limits: ArrayRef = Arc::new(Int32Array::from(vec![-1, -1, -1]));
+        let output = spark_split_inner(&[values, formats, limits])?;
+        let output = output
+            .as_any()
+            .downcast_ref::<ListArray>()
+            .expect("list output");
+        assert_eq!(output.len(), 3);
+        let first = output.value(0);
+        let first = first
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("string parts");
+        assert_eq!((first.len(), first.value(0), first.value(2)), (3, "a", "c"));
+        let second = output.value(1);
+        let second = second
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("string parts");
+        assert_eq!(
+            (second.len(), second.value(0), second.value(1)),
+            (2, "a", "b")
+        );
+        assert!(output.is_null(2));
+        Ok(())
+    }
 }

--- a/crates/sail-function/src/scalar/string/spark_split.rs
+++ b/crates/sail-function/src/scalar/string/spark_split.rs
@@ -190,21 +190,34 @@ mod tests {
     /// null inputs yield null outputs.
     #[test]
     fn split_with_column_pattern() -> Result<()> {
-        let values: ArrayRef = Arc::new(StringArray::from(vec![Some("a-b-c"), Some("a:b"), None]));
-        let formats: ArrayRef = Arc::new(StringArray::from(vec![Some("-"), Some(":"), Some("-")]));
-        let limits: ArrayRef = Arc::new(Int32Array::from(vec![-1, -1, -1]));
+        let values: ArrayRef = Arc::new(StringArray::from(vec![
+            Some("a-b-c"),
+            Some("a:b"),
+            None,
+            Some("x-y"),
+        ]));
+        let formats: ArrayRef = Arc::new(StringArray::from(vec![
+            Some("-"),
+            Some(":"),
+            Some("-"),
+            Some("-"),
+        ]));
+        let limits: ArrayRef = Arc::new(Int32Array::from(vec![-1, -1, -1, -1]));
         let output = spark_split_inner(&[values, formats, limits])?;
         let output = output
             .as_any()
             .downcast_ref::<ListArray>()
             .expect("list output");
-        assert_eq!(output.len(), 3);
+        assert_eq!(output.len(), 4);
         let first = output.value(0);
         let first = first
             .as_any()
             .downcast_ref::<StringArray>()
             .expect("string parts");
-        assert_eq!((first.len(), first.value(0), first.value(2)), (3, "a", "c"));
+        assert_eq!(
+            (first.len(), first.value(0), first.value(1), first.value(2)),
+            (3, "a", "b", "c")
+        );
         let second = output.value(1);
         let second = second
             .as_any()
@@ -215,6 +228,17 @@ mod tests {
             (2, "a", "b")
         );
         assert!(output.is_null(2));
+        // Row 3 reuses "-" after row 0 compiled it: the memoized regex must
+        // split exactly as a fresh compile would.
+        let fourth = output.value(3);
+        let fourth = fourth
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("string parts");
+        assert_eq!(
+            (fourth.len(), fourth.value(0), fourth.value(1)),
+            (2, "x", "y")
+        );
         Ok(())
     }
 }

--- a/crates/sail-function/src/scalar/string/spark_split.rs
+++ b/crates/sail-function/src/scalar/string/spark_split.rs
@@ -141,12 +141,11 @@ where
                 {
                     builder.append_null();
                 } else {
-                    // By reference: cloning a Regex per row would discard its
-                    // lazy-DFA cache and rebuild the automaton on every match.
-                    let format_regex = match format_scalar_opt.as_ref() {
-                        Some(format_regex) => format_regex,
-                        None => regex_memo.get_or_try_insert_ref(format.value(i), parse_regex)?,
-                    };
+                    let format_regex = regex_memo.resolve(
+                        format_scalar_opt.as_ref(),
+                        || format.value(i),
+                        parse_regex,
+                    )?;
                     let limit = limit_scalar_opt.unwrap_or_else(|| limit.value(i));
 
                     let values_format: Vec<Option<String>> =

--- a/crates/sail-function/src/scalar/string/spark_split.rs
+++ b/crates/sail-function/src/scalar/string/spark_split.rs
@@ -141,14 +141,16 @@ where
                 {
                     builder.append_null();
                 } else {
+                    // By reference: cloning a Regex per row would discard its
+                    // lazy-DFA cache and rebuild the automaton on every match.
                     let format_regex = match format_scalar_opt.as_ref() {
-                        Some(format_regex) => format_regex.clone(),
-                        None => regex_memo.get_or_try_insert(format.value(i), parse_regex)?,
+                        Some(format_regex) => format_regex,
+                        None => regex_memo.get_or_try_insert_ref(format.value(i), parse_regex)?,
                     };
                     let limit = limit_scalar_opt.unwrap_or_else(|| limit.value(i));
 
                     let values_format: Vec<Option<String>> =
-                        split_to_array(values.value(i), &format_regex, limit)?;
+                        split_to_array(values.value(i), format_regex, limit)?;
                     builder.append_value(values_format);
                 }
             }

--- a/python/pysail/tests/spark/function/features/string/regexp_extract.feature
+++ b/python/pysail/tests/spark/function/features/string/regexp_extract.feature
@@ -54,6 +54,20 @@ Feature: regexp_extract() extracts regex capture groups from strings
         | regexp_extract with anchored pattern at beginning | '123abc' | '^(\\d+)' | 123    |
         | regexp_extract with anchored pattern at end       | 'abc123' | '(\\d+)$' | 123    |
 
+  Rule: Pattern from a column
+
+    Scenario: regexp_extract with the pattern supplied by a column
+      When query
+        """
+        SELECT regexp_extract(s, p, 1) AS result FROM VALUES ('a11b', '([0-9]+)'), ('a22b', '([0-9]+)'), ('a33b', '([a-z]+)'), ('a44b', CAST(NULL AS STRING)) AS t(s, p)
+        """
+      Then query result
+        | result |
+        | 11     |
+        | 22     |
+        | a      |
+        | NULL   |
+
   @function(nullability)
   Rule: Output schema
 

--- a/python/pysail/tests/spark/function/features/string/regexp_extract_all.feature
+++ b/python/pysail/tests/spark/function/features/string/regexp_extract_all.feature
@@ -73,6 +73,20 @@ Feature: regexp_extract_all() extracts all regex capture group matches from stri
         | regexp_extract_all returns NULL when input is NULL   | NULL, r'(\d+)' |
         | regexp_extract_all returns NULL when pattern is NULL | 'abc', NULL    |
 
+  Rule: Pattern from a column
+
+    Scenario: regexp_extract_all with the pattern supplied by a column
+      When query
+        """
+        SELECT regexp_extract_all(s, p, 1) AS result FROM VALUES ('1a2b', '([0-9])'), ('3c4d', '([0-9])'), ('3c4d', '([a-z])'), ('5e6f', CAST(NULL AS STRING)) AS t(s, p)
+        """
+      Then query result
+        | result |
+        | [1, 2] |
+        | [3, 4] |
+        | [c, d] |
+        | NULL   |
+
   @function(nullability)
   Rule: Output schema
 


### PR DESCRIPTION
## Summary

- `split`, `regexp_extract`, and `regexp_extract_all` compiled their pattern with `Regex::new` per row whenever the pattern argument is a column (e.g. selected per row by a CASE), and additionally cloned the compiled `Regex` per row — `Regex::clone` does not share the internal lazy-DFA cache, so every row also rebuilt the automaton's transition table.
- A `StrMemo` helper computes any expensive `&str -> T` once per distinct value per batch; the three regex kernels use it and access the compiled regex by reference (`get_or_try_insert_ref`), never by clone.
- Result on a 41M-row column-pattern workload: `regexp_extract` 28.0s → 2.1s, `regexp_extract_all` 24.9s → 3.2s, `split` 5.3s → 3.2s — parity with Spark 4.2, checksums unchanged. Literal patterns also benefit: their scalar arm cloned per row too.

<details>
<summary><b>Mechanism and measurements</b></summary>

## Why per-row compilation happens

When the pattern argument is a column, the kernel receives an array of pattern strings and must produce a `Regex` per row. The pathological but common case is low cardinality: a CASE over a handful of literal patterns materializes a 8192-row batch containing 2–3 distinct strings, and the kernel compiled each row's string independently (~65 µs per `Regex::new` for the benchmark's pattern).

Cloning was the second, subtler cost: profiles of `regexp_extract` over a column pattern showed `Lazy::init_cache` at 19% of CPU, run-time determinization ~17%, determinizer-state hashing ~11%, cache alloc/drop ~5% — the lazy DFA was being rebuilt per row even for an already-compiled regex, because `Regex::clone` starts with an empty DFA cache. Capture extraction itself is not the bottleneck (~2x the cost of `find`).

## `StrMemo`

A per-batch `&str -> T` map keyed by strings borrowed from the input array. It lives for one kernel invocation, so there are no concurrency, growth, or invalidation concerns; it is suitable only for low-cardinality inputs (patterns, formats) — per-row-unique inputs would just pay overhead. `get_or_try_insert_ref` returns `&T` so kernels use the compiled `Regex` in place.

## Measurements

NYC yellow taxi 2024, 12 months (~41M rows), one machine (16 cores / 32 GB), `local[16]`, median of 3 runs after warmup; queries wrapped in a 1-row checksum aggregation, checksums matching Spark 4.2.

| query | before | after | spark 4.2 |
|---|---|---|---|
| regexp_extract, column pattern | 28.0s | 2.1s | 2.0s |
| regexp_extract_all, column pattern | 24.9s | 3.2s | 2.5s |
| split, column pattern | 5.3s | 3.2s | 2.8s |

</details>

<details>
<summary><b>Proposed follow-up</b></summary>

`StrMemo` is an interim measure at the kernel layer. The engine-level replacement is encoding-aware scalar evaluation — dictionary/REE inputs evaluated once per distinct value, plus operators that emit encoded output (e.g. CASE over literals). That mechanism does not exist at the query-engine layer sail builds on today; once it does, `StrMemo` is deleted — every use is one explicit call.

</details>
