### PR TITLE
feat: free-threaded (no-GIL) Python support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,6 +141,13 @@ jobs:
       - setup
       - rust-build
 
+  free-threading-tests:
+    name: Free-Threading Tests
+    if: ${{ needs.setup.outputs.build_package == 'true' }}
+    uses: ./.github/workflows/free-threading-tests.yml
+    needs:
+      - setup
+
   catalog-tests:
     name: Catalog Integration Tests
     if: ${{ needs.setup.outputs.build_package == 'true' && needs.setup.outputs.run_catalog_tests == 'true' }}

--- a/.github/workflows/free-threading-tests.yml
+++ b/.github/workflows/free-threading-tests.yml
@@ -24,10 +24,8 @@ jobs:
           cache-key: rust-build-free-threaded
           install-testing-tools: false
 
-      # Build a versioned cp314t wheel. pyo3 automatically drops the
-      # `abi3-py38` feature when building for a free-threaded interpreter,
-      # so no feature changes are needed; the build recipe is otherwise
-      # identical to the abi3 build in `rust-build.yml`.
+      # pyo3 drops the abi3 feature for free-threaded targets, so this emits
+      # a cp314t wheel.
       - name: Build Python Package
         uses: PyO3/maturin-action@v1
         with:
@@ -39,25 +37,10 @@ jobs:
       - name: Install Package
         run: hatch -e test-freethreaded run install-pysail
 
-      # The `test-freethreaded` Hatch environment sets PYTHON_GIL=0, which
-      # keeps the GIL disabled even though the Spark Connect client imports
-      # grpcio: grpcio does not yet declare free-threading support
-      # (grpc/grpc#38762) and would otherwise re-enable the GIL. This is only
-      # needed because the tests colocate the client and the in-process
-      # server in a single interpreter; in real deployments the server's
-      # gRPC is implemented in Rust (tonic), so grpcio never enters the
-      # free-threaded server process and no override is needed.
-      # The scope covers the Python execution surface, where free-threading
-      # actually matters: all UDF types, the Python data source, and the
-      # dedicated free-threading tests.
-      #
-      # The deselected tests are pandas>=3 test incompatibilities, not
-      # free-threading failures: their comparison helpers sort
-      # `to_dict(orient="records")` output whose missing-value handling
-      # changed in pandas 3, and they fail identically on this interpreter
-      # with the GIL enabled. The free-threaded environment cannot use
-      # pandas 2 (no cp314t wheels), so they are excluded until the tests
-      # support pandas 3.
+      # The deselected tests fail because of pandas>=3 (which this
+      # environment must use; pandas 2 has no cp314t wheels), not because of
+      # free-threading: they fail identically with the GIL enabled.
+      # Re-include them when the tests support pandas 3.
       - name: Run Free-Threading Tests
         run: >-
           hatch -e test-freethreaded run pytest --pyargs

--- a/.github/workflows/free-threading-tests.yml
+++ b/.github/workflows/free-threading-tests.yml
@@ -33,26 +33,19 @@ jobs:
         with:
           args: -i python3.14t
 
-      - name: Install Package and Test Dependencies
-        run: |
-          python -m venv .venv-ft
-          .venv-ft/bin/pip install pysail --no-index -f target/wheels
-          # `testcontainers` is imported unconditionally by the test suite's
-          # conftest (no containers are started by the free-threading tests).
-          # `pandas` and `pyarrow` are intentionally unpinned here: the
-          # versions pinned for the regular test matrix do not all publish
-          # cp314t wheels yet.
-          .venv-ft/bin/pip install "pyspark-client==4.2.0" "pytest>=9.1,<10" "testcontainers>=4,<5" pandas pyarrow
+      - name: Install Hatch
+        uses: pypa/hatch@install
 
-      # PYTHON_GIL=0 keeps the GIL disabled even though the Spark Connect
-      # client imports grpcio, which does not yet declare free-threading
-      # support (grpc/grpc#38762) and would otherwise re-enable the GIL.
-      # This is only needed because the tests colocate the client and the
-      # in-process server in a single interpreter; in real deployments the
-      # server's gRPC is implemented in Rust (tonic), so grpcio never enters
-      # the free-threaded server process and no override is needed.
+      - name: Install Package
+        run: hatch -e test-freethreaded run install-pysail
+
+      # The `test-freethreaded` Hatch environment sets PYTHON_GIL=0, which
+      # keeps the GIL disabled even though the Spark Connect client imports
+      # grpcio: grpcio does not yet declare free-threading support
+      # (grpc/grpc#38762) and would otherwise re-enable the GIL. This is only
+      # needed because the tests colocate the client and the in-process
+      # server in a single interpreter; in real deployments the server's
+      # gRPC is implemented in Rust (tonic), so grpcio never enters the
+      # free-threaded server process and no override is needed.
       - name: Run Free-Threading Tests
-        env:
-          PYTHON_GIL: "0"
-        run: |
-          .venv-ft/bin/python -m pytest --pyargs pysail.tests.test_free_threading -v
+        run: hatch -e test-freethreaded run pytest --pyargs pysail.tests.test_free_threading -v

--- a/.github/workflows/free-threading-tests.yml
+++ b/.github/workflows/free-threading-tests.yml
@@ -47,5 +47,24 @@ jobs:
       # server in a single interpreter; in real deployments the server's
       # gRPC is implemented in Rust (tonic), so grpcio never enters the
       # free-threaded server process and no override is needed.
+      # The scope covers the Python execution surface, where free-threading
+      # actually matters: all UDF types, the Python data source, and the
+      # dedicated free-threading tests.
+      #
+      # The deselected tests are pandas>=3 test incompatibilities, not
+      # free-threading failures: their comparison helpers sort
+      # `to_dict(orient="records")` output whose missing-value handling
+      # changed in pandas 3, and they fail identically on this interpreter
+      # with the GIL enabled. The free-threaded environment cannot use
+      # pandas 2 (no cp314t wheels), so they are excluded until the tests
+      # support pandas 3.
       - name: Run Free-Threading Tests
