### PR TITLE
feat: implement vector_norm

### DIFF
--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -3002,6 +3002,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node_inner.is::<SparkArrayCompact>()
             || node_inner.is::<SparkCastStringToInt32>()
             || node_inner.is::<VectorInnerProduct>()
+            || node_inner.is::<VectorNorm>()
             || node_inner.is::<BitmapCount>()
             || node_inner.is::<FormatStringFunc>()
             || node_inner.is::<GreatestFunc>()

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -250,6 +250,7 @@ use sail_function::scalar::variant::spark_variant_explode::SparkVariantExplodeUd
 use sail_function::scalar::variant::spark_variant_get::SparkVariantGet;
 use sail_function::scalar::variant::spark_variant_to_json::SparkVariantToJsonUdf;
 use sail_function::scalar::vector::inner_product::VectorInnerProduct;
+use sail_function::scalar::vector::norm::VectorNorm;
 use sail_function::scalar::xml::from_xml::SparkFromXml;
 use sail_function::scalar::xml::to_xml::SparkToXml;
 use sail_function::scalar::xml::xpath::Xpath;
@@ -2810,6 +2811,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 Ok(Arc::new(ScalarUDF::from(SparkCastStringToInt32::new())))
             }
             "vector_inner_product" => Ok(Arc::new(ScalarUDF::from(VectorInnerProduct::new()))),
+            "vector_norm" => Ok(Arc::new(ScalarUDF::from(VectorNorm::new()))),
             "bitmap_count" => Ok(Arc::new(ScalarUDF::from(BitmapCount::new()))),
             "format_string" => Ok(Arc::new(ScalarUDF::from(FormatStringFunc::new()))),
             "greatest" => Ok(Arc::new(ScalarUDF::from(GreatestFunc::new()))),
@@ -5421,6 +5423,16 @@ mod tests {
                 .is_some()
         );
         assert_eq!(decoded.name(), "vector_inner_product");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_round_trip_vector_norm_udf() -> Result<()> {
+        let decoded = round_trip_udf(ScalarUDF::from(VectorNorm::new()))?;
+
+        assert!(decoded.inner().downcast_ref::<VectorNorm>().is_some());
+        assert_eq!(decoded.name(), "vector_norm");
 
         Ok(())
     }

--- a/crates/sail-function/src/scalar/vector/mod.rs
+++ b/crates/sail-function/src/scalar/vector/mod.rs
@@ -1,1 +1,2 @@
 pub mod inner_product;
+pub mod norm;

