### PR TITLE
fix: type CASE and IF from every branch, not just the first

### DIFF
--- a/crates/sail-plan/src/function/scalar/conditional.rs
+++ b/crates/sail-plan/src/function/scalar/conditional.rs
@@ -1,9 +1,11 @@
 use std::sync::Arc;
 
-use arrow::datatypes::{DataType, TimeUnit};
+use arrow::datatypes::{DataType, Field, FieldRef, Fields, TimeUnit};
 use datafusion::functions::expr_fn;
 use datafusion_common::ScalarValue;
+use datafusion_expr::type_coercion::binary::type_union_coercion;
 use datafusion_expr::{ExprSchemable, ScalarUDF, cast, expr, lit};
+use sail_common::spec::ARROW_DECIMAL128_MAX_PRECISION;
 use sail_common_datafusion::utils::items::ItemTaker;
 use sail_function::scalar::datetime::spark_date::SparkDate;
 use sail_function::scalar::datetime::spark_timestamp::SparkTimestamp;
@@ -33,7 +35,7 @@ fn case(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
             }
         }
     }
-    let branch_values = coerce_string_temporal_values(branch_values, &function_context)?;
+    let branch_values = coerce_conditional_branches(branch_values, &function_context)?;
     let when_then_expr = conditions
         .into_iter()
         .zip(branch_values)
@@ -53,7 +55,7 @@ fn if_expr(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     } = input;
     let (when_expr, then_expr, else_expr) = arguments.three()?;
     let (then_expr, else_expr) =
