### PR TITLE
fix: disabled file cache configuration

### DIFF
--- a/crates/sail-session/src/runtime.rs
+++ b/crates/sail-session/src/runtime.rs
@@ -45,9 +45,21 @@ impl RuntimeEnvFactory {
     {
         let registry = DynamicObjectStoreRegistry::new(self.runtime.clone());
         let cache_config = CacheManagerConfig::default()
-            .with_file_statistics_cache(Some(self.create_file_statistics_cache()))
-            .with_list_files_cache(Some(self.create_file_listing_cache()))
+            .with_file_statistics_cache(self.create_file_statistics_cache())
+            .with_list_files_cache(self.create_file_listing_cache())
             .with_file_metadata_cache(Some(self.create_file_metadata_cache()));
+        let cache_config = match &self.config.parquet.file_statistics_cache.r#type {
+            CacheType::None => cache_config.with_file_statistics_cache_limit(0),
+            CacheType::Global | CacheType::Session => cache_config,
+        };
+        let cache_config = match &self.config.execution.file_listing_cache.r#type {
+            CacheType::None => cache_config.with_list_files_cache_limit(0),
+            CacheType::Global | CacheType::Session => cache_config,
+        };
+        let cache_config = match &self.config.parquet.file_metadata_cache.r#type {
+            CacheType::None => cache_config.with_metadata_cache_limit(0),
+            CacheType::Global | CacheType::Session => cache_config,
+        };
         let builder = RuntimeEnvBuilder::default()
             .with_object_store_registry(Arc::new(registry))
             .with_cache_manager(cache_config)
@@ -86,50 +98,54 @@ impl RuntimeEnvFactory {
         builder
     }
 
-    fn create_file_statistics_cache(&mut self) -> Arc<dyn FileStatisticsCache> {
+    fn create_file_statistics_cache(&mut self) -> Option<Arc<dyn FileStatisticsCache>> {
         let ttl = self.config.parquet.file_statistics_cache.ttl;
         let max_entries = self.config.parquet.file_statistics_cache.max_entries;
         match &self.config.parquet.file_statistics_cache.r#type {
             CacheType::None => {
                 debug!("Not using file statistics cache");
-                Arc::new(MokaFileStatisticsCache::new(ttl, Some(0)))
+                None
             }
             CacheType::Global => {
                 debug!("Using global file statistics cache");
-                self.global_file_statistics_cache
-                    .get_or_insert_with(|| {
-                        Arc::new(MokaFileStatisticsCache::new(ttl, max_entries))
-                            as Arc<dyn FileStatisticsCache>
-                    })
-                    .clone()
+                Some(
+                    self.global_file_statistics_cache
+                        .get_or_insert_with(|| {
+                            Arc::new(MokaFileStatisticsCache::new(ttl, max_entries))
+                                as Arc<dyn FileStatisticsCache>
+                        })
+                        .clone(),
+                )
             }
             CacheType::Session => {
                 debug!("Using session file statistics cache");
-                Arc::new(MokaFileStatisticsCache::new(ttl, max_entries))
+                Some(Arc::new(MokaFileStatisticsCache::new(ttl, max_entries)))
             }
         }
     }
 
-    fn create_file_listing_cache(&mut self) -> Arc<dyn ListFilesCache> {
+    fn create_file_listing_cache(&mut self) -> Option<Arc<dyn ListFilesCache>> {
         let ttl = self.config.execution.file_listing_cache.ttl;
         let max_entries = self.config.execution.file_listing_cache.max_entries;
         match &self.config.execution.file_listing_cache.r#type {
             CacheType::None => {
                 debug!("Not using file listing cache");
-                Arc::new(MokaFileListingCache::new(ttl, Some(0)))
+                None
             }
             CacheType::Global => {
                 debug!("Using global file listing cache");
-                self.global_file_listing_cache
-                    .get_or_insert_with(|| {
-                        Arc::new(MokaFileListingCache::new(ttl, max_entries))
-                            as Arc<dyn ListFilesCache>
-                    })
-                    .clone()
+                Some(
+                    self.global_file_listing_cache
+                        .get_or_insert_with(|| {
+                            Arc::new(MokaFileListingCache::new(ttl, max_entries))
+                                as Arc<dyn ListFilesCache>
+                        })
+                        .clone(),
+                )
             }
             CacheType::Session => {
                 debug!("Using session file listing cache");
-                Arc::new(MokaFileListingCache::new(ttl, max_entries))
+                Some(Arc::new(MokaFileListingCache::new(ttl, max_entries)))
             }
         }
     }


### PR DESCRIPTION
Sail previously represented disabled caches as `Some(zero_capacity_cache)`.

For file listings, the presence of a cache changes Sail’s behavior: on a cache miss, it collects the entire object-store listing into memory before returning any results. A zero-capacity cache immediately discards that listing, so schema inference still materializes the full prefix without receiving any reuse benefit. This prevents operations such as schema sampling with `.take(10)` from short-circuiting the listing stream. Scan planning can then list the prefix again.

File-statistics caching had the same configuration mismatch: it was structurally enabled but unable to retain entries, resulting in unnecessary lookups and writes.

Relevant DataFusion reference:
https://github.com/apache/datafusion/blob/5134a1adff1498e18cc3af34a79aaa62ccc4efb8/datafusion/execution/src/cache/cache_manager.rs#L314-L370