--- a/crates/sail-function/src/scalar/vector/norm.rs
+++ b/crates/sail-function/src/scalar/vector/norm.rs
@@ -1,0 +1,210 @@
+use std::sync::Arc;
+
+use datafusion::arrow::array::{
+    Array, ArrayRef, AsArray, Float32Array, GenericListArray, OffsetSizeTrait, as_large_list_array,
+    as_list_array,
+};
+use datafusion::arrow::datatypes::{DataType, Float32Type};
+use datafusion_common::{Result, exec_err, plan_err};
+use datafusion_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, TypeSignature, Volatility,
+};
+
+use crate::functions_nested_utils::make_scalar_function;
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct VectorNorm {
+    signature: Signature,
+}
+
+impl Default for VectorNorm {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VectorNorm {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::one_of(
+                vec![TypeSignature::Any(1), TypeSignature::Any(2)],
+                Volatility::Immutable,
+            ),
+        }
+    }
+}
+
+impl ScalarUDFImpl for VectorNorm {
+    fn name(&self) -> &str {
+        "vector_norm"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        let valid = match arg_types {
+            [vector] => is_float_vector(vector),
+            [vector, degree] => is_float_vector(vector) && degree == &DataType::Float32,
+            _ => false,
+        };
+        if !valid {
+            return plan_err!(
+                "vector_norm expects ARRAY<FLOAT> and an optional FLOAT degree, got {arg_types:?}"
+            );
+        }
+        Ok(DataType::Float32)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(vector_norm_inner)(&args.args)
+    }
+}
+
+fn is_float_vector(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::List(field) | DataType::LargeList(field)
+            if field.data_type() == &DataType::Float32
+    )
+}
+
+fn vector_norm_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    if !(1..=2).contains(&args.len()) {
+        return exec_err!("vector_norm needs one vector and an optional degree argument");
+    }
+    let degree = args.get(1).map(|array| array.as_primitive::<Float32Type>());
+    match args[0].data_type() {
+        DataType::List(_) => compute_norm(as_list_array(&args[0]), degree),
+        DataType::LargeList(_) => compute_norm(as_large_list_array(&args[0]), degree),
+        data_type => exec_err!("vector_norm expects an ARRAY<FLOAT> argument, got {data_type:?}"),
+    }
+}
+
+fn compute_norm<O: OffsetSizeTrait>(
+    vectors: &GenericListArray<O>,
+    degrees: Option<&Float32Array>,
+) -> Result<ArrayRef> {
+    let values = (0..vectors.len()).map(|row| {
+        if vectors.is_null(row) || degrees.is_some_and(|degrees| degrees.is_null(row)) {
+            return Ok(None);
+        }
+        let degree = degrees.map_or(2.0, |degrees| degrees.value(row));
+        let norm_kind = NormKind::try_from(degree)?;
+        let values = vectors.value(row);
+        let vector = values.as_primitive::<Float32Type>();
+        if vector.null_count() > 0 {
+            return Ok(None);
+        }
+        Ok(Some(norm_kind.compute(vector.values())))
+    });
+    let values = values.collect::<Result<Vec<Option<f32>>>>()?;
+    Ok(Arc::new(Float32Array::from(values)))
+}
+
+#[derive(Clone, Copy)]
+enum NormKind {
+    L1,
+    L2,
+    Infinity,
+}
+
+impl TryFrom<f32> for NormKind {
+    type Error = datafusion_common::DataFusionError;
+
+    fn try_from(degree: f32) -> Result<Self> {
+        if degree == 1.0 {
+            Ok(Self::L1)
+        } else if degree == 2.0 {
+            Ok(Self::L2)
+        } else if degree.is_infinite() && degree.is_sign_positive() {
+            Ok(Self::Infinity)
+        } else {
+            exec_err!(
+                "INVALID_VECTOR_NORM_DEGREE: vector_norm degree must be 1.0, 2.0, or positive infinity, got {degree}"
+            )
+        }
+    }
+}
+
+impl NormKind {
+    fn compute(self, values: &[f32]) -> f32 {
+        match self {
+            Self::L1 => values.iter().map(|value| value.abs()).sum(),
+            Self::L2 => {
+                let squared_sum = values.iter().map(|value| value * value).sum::<f32>();
+                if squared_sum == 0.0 {
+                    0.0
+                } else {
+                    squared_sum.sqrt()
+                }
+            }
+            Self::Infinity => values.iter().map(|value| value.abs()).fold(0.0, f32::max),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::array::{Float32Array, ListArray};
+
+    use super::*;
+
+    #[test]
+    fn computes_supported_norms_and_preserves_nulls() -> Result<()> {
+        let vectors = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![
+            Some(vec![Some(3.0), Some(4.0)]),
+            Some(vec![]),
+            Some(vec![Some(3.0), None]),
+            None,
+        ]);
+        let degrees = Float32Array::from(vec![Some(1.0), Some(2.0), Some(2.0), Some(2.0)]);
+
+        let actual = compute_norm(&vectors, Some(&degrees))?;
+        let actual = actual.as_primitive::<Float32Type>();
+        let expected = Float32Array::from(vec![Some(7.0), Some(0.0), None, None]);
+        assert_eq!(actual, &expected);
+        Ok(())
+    }
+
+    #[test]
+    fn defaults_to_l2_and_supports_infinity_norm() -> Result<()> {
+        let vectors = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(vec![
+            Some(-3.0),
+            Some(4.0),
+        ])]);
+
+        let l2 = compute_norm(&vectors, None)?;
+        assert_eq!(l2.as_primitive::<Float32Type>().value(0), 5.0);
+
+        let infinity = Float32Array::from(vec![Some(f32::INFINITY)]);
+        let max = compute_norm(&vectors, Some(&infinity))?;
+        assert_eq!(max.as_primitive::<Float32Type>().value(0), 4.0);
+        Ok(())
+    }
+
+    #[test]
+    fn supports_large_list_arrays() -> Result<()> {
+        let vectors =
+            datafusion::arrow::array::LargeListArray::from_iter_primitive::<Float32Type, _, _>(
+                vec![Some(vec![Some(1.0), Some(2.0), Some(2.0)])],
+            );
+
+        let actual = compute_norm(&vectors, None)?;
+        let actual = actual.as_primitive::<Float32Type>();
+        assert_eq!(actual.value(0), 3.0);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_non_vector_arguments_and_invalid_degrees() {
+        let error = vector_norm_inner(&[Arc::new(Float32Array::from(vec![1.0]))]);
+        assert!(matches!(error, Err(error) if error.to_string().contains("ARRAY<FLOAT>")));
+
+        let invalid = NormKind::try_from(3.0);
+        assert!(
+            matches!(invalid, Err(error) if error.to_string().contains("INVALID_VECTOR_NORM_DEGREE"))
+        );
+    }
+}