-        coerce_string_temporal_values(vec![then_expr, else_expr], &function_context)?.two()?;
+        coerce_conditional_branches(vec![then_expr, else_expr], &function_context)?.two()?;
     Ok(expr::Expr::Case(expr::Case {
         expr: None,
         when_then_expr: vec![(Box::new(when_expr), Box::new(then_expr))],
@@ -68,6 +70,244 @@ fn coalesce(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     } = input;
     let arguments = coerce_string_temporal_values(arguments, &function_context)?;
     Ok(expr_fn::coalesce(arguments))
+}
+
+/// Unifies the result branches of `CASE`/`IF`, in the order the two steps require.
+///
+/// String and temporal branches must be homogenised FIRST: DataFusion's `type_union_coercion`
+/// answers `Date32` for `(Utf8, Date32)`, the opposite of Spark's non-ANSI `stringPromotion`, so
+/// running the type fold first would type a string/date conditional as `date`.
+fn coerce_conditional_branches(
+    values: Vec<expr::Expr>,
+    function_context: &FunctionContextInput<'_>,
+) -> PlanResult<Vec<expr::Expr>> {
+    let values = coerce_string_temporal_values(values, function_context)?;
+    coerce_branch_values(values, function_context)
+}
+
+/// Casts the result branches of `CASE`/`IF` to their common type.
+///
+/// Spark's `CaseWhenCoercion` and `IfCoercion` unify every `THEN` value **and** the `ELSE` value
+/// before the expression is typed, and leave the branches untouched when the values have no common
+/// type. `Expr::Case::get_type` instead reports the type of the first non-null `THEN` branch, so
+/// without this the resolved plan carries a narrower type than Spark declares.
+fn coerce_branch_values(
+    values: Vec<expr::Expr>,
+    function_context: &FunctionContextInput<'_>,
+) -> PlanResult<Vec<expr::Expr>> {
+    let data_types = values
+        .iter()
+        .map(|value| value.get_type(function_context.schema))
+        .collect::<Result<Vec<_>, _>>()?;
+    let Some(common_type) = common_branch_type(&data_types) else {
+        return Ok(values);
+    };
+    Ok(values
+        .into_iter()
+        .map(|value| value.cast_to(&common_type, function_context.schema))
+        .collect::<Result<Vec<_>, _>>()?)
+}
+
+/// The type Spark gives a conditional whose branches have the types `data_types`.
+///
+/// Folds the branches left to right, as Spark's ANSI `findWiderCommonType` does
+/// (<https://github.com/apache/spark/blob/v4.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala#L150-L156>). The non-ANSI dialect first partitions the string-typed
+/// branches and folds those ahead of the rest, because `findWiderTypeForTwo` is not associative
+/// for `StringType` (<https://github.com/apache/spark/blob/v4.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala#L175-L186>); that partition is not reproduced here, and is
+/// currently masked by `coerce_string_temporal_values`, which already homogenises the string and
+/// temporal branches before this runs.
+///
+/// Returns `None` when the branches have no common type, so the caller leaves them untouched and
+/// the mismatch is reported later, the way Spark's `.getOrElse(c)` does.
+///
+/// `Decimal256` is decided for the whole slice at once. Spark decimals never exceed 38 digits, so
+/// a wider one describes a value Spark has no type for and the rules below would narrow it; Sail
+/// does accept such decimals (`CAST(1 AS DECIMAL(50, 10))`, which Spark rejects outright), so they
+/// reach here. Applying that exception per PAIR instead would let a fold alternate between two
+/// rule sets and make the answer depend on the order the branches are written in — the very thing
+/// this module exists to remove, and the check reaches inside containers for the same reason: the
+/// rules below recurse into element types, so a `Decimal256` element must switch them off too.
+fn common_branch_type(data_types: &[DataType]) -> Option<DataType> {
+    let (first, rest) = data_types.split_first()?;
+    if data_types.iter().any(contains_decimal256_type) {
+        return rest
+            .iter()
+            .try_fold(first.clone(), |left, right| {
+                type_union_coercion(&left, right)
+            });
+    }
+    rest.iter().try_fold(first.clone(), |left, right| {
+        branch_type_coercion(&left, right)
+    })
+}
+
+/// The wider of two branch types, following Spark where `type_union_coercion` does not.
+///
+/// Two arms of Spark's `findWiderTypeForDecimal` (<https://github.com/apache/spark/blob/v4.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionHelper.scala#L186-L198>) disagree
+/// with DataFusion, and both decide the type a conditional reports:
+///
+/// * a float against a decimal widens to `DOUBLE` (<https://github.com/apache/spark/blob/v4.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionHelper.scala#L194>), whereas DataFusion turns the float
+///   into `Decimal128(30, 15)` — which then overflows on values Spark represents perfectly well;
+/// * once the widened precision passes 38, Spark drops fractional digits to keep the integral
+///   ones (`DecimalType.boundedPreferIntegralDigits`, <https://github.com/apache/spark/blob/v4.2.0/sql/api/src/main/scala/org/apache/spark/sql/types/DecimalType.scala#L148-L158>), whereas
+///   DataFusion clamps precision and scale independently and so drops the integral digits.
+///
+/// Every other pair is left to `type_union_coercion`, and both rules also reach the element type
+/// of a container: Spark unifies `array`/`map`/`struct` branches by recursing `findWiderTypeForTwo`
+/// into the element (`findTypeForComplex`), whereas `type_union_coercion` recurses into itself and
+/// so would answer the element with DataFusion's rules.
+fn branch_type_coercion(left: &DataType, right: &DataType) -> Option<DataType> {
+    if (left.is_floating() && right.is_decimal()) || (left.is_decimal() && right.is_floating()) {
+        return Some(DataType::Float64);
+    }
+    if let Some(data_type) = wider_decimal_type(left, right) {
+        return Some(data_type);
+    }
+    let coerced = type_union_coercion(left, right)?;
+    Some(coerce_nested_types(left, right, coerced))
+}
+
+/// Replaces the element type DataFusion chose for a container with the one Spark's rules give.
+///
+/// The container shape — field names, `containsNull`, `valueContainsNull`, the fixed-size length —
+/// is left exactly as `type_union_coercion` decided it; only the element data type is substituted.
+/// Matching on the COERCED type rather than on the inputs matters: DataFusion legitimately answers
+/// a different container variant than either branch (`List` for two `FixedSizeList`s of different
+/// lengths, `LargeList` for a `List` against a `LargeList`), and requiring all three to agree would
+/// silently skip the substitution exactly there.
+fn coerce_nested_types(left: &DataType, right: &DataType, coerced: DataType) -> DataType {
+    if let (Some(left_field), Some(right_field), Some(coerced_field)) = (
+        container_element_field(left),
+        container_element_field(right),
+        container_element_field(&coerced),
+    ) {
+        let field = coerce_element_field(left_field, right_field, coerced_field);
+        return with_element_field(&coerced, field);
+    }
+    if let (DataType::Struct(left), DataType::Struct(right), DataType::Struct(coerced_fields)) =
+        (left, right, &coerced)
+    {
+        if let Some(fields) = coerce_struct_fields(left, right, coerced_fields) {
+            return DataType::Struct(fields);
+        }
+    }
+    coerced
+}
+
+/// The single field a container holds its elements in: the element for a list, the key-value
+/// entries struct for a map.
+fn container_element_field(data_type: &DataType) -> Option<&FieldRef> {
+    match data_type {
+        DataType::List(field)
+        | DataType::LargeList(field)
+        | DataType::FixedSizeList(field, _)
+        | DataType::Map(field, _) => Some(field),
+        _ => None,
+    }
+}
+
+fn with_element_field(data_type: &DataType, field: Field) -> DataType {
+    let field = Arc::new(field);
+    match data_type {
+        DataType::List(_) => DataType::List(field),
+        DataType::LargeList(_) => DataType::LargeList(field),
+        DataType::FixedSizeList(_, size) => DataType::FixedSizeList(field, *size),
+        DataType::Map(_, sorted) => DataType::Map(field, *sorted),
+        other => other.clone(),
+    }
+}
+
+fn coerce_element_field(left: &Field, right: &Field, coerced: &Field) -> Field {
+    match branch_type_coercion(left.data_type(), right.data_type()) {
+        Some(data_type) => coerced.clone().with_data_type(data_type),
+        None => coerced.clone(),
+    }
+}
+
+/// `None` when the branches do not name their fields the same way at the same positions.
+///
+/// DataFusion pairs struct fields by NAME and emits them in the left branch's order, so pairing
+/// them positionally here would coerce fields that are not the same column and attach the answer
+/// to a third field's name. Spark rejects such branches outright — `findTypeForComplex` requires
+/// `resolver(field1.name, field2.name)` at every position — so leaving DataFusion's answer alone
+/// is both safe and the closer of the two to Spark.
+///
+/// The comparison is case-insensitive because Spark's resolver is: under the default
+/// `spark.sql.caseSensitive = false`, `struct<A: …>` and `struct<a: …>` are the same field and
+/// Spark merges them. DataFusion's own name matching is case-sensitive, so it reaches those two
+/// through its positional path — which pairs them the way Spark does, and is therefore safe to
+/// build on.
+fn coerce_struct_fields(left: &Fields, right: &Fields, coerced: &Fields) -> Option<Fields> {
+    if left.len() != right.len() || left.len() != coerced.len() {
+        return None;
+    }
+    if left
+        .iter()
+        .zip(right.iter())
+        .zip(coerced.iter())
+        .any(|((left, right), coerced)| {
+            !left.name().eq_ignore_ascii_case(right.name())
+                || !left.name().eq_ignore_ascii_case(coerced.name())
+        })
+    {
+        return None;
+    }
+    Some(Fields::from(
+        left.iter()
+            .zip(right.iter())
+            .zip(coerced.iter())
+            .map(|((left, right), coerced)| coerce_element_field(left, right, coerced))
+            .collect::<Vec<_>>(),
+    ))
+}
+
+/// Spark's `widerDecimalType` (<https://github.com/apache/spark/blob/v4.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecisionTypeCoercion.scala#L195-L199>), applied only when
+/// the result overflows 38 digits — below that DataFusion already agrees with Spark.
+fn wider_decimal_type(left: &DataType, right: &DataType) -> Option<DataType> {
+    let (left_precision, left_scale) = decimal_type_for(left)?;
+    let (right_precision, right_scale) = decimal_type_for(right)?;
+    let scale = left_scale.max(right_scale);
+    let range = (left_precision - left_scale).max(right_precision - right_scale);
+    let max_precision = i32::from(ARROW_DECIMAL128_MAX_PRECISION);
+    if range + scale <= max_precision {
+        return None;
+    }
+    // Spark keeps the integral digits and gives what is left to the scale, so the result is
+    // `38 - range`. `range` is at least 1 here, so this is in `[0, 37]`.
+    let scale = i8::try_from((max_precision - range).max(0)).unwrap_or(0);
+    Some(DataType::Decimal128(ARROW_DECIMAL128_MAX_PRECISION, scale))
+}
+
+/// The decimal Spark uses for a type: decimals as they are, integrals via `DecimalType.forType`.
+/// Anything else has no decimal form, and neither does `Decimal256` — `common_branch_type` keeps
+/// those out of these rules entirely, and answering `None` holds that line here too.
+fn decimal_type_for(data_type: &DataType) -> Option<(i32, i32)> {
+    match data_type {
+        DataType::Decimal32(precision, scale)
+        | DataType::Decimal64(precision, scale)
+        | DataType::Decimal128(precision, scale) => {
+            Some((i32::from(*precision), i32::from(*scale)))
+        }
+        DataType::Int8 | DataType::UInt8 => Some((3, 0)),
+        DataType::Int16 | DataType::UInt16 => Some((5, 0)),
+        DataType::Int32 | DataType::UInt32 => Some((10, 0)),
+        DataType::Int64 | DataType::UInt64 => Some((20, 0)),
+        _ => None,
+    }
+}
+
+fn contains_decimal256_type(data_type: &DataType) -> bool {
+    match data_type {
+        DataType::Decimal256(_, _) => true,
+        DataType::List(field)
+        | DataType::LargeList(field)
+        | DataType::FixedSizeList(field, _)
+        | DataType::Map(field, _) => contains_decimal256_type(field.data_type()),
+        DataType::Struct(fields) => fields
+            .iter()
+            .any(|field| contains_decimal256_type(field.data_type())),
+        _ => false,
+    }
 }
 
 fn coerce_string_temporal_values(

--- a/crates/sail-plan/src/function/scalar/conditional.rs
+++ b/crates/sail-plan/src/function/scalar/conditional.rs
@@ -151,10 +151,9 @@ fn coerce_nested_types(left: &DataType, right: &DataType, coerced: DataType) -> 
     }
     if let (DataType::Struct(left), DataType::Struct(right), DataType::Struct(coerced_fields)) =
         (left, right, &coerced)
+        && let Some(fields) = coerce_struct_fields(left, right, coerced_fields)
     {
-        if let Some(fields) = coerce_struct_fields(left, right, coerced_fields) {
-            return DataType::Struct(fields);
-        }
+        return DataType::Struct(fields);
     }
     coerced
 }

--- a/crates/sail-plan/src/function/scalar/conditional.rs
+++ b/crates/sail-plan/src/function/scalar/conditional.rs
@@ -72,11 +72,9 @@ fn coalesce(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     Ok(expr_fn::coalesce(arguments))
 }
 
-/// Unifies the result branches of `CASE`/`IF`, in the order the two steps require.
-///
-/// String and temporal branches must be homogenised FIRST: DataFusion's `type_union_coercion`
-/// answers `Date32` for `(Utf8, Date32)`, the opposite of Spark's non-ANSI `stringPromotion`, so
-/// running the type fold first would type a string/date conditional as `date`.
+/// Unifies the result branches of `CASE`/`IF`. The order matters: `type_union_coercion` answers
+/// `Date32` for `(Utf8, Date32)`, the opposite of Spark's non-ANSI `stringPromotion`, so the
+/// string/temporal pass has to run first.
 fn coerce_conditional_branches(
     values: Vec<expr::Expr>,
     function_context: &FunctionContextInput<'_>,
@@ -85,12 +83,9 @@ fn coerce_conditional_branches(
     coerce_branch_values(values, function_context)
 }
 
-/// Casts the result branches of `CASE`/`IF` to their common type.
-///
-/// Spark's `CaseWhenCoercion` and `IfCoercion` unify every `THEN` value **and** the `ELSE` value
-/// before the expression is typed, and leave the branches untouched when the values have no common
-/// type. `Expr::Case::get_type` instead reports the type of the first non-null `THEN` branch, so
-/// without this the resolved plan carries a narrower type than Spark declares.
+/// Casts the result branches to their common type, the way `CaseWhenCoercion` / `IfCoercion` do
+/// (`TypeCoercionHelper.scala:498-538`). Without this the plan takes `Expr::Case::get_type`, which
+/// reports the first non-null `THEN` branch and ignores the `ELSE`.
 fn coerce_branch_values(
     values: Vec<expr::Expr>,
     function_context: &FunctionContextInput<'_>,
@@ -108,54 +103,29 @@ fn coerce_branch_values(
         .collect::<Result<Vec<_>, _>>()?)
 }
 
-/// The type Spark gives a conditional whose branches have the types `data_types`.
+/// The type Spark gives a conditional, folding the branches left to right as `findWiderCommonType`
+/// does. `None` means no common type, and the caller then leaves the branches alone the way Spark's
+/// `.getOrElse(c)` does. Spark's non-ANSI string partition is not reproduced.
 ///
-/// Folds the branches left to right, as Spark's ANSI `findWiderCommonType` does
-/// (<https://github.com/apache/spark/blob/v4.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/AnsiTypeCoercion.scala#L150-L156>). The non-ANSI dialect first partitions the string-typed
-/// branches and folds those ahead of the rest, because `findWiderTypeForTwo` is not associative
-/// for `StringType` (<https://github.com/apache/spark/blob/v4.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercion.scala#L175-L186>); that partition is not reproduced here, and is
-/// currently masked by `coerce_string_temporal_values`, which already homogenises the string and
-/// temporal branches before this runs.
-///
-/// Returns `None` when the branches have no common type, so the caller leaves them untouched and
-/// the mismatch is reported later, the way Spark's `.getOrElse(c)` does.
-///
-/// `Decimal256` is decided for the whole slice at once. Spark decimals never exceed 38 digits, so
-/// a wider one describes a value Spark has no type for and the rules below would narrow it; Sail
-/// does accept such decimals (`CAST(1 AS DECIMAL(50, 10))`, which Spark rejects outright), so they
-/// reach here. Applying that exception per PAIR instead would let a fold alternate between two
-/// rule sets and make the answer depend on the order the branches are written in — the very thing
-/// this module exists to remove, and the check reaches inside containers for the same reason: the
-/// rules below recurse into element types, so a `Decimal256` element must switch them off too.
+/// A `Decimal256` anywhere in any branch switches the rules below off for the WHOLE conditional.
+/// Spark has no such type, so they would only narrow it, and deciding per pair instead would let a
+/// fold alternate between two rule sets and depend on branch order.
 fn common_branch_type(data_types: &[DataType]) -> Option<DataType> {
     let (first, rest) = data_types.split_first()?;
     if data_types.iter().any(contains_decimal256_type) {
-        return rest
-            .iter()
-            .try_fold(first.clone(), |left, right| {
-                type_union_coercion(&left, right)
-            });
+        return rest.iter().try_fold(first.clone(), |left, right| {
+            type_union_coercion(&left, right)
+        });
     }
     rest.iter().try_fold(first.clone(), |left, right| {
         branch_type_coercion(&left, right)
     })
 }
 
-/// The wider of two branch types, following Spark where `type_union_coercion` does not.
-///
-/// Two arms of Spark's `findWiderTypeForDecimal` (<https://github.com/apache/spark/blob/v4.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionHelper.scala#L186-L198>) disagree
-/// with DataFusion, and both decide the type a conditional reports:
-///
-/// * a float against a decimal widens to `DOUBLE` (<https://github.com/apache/spark/blob/v4.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/TypeCoercionHelper.scala#L194>), whereas DataFusion turns the float
-///   into `Decimal128(30, 15)` — which then overflows on values Spark represents perfectly well;
-/// * once the widened precision passes 38, Spark drops fractional digits to keep the integral
-///   ones (`DecimalType.boundedPreferIntegralDigits`, <https://github.com/apache/spark/blob/v4.2.0/sql/api/src/main/scala/org/apache/spark/sql/types/DecimalType.scala#L148-L158>), whereas
-///   DataFusion clamps precision and scale independently and so drops the integral digits.
-///
-/// Every other pair is left to `type_union_coercion`, and both rules also reach the element type
-/// of a container: Spark unifies `array`/`map`/`struct` branches by recursing `findWiderTypeForTwo`
-/// into the element (`findTypeForComplex`), whereas `type_union_coercion` recurses into itself and
-/// so would answer the element with DataFusion's rules.
+/// The wider of two branch types, following the two arms of Spark's `findWiderTypeForDecimal`
+/// (`TypeCoercionHelper.scala:186-198`) that DataFusion answers differently. Both also reach a
+/// container's element type, since `findTypeForComplex` recurses into it. Everything else is left
+/// to `type_union_coercion`.
 fn branch_type_coercion(left: &DataType, right: &DataType) -> Option<DataType> {
     if (left.is_floating() && right.is_decimal()) || (left.is_decimal() && right.is_floating()) {
         return Some(DataType::Float64);
@@ -167,14 +137,9 @@ fn branch_type_coercion(left: &DataType, right: &DataType) -> Option<DataType> {
     Some(coerce_nested_types(left, right, coerced))
 }
 
-/// Replaces the element type DataFusion chose for a container with the one Spark's rules give.
-///
-/// The container shape — field names, `containsNull`, `valueContainsNull`, the fixed-size length —
-/// is left exactly as `type_union_coercion` decided it; only the element data type is substituted.
-/// Matching on the COERCED type rather than on the inputs matters: DataFusion legitimately answers
-/// a different container variant than either branch (`List` for two `FixedSizeList`s of different
-/// lengths, `LargeList` for a `List` against a `LargeList`), and requiring all three to agree would
-/// silently skip the substitution exactly there.
+/// Substitutes the element type of a container, keeping the shape `type_union_coercion` decided.
+/// Matching on the COERCED type is deliberate: DataFusion can answer a different container variant
+/// than either branch, and requiring all three to agree would skip the substitution exactly there.
 fn coerce_nested_types(left: &DataType, right: &DataType, coerced: DataType) -> DataType {
     if let (Some(left_field), Some(right_field), Some(coerced_field)) = (
         container_element_field(left),
@@ -194,8 +159,7 @@ fn coerce_nested_types(left: &DataType, right: &DataType, coerced: DataType) -> 
     coerced
 }
 
-/// The single field a container holds its elements in: the element for a list, the key-value
-/// entries struct for a map.
+/// The field a container holds its elements in: the element for a list, the entries struct for a map.
 fn container_element_field(data_type: &DataType) -> Option<&FieldRef> {
     match data_type {
         DataType::List(field)
@@ -224,19 +188,10 @@ fn coerce_element_field(left: &Field, right: &Field, coerced: &Field) -> Field {
     }
 }
 
-/// `None` when the branches do not name their fields the same way at the same positions.
-///
-/// DataFusion pairs struct fields by NAME and emits them in the left branch's order, so pairing
-/// them positionally here would coerce fields that are not the same column and attach the answer
-/// to a third field's name. Spark rejects such branches outright — `findTypeForComplex` requires
-/// `resolver(field1.name, field2.name)` at every position — so leaving DataFusion's answer alone
-/// is both safe and the closer of the two to Spark.
-///
-/// The comparison is case-insensitive because Spark's resolver is: under the default
-/// `spark.sql.caseSensitive = false`, `struct<A: …>` and `struct<a: …>` are the same field and
-/// Spark merges them. DataFusion's own name matching is case-sensitive, so it reaches those two
-/// through its positional path — which pairs them the way Spark does, and is therefore safe to
-/// build on.
+/// `None` when the fields are not named the same way at the same positions. DataFusion pairs struct
+/// fields by NAME, so pairing them positionally here would coerce fields that are not the same
+/// column; Spark rejects those branches outright, so standing aside is the closer answer. The
+/// comparison ignores case because Spark's resolver does under the default `caseSensitive = false`.
 fn coerce_struct_fields(left: &Fields, right: &Fields, coerced: &Fields) -> Option<Fields> {
     if left.len() != right.len() || left.len() != coerced.len() {
         return None;
@@ -261,8 +216,9 @@ fn coerce_struct_fields(left: &Fields, right: &Fields, coerced: &Fields) -> Opti
     ))
 }
 
-/// Spark's `widerDecimalType` (<https://github.com/apache/spark/blob/v4.2.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/DecimalPrecisionTypeCoercion.scala#L195-L199>), applied only when
-/// the result overflows 38 digits — below that DataFusion already agrees with Spark.
+/// Spark's `widerDecimalType` (`DecimalPrecisionTypeCoercion.scala:195-199`), applied only past 38
+/// digits — below that DataFusion already agrees. Assumes the non-legacy `boundedPreferIntegralDigits`,
+/// which is the default (`spark.sql.legacy.decimal.retainFractionDigitsOnTruncate = false`).
 fn wider_decimal_type(left: &DataType, right: &DataType) -> Option<DataType> {
     let (left_precision, left_scale) = decimal_type_for(left)?;
     let (right_precision, right_scale) = decimal_type_for(right)?;
@@ -278,9 +234,8 @@ fn wider_decimal_type(left: &DataType, right: &DataType) -> Option<DataType> {
     Some(DataType::Decimal128(ARROW_DECIMAL128_MAX_PRECISION, scale))
 }
 
-/// The decimal Spark uses for a type: decimals as they are, integrals via `DecimalType.forType`.
-/// Anything else has no decimal form, and neither does `Decimal256` — `common_branch_type` keeps
-/// those out of these rules entirely, and answering `None` holds that line here too.
+/// The decimal Spark uses for a type: decimals as they are, integrals via `DecimalType.forType`
+/// (`DecimalType.scala:133-140`). `Decimal256` answers `None`, holding `common_branch_type`'s line.
 fn decimal_type_for(data_type: &DataType) -> Option<(i32, i32)> {
     match data_type {
         DataType::Decimal32(precision, scale)

--- a/python/pysail/tests/spark/function/features/conditional/case_branch_type_coercion.feature
+++ b/python/pysail/tests/spark/function/features/conditional/case_branch_type_coercion.feature
@@ -1,0 +1,531 @@
+Feature: CASE WHEN and IF type their result from every branch, not just the first
+
+  # `CaseWhenCoercion` / `IfCoercion` (`TypeCoercionHelper.scala:498-515`, `:521-538`) cast every
+  # `THEN` and the `ELSE` to `findWiderCommonType` before `dataType` merges them, so the declared
+  # type never depends on branch order.
+  #
+  # Expected types and values captured from Spark Connect 4.2.0 (JVM, session timezone UTC).
+
+  Rule: A conditional types from every branch
+
+    # No FROM clause: also covers the constant-foldable path, typed with no input schema.
+    Scenario Outline: <case> types as <result>
+      When query
+        """
+        SELECT typeof(<expr>) AS t, CAST(<expr> AS STRING) AS v
+        """
+      Then query result
+        | t        | v       |
+        | <result> | <value> |
+
+      Examples:
+        | case                        | expr                                                          | result        | value  |
+        | CASE decimal / int          | CASE WHEN true THEN CAST(1.5 AS DECIMAL(12,4)) ELSE 0 END     | decimal(14,4) | 1.5000 |
+        | CASE int THEN / bigint ELSE | CASE WHEN true THEN CAST(1 AS INT) ELSE CAST(2 AS BIGINT) END | bigint        | 1      |
+        | IF int / bigint             | IF(true, CAST(1 AS INT), CAST(2 AS BIGINT))                   | bigint        | 1      |
+
+  Rule: The widest result branch decides the type, whatever position it is written in
+
+    # The winning branch is neither the first nor the `ELSE`: type and value come from different
+    # branches.
+    Scenario Outline: three branches ordered <order> still type as bigint
+      When query
+        """
+        SELECT
+          typeof(CASE WHEN c = 1 THEN CAST(1 AS <first>)
+                      WHEN c = 2 THEN CAST(2 AS <second>)
+                      ELSE CAST(3 AS <third>) END) AS t,
+          CAST(CASE WHEN c = 1 THEN CAST(1 AS <first>)
+                    WHEN c = 2 THEN CAST(2 AS <second>)
+                    ELSE CAST(3 AS <third>) END AS STRING) AS v
+        FROM VALUES (2) AS t(c)
+        """
+      Then query result
+        | t      | v |
+        | bigint | 2 |
+
+      Examples:
+        | order            | first    | second | third    |
+        | widest last      | SMALLINT | INT    | BIGINT   |
+        | widest first     | BIGINT   | INT    | SMALLINT |
+        | widest in middle | INT      | BIGINT | SMALLINT |
+
+    Scenario Outline: a THEN of <then> against an ELSE of <els> yields <result>
+      When query
+        """
+        SELECT typeof(CASE WHEN c THEN CAST(1 AS <then>) ELSE CAST(2 AS <els>) END) AS t,
+               CAST(CASE WHEN c THEN CAST(1 AS <then>) ELSE CAST(2 AS <els>) END AS STRING) AS v
+        FROM VALUES (false) AS t(c)
+        """
+      Then query result
+        | t        | v       |
+        | <result> | <value> |
+
+      Examples:
+        | then     | els      | result   | value |
+        | INT      | BIGINT   | bigint   | 2     |
+        | SMALLINT | INT      | int      | 2     |
+        | TINYINT  | SMALLINT | smallint | 2     |
+        | INT      | DOUBLE   | double   | 2.0   |
+        | BIGINT   | DOUBLE   | double   | 2.0   |
+
+    Scenario: the last WHEN branch widens the type when there is no ELSE
+      When query
+        """
+        SELECT typeof(CASE WHEN c = 1 THEN CAST(1 AS INT)
+                           WHEN c = 2 THEN CAST(2 AS BIGINT) END) AS t,
+               CAST(CASE WHEN c = 1 THEN CAST(1 AS INT)
+                         WHEN c = 2 THEN CAST(2 AS BIGINT) END AS STRING) AS v
+        FROM VALUES (1) AS t(c)
+        """
+      Then query result
+        | t      | v |
+        | bigint | 1 |
+
+    Scenario: a single branch with no ELSE keeps its own type
+      When query
+        """
+        SELECT typeof(CASE WHEN c THEN CAST(1 AS INT) END) AS t,
+               CAST(CASE WHEN c THEN CAST(1 AS INT) END AS STRING) AS v
+        FROM VALUES (true) AS t(c)
+        """
+      Then query result
+        | t   | v |
+        | int | 1 |
+
+    Scenario: the CASE operand form widens across branches too
+      When query
+        """
+        SELECT typeof(CASE c WHEN 1 THEN CAST(1 AS INT) ELSE CAST(2 AS BIGINT) END) AS t,
+               CAST(CASE c WHEN 1 THEN CAST(1 AS INT) ELSE CAST(2 AS BIGINT) END AS STRING) AS v
+        FROM VALUES (1) AS t(c)
+        """
+      Then query result
+        | t      | v |
+        | bigint | 1 |
+
+  Rule: An integer branch widens a decimal branch to the common decimal type
+
+    # `Int -> decimal(10,0)` (`DecimalType.forType`), then
+    # `widerDecimalType = (max(s1,s2) + max(p1-s1, p2-s2), max(s1,s2))`.
+    Scenario Outline: <then> against an integer branch of <els> yields <result>
+      When query
+        """
+        SELECT typeof(CASE WHEN c THEN CAST(1.5 AS <then>) ELSE <els> END) AS t,
+               CAST(CASE WHEN c THEN CAST(1.5 AS <then>) ELSE <els> END AS STRING) AS v
+        FROM VALUES (<taken>) AS t(c)
+        """
+      Then query result
+        | t        | v       |
+        | <result> | <value> |
+
+      Examples:
+        | then          | els | taken | result        | value  |
+        | DECIMAL(12,4) | 0   | true  | decimal(14,4) | 1.5000 |
+        | DECIMAL(12,4) | 0   | false | decimal(14,4) | 0.0000 |
+        | DECIMAL(10,2) | 5   | true  | decimal(12,2) | 1.50   |
+        | DECIMAL(10,2) | 5   | false | decimal(12,2) | 5.00   |
+        | DECIMAL(5,2)  | 0   | true  | decimal(12,2) | 1.50   |
+        | DECIMAL(5,2)  | 0   | false | decimal(12,2) | 0.00   |
+
+  Rule: A float branch against a decimal branch widens to double
+
+    # `findWiderTypeForDecimal` (`TypeCoercionHelper.scala:194`) answers DoubleType for
+    # `(FractionalType, DecimalType)` in either order.
+    Scenario Outline: <case> yields double
+      When query
+        """
+        SELECT typeof(<expr>) AS t, CAST(<expr> AS STRING) AS v
+        FROM VALUES (<taken>) AS t(c)
+        """
+      Then query result
+        | t      | v       |
+        | double | <value> |
+
+      Examples:
+        | case              | expr                                                                     | taken | value |
+        | CASE double THEN  | CASE WHEN c THEN CAST(1.5 AS DOUBLE) ELSE CAST(2.5 AS DECIMAL(10,2)) END | true  | 1.5   |
+        | CASE decimal THEN | CASE WHEN c THEN CAST(2.5 AS DECIMAL(10,2)) ELSE CAST(1.5 AS DOUBLE) END | true  | 2.5   |
+        | CASE float THEN   | CASE WHEN c THEN CAST(1.5 AS FLOAT) ELSE CAST(2.5 AS DECIMAL(10,2)) END  | true  | 1.5   |
+        | if double first   | if(c, CAST(1.5 AS DOUBLE), CAST(2.5 AS DECIMAL(10,2)))                   | true  | 1.5   |
+        | if decimal first  | if(c, CAST(2.5 AS DECIMAL(10,2)), CAST(1.5 AS DOUBLE))                   | true  | 2.5   |
+
+    # `decimal(30,15)` leaves only 15 integral digits and overflows where DOUBLE does not — on the
+    # branch that is not even taken. Compared rather than rendered, to keep float formatting out.
+    Scenario: a double branch keeps a magnitude that a decimal(30,15) could not hold
+      When query
+        """
+        SELECT typeof(CASE WHEN c THEN CAST(2.5 AS DECIMAL(10,2)) ELSE CAST(1e20 AS DOUBLE) END) AS t,
+               CAST(CASE WHEN c THEN CAST(2.5 AS DECIMAL(10,2)) ELSE CAST(1e20 AS DOUBLE) END
+                    = CAST(1e20 AS DOUBLE) AS STRING) AS v
+        FROM VALUES (false) AS t(c)
+        """
+      Then query result
+        | t      | v    |
+        | double | true |
+
+  Rule: A decimal wider than 38 digits drops fractional digits, not integral ones
+
+    # `boundedPreferIntegralDigits` (`DecimalType.scala:148-158`): past precision 38 Spark cuts the
+    # SCALE so the integral digits survive.
+    Scenario Outline: <then> against <els> yields <result>
+      When query
+        """
+        SELECT typeof(CASE WHEN c THEN CAST(1 AS <then>) ELSE CAST(2 AS <els>) END) AS t,
+               CAST(CASE WHEN c THEN CAST(1 AS <then>) ELSE CAST(2 AS <els>) END AS STRING) AS v
+        FROM VALUES (true) AS t(c)
+        """
+      Then query result
+        | t        | v       |
+        | <result> | <value> |
+
+      Examples:
+        | then           | els            | result         | value        |
+        | DECIMAL(38,10) | DECIMAL(38,0)  | decimal(38,0)  | 1            |
+        | DECIMAL(38,0)  | DECIMAL(38,10) | decimal(38,0)  | 1            |
+        | DECIMAL(38,20) | DECIMAL(38,0)  | decimal(38,0)  | 1            |
+        | DECIMAL(38,10) | BIGINT         | decimal(38,10) | 1.0000000000 |
+
+  Rule: IF unifies its two result branches the same way
+
+    Scenario Outline: if with a <then> branch and an <els> branch yields <result>
+      When query
+        """
+        SELECT typeof(if(c, CAST(1 AS <then>), CAST(2 AS <els>))) AS t,
+               CAST(if(c, CAST(1 AS <then>), CAST(2 AS <els>)) AS STRING) AS v
+        FROM VALUES (<taken>) AS t(c)
+        """
+      Then query result
+        | t        | v       |
+        | <result> | <value> |
+
+      Examples:
+        | then     | els    | taken | result | value |
+        | INT      | BIGINT | true  | bigint | 1     |
+        | INT      | BIGINT | false | bigint | 2     |
+        | SMALLINT | INT    | true  | int    | 1     |
+        | INT      | DOUBLE | true  | double | 1.0   |
+
+    Scenario: if widens a decimal branch against an integer branch
+      When query
+        """
+        SELECT typeof(if(c, CAST(1.5 AS DECIMAL(12,4)), 0)) AS t,
+               CAST(if(c, CAST(1.5 AS DECIMAL(12,4)), 0) AS STRING) AS v
+        FROM VALUES (true) AS t(c)
+        """
+      Then query result
+        | t             | v      |
+        | decimal(14,4) | 1.5000 |
+
+  Rule: A NULL branch never decides the type
+
+    Scenario Outline: a <null> THEN against a bigint ELSE stays bigint
+      When query
+        """
+        SELECT typeof(CASE WHEN c THEN <null> ELSE CAST(2 AS BIGINT) END) AS t,
+               CAST(CASE WHEN c THEN <null> ELSE CAST(2 AS BIGINT) END AS STRING) AS v
+        FROM VALUES (false) AS t(c)
+        """
+      Then query result
+        | t      | v |
+        | bigint | 2 |
+
+      Examples:
+        | null              |
+        | NULL              |
+        | CAST(NULL AS INT) |
+
+  Rule: Nested element types widen along with the branches
+
+    Scenario Outline: <case> widens its element type to bigint
+      When query
+        """
+        SELECT typeof(CASE WHEN c THEN <then> ELSE <els> END) AS t,
+               CAST(CASE WHEN c THEN <then> ELSE <els> END AS STRING) AS v
+        FROM VALUES (true) AS t(c)
+        """
+      Then query result
+        | t        | v       |
+        | <result> | <value> |
+
+      Examples:
+        | case   | then                              | els                                  | result             | value    |
+        | array  | array(CAST(1 AS INT))             | array(CAST(2 AS BIGINT))             | array<bigint>      | [1]      |
+        | struct | named_struct('a', CAST(1 AS INT)) | named_struct('a', CAST(2 AS BIGINT)) | struct<a:bigint>   | {1}      |
+        | map    | map('k', CAST(1 AS INT))          | map('k', CAST(2 AS BIGINT))          | map<string,bigint> | {k -> 1} |
+
+  Rule: The declared schema carries the widened type, for every scalar pair
+
+    # Asserts the schema as the client receives it, not `typeof`. Nullable columns on purpose:
+    # `CaseWhen` nullability is a separate, still-open gap.
+    Scenario Outline: the schema of a <then> branch against a <els> branch is <result>
+      When query
+        """
+        SELECT CASE WHEN c THEN a ELSE b END AS r
+        FROM VALUES
+          (true, CAST(1 AS <then>), CAST(2 AS <els>)),
+          (false, CAST(NULL AS <then>), CAST(NULL AS <els>))
+        AS t(c, a, b)
+        """
+      Then query schema
+        """
+        root
+         |-- r: <result> (nullable = true)
+        """
+
+      Examples:
+        | then          | els           | result        |
+        | INT           | BIGINT        | long          |
+        | SMALLINT      | INT           | integer       |
+        | TINYINT       | BIGINT        | long          |
+        | INT           | DOUBLE        | double        |
+        | DECIMAL(12,4) | INT           | decimal(14,4) |
+        | INT           | DECIMAL(12,4) | decimal(14,4) |
+        | DECIMAL(10,2) | BIGINT        | decimal(22,2) |
+        | DOUBLE        | DECIMAL(10,2) | double        |
+
+  Rule: The declared schema widens inside arrays, maps and structs too
+
+    # `typeof` renders no nullability, so `containsNull` / `valueContainsNull` need a schema tree.
+    # The ELSE is omitted deliberately: with one, the open `CaseWhen` nullability gap would mask
+    # the nested widening this Rule pins. Without it both engines agree on `true`.
+    Scenario: an array branch widens its element type in the reported schema
+      When query
+        """
+        SELECT CASE WHEN c THEN array(a) WHEN NOT c THEN array(b) END AS r
+        FROM VALUES
+          (true, CAST(1 AS INT), CAST(2 AS BIGINT)),
+          (false, CAST(NULL AS INT), CAST(NULL AS BIGINT))
+        AS t(c, a, b)
+        """
+      Then query schema
+        """
+        root
+         |-- r: array (nullable = true)
+         |    |-- element: long (containsNull = true)
+        """
+
+    Scenario: a map branch widens its value type in the reported schema
+      When query
+        """
+        SELECT CASE WHEN c THEN map('k', a) WHEN NOT c THEN map('k', b) END AS r
+        FROM VALUES
+          (true, CAST(1 AS INT), CAST(2 AS BIGINT)),
+          (false, CAST(NULL AS INT), CAST(NULL AS BIGINT))
+        AS t(c, a, b)
+        """
+      Then query schema
+        """
+        root
+         |-- r: map (nullable = true)
+         |    |-- key: string
+         |    |-- value: long (valueContainsNull = true)
+        """
+
+    Scenario: a struct branch widens its field type in the reported schema
+      When query
+        """
+        SELECT CASE WHEN c THEN named_struct('f', a) WHEN NOT c THEN named_struct('f', b) END AS r
+        FROM VALUES
+          (true, CAST(1 AS INT), CAST(2 AS BIGINT)),
+          (false, CAST(NULL AS INT), CAST(NULL AS BIGINT))
+        AS t(c, a, b)
+        """
+      Then query schema
+        """
+        root
+         |-- r: struct (nullable = true)
+         |    |-- f: long (nullable = true)
+        """
+
+  Rule: The decimal rules apply inside arrays, maps and structs too
+
+    # `findTypeForComplex` (`TypeCoercionHelper.scala:137-177`) recurses `findWiderTypeForTwo` into
+    # the element, so the same two rules decide an element as a scalar branch.
+    Scenario Outline: A <container> branch applies <rule> to its element type
+      When query
+        """
+        SELECT typeof(if(c, <narrow>, <wide>)) AS t FROM VALUES (true) AS t(c)
+        """
+      Then query result
+        | t        |
+        | <result> |
+
+      Examples:
+        | container | rule            | narrow                                         | wide                                        | result                    |
+        | array     | the 38 bound    | array(CAST(1.5 AS DECIMAL(20,15)))             | array(CAST(2 AS DECIMAL(30,0)))             | array<decimal(38,8)>      |
+        | struct    | the 38 bound    | named_struct('f', CAST(1.5 AS DECIMAL(20,15))) | named_struct('f', CAST(2 AS DECIMAL(30,0))) | struct<f:decimal(38,8)>   |
+        | map       | the 38 bound    | map('k', CAST(1.5 AS DECIMAL(20,15)))          | map('k', CAST(2 AS DECIMAL(30,0)))          | map<string,decimal(38,8)> |
+        | array     | float to double | array(CAST(1.5 AS DOUBLE))                     | array(CAST(2.5 AS DECIMAL(10,2)))           | array<double>             |
+
+  Rule: The decimal rules hold with ANSI disabled too
+
+    # `findWiderTypeForDecimal` is reached from both dialects, so no decimal answer above is
+    # ANSI-specific. Every other scenario runs on the session default, ANSI-on; these pin the rest.
+    Scenario Outline: With ANSI disabled, <then> against <els> still yields <result>
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT typeof(CASE WHEN c THEN CAST(1 AS <then>) ELSE CAST(2 AS <els>) END) AS t
+        FROM VALUES (true) AS t(c)
+        """
+      Then query result
+        | t        |
+        | <result> |
+
+      Examples:
+        | then           | els           | result        |
+        | INT            | BIGINT        | bigint        |
+        | DECIMAL(12,4)  | INT           | decimal(14,4) |
+        | DOUBLE         | DECIMAL(10,2) | double        |
+        | DECIMAL(38,20) | DECIMAL(38,0) | decimal(38,0) |
+
+  Rule: Struct branches pair their fields by name
+
+    # `findTypeForComplex` (`TypeCoercionHelper.scala:163-176`) pairs struct fields positionally and
+    # requires the names to resolve at every position, so Spark rejects any name mismatch. Sail is
+    # more lenient: DataFusion pairs by NAME and emits them in the left branch's order. The element
+    # rules must therefore either follow that pairing or stand aside — pairing positionally on top
+    # of a by-name result would coerce two fields that are not the same column.
+    Scenario: struct branches naming different fields are rejected
+      When query
+        """
+        SELECT if(c, named_struct('a', CAST(1 AS INT)), named_struct('b', CAST(2 AS BIGINT))) AS r
+        FROM VALUES (false) AS t(c)
+        """
+      Then query error .*(DATA_DIFF_TYPES|Unsupported CAST).*
+
+    Scenario: struct branches naming the same field widen it
+      When query
+        """
+        SELECT typeof(if(c, named_struct('a', CAST(1 AS INT)), named_struct('a', CAST(2 AS BIGINT)))) AS t
+        FROM VALUES (false) AS t(c)
+        """
+      Then query result
+        | t                |
+        | struct<a:bigint> |
+
+    # Spark rejects a reordering outright; Sail resolves it by name instead. Pinned so the values
+    # cannot silently land under the wrong field name if the pairing is ever revisited.
+    @sail-bug
+    Scenario: struct branches listing the same fields in a different order are rejected
+      When query
+        """
+        SELECT if(c, named_struct('a', CAST(1 AS INT), 'b', CAST(2 AS BIGINT)),
+                     named_struct('b', CAST(3 AS BIGINT), 'a', CAST(4 AS INT))) AS r
+        FROM VALUES (false) AS t(c)
+        """
+      Then query error .*DATA_DIFF_TYPES.*
+
+    @sail-only
+    Scenario: a reordered struct still resolves each field by its own name
+      When query
+        """
+        SELECT CAST(if(c, named_struct('a', CAST(1 AS INT), 'b', CAST(2 AS BIGINT)),
+                          named_struct('b', CAST(3 AS BIGINT), 'a', CAST(4 AS INT))) AS STRING) AS v
+        FROM VALUES (false) AS t(c)
+        """
+      Then query result
+        | v      |
+        | {4, 3} |
+
+  Rule: Decimal256 branches keep their width, at any depth
+
+    # Spark decimals never exceed 38 digits, so `CAST(1 AS DECIMAL(50, 10))` is rejected outright and
+    # there is no Spark answer to match — these are `@sail-only`. What they pin is INTERNAL: the
+    # `Decimal256` exception is decided for the whole conditional, so a nested branch resolves the
+    # same way a scalar one does. Narrowing either to DOUBLE would drop 20 significant digits.
+    @sail-only
+    Scenario Outline: <case> keeps the wider decimal
+      When query
+        """
+        SELECT typeof(if(c, <narrow>, <wide>)) AS t FROM VALUES (true) AS t(c)
+        """
+      Then query result
+        | t        |
+        | <result> |
+
+      Examples:
+        | case          | narrow                           | wide                       | result                |
+        | a scalar pair | CAST(1 AS DECIMAL(50,10))        | CAST(1.5 AS DOUBLE)        | decimal(55,15)        |
+        | inside array  | array(CAST(1 AS DECIMAL(50,10))) | array(CAST(1.5 AS DOUBLE)) | array<decimal(55,15)> |
+
+  Rule: Branches with no common type are rejected instead of silently typed
+
+    # Spark raises `DATATYPE_MISMATCH.DATA_DIFF_TYPES` (`conditionalExpressions.scala:220-227`);
+    # Sail refuses during planning. The pattern matches either, since a bare `.*` would stay green
+    # on a parse error or a dropped connection.
+    Scenario: a boolean branch against an integer branch is rejected
+      When query
+        """
+        SELECT CASE WHEN c THEN true ELSE 1 END AS r FROM VALUES (true) AS t(c)
+        """
+      Then query error .*(DATA_DIFF_TYPES|Failed to coerce then).*
+
+    Scenario: if with a boolean branch against an integer branch is rejected
+      When query
+        """
+        SELECT if(c, true, 1) AS r FROM VALUES (true) AS t(c)
+        """
+      Then query error .*(DATA_DIFF_TYPES|Failed to coerce then).*
+
+  Rule: An integral branch against a float branch widens per dialect
+
+    # ANSI's `findTightestCommonType` returns DoubleType for integral-meets-float
+    # (`AnsiTypeCoercion.scala:113-124`); the non-ANSI path (`TypeCoercion.scala:88-92`) answers
+    # plain FLOAT, which is what Sail answers — hence the explicit ANSI pin.
+    #
+    # Still open, and not specific to CASE: `coalesce`, `greatest`, `least`, `array`, `UNION ALL`,
+    # `+` and `*` all answer `float` too, so this belongs in a shared numeric-coercion fix rather
+    # than in the conditional builder.
+    #
+    # The ANSI-off counterpart, which Sail already gets right.
+    Scenario: With ANSI disabled, an integral branch against a float branch stays float
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT typeof(CASE WHEN c THEN CAST(1 AS FLOAT) ELSE CAST(2147483647 AS INT) END) AS t
+        FROM VALUES (false) AS t(c)
+        """
+      Then query result
+        | t     |
+        | float |
+
+    @sail-bug
+    Scenario Outline: <case> widens to double under ANSI
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT typeof(<expr>) AS t FROM VALUES (false) AS t(c)
+        """
+      Then query result
+        | t      |
+        | double |
+
+      Examples:
+        | case              | expr                                                               |
+        | CASE with INT_MAX | CASE WHEN c THEN CAST(1 AS FLOAT) ELSE CAST(2147483647 AS INT) END |
+        | if with INT_MAX   | if(c, CAST(1 AS FLOAT), CAST(2147483647 AS INT))                   |
+        | CASE with 2^24+1  | CASE WHEN c THEN CAST(1 AS FLOAT) ELSE CAST(16777217 AS INT) END   |
+
+    # The value half, kept separate: a strict xfail is satisfied by EITHER assertion failing, so a
+    # combined scenario could not tell "Sail answers float" from "Sail rounds through float32", and
+    # would stay green if only one of the two were ever fixed. Read back through DECIMAL(20,0) so
+    # the assertion pins the number and not how each engine formats a float.
+    @sail-bug
+    Scenario Outline: <case> keeps an integral branch exact instead of rounding it through float32
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT CAST(CAST(<expr> AS DECIMAL(20,0)) AS STRING) AS v
+        FROM VALUES (false) AS t(c)
+        """
+      Then query result
+        | v       |
+        | <value> |
+
+      Examples:
+        | case              | expr                                                               | value      |
+        | CASE with INT_MAX | CASE WHEN c THEN CAST(1 AS FLOAT) ELSE CAST(2147483647 AS INT) END | 2147483647 |
+        | if with INT_MAX   | if(c, CAST(1 AS FLOAT), CAST(2147483647 AS INT))                   | 2147483647 |
+        | CASE with 2^24+1  | CASE WHEN c THEN CAST(1 AS FLOAT) ELSE CAST(16777217 AS INT) END   | 16777217   |

--- a/python/pysail/tests/spark/function/test_conditional_arrow_schema.py
+++ b/python/pysail/tests/spark/function/test_conditional_arrow_schema.py
@@ -1,0 +1,116 @@
+from decimal import Decimal
+
+import pytest
+
+from pysail.testing.spark.utils.common import pyspark_version
+
+pytestmark = pytest.mark.skipif(
+    pyspark_version() < (4,),
+    reason="DataFrame.toArrow requires PySpark 4+",
+)
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        # Each case picks a value the FIRST branch's type cannot hold, so it only passes when the
+        # conditional was typed from every branch: `collect()` reads the data and survives a narrow
+        # schema, but `toArrow()` builds from the declared schema and does not.
+        pytest.param(
+            "SELECT CASE WHEN c THEN CAST(1 AS INT) ELSE CAST(3000000000 AS BIGINT) END AS r "
+            "FROM VALUES (false) AS t(c)",
+            3000000000,
+            id="else_bigint_past_int_max",
+        ),
+        pytest.param(
+            "SELECT CASE WHEN c THEN CAST(1 AS INT) ELSE CAST(9223372036854775807 AS BIGINT) END AS r "
+            "FROM VALUES (false) AS t(c)",
+            9223372036854775807,
+            id="else_bigint_at_max",
+        ),
+        pytest.param(
+            "SELECT CASE WHEN c THEN CAST(1 AS SMALLINT) ELSE CAST(70000 AS INT) END AS r "
+            "FROM VALUES (false) AS t(c)",
+            70000,
+            id="else_int_past_smallint",
+        ),
+        pytest.param(
+            "SELECT CASE WHEN c THEN CAST(1 AS TINYINT) ELSE CAST(300 AS BIGINT) END AS r "
+            "FROM VALUES (false) AS t(c)",
+            300,
+            id="else_bigint_past_tinyint",
+        ),
+        pytest.param(
+            "SELECT CASE WHEN c THEN CAST(1 AS INT) ELSE CAST(2.5 AS DOUBLE) END AS r "
+            "FROM VALUES (false) AS t(c)",
+            2.5,
+            id="else_double_against_int",
+        ),
+        pytest.param(
+            "SELECT CASE WHEN c THEN CAST(1 AS INT) ELSE CAST(1.5 AS DECIMAL(12,4)) END AS r "
+            "FROM VALUES (false) AS t(c)",
+            Decimal("1.5000"),
+            id="else_decimal_against_int",
+        ),
+        pytest.param(
+            "SELECT CASE WHEN c THEN CAST(1 AS DECIMAL(5,2)) ELSE CAST(99999 AS INT) END AS r "
+            "FROM VALUES (false) AS t(c)",
+            Decimal("99999.00"),
+            id="else_int_past_decimal_precision",
+        ),
+        pytest.param(
+            "SELECT CASE WHEN c THEN CAST(1 AS DECIMAL(10,2)) ELSE CAST(123456789012 AS BIGINT) END AS r "
+            "FROM VALUES (false) AS t(c)",
+            Decimal("123456789012.00"),
+            id="else_bigint_past_decimal_precision",
+        ),
+        # The wide branch as a COLUMN, not a foldable literal: a rule that only inspects literals
+        # would look correct on every case above and still narrow real data.
+        pytest.param(
+            "SELECT CASE WHEN c THEN CAST(1 AS INT) ELSE b END AS r "
+            "FROM VALUES (false, CAST(3000000000 AS BIGINT)) AS t(c, b)",
+            3000000000,
+            id="else_bigint_column",
+        ),
+        # The wide branch in a middle WHEN rather than the ELSE, so neither the first branch nor
+        # the else position can be the one that decides the type.
+        pytest.param(
+            "SELECT CASE WHEN c THEN CAST(1 AS INT) WHEN NOT c THEN CAST(3000000000 AS BIGINT) "
+            "ELSE CAST(2 AS INT) END AS r FROM VALUES (false) AS t(c)",
+            3000000000,
+            id="middle_when_bigint",
+        ),
+        # `IF` goes through the same builder and must widen the same way.
+        pytest.param(
+            "SELECT if(c, CAST(1 AS INT), CAST(3000000000 AS BIGINT)) AS r FROM VALUES (false) AS t(c)",
+            3000000000,
+            id="if_else_bigint",
+        ),
+        pytest.param(
+            "SELECT if(c, CAST(1 AS INT), CAST(2.5 AS DOUBLE)) AS r FROM VALUES (false) AS t(c)",
+            2.5,
+            id="if_else_double",
+        ),
+        # Nested: the element type of an array branch has to widen too, or the declared
+        # `array<int>` cannot carry the `array<bigint>` the data actually holds.
+        pytest.param(
+            "SELECT CASE WHEN c THEN array(CAST(1 AS INT)) ELSE array(CAST(3000000000 AS BIGINT)) END AS r "
+            "FROM VALUES (false) AS t(c)",
+            [3000000000],
+            id="array_element_bigint",
+        ),
+    ],
+)
+def test_conditional_arrow_schema_holds_the_widened_value(spark, query, expected):
+    """A conditional's declared schema must describe the data it carries.
+
+    Spark widens every branch of a `CASE`/`IF` before typing it, so the reported schema is the wider
+    type and an Arrow consumer can build from it. Typing the conditional from the first `THEN`
+    instead leaves the schema narrow while the data stays wide: `collect()` still returns the right
+    value because it reads the data, but `toArrow()` builds from the declared schema and raises
+    "Integer value 3000000000 not in range" — and so would a Parquet write or an Arrow IPC stream.
+    """
+    df = spark.sql(query)
+
+    assert df.toArrow().column("r").to_pylist() == [expected]
+    assert df.collect()[0][0] == expected

--- a/python/pysail/tests/spark/function/test_conditional_arrow_schema.py
+++ b/python/pysail/tests/spark/function/test_conditional_arrow_schema.py
@@ -29,20 +29,17 @@ pytestmark = pytest.mark.skipif(
             id="else_bigint_at_max",
         ),
         pytest.param(
-            "SELECT CASE WHEN c THEN CAST(1 AS SMALLINT) ELSE CAST(70000 AS INT) END AS r "
-            "FROM VALUES (false) AS t(c)",
+            "SELECT CASE WHEN c THEN CAST(1 AS SMALLINT) ELSE CAST(70000 AS INT) END AS r FROM VALUES (false) AS t(c)",
             70000,
             id="else_int_past_smallint",
         ),
         pytest.param(
-            "SELECT CASE WHEN c THEN CAST(1 AS TINYINT) ELSE CAST(300 AS BIGINT) END AS r "
-            "FROM VALUES (false) AS t(c)",
+            "SELECT CASE WHEN c THEN CAST(1 AS TINYINT) ELSE CAST(300 AS BIGINT) END AS r FROM VALUES (false) AS t(c)",
             300,
             id="else_bigint_past_tinyint",
         ),
         pytest.param(
-            "SELECT CASE WHEN c THEN CAST(1 AS INT) ELSE CAST(2.5 AS DOUBLE) END AS r "
-            "FROM VALUES (false) AS t(c)",
+            "SELECT CASE WHEN c THEN CAST(1 AS INT) ELSE CAST(2.5 AS DOUBLE) END AS r FROM VALUES (false) AS t(c)",
             2.5,
             id="else_double_against_int",
         ),


### PR DESCRIPTION
`CASE`/`IF` took their type from the first non-null `THEN` branch and ignored the `ELSE`,
so any conditional whose widest branch was not written first was under-typed.

Spark unifies the branches **before** typing the expression: `CaseWhen` and `If` are
`ComplexTypeMergingExpression`s whose `inputTypesForMerging` covers every `THEN` value
*and* the `ELSE` value, and `CaseWhenCoercion` / `IfCoercion` cast all of them to
`findWiderCommonType` before analysis completes. That is why the declared type never
depends on branch order in Spark.

```sql
SELECT typeof(CASE WHEN true THEN CAST(1 AS INT) ELSE CAST(2 AS BIGINT) END);
-- Spark: bigint    Sail before: int
```

The values were already right — DataFusion's `TypeCoercion` analyzer coerces the branches
at execution time — so what was wrong was the schema Spark Connect *announces*. That still
breaks real consumers: anything that builds from the declared schema fails on a value the
narrow type cannot hold.

```
CASE WHEN c THEN CAST(1 AS INT) ELSE CAST(3000000000 AS BIGINT) END
  df.collect()  ->  3000000000            (the data is wide)
  df.toArrow()  ->  ArrowInvalid: Integer value 3000000000 not in range
```

The fix unifies the branches in the resolver. That placement is load-bearing: `analyze_schema`
serves the client schema off `plan.schema()` of the **resolved** plan, before any analyzer rule
runs, so a `TypeCoercion` analyzer rule could not fix the reported type.

Because the fix now inserts real casts, it also has to reproduce two Spark rules that
DataFusion answers differently — without them the casts themselves would lose data:

- **`FractionalType` ⊕ `DecimalType` → `DOUBLE`** (`findWiderTypeForDecimal`). DataFusion
  answers `Decimal128(30,15)`, which holds only 15 integral digits and overflows on
  magnitudes a `DOUBLE` carries fine.
- **Past 38 digits, cut the SCALE, not the integral digits**
  (`DecimalType.boundedPreferIntegralDigits`). DataFusion clamps precision and scale
  independently, so a `DECIMAL(38,0)` branch would be cast to `decimal(38,20)`.

Both also apply to the element type of an `array`/`map`/`struct` branch, since Spark's
`findTypeForComplex` recurses `findWiderTypeForTwo` into the element.

### Tests

`case_branch_type_coercion.feature` — 30 scenarios covering branch order, the two decimal
rules, `IF`, the `CASE <operand> WHEN` form, NULL branches, nested containers, the reported
output schema, both ANSI dialects, and the pairs with no common type.

`test_conditional_arrow_schema.py` — 13 cases reading the result through `toArrow()`, which
builds from the declared schema and is the only assertion that catches the schema and the
data disagreeing. It lives in Python because there is no Arrow step in the BDD vocabulary.

Every expected type and value was captured from Spark Connect 4.2.0 (JVM), and the whole
file passes against it. TPC-H and TPC-DS are unchanged — **zero snapshots moved**.

### Known gaps, left out on purpose

- `float` ⊕ integral answers `float` where ANSI Spark answers `double`. The root cause is
  DataFusion's `numerical_coercion`, which answers the same for `coalesce`, `greatest`,
  `least`, `array`, `UNION ALL`, `+` and `*` — fixing it only here would make the engine
  inconsistent with itself. Tagged `@sail-bug`, with the ANSI-off counterpart pinned as a
  passing scenario since Sail is right in that dialect.
- `CaseWhen` nullability: Spark's `TrueLiteral` rule is not reproduced, so a `CASE` with an
  `ELSE` reports `nullable = true` where Spark reports `false`. `IF` already matches. Separate
  axis, untouched here.
- `coalesce`/`nvl`/`ifnull` are unified by the same Spark function and still carry the
  original bug.

### Relationship to #2225

Same class of bug on a different surface: #2225 fixes Spark coercion for the `+ - * /`
operators, this one for `CASE`/`IF`. Both land in the resolver rather than in an
analyzer rule, which is the placement agreed for #2225 — and for conditionals it is
not just a preference: `analyze_schema` reads `plan.schema()` off the resolved plan,
before any AnalyzerRule runs, so an analyzer rule cannot reach the reported type at all.

The two are independent and can land in either order. The `float` ⊕ integral gap listed
below is shared between them and belongs in whichever shared numeric-coercion fix comes
later.