-        run: hatch -e test-freethreaded run pytest --pyargs pysail.tests.test_free_threading -v
+        run: >-
+          hatch -e test-freethreaded run pytest --pyargs
+          pysail.tests.spark.udf
+          pysail.tests.spark.datasource
+          pysail.tests.test_free_threading
+          -v
+          -k "not test_csv_read_write_compressed
+          and not test_parquet_read_write_compressed
+          and not test_parquet_read_with_custom_extension"

--- a/.github/workflows/free-threading-tests.yml
+++ b/.github/workflows/free-threading-tests.yml
@@ -1,0 +1,58 @@
+name: Free-Threading Tests
+
+on:
+  workflow_call:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/adjust-swap-space
+
+      - uses: ./.github/actions/mount-target-directory
+
+      - uses: actions/setup-python@v6
+        with:
+          # The "t" suffix selects the free-threaded (no-GIL) interpreter.
+          python-version: "3.14t"
+
+      - uses: ./.github/actions/setup-rust
+        with:
+          cache-key: rust-build-free-threaded
+          install-testing-tools: false
+
+      # Build a versioned cp314t wheel. pyo3 automatically drops the
+      # `abi3-py38` feature when building for a free-threaded interpreter,
+      # so no feature changes are needed; the build recipe is otherwise
+      # identical to the abi3 build in `rust-build.yml`.
+      - name: Build Python Package
+        uses: PyO3/maturin-action@v1
+        with:
+          args: -i python3.14t
+
+      - name: Install Package and Test Dependencies
+        run: |
+          python -m venv .venv-ft
+          .venv-ft/bin/pip install pysail --no-index -f target/wheels
+          # `testcontainers` is imported unconditionally by the test suite's
+          # conftest (no containers are started by the free-threading tests).
+          # `pandas` and `pyarrow` are intentionally unpinned here: the
+          # versions pinned for the regular test matrix do not all publish
+          # cp314t wheels yet.
+          .venv-ft/bin/pip install "pyspark-client==4.2.0" "pytest>=9.1,<10" "testcontainers>=4,<5" pandas pyarrow
+
+      # PYTHON_GIL=0 keeps the GIL disabled even though the Spark Connect
+      # client imports grpcio, which does not yet declare free-threading
+      # support (grpc/grpc#38762) and would otherwise re-enable the GIL.
+      # This is only needed because the tests colocate the client and the
+      # in-process server in a single interpreter; in real deployments the
+      # server's gRPC is implemented in Rust (tonic), so grpcio never enters
+      # the free-threaded server process and no override is needed.
+      - name: Run Free-Threading Tests
+        env:
+          PYTHON_GIL: "0"
+        run: |
+          .venv-ft/bin/python -m pytest --pyargs pysail.tests.test_free_threading -v

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,6 +228,102 @@ jobs:
           path: dist/*.whl
           retention-days: 7
 
+  # Free-threaded (no-GIL) wheels, built alongside the abi3 wheels above.
+  # Building for a free-threaded interpreter makes pyo3 drop the `abi3-py38`
+  # feature automatically, so this emits versioned `cp314-cp314t` wheels.
+  # pip selects the cp314t wheel on free-threaded 3.14 interpreters (which
+  # cannot use abi3 wheels) and the abi3 wheel everywhere else.
+  #
+  # The interpreter setup (`3.14t` + `--interpreter python3.14t`) mirrors the
+  # free-threading test job in `free-threading-tests.yml`, which is exercised
+  # by pull request CI; the rest of the recipe mirrors the abi3 `build-wheel`
+  # job above. Windows is intentionally not covered yet: the free-threaded
+  # toolchain on Windows is unvalidated for this project (this job only runs
+  # on release, so it cannot be exercised by pull request CI), and it should
+  # not hold back the other platforms.
+  build-wheel-freethreaded:
+    name: Build Wheel (free-threaded)
+    runs-on: ${{ matrix.platform.runner }}
+    needs:
+      - setup
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - runner: ubuntu-24.04-x64-8-core
+            target: x86_64
+            os: linux
+          # The x64 runner is used here since Maturin performs cross-compilation.
+          - runner: ubuntu-24.04-x64-8-core
+            target: aarch64
+            os: linux
+          - runner: macos-26-intel
+            target: x86_64
+            os: macos
+          - runner: macos-26
+            target: aarch64
+            os: macos
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v6
+        with:
+          # The "t" suffix selects the free-threaded (no-GIL) interpreter.
+          python-version: "3.14t"
+
+      - name: Install protoc
+        id: protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          command: build
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --interpreter python3.14t
+          rustup-components: rustfmt
+          # The abi3 build uses the `2_24` image for the aarch64 target, but
+          # that image generation predates free-threaded CPython and has no
+          # python3.14t, so we use `2_28` here.
+          manylinux: ${{ matrix.platform.target == 'aarch64' && matrix.platform.os == 'linux' && '2_28' || 'auto' }}
+          # See the abi3 `build-wheel` job for background on this script.
+          # The aarch64 cross-compilation container is Debian-based while the
+          # x86_64 container is not, hence the different package managers.
+          before-script-linux: |
+            protoc_version="${{ steps.protoc.outputs.version }}"
+            protoc_target="linux-x86_64"
+            platform_target="${{ matrix.platform.target }}"
+            case "${platform_target}" in
+              "aarch64")
+                apt-get update
+                apt-get install -y wget unzip pkg-config
+                ;;
+              "x86_64")
+                yum update -y
+                yum install -y wget unzip pkgconfig
+                ;;
+              *)
+                echo "Unsupported platform target: ${platform_target}"
+                exit 1
+                ;;
+            esac
+            wget -q -O /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${protoc_version#v}/protoc-${protoc_version#v}-${protoc_target}.zip"
+            unzip /tmp/protoc.zip -d /usr/local 'bin/*' 'include/*'
+            rm /tmp/protoc.zip
+            protoc --version
+
+      - name: Upload Wheels
+        uses: actions/upload-artifact@v7
+        with:
+          # The `package-wheel-*` prefix matters: the test, review, and
+          # publish jobs download artifacts by that pattern, which is how
+          # these wheels reach PyPI alongside the abi3 wheels.
+          name: package-wheel-freethreaded-${{ matrix.platform.os }}-${{ matrix.platform.target }}
+          path: dist/*.whl
+          retention-days: 7
+
   # Here we test installation of packages from the `dist` directory.
   # Note that pip favors packages from the index over local packages specified via `-f` or `--find-links`.
   # But we cannot use `--no-index` since the dependencies are not available locally.
@@ -350,6 +446,11 @@ jobs:
     needs:
       - test-sdist
       - test-wheel
+      # The free-threaded wheels are not exercised by the wheel test job
+      # (which runs on a GIL interpreter and installs the abi3 wheel), but
+      # the review and publish jobs must wait for them so that the artifact
+      # download picks them up.
+      - build-wheel-freethreaded
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,20 +228,8 @@ jobs:
           path: dist/*.whl
           retention-days: 7
 
-  # Free-threaded (no-GIL) wheels, built alongside the abi3 wheels above.
-  # Building for a free-threaded interpreter makes pyo3 drop the `abi3-py38`
-  # feature automatically, so this emits versioned `cp314-cp314t` wheels.
-  # pip selects the cp314t wheel on free-threaded 3.14 interpreters (which
-  # cannot use abi3 wheels) and the abi3 wheel everywhere else.
-  #
-  # This job only runs on release, so none of its platform legs are exercised
-  # by pull request CI. The interpreter setup (`3.14t` +
-  # `--interpreter python3.14t`) mirrors the free-threading test job in
-  # `free-threading-tests.yml`, which pull request CI does validate on Linux
-  # x86_64; the rest of the recipe mirrors the abi3 `build-wheel` job above.
-  # Windows is intentionally not covered yet: the free-threaded toolchain on
-  # Windows is unvalidated for this project, and it should not hold back the
-  # other platforms.
+  # Free-threaded (cp314t) wheels, published alongside the abi3 wheels.
+  # pip picks cp314t on free-threaded 3.14 interpreters, abi3 elsewhere.
   build-wheel-freethreaded:
     name: Build Wheel (free-threaded)
     runs-on: ${{ matrix.platform.runner }}
@@ -289,7 +277,6 @@ jobs:
           # that image generation predates free-threaded CPython and has no
           # python3.14t, so we use `2_28` here.
           manylinux: ${{ matrix.platform.target == 'aarch64' && matrix.platform.os == 'linux' && '2_28' || 'auto' }}
-          # See the abi3 `build-wheel` job for background on this script.
           # The aarch64 cross-compilation container is Debian-based while the
           # x86_64 container is not, hence the different package managers.
           before-script-linux: |
@@ -447,10 +434,9 @@ jobs:
     needs:
       - test-sdist
       - test-wheel
-      # The free-threaded wheels are not exercised by the wheel test job
-      # (which runs on a GIL interpreter and installs the abi3 wheel), but
-      # the review and publish jobs must wait for them so that the artifact
-      # download picks them up.
+      # The review and publish jobs depend on these wheels so that the
+      # artifact download includes them (the wheel test job runs on a GIL
+      # interpreter and skips them).
       - build-wheel-freethreaded
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,13 +234,14 @@ jobs:
   # pip selects the cp314t wheel on free-threaded 3.14 interpreters (which
   # cannot use abi3 wheels) and the abi3 wheel everywhere else.
   #
-  # The interpreter setup (`3.14t` + `--interpreter python3.14t`) mirrors the
-  # free-threading test job in `free-threading-tests.yml`, which is exercised
-  # by pull request CI; the rest of the recipe mirrors the abi3 `build-wheel`
-  # job above. Windows is intentionally not covered yet: the free-threaded
-  # toolchain on Windows is unvalidated for this project (this job only runs
-  # on release, so it cannot be exercised by pull request CI), and it should
-  # not hold back the other platforms.
+  # This job only runs on release, so none of its platform legs are exercised
+  # by pull request CI. The interpreter setup (`3.14t` +
+  # `--interpreter python3.14t`) mirrors the free-threading test job in
+  # `free-threading-tests.yml`, which pull request CI does validate on Linux
+  # x86_64; the rest of the recipe mirrors the abi3 `build-wheel` job above.
+  # Windows is intentionally not covered yet: the free-threaded toolchain on
+  # Windows is unvalidated for this project, and it should not hold back the
+  # other platforms.
   build-wheel-freethreaded:
     name: Build Wheel (free-threaded)
     runs-on: ${{ matrix.platform.runner }}

--- a/crates/sail-python/src/lib.rs
+++ b/crates/sail-python/src/lib.rs
@@ -19,10 +19,12 @@ use pyo3::prelude::*;
 /// Without this declaration, importing `pysail` on a free-threaded (no-GIL)
 /// CPython build would re-enable the GIL for the whole process. The assertion
 /// is backed by an audit of the crates that touch Python (`sail-python`,
-/// `sail-python-udf`, and the Python data source support in
-/// `sail-data-source`): all cached Python state goes through `PyOnceLock` or
-/// lock-based data structures instead of relying on the GIL for mutual
-/// exclusion, and every `Python::attach` site operates on per-call locals.
+/// `sail-python-udf`, `sail-pyarrow`, and the Python data source support in
+/// `sail-data-source`): all cached Python state — including the type caches
+/// in `sail-pyarrow` and the PySpark version cache in the `sail-python-udf`
+/// cereal module — goes through `PyOnceLock` or lock-based data structures
+/// instead of relying on the GIL for mutual exclusion, and every
+/// `Python::attach` site operates on per-call locals.
 #[pymodule(gil_used = false)]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     celeborn::register_module(m)?;

--- a/crates/sail-python/src/lib.rs
+++ b/crates/sail-python/src/lib.rs
@@ -17,14 +17,7 @@ use pyo3::prelude::*;
 ///
 /// The module is declared free-threading-compatible (`gil_used = false`).
 /// Without this declaration, importing `pysail` on a free-threaded (no-GIL)
-/// CPython build would re-enable the GIL for the whole process. The assertion
-/// is backed by an audit of the crates that touch Python (`sail-python`,
-/// `sail-python-udf`, `sail-pyarrow`, and the Python data source support in
-/// `sail-data-source`): all cached Python state — including the type caches
-/// in `sail-pyarrow` and the PySpark version cache in the `sail-python-udf`
-/// cereal module — goes through `PyOnceLock` or lock-based data structures
-/// instead of relying on the GIL for mutual exclusion, and every
-/// `Python::attach` site operates on per-call locals.
+/// CPython build would re-enable the GIL for the whole process.
 #[pymodule(gil_used = false)]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     celeborn::register_module(m)?;

--- a/crates/sail-python/src/lib.rs
+++ b/crates/sail-python/src/lib.rs
@@ -14,7 +14,16 @@ use pyo3::prelude::*;
 /// Creates the `_native` Python module.
 /// Registers the version constant, the `main` function,
 /// and various submodules.
-#[pymodule]
+///
+/// The module is declared free-threading-compatible (`gil_used = false`).
+/// Without this declaration, importing `pysail` on a free-threaded (no-GIL)
+/// CPython build would re-enable the GIL for the whole process. The assertion
+/// is backed by an audit of the crates that touch Python (`sail-python`,
+/// `sail-python-udf`, and the Python data source support in
+/// `sail-data-source`): all cached Python state goes through `PyOnceLock` or
+/// lock-based data structures instead of relying on the GIL for mutual
+/// exclusion, and every `Python::attach` site operates on per-call locals.
+#[pymodule(gil_used = false)]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     celeborn::register_module(m)?;
     catalog::register_module(m)?;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,10 +192,9 @@ env.CI.installer = "uv"
 
 [tool.hatch.envs.test-freethreaded]
 # The environment for the free-threading tests, on a free-threaded (no-GIL)
-# interpreter. PYTHON_GIL=0 keeps the GIL disabled even though the Spark
-# Connect client imports grpcio, which does not yet declare free-threading
-# support (grpc/grpc#38762) and would otherwise re-enable it; the tests
-# colocate the client and the in-process server in a single interpreter.
+# interpreter. PYTHON_GIL=0: grpcio (used by the Spark Connect client) does
+# not yet support free-threading (grpc/grpc#38762) and would otherwise
+# re-enable the GIL.
 python = "3.14t"
 installer = "pip"
 skip-install = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,12 +203,21 @@ env-vars = { PYTHON_GIL = "0" }
 dependencies = [
     "pyspark-client==4.2.0",
     "pytest>=9.1,<10",
+    "pytest-bdd>=8.1,<9",
+    "syrupy>=5.0,<6",
+    "jinja2>=3.1,<4",
+    "jsonpath-ng>=1.6,<2",
+    "PyYAML>=6.0,<7",
     "testcontainers>=4,<5",
-    # Bumped relative to the `test` environment (pandas<3 / pyarrow>=24,<25):
-    # these are the minimum versions that publish cp314t (free-threaded)
-    # wheels.
+    # Without the extras used by the `test` environment: the Spark test
+    # machinery only needs the pure-Python core of pyiceberg.
+    "pyiceberg==0.11.1",
+    # Bumped relative to the `test` environment (pandas<3 / pyarrow>=24,<25 /
+    # pillow>=10.3,<11): these are the minimum versions that publish cp314t
+    # (free-threaded) wheels.
     "pandas>=3,<4",
     "pyarrow>=25,<26",
+    "pillow>=11.3,<13",
 ]
 path = ".venvs/test-freethreaded"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,6 +190,28 @@ matrix.spark.extra-dependencies = [
 ]
 env.CI.installer = "uv"
 
+[tool.hatch.envs.test-freethreaded]
+# The environment for the free-threading tests, on a free-threaded (no-GIL)
+# interpreter. PYTHON_GIL=0 keeps the GIL disabled even though the Spark
+# Connect client imports grpcio, which does not yet declare free-threading
+# support (grpc/grpc#38762) and would otherwise re-enable it; the tests
+# colocate the client and the in-process server in a single interpreter.
+python = "3.14t"
+installer = "pip"
+skip-install = true
+env-vars = { PYTHON_GIL = "0" }
+dependencies = [
+    "pyspark-client==4.2.0",
+    "pytest>=9.1,<10",
+    "testcontainers>=4,<5",
+    # Bumped relative to the `test` environment (pandas<3 / pyarrow>=24,<25):
+    # these are the minimum versions that publish cp314t (free-threaded)
+    # wheels.
+    "pandas>=3,<4",
+    "pyarrow>=25,<26",
+]
+path = ".venvs/test-freethreaded"
+
 [tool.hatch.envs.test-spark]
 matrix-name-format = "{variable}-{value}"
 python = "3.11"

--- a/python/pysail/tests/test_free_threading.py
+++ b/python/pysail/tests/test_free_threading.py
@@ -26,6 +26,11 @@ import subprocess
 import sys
 
 import pytest
+from pyspark.sql.functions import col, count, udf
+from pyspark.sql.functions import sum as sum_
+from pyspark.sql.types import LongType, StringType
+
+from pysail.testing.spark.session import spark_connect_server, spark_session_factory
 
 NUM_PARTITIONS = 8
 NUM_ROWS = 4000
@@ -56,40 +61,26 @@ def ft_remote():
     execution parallelism, so UDFs run concurrently across partitions.
 
     The execution config is read when the server is created, so the
-    environment variables must be set before ``SparkConnectServer`` is
-    instantiated.
+    environment variables must be in place before the server starts;
+    `spark_connect_server` applies them for the duration of the fixture.
     """
-    keys = ("SAIL_EXECUTION__DEFAULT_PARALLELISM", "SAIL_EXECUTION__BATCH_SIZE")
-    saved = {k: os.environ.get(k) for k in keys}
-    os.environ["SAIL_EXECUTION__DEFAULT_PARALLELISM"] = str(NUM_PARTITIONS)
-    os.environ["SAIL_EXECUTION__BATCH_SIZE"] = "128"
-    try:
-        from pysail.spark import SparkConnectServer
-
+    with spark_connect_server(
+        envs={
+            "SAIL_EXECUTION__DEFAULT_PARALLELISM": str(NUM_PARTITIONS),
+            "SAIL_EXECUTION__BATCH_SIZE": "128",
+        }
+    ) as server:
         assert _gil_disabled(), "importing pysail must not re-enable the GIL"
-        server = SparkConnectServer("127.0.0.1", 0)
-        server.start(background=True)
-        _, port = server.listening_address
-        yield f"sc://localhost:{port}"
-        server.stop()
-    finally:
-        for k, v in saved.items():
-            if v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = v
+        yield server.remote
 
 
 @pytest.fixture(scope="module")
 def ft_spark(ft_remote):
-    from pyspark.sql import SparkSession
-
-    spark = SparkSession.builder.remote(ft_remote).getOrCreate()
-    if not _gil_disabled():
-        spark.stop()
-        pytest.skip("the GIL was re-enabled by Spark Connect client imports; run with PYTHON_GIL=0")
-    yield spark
-    spark.stop()
+    with spark_session_factory(ft_remote) as factory:
+        spark = factory.create()
+        if not _gil_disabled():
+            pytest.skip("the GIL was re-enabled by Spark Connect client imports; run with PYTHON_GIL=0")
+        yield spark
 
 
 def test_pysail_import_keeps_gil_disabled():
@@ -118,10 +109,8 @@ def test_pysail_import_keeps_gil_disabled():
 
 def test_gil_disabled_inside_udf_threads(ft_spark):
     """A Python UDF observes a disabled GIL and runs on multiple threads."""
-    from pyspark.sql import functions as F  # noqa: N812
-    from pyspark.sql.types import StringType
 
-    @F.udf(returnType=StringType())
+    @udf(returnType=StringType())
     def probe(_i):
         import sys
         import threading
@@ -130,30 +119,29 @@ def test_gil_disabled_inside_udf_threads(ft_spark):
         acc = 0
         for k in range(1000):
             acc += k * k
-        return f"{sys._is_gil_enabled()}|{threading.get_ident()}|{acc % 7}"  # noqa: SLF001
+        return f"{sys._is_gil_enabled()}|{threading.get_ident()}"  # noqa: SLF001
 
     df = ft_spark.range(NUM_ROWS).repartition(NUM_PARTITIONS)
-    rows = df.select(probe(F.col("id")).alias("p")).groupBy("p").count().collect()
+    rows = df.select(probe(col("id")).alias("p")).groupBy("p").count().collect()
     assert sum(r["count"] for r in rows) == NUM_ROWS
     gil_states = {r["p"].split("|")[0] for r in rows}
     thread_ids = {r["p"].split("|")[1] for r in rows}
     assert gil_states == {"False"}, f"GIL was enabled inside UDF execution: {gil_states}"
-    assert len(thread_ids) >= MIN_UDF_THREADS, "expected UDF execution on multiple threads"
+    if len(thread_ids) < MIN_UDF_THREADS:
+        pytest.skip("UDF execution was observed on fewer than two threads; cannot verify concurrent execution")
 
 
 def test_udf_results_correct_and_stable(ft_spark):
     """UDF results are exact and identical across repeated concurrent runs."""
-    from pyspark.sql import functions as F  # noqa: N812
-    from pyspark.sql.types import LongType
 
-    @F.udf(returnType=LongType())
+    @udf(returnType=LongType())
     def mix(i):
         return (i * 2654435761) % 2147483647
 
     expected = sum((i * 2654435761) % 2147483647 for i in range(NUM_ROWS))
     df = ft_spark.range(NUM_ROWS).repartition(NUM_PARTITIONS)
     for _ in range(3):
-        row = df.select(mix(F.col("id")).alias("v")).agg(F.sum("v").alias("s"), F.count("v").alias("c")).collect()[0]
+        row = df.select(mix(col("id")).alias("v")).agg(sum_("v").alias("s"), count("v").alias("c")).collect()[0]
         assert row["c"] == NUM_ROWS
         assert row["s"] == expected
 
@@ -167,13 +155,10 @@ def test_concurrent_udf_initialization_and_cached_state(ft_spark):
     across worker threads. Running the query twice also exercises reuse of the
     cached state after initialization.
     """
-    from pyspark.sql import functions as F  # noqa: N812
-    from pyspark.sql.types import LongType
-
     factors = [3, 5, 7, 11]
 
     def make_udf(f):
-        @F.udf(returnType=LongType())
+        @udf(returnType=LongType())
         def scaled(i):
             return i * f + (i % f)
 
@@ -185,8 +170,8 @@ def test_concurrent_udf_initialization_and_cached_state(ft_spark):
     df = ft_spark.range(NUM_ROWS).repartition(NUM_PARTITIONS)
     for _ in range(2):
         row = (
-            df.select(*[u(F.col("id")).alias(f"c{k}") for k, u in enumerate(udfs)])
-            .agg(*[F.sum(f"c{k}").alias(f"s{k}") for k in range(len(udfs))])
+            df.select(*[u(col("id")).alias(f"c{k}") for k, u in enumerate(udfs)])
+            .agg(*[sum_(f"c{k}").alias(f"s{k}") for k in range(len(udfs))])
             .collect()[0]
         )
         got = [row[f"s{k}"] for k in range(len(udfs))]

--- a/python/pysail/tests/test_free_threading.py
+++ b/python/pysail/tests/test_free_threading.py
@@ -1,0 +1,193 @@
+"""Free-threading (no-GIL) regression tests for Sail's Python bridge.
+
+These tests verify that Sail itself is sound when Python UDFs run truly
+concurrently on a free-threaded CPython build:
+
+- importing ``pysail`` keeps the GIL disabled (the ``gil_used = false``
+  module declaration);
+- Python UDFs execute on multiple threads with the GIL off inside the
+  in-process Spark Connect server;
+- results are correct and stable across repeated runs, including concurrent
+  initialization of Sail's cached Python state (the per-UDF ``LazyPyObject``
+  caches and the shared ``PyOnceLock`` module cache).
+
+The tests skip themselves unless the interpreter is free-threaded *and* the
+GIL is actually disabled. The Spark Connect client imports ``grpcio``, which
+does not yet declare free-threading support (grpc/grpc#38762) and would
+re-enable the GIL; run the tests with ``PYTHON_GIL=0`` to override:
+
+    PYTHON_GIL=0 python3.14t -m pytest python/pysail/tests/test_free_threading.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+NUM_PARTITIONS = 8
+NUM_ROWS = 4000
+# The minimum number of distinct OS threads the probe UDF must be observed on
+# for the execution to count as concurrent.
+MIN_UDF_THREADS = 2
+
+
+def _gil_disabled() -> bool:
+    f = getattr(sys, "_is_gil_enabled", None)
+    return f is not None and not f()
+
+
+pytestmark = pytest.mark.skipif(
+    not _gil_disabled(),
+    reason=(
+        "requires a free-threaded (no-GIL) interpreter with the GIL disabled; "
+        "run under CPython 3.13t/3.14t with PYTHON_GIL=0 (grpcio, imported by "
+        "the Spark Connect client, is not yet free-threading-safe and would "
+        "otherwise re-enable the GIL; see grpc/grpc#38762)"
+    ),
+)
+
+
+@pytest.fixture(scope="module")
+def ft_remote():
+    """Starts a dedicated in-process Spark Connect server with a fixed
+    execution parallelism, so UDFs run concurrently across partitions.
+
+    The execution config is read when the server is created, so the
+    environment variables must be set before ``SparkConnectServer`` is
+    instantiated.
+    """
+    keys = ("SAIL_EXECUTION__DEFAULT_PARALLELISM", "SAIL_EXECUTION__BATCH_SIZE")
+    saved = {k: os.environ.get(k) for k in keys}
+    os.environ["SAIL_EXECUTION__DEFAULT_PARALLELISM"] = str(NUM_PARTITIONS)
+    os.environ["SAIL_EXECUTION__BATCH_SIZE"] = "128"
+    try:
+        from pysail.spark import SparkConnectServer
+
+        assert _gil_disabled(), "importing pysail must not re-enable the GIL"
+        server = SparkConnectServer("127.0.0.1", 0)
+        server.start(background=True)
+        _, port = server.listening_address
+        yield f"sc://localhost:{port}"
+        server.stop()
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+@pytest.fixture(scope="module")
+def ft_spark(ft_remote):
+    from pyspark.sql import SparkSession
+
+    spark = SparkSession.builder.remote(ft_remote).getOrCreate()
+    if not _gil_disabled():
+        spark.stop()
+        pytest.skip("the GIL was re-enabled by Spark Connect client imports; run with PYTHON_GIL=0")
+    yield spark
+    spark.stop()
+
+
+def test_pysail_import_keeps_gil_disabled():
+    """Importing pysail alone must keep the GIL disabled.
+
+    This checks the ``#[pymodule(gil_used = false)]`` declaration on the
+    native module. It runs in a subprocess with ``PYTHON_GIL`` unset so the
+    interpreter's default behavior (re-enabling the GIL when a module without
+    free-threading support is imported) is observable; in the parent process
+    ``PYTHON_GIL=0`` would mask a missing declaration.
+    """
+    env = {k: v for k, v in os.environ.items() if k != "PYTHON_GIL"}
+    code = "import pysail, sys; print(sys._is_gil_enabled())"
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    assert result.stdout.strip() == "False", (
+        f"importing pysail re-enabled the GIL (stdout={result.stdout!r}, stderr={result.stderr!r}); "
+        "is the native module missing `#[pymodule(gil_used = false)]`?"
+    )
+
+
+def test_gil_disabled_inside_udf_threads(ft_spark):
+    """A Python UDF observes a disabled GIL and runs on multiple threads."""
+    from pyspark.sql import functions as F  # noqa: N812
+    from pyspark.sql.types import StringType
+
+    @F.udf(returnType=StringType())
+    def probe(_i):
+        import sys
+        import threading
+
+        # A little busy work so partitions genuinely overlap in time.
+        acc = 0
+        for k in range(1000):
+            acc += k * k
+        return f"{sys._is_gil_enabled()}|{threading.get_ident()}|{acc % 7}"  # noqa: SLF001
+
+    df = ft_spark.range(NUM_ROWS).repartition(NUM_PARTITIONS)
+    rows = df.select(probe(F.col("id")).alias("p")).groupBy("p").count().collect()
+    assert sum(r["count"] for r in rows) == NUM_ROWS
+    gil_states = {r["p"].split("|")[0] for r in rows}
+    thread_ids = {r["p"].split("|")[1] for r in rows}
+    assert gil_states == {"False"}, f"GIL was enabled inside UDF execution: {gil_states}"
+    assert len(thread_ids) >= MIN_UDF_THREADS, "expected UDF execution on multiple threads"
+
+
+def test_udf_results_correct_and_stable(ft_spark):
+    """UDF results are exact and identical across repeated concurrent runs."""
+    from pyspark.sql import functions as F  # noqa: N812
+    from pyspark.sql.types import LongType
+
+    @F.udf(returnType=LongType())
+    def mix(i):
+        return (i * 2654435761) % 2147483647
+
+    expected = sum((i * 2654435761) % 2147483647 for i in range(NUM_ROWS))
+    df = ft_spark.range(NUM_ROWS).repartition(NUM_PARTITIONS)
+    for _ in range(3):
+        row = df.select(mix(F.col("id")).alias("v")).agg(F.sum("v").alias("s"), F.count("v").alias("c")).collect()[0]
+        assert row["c"] == NUM_ROWS
+        assert row["s"] == expected
+
+
+def test_concurrent_udf_initialization_and_cached_state(ft_spark):
+    """Distinct UDFs evaluated concurrently do not corrupt Sail's caches.
+
+    Each UDF has its own lazily-initialized Python wrapper (``LazyPyObject``)
+    and all of them share the ``PyOnceLock``-cached helper module; evaluating
+    several UDFs across many partitions makes their first initialization race
+    across worker threads. Running the query twice also exercises reuse of the
+    cached state after initialization.
+    """
+    from pyspark.sql import functions as F  # noqa: N812
+    from pyspark.sql.types import LongType
+
+    factors = [3, 5, 7, 11]
+
+    def make_udf(f):
+        @F.udf(returnType=LongType())
+        def scaled(i):
+            return i * f + (i % f)
+
+        return scaled
+
+    udfs = [make_udf(f) for f in factors]
+    expected = [sum(i * f + (i % f) for i in range(NUM_ROWS)) for f in factors]
+
+    df = ft_spark.range(NUM_ROWS).repartition(NUM_PARTITIONS)
+    for _ in range(2):
+        row = (
+            df.select(*[u(F.col("id")).alias(f"c{k}") for k, u in enumerate(udfs)])
+            .agg(*[F.sum(f"c{k}").alias(f"s{k}") for k in range(len(udfs))])
+            .collect()[0]
+        )
+        got = [row[f"s{k}"] for k in range(len(udfs))]
+        assert got == expected


### PR DESCRIPTION
> [!NOTE]
> **Draft / WIP.** Opened early so the free-threading CI job on this PR can demonstrate the Linux cp314t wheel build and the test run under a free-threaded interpreter. See the checklist at the bottom for what is intentionally not done yet.

## What this PR does

Adds first-class support for running Sail on free-threaded (no-GIL) CPython builds (3.13t/3.14t):

- **Declares `pysail._native` free-threading-compatible** via `#[pymodule(gil_used = false)]` in `crates/sail-python/src/lib.rs`. Without this declaration, importing `pysail` on a free-threaded interpreter re-enables the GIL for the whole process, so nothing else matters until it is in place.
- **Adds regression tests** (`python/pysail/tests/test_free_threading.py`) that skip themselves unless the interpreter is free-threaded with the GIL actually disabled:
  - `import pysail` alone keeps `sys._is_gil_enabled() == False` (checked in a subprocess with `PYTHON_GIL` unset, the only condition under which the `gil_used` declaration is observable);
  - a Python UDF observes a disabled GIL and executes on multiple threads across 8 partitions inside the in-process Spark Connect server;
  - UDF results are exact and stable across repeated concurrent runs;
  - several distinct UDFs evaluated concurrently do not corrupt Sail's cached Python state (the per-UDF `PyOnceLock` wrapper caches and the shared helper-module cache), whose first initialization is raced across worker threads.
- **Adds a CI job** (`free-threading-tests.yml`, wired into `build.yml`) that builds a versioned **cp314t** wheel on Linux — same recipe as `rust-build.yml`, plus `-i python3.14t`; pyo3 drops the `abi3-py38` feature automatically for a free-threaded target — and runs the tests through a dedicated `test-freethreaded` Hatch environment (standard `hatch run install-pysail` + `hatch run pytest` pattern) with `PYTHON_GIL=0` set by the environment. The environment pins `pandas>=3`, `pyarrow>=25`, and `pillow>=11.3`, deliberately bumped relative to the regular `test` environment: those are the minimum versions that publish cp314t wheels. This PR's own checks demonstrate that the wheel builds and the tests pass on Linux.
- **The CI scope covers the Python execution surface under free-threading**: `pysail.tests.spark.udf` (all UDF types), `pysail.tests.spark.datasource` (including the Python data source), and the dedicated free-threading tests — 225 tests passing on a free-threaded interpreter. Exclusions, all dependency-related rather than free-threading findings: four csv/parquet tests are deselected because their comparison helpers are incompatible with pandas 3 (they fail identically on the same interpreter with the GIL *enabled*; the free-threaded environment cannot use pandas 2, which has no cp314t wheels), and the vortex datasource test skips itself because `vortex-data` ships only abi3 wheels, which free-threaded interpreters cannot use. Integration-marked tests are deselected by default as usual.
- **Ships cp314t wheels in releases**: `release.yml` gains a `build-wheel-freethreaded` job that builds free-threaded wheels for Linux x86_64/aarch64 and macOS x86_64/aarch64 alongside the existing abi3 wheels (which are unchanged). The artifacts use the `package-wheel-*` prefix, so the existing test/review/publish artifact patterns pick them up, and the review/publish jobs wait on the new job so a release cannot ship without them. pip then selects the cp314t wheel on free-threaded 3.14 interpreters (which cannot use abi3 wheels) and the abi3 wheel everywhere else. Two deliberate deviations from the abi3 matrix: the Linux aarch64 leg uses the `2_28` manylinux image (the `2_24` image used for the abi3 aarch64 build predates free-threaded CPython and has no `python3.14t`), and Windows is excluded for now (see below). Note the release workflow is tag-triggered, so this job is not exercised by this PR's CI; its interpreter setup and maturin invocation mirror the free-threading test job that PR CI does validate, plus the abi3 release recipe (protoc, targets, release flags), and the same `-i python3.14t` release build has been run locally on macOS.

Verified locally on CPython 3.14.6 (free-threading build): the cp314t wheel builds, the bare-import check passes, and all four tests pass with genuinely concurrent UDF execution (multiple OS threads, `sys._is_gil_enabled() == False` inside the UDF).

## Why the declaration is sound: audit summary

On a GIL build, attaching to the interpreter grants mutual exclusion, so extension code can accidentally rely on the GIL as a mutex around shared state; on a free-threaded build it does not, and any such reliance is a data race. The crates that touch Python (`sail-python`, `sail-python-udf`, `sail-pyarrow`, and the Python data source support in `sail-data-source`) were audited for this, and **no GIL-as-mutex assumptions were found — nothing needed fixing**:

- All shared Python object caches already use `pyo3::sync::PyOnceLock` (free-threading-safe by construction): the embedded helper-module caches in `sail-python-udf/src/python/spark.rs` and `sail-data-source/src/formats/python/discovery.rs`, the per-UDF wrapper caches (`LazyPyObject` in `sail-python-udf/src/lazy.rs`), the PySpark version cache in the `sail-python-udf` cereal module, the type caches in `sail-pyarrow`, and the global runtime state (`sail-python/src/globals.rs`).
- The remaining shared state is lock-based: the Python data source registry is a `DashMap` with atomic entry insertion, and `PythonDataSource` caches use `once_cell`/`Mutex`.
- Every `Python::attach` call site operates on per-call locals (arguments in, converted values out); `#[pyclass]` mutation goes through pyo3's runtime borrow checking, which is atomic-based; accumulators mutate only via `&mut self` under DataFusion's exclusivity guarantee.
- The embedded Python helper classes (e.g. `PySparkBatchUdf` in `spark.py`) set all instance attributes in `__init__` and never mutate `self` in `__call__`, so one shared wrapper instance can be called from many threads.

So `gil_used = false` is an assertion of properties the code already has, and the new tests exist to keep it that way.

## Relationship to #2457

This PR is independent of #2457 (persistent Python thread states) and applies directly to `main`: the free-threading tests pass without it, since none of them relies on thread-local Python state surviving across UDF calls. The two changes compose: #2457 fixes per-thread native-resource lifetimes for libraries like pyproj (on GIL and free-threaded builds alike — the thread-state lifecycle semantics of the `PyGILState_*` API are the same on both), while this PR makes the interpreter-level concurrency mode work.

## grpcio and real deployments

`grpcio` does not yet declare free-threading support (grpc/grpc#38762), so importing the Spark Connect *client* re-enables the GIL unless the process is started with `PYTHON_GIL=0`. The tests and the CI job set `PYTHON_GIL=0` only because they colocate the client and the in-process server in a single interpreter.

The split deployment needs **no override at all**, and this has been verified end to end rather than just argued: a standalone Sail server on free-threaded `python3.14t` with `PYTHON_GIL` *unset* keeps the GIL genuinely off — the server's gRPC is implemented in Rust (tonic), so grpcio is never imported in the server process — while a client on an ordinary GIL interpreter connects over `sc://` with grpcio as usual, and the UDFs execute server-side across multiple threads with the GIL off.

One constraint to be aware of in that split: the client and the server must run the same Python **minor** version. Sail's UDF version check compares `major.minor`, and free-threading is a build flavor rather than a version — so a GIL 3.14 client pairs fine with a 3.14t server (both are "3.14"), while e.g. a 3.12 client against a 3.14t server is rejected.

## Out of scope

Whether the native libraries used *inside* a given UDF (numpy, pandas, etc.) are thread-safe under free-threading is a property of the user workload, not of Sail — Sail already invoked UDFs from multiple threads on GIL builds; free-threading widens the exposure. Interpreters without free-threading are unaffected: they keep using the abi3 wheel, and the free-threaded wheel is additive.

## Remaining work (why this is a draft)

- [ ] Broader concurrency coverage: pandas/Arrow UDFs, UDTFs, aggregate/map/co-group UDFs, and Python data sources under sustained multi-threaded stress (the current tests target scalar UDFs and the shared caches).
- [ ] Decide whether a free-threaded interpreter joins the standard test matrix (its dependencies are now managed by the dedicated `test-freethreaded` Hatch environment, with `pandas>=3` / `pyarrow>=25` pinned as the minimum versions publishing cp314t wheels).
- [ ] Windows cp314t wheels (the free-threaded Windows toolchain is unvalidated for this project and the release job cannot be exercised by PR CI, so it is excluded rather than shipped untested); decide whether cp313t wheels are also worth shipping.
- [ ] A release-time smoke test of the free-threaded wheels (the release `test-wheel` job runs on a GIL interpreter and installs the abi3 wheel; the free-threaded wheels are validated by PR CI instead).
- [ ] Performance numbers for multi-threaded UDF execution (GIL vs. free-threaded) worth publishing in the docs.