--- a/crates/sail-plan/src/function/scalar/vector.rs
+++ b/crates/sail-plan/src/function/scalar/vector.rs
@@ -1,4 +1,5 @@
 use sail_function::scalar::vector::inner_product::VectorInnerProduct;
+use sail_function::scalar::vector::norm::VectorNorm;
 
 use crate::function::common::ScalarFunction;
 
@@ -12,7 +13,7 @@ pub(super) fn list_built_in_vector_functions() -> Vec<(&'static str, ScalarFunct
         ),
         ("vector_inner_product", F::udf(VectorInnerProduct::new())),
         ("vector_l2_distance", F::unknown("vector_l2_distance")),
-        ("vector_norm", F::unknown("vector_norm")),
+        ("vector_norm", F::udf(VectorNorm::new())),
         ("vector_normalize", F::unknown("vector_normalize")),
     ]
 }

--- a/crates/sail-spark-connect/tests/gold_data/function/vector.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/vector.json
@@ -111,7 +111,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: vector_norm"
+        "success": "ok"
       }
     },
     {
@@ -133,7 +133,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: vector_norm"
+        "success": "ok"
       }
     },
     {
@@ -155,7 +155,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: vector_norm"
+        "success": "ok"
       }
     },
     {

--- a/python/pysail/tests/spark/function/features/vector/vector_norm.feature
+++ b/python/pysail/tests/spark/function/features/vector/vector_norm.feature
@@ -49,7 +49,7 @@ Feature: vector_norm
         """
       Then query result
         | l1    | l2       | l_infinity |
-        | 136.0 | 38.67816 | 16.0        |
+        | 136.0 | 38.678158 | 16.0        |
   Rule: Null handling
     Scenario: typed null vector returns NULL
       When query

--- a/python/pysail/tests/spark/function/features/vector/vector_norm.feature
+++ b/python/pysail/tests/spark/function/features/vector/vector_norm.feature
@@ -1,0 +1,112 @@
+@spark-4.2
+Feature: vector_norm
+  Rule: Basic results
+    Scenario: L1, L2, and L-infinity norms
+      When query
+        """
+        SELECT
+          vector_norm(array(3.0F, 4.0F), 1.0F) AS l1,
+          vector_norm(array(3.0F, 4.0F)) AS l2,
+          vector_norm(array(-3.0F, 4.0F), float('inf')) AS l_infinity
+        """
+      Then query result
+        | l1  | l2 | l_infinity |
+        | 7.0 | 5.0 | 4.0         |
+    Scenario: vector columns from VALUES execute the UDF
+      When query
+        """
+        SELECT vector_norm(vector, degree) AS result
+        FROM VALUES
+          (array(3.0F, 4.0F), 1.0F),
+          (array(3.0F, 4.0F), 2.0F),
+          (array(-3.0F, 4.0F), float('inf'))
+        AS t(vector, degree)
+        """
+      Then query result
+        | result |
+        | 7.0    |
+        | 5.0    |
+        | 4.0    |
+    Scenario: empty ARRAY<FLOAT> input returns 0.0
+      When query
+        """
+        SELECT vector_norm(CAST(array() AS ARRAY<FLOAT>)) AS result
+        """
+      Then query result
+        | result |
+        | 0.0    |
+    Scenario: upstream 16-element case supports each norm degree
+      When query
+        """
+        SELECT
+          vector_norm(vector, 1.0F) AS l1,
+          vector_norm(vector, 2.0F) AS l2,
+          vector_norm(vector, float('inf')) AS l_infinity
+        FROM VALUES (
+          array(1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F,
+                9.0F, 10.0F, 11.0F, 12.0F, 13.0F, 14.0F, 15.0F, 16.0F)
+        ) AS t(vector)
+        """
+      Then query result
+        | l1    | l2       | l_infinity |
+        | 136.0 | 38.67816 | 16.0        |
+  Rule: Null handling
+    Scenario: typed null vector returns NULL
+      When query
+        """
+        SELECT vector_norm(CAST(NULL AS ARRAY<FLOAT>)) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+    Scenario: array containing a null element returns NULL
+      When query
+        """
+        SELECT vector_norm(array(3.0F, CAST(NULL AS FLOAT), 4.0F)) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+  Rule: Output schema
+    @function(nullability)
+    Scenario: declared FLOAT output schema and nullability
+      When query
+        """
+        SELECT vector_norm(array(3.0F, 4.0F)) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: float (nullable = true)
+        """
+  Rule: Error cases
+    Scenario: untyped NULL is rejected
+      When query
+        """
+        SELECT vector_norm(NULL) AS result
+        """
+      Then query error (?i)(DATATYPE_MISMATCH|UNEXPECTED_INPUT_TYPE|ARRAY|FLOAT|vector_norm)
+    Scenario: ARRAY<DOUBLE> input is rejected
+      When query
+        """
+        SELECT vector_norm(array(1.0D, 2.0D)) AS result
+        """
+      Then query error (?i)(DATATYPE_MISMATCH|UNEXPECTED_INPUT_TYPE|ARRAY|FLOAT|vector_norm)
+    Scenario: ARRAY<INT> input is rejected
+      When query
+        """
+        SELECT vector_norm(array(1, 2)) AS result
+        """
+      Then query error (?i)(DATATYPE_MISMATCH|UNEXPECTED_INPUT_TYPE|ARRAY|FLOAT|vector_norm)
+    Scenario: non-array value is rejected
+      When query
+        """
+        SELECT vector_norm(1.0F) AS result
+        """
+      Then query error (?i)(DATATYPE_MISMATCH|UNEXPECTED_INPUT_TYPE|ARRAY|FLOAT|vector_norm)
+    Scenario: invalid norm degree is rejected
+      When query
+        """
+        SELECT vector_norm(array(3.0F, 4.0F), 3.0F) AS result
+        """
+      Then query error (?i)(INVALID_VECTOR_NORM_DEGREE|degree must be 1.0|2.0|positive infinity)

--- a/python/pysail/tests/spark/function/features/vector/vector_norm.feature
+++ b/python/pysail/tests/spark/function/features/vector/vector_norm.feature
@@ -49,7 +49,7 @@ Feature: vector_norm
         """
       Then query result
         | l1    | l2       | l_infinity |
-        | 136.0 | 38.678158 | 16.0        |
+        | 136.0 | 38.67816 | 16.0        |
   Rule: Null handling
     Scenario: typed null vector returns NULL
       When query


### PR DESCRIPTION
## Summary

Implement Spark-compatible `vector_norm` support for the vector-function parity work in #2358.

## What changed

- Add a native `vector_norm` scalar UDF for `ARRAY<FLOAT>` and `LARGE_LIST<FLOAT>` inputs.
- Support the optional norm degree, defaulting to L2 when omitted.
- Implement the supported Spark degrees: `1.0` for L1 / Manhattan norm, `2.0` for L2 / Euclidean norm, and positive infinity for L-infinity / maximum absolute value.
- Return `0.0` for empty vectors and `NULL` for null vectors or vectors containing null elements.
- Register the UDF in Sail’s scalar-function planner registry and remote execution codec.
- Add unit coverage for supported norms, default degree handling, infinity norm, empty/null behavior, large-list inputs, invalid arguments, and invalid degrees.
- Add a remote codec round-trip test for the new UDF.

## Validation

- `cargo test -p sail-function norm --lib` — 4 passed.
- `cargo check -p sail-execution --tests` — passed.
- `cargo check -p sail-function --tests` — passed.
- `cargo check -p sail-plan --lib` — passed.
- `cargo check -p sail-execution --lib` — passed.
- `cargo clippy -p sail-function --lib --no-deps -- -D warnings` — passed.
- `git diff --check` — passed.

The execution codec test target compiles successfully through `cargo check --tests`. Linking the full `sail-execution` test binary is unusually expensive in the sandbox and stalled during the final linker stage; no source-level or test-compilation errors were reported.

Closes #2358