### PR TITLE
feat: align file scan partitioning with Spark

### DIFF
--- a/crates/sail-common-datafusion/src/datasource.rs
+++ b/crates/sail-common-datafusion/src/datasource.rs
@@ -187,8 +187,8 @@ pub struct BucketBy {
 /// Spark-compatible controls for packing files into scan partitions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd)]
 pub struct FileScanPartitioningOptions {
-    pub max_partition_bytes: u64,
-    pub open_cost_bytes: u64,
+    pub max_partition_bytes: i64,
+    pub open_cost_bytes: i64,
     pub min_partitions: Option<usize>,
     pub max_partitions: Option<usize>,
 }

--- a/crates/sail-common-datafusion/src/datasource.rs
+++ b/crates/sail-common-datafusion/src/datasource.rs
@@ -184,6 +184,26 @@ pub struct BucketBy {
     pub num_buckets: usize,
 }
 
+/// Spark-compatible controls for packing files into scan partitions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd)]
+pub struct FileScanPartitioningOptions {
+    pub max_partition_bytes: u64,
+    pub open_cost_bytes: u64,
+    pub min_partitions: Option<usize>,
+    pub max_partitions: Option<usize>,
+}
+
+impl Default for FileScanPartitioningOptions {
+    fn default() -> Self {
+        Self {
+            max_partition_bytes: 128 * 1024 * 1024,
+            open_cost_bytes: 4 * 1024 * 1024,
+            min_partitions: None,
+            max_partitions: None,
+        }
+    }
+}
+
 /// Information required to create a data source.
 #[derive(Debug, Clone)]
 pub struct SourceInfo {
@@ -196,6 +216,7 @@ pub struct SourceInfo {
     pub partition_by: Vec<String>,
     pub bucket_by: Option<BucketBy>,
     pub sort_order: Vec<Sort>,
+    pub file_scan_partitioning: FileScanPartitioningOptions,
     /// The layers of options for the data source.
     /// A later layer can override earlier ones.
     pub options: Vec<OptionLayer>,

--- a/crates/sail-data-source/src/formats/csv/read.rs
+++ b/crates/sail-data-source/src/formats/csv/read.rs
@@ -142,6 +142,10 @@ impl ReadFormat for CsvReadFormat {
         Ok(config)
     }
 
+    fn is_splittable(&self) -> bool {
+        !self.options.multi_line
+    }
+
     fn path_glob_filter(&self) -> Option<&str> {
         self.options.path_glob_filter.as_deref()
     }

--- a/crates/sail-data-source/src/formats/json/read.rs
+++ b/crates/sail-data-source/src/formats/json/read.rs
@@ -117,6 +117,10 @@ impl ReadFormat for JsonReadFormat {
         Ok(config)
     }
 
+    fn is_splittable(&self) -> bool {
+        true
+    }
+
     fn path_glob_filter(&self) -> Option<&str> {
         self.options.path_glob_filter.as_deref()
     }

--- a/crates/sail-data-source/src/formats/parquet/read.rs
+++ b/crates/sail-data-source/src/formats/parquet/read.rs
@@ -167,6 +167,10 @@ impl ReadFormat for ParquetReadFormat {
         Ok(config)
     }
 
+    fn is_splittable(&self) -> bool {
+        true
+    }
+
     fn requires_explicit_schema_validation(&self) -> bool {
         true
     }

--- a/crates/sail-data-source/src/formats/rate/mod.rs
+++ b/crates/sail-data-source/src/formats/rate/mod.rs
@@ -42,6 +42,7 @@ impl TableFormat for RateTableFormat {
             partition_by,
             bucket_by,
             sort_order,
+            file_scan_partitioning: _,
             options,
             read_case_sensitive: _,
         } = info;

--- a/crates/sail-data-source/src/formats/socket/mod.rs
+++ b/crates/sail-data-source/src/formats/socket/mod.rs
@@ -42,6 +42,7 @@ impl TableFormat for SocketTableFormat {
             partition_by,
             bucket_by,
             sort_order,
+            file_scan_partitioning: _,
             options,
             read_case_sensitive: _,
         } = info;

--- a/crates/sail-data-source/src/formats/text/read.rs
+++ b/crates/sail-data-source/src/formats/text/read.rs
@@ -74,6 +74,10 @@ impl ReadFormat for TextReadFormat {
         Ok(config)
     }
 
+    fn is_splittable(&self) -> bool {
+        !self.options.whole_text
+    }
+
     fn path_glob_filter(&self) -> Option<&str> {
         self.options.path_glob_filter.as_deref()
     }

--- a/crates/sail-data-source/src/listing/planner.rs
+++ b/crates/sail-data-source/src/listing/planner.rs
@@ -20,17 +20,18 @@ use datafusion::physical_expr_common::sort_expr::LexOrdering;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::empty::EmptyExec;
 use datafusion::physical_planner::{ExtensionPlanner, PhysicalPlanner};
+use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_common::stats::Precision;
-use datafusion_common::{Statistics, internal_err, plan_err, project_schema};
-use datafusion_datasource::ListingTableUrl;
+use datafusion_common::{DataFusionError, Statistics, internal_err, plan_err, project_schema};
 use datafusion_datasource::file_groups::FileGroup;
-use datafusion_datasource::file_scan_config::FileScanConfig;
 use datafusion_datasource::source::DataSourceExec;
+use datafusion_datasource::{ListingTableUrl, PartitionedFile};
 use futures::{Stream, StreamExt, TryStreamExt, future, stream};
 use object_store::ObjectStore;
 use sail_common_datafusion::datasource::create_sort_order;
 use sail_common_datafusion::streaming::event::schema::is_flow_event_schema;
 use sail_physical_plan::barrier::BarrierExec;
+use sail_physical_plan::file_scan_partitioning::FileScanPartitioningFenceExec;
 
 use crate::listing::delete::FileDeleteExec;
 use crate::listing::source::{ListingScanInput, ListingSinkInput};
@@ -108,7 +109,7 @@ impl ExtensionPlanner for ListingPhysicalPlanner {
         let statistic_file_limit = if filters.is_empty() { limit } else { None };
 
         let ListFilesResult {
-            mut file_groups,
+            file_groups,
             statistics,
             grouped_by_partition: partitioned_by_file_group,
         } = list_files_for_scan(
@@ -127,35 +128,6 @@ impl ExtensionPlanner for ListingPhysicalPlanner {
 
         let output_ordering =
             try_create_output_ordering(source, session_state.execution_props(), &file_groups)?;
-
-        match session_state
-            .config_options()
-            .execution
-            .split_file_groups_by_statistics
-            .then(|| {
-                output_ordering.first().map(|output_ordering| {
-                    FileScanConfig::split_groups_by_statistics_with_target_partitions(
-                        table_schema,
-                        &file_groups,
-                        output_ordering,
-                        source.config().target_partitions,
-                    )
-                })
-            })
-            .flatten()
-        {
-            Some(Err(e)) => log::debug!("failed to split file groups by statistics: {e}"),
-            Some(Ok(new_groups)) => {
-                if new_groups.len() <= source.config().target_partitions {
-                    file_groups = new_groups;
-                } else {
-                    log::debug!(
-                        "attempted to split file groups by statistics, but there were more file groups than target_partitions; falling back to unordered"
-                    )
-                }
-            }
-            None => {} // no ordering required
-        };
 
         // If user specified ordering, that's already handled in `try_create_output_ordering`.
         // When no ordering is specified and we derived ordering from files, keep it.
@@ -181,7 +153,7 @@ impl ExtensionPlanner for ListingPhysicalPlanner {
                     constraints: source.config().constraints.clone(),
                     projection,
                     limit,
-                    preserve_order: false,
+                    preserve_order: true,
                     output_ordering,
                     statistics,
                     partitioned_by_file_group,
@@ -191,7 +163,9 @@ impl ExtensionPlanner for ListingPhysicalPlanner {
             )
             .await?;
 
-        Ok(Some(DataSourceExec::from_data_source(config)))
+        Ok(Some(Arc::new(FileScanPartitioningFenceExec::new(
+            DataSourceExec::from_data_source(config),
+        ))))
     }
 }
 
@@ -399,45 +373,50 @@ async fn list_files_for_scan<'a>(
     let (file_group, inexact_stats) =
         get_files_with_limit(files, limit, source.config().collect_stat).await?;
 
-    let threshold = ctx.config_options().optimizer.preserve_file_partitions;
-
-    let (file_groups, grouped_by_partition) = if threshold > 0 && !partition_cols.is_empty() {
-        let grouped = file_group.group_by_partition_values(source.config().target_partitions);
-        if grouped.len() >= threshold {
-            (grouped, true)
-        } else {
-            let all_files: Vec<_> = grouped.into_iter().flat_map(|g| g.into_inner()).collect();
-            (
-                pack_file_groups(
-                    FileGroup::new(all_files),
-                    source.config().target_partitions,
-                    source.config().file_scan_partitioning,
-                ),
-                false,
-            )
-        }
+    let split_files = source.config().read_format.is_splittable()
+        && source.config().compression == CompressionTypeVariant::UNCOMPRESSED;
+    let file_groups = if split_files {
+        // Keep listing order until after files become ranges. Spark sorts the
+        // ranges, not the original files, so ties must retain listing order.
+        vec![file_group]
     } else {
-        (
-            pack_file_groups(
-                file_group,
-                source.config().target_partitions,
-                source.config().file_scan_partitioning,
-            ),
+        pack_file_groups(
+            file_group,
+            source.config().target_partitions,
+            source.config().file_scan_partitioning,
             false,
-        )
+        )?
+        .0
     };
 
-    let (file_groups, stats) = datafusion_datasource::compute_all_files_statistics(
+    // Compute table statistics from whole files. Repeating full-file statistics
+    // on every generated byte range would multiply row counts and byte sizes.
+    let (mut file_groups, stats) = datafusion_datasource::compute_all_files_statistics(
         file_groups,
         source.config().schema.table_schema().clone(),
         source.config().collect_stat,
         inexact_stats,
     )?;
 
+    if split_files {
+        let files = file_groups
+            .iter()
+            .flat_map(FileGroup::iter)
+            .cloned()
+            .collect();
+        file_groups = pack_file_groups(
+            FileGroup::new(files),
+            source.config().target_partitions,
+            source.config().file_scan_partitioning,
+            true,
+        )?
+        .0;
+    }
+
     Ok(ListFilesResult {
         file_groups,
         statistics: stats,
-        grouped_by_partition,
+        grouped_by_partition: false,
     })
 }
 
@@ -446,64 +425,136 @@ fn pack_file_groups(
     file_group: FileGroup,
     target_partitions: usize,
     options: sail_common_datafusion::datasource::FileScanPartitioningOptions,
-) -> Vec<FileGroup> {
+    split_files: bool,
+) -> datafusion_common::Result<(Vec<FileGroup>, bool)> {
     let files = file_group.into_inner();
     if files.is_empty() {
-        return vec![];
+        return Ok((vec![], false));
     }
 
-    let total_bytes = total_scan_bytes(&files, options.open_cost_bytes);
+    let total_bytes = total_scan_bytes(&files, options.open_cost_bytes)?;
     let min_partitions = options.min_partitions.unwrap_or(target_partitions).max(1);
-    let bytes_per_partition = total_bytes / min_partitions as u64;
+    let min_partitions = i64::try_from(min_partitions).map_err(|_| {
+        DataFusionError::Plan("file scan minimum partition count exceeds i64".to_string())
+    })?;
+    let bytes_per_partition = total_bytes / min_partitions;
     let max_split_bytes = options
         .max_partition_bytes
         .min(options.open_cost_bytes.max(bytes_per_partition));
-    let groups = pack_files(files, max_split_bytes, options.open_cost_bytes);
+
+    let (files, changed) = if split_files {
+        split_file_ranges(files, max_split_bytes)?
+    } else {
+        (files, false)
+    };
+
+    // Spark's maxPartitionNum rescale charges openCostInBytes once for each
+    // generated PartitionedFile range, not once for each original object.
+    let total_bytes = total_scan_bytes(&files, options.open_cost_bytes)?;
+    let groups = pack_files(files, max_split_bytes, options.open_cost_bytes)?;
 
     let Some(max_partitions) = options
         .max_partitions
         .filter(|max_partitions| *max_partitions > 0 && groups.len() > *max_partitions)
     else {
-        return groups;
+        return Ok((groups, changed));
     };
     let files = groups.into_iter().flat_map(FileGroup::into_inner).collect();
-    let desired_split_bytes = total_bytes.div_ceil(max_partitions as u64);
-    pack_files(files, desired_split_bytes, options.open_cost_bytes)
+    let max_partitions = i64::try_from(max_partitions).map_err(|_| {
+        DataFusionError::Plan("file scan maximum partition count exceeds i64".to_string())
+    })?;
+    let desired_split_bytes = divide_rounding_away_from_zero(total_bytes, max_partitions);
+    Ok((
+        pack_files(files, desired_split_bytes, options.open_cost_bytes)?,
+        changed,
+    ))
 }
 
-fn total_scan_bytes(files: &[datafusion_datasource::PartitionedFile], open_cost_bytes: u64) -> u64 {
-    files.iter().fold(0_u64, |total, file| {
-        total
-            .saturating_add(file.effective_size())
-            .saturating_add(open_cost_bytes)
+fn split_file_ranges(
+    files: Vec<PartitionedFile>,
+    max_split_bytes: i64,
+) -> datafusion_common::Result<(Vec<PartitionedFile>, bool)> {
+    if max_split_bytes == 0 {
+        return plan_err!("file scan split size must be non-zero");
+    }
+    if max_split_bytes < 0 {
+        return Ok((vec![], !files.is_empty()));
+    }
+
+    let max_split_bytes = max_split_bytes as u64;
+    let mut output = vec![];
+    let mut changed = false;
+    for file in files {
+        let (mut offset, file_end) = file.range();
+        let output_start = output.len();
+        while offset < file_end {
+            let range_end = offset.saturating_add(max_split_bytes).min(file_end);
+            let range_start = i64::try_from(offset).map_err(|_| {
+                DataFusionError::Plan(
+                    "file range start exceeds Spark's signed 64-bit byte domain".to_string(),
+                )
+            })?;
+            let range_end = i64::try_from(range_end).map_err(|_| {
+                DataFusionError::Plan(
+                    "file range end exceeds Spark's signed 64-bit byte domain".to_string(),
+                )
+            })?;
+            output.push(file.clone().with_range(range_start, range_end));
+            offset = range_end as u64;
+        }
+        changed |= output.len() - output_start != 1;
+    }
+    Ok((output, changed))
+}
+
+fn total_scan_bytes(
+    files: &[PartitionedFile],
+    open_cost_bytes: i64,
+) -> datafusion_common::Result<i64> {
+    files.iter().try_fold(0_i64, |total, file| {
+        let file_size = i64::try_from(file.effective_size()).map_err(|_| {
+            DataFusionError::Plan("file size exceeds Spark's signed 64-bit byte domain".to_string())
+        })?;
+        Ok(total.wrapping_add(file_size).wrapping_add(open_cost_bytes))
     })
 }
 
 fn pack_files(
-    mut files: Vec<datafusion_datasource::PartitionedFile>,
-    max_split_bytes: u64,
-    open_cost_bytes: u64,
-) -> Vec<FileGroup> {
+    mut files: Vec<PartitionedFile>,
+    max_split_bytes: i64,
+    open_cost_bytes: i64,
+) -> datafusion_common::Result<Vec<FileGroup>> {
     files.sort_by_key(|file| std::cmp::Reverse(file.effective_size()));
 
     let mut groups = vec![];
     let mut current_files = vec![];
-    let mut current_size = 0_u64;
+    let mut current_size = 0_i64;
     for file in files {
-        let file_size = file.effective_size();
-        if !current_files.is_empty() && current_size.saturating_add(file_size) > max_split_bytes {
+        let file_size = i64::try_from(file.effective_size()).map_err(|_| {
+            DataFusionError::Plan("file size exceeds Spark's signed 64-bit byte domain".to_string())
+        })?;
+        if !current_files.is_empty() && current_size.wrapping_add(file_size) > max_split_bytes {
             groups.push(FileGroup::new(std::mem::take(&mut current_files)));
             current_size = 0;
         }
         current_size = current_size
-            .saturating_add(file_size)
-            .saturating_add(open_cost_bytes);
+            .wrapping_add(file_size)
+            .wrapping_add(open_cost_bytes);
         current_files.push(file);
     }
     if !current_files.is_empty() {
         groups.push(FileGroup::new(current_files));
     }
-    groups
+    Ok(groups)
+}
+
+fn divide_rounding_away_from_zero(dividend: i64, divisor: i64) -> i64 {
+    let quotient = dividend / divisor;
+    match dividend % divisor {
+        0 => quotient,
+        _ if dividend > 0 => quotient + 1,
+        _ => quotient - 1,
+    }
 }
 
 async fn do_collect_statistics_and_ordering(
@@ -642,7 +693,19 @@ mod tests {
             .collect()
     }
 
-    fn options(max_partition_bytes: u64, open_cost_bytes: u64) -> FileScanPartitioningOptions {
+    fn ranges(groups: &[FileGroup]) -> Vec<Vec<Option<(i64, i64)>>> {
+        groups
+            .iter()
+            .map(|group| {
+                group
+                    .iter()
+                    .map(|file| file.range.as_ref().map(|range| (range.start, range.end)))
+                    .collect()
+            })
+            .collect()
+    }
+
+    fn options(max_partition_bytes: i64, open_cost_bytes: i64) -> FileScanPartitioningOptions {
         FileScanPartitioningOptions {
             max_partition_bytes,
             open_cost_bytes,
@@ -659,7 +722,7 @@ mod tests {
             PartitionedFile::new("a", 8),
         ]);
 
-        let groups = pack_file_groups(files, 2, options(10, 0));
+        let groups = pack_file_groups(files, 2, options(10, 0), false).unwrap().0;
 
         assert_eq!(paths(&groups), vec![vec!["b"], vec!["a", "d"], vec!["c"]]);
     }
@@ -672,8 +735,10 @@ mod tests {
             PartitionedFile::new("c", 4),
         ]);
 
-        let without_open_cost = pack_file_groups(files.clone(), 1, options(12, 0));
-        let with_open_cost = pack_file_groups(files, 1, options(12, 5));
+        let without_open_cost = pack_file_groups(files.clone(), 1, options(12, 0), false)
+            .unwrap()
+            .0;
+        let with_open_cost = pack_file_groups(files, 1, options(12, 5), false).unwrap().0;
 
         assert_eq!(paths(&without_open_cost), vec![vec!["a", "b", "c"]]);
         assert_eq!(
@@ -690,11 +755,15 @@ mod tests {
         ]);
 
         assert_eq!(
-            paths(&pack_file_groups(files.clone(), 1, options(10, 0))),
+            paths(
+                &pack_file_groups(files.clone(), 1, options(10, 0), false)
+                    .unwrap()
+                    .0
+            ),
             vec![vec!["a"], vec!["b"]]
         );
         assert_eq!(
-            paths(&pack_file_groups(files, 1, options(20, 0))),
+            paths(&pack_file_groups(files, 1, options(20, 0), false).unwrap().0),
             vec![vec!["a", "b"]]
         );
     }
@@ -706,7 +775,7 @@ mod tests {
             PartitionedFile::new("b", 2),
         ]);
 
-        let groups = pack_file_groups(files, 1, options(10, 3));
+        let groups = pack_file_groups(files, 1, options(10, 3), false).unwrap().0;
 
         assert_eq!(paths(&groups), vec![vec!["a", "b"]]);
     }
@@ -724,7 +793,7 @@ mod tests {
             max_partitions: None,
         };
 
-        let groups = pack_file_groups(files, 1, options);
+        let groups = pack_file_groups(files, 1, options, false).unwrap().0;
 
         assert_eq!(paths(&groups), vec![vec!["a"], vec!["b"]]);
     }
@@ -744,8 +813,120 @@ mod tests {
             ..Default::default()
         };
 
-        let groups = pack_file_groups(files, 4, options);
+        let groups = pack_file_groups(files, 4, options, false).unwrap().0;
 
         assert_eq!(paths(&groups), vec![vec!["a", "b"], vec!["c", "d"]]);
+    }
+
+    #[test]
+    fn splits_large_splittable_files_before_packing() {
+        let files = FileGroup::new(vec![PartitionedFile::new("a", 25)]);
+
+        let (groups, changed) = pack_file_groups(files, 1, options(10, 0), true).unwrap();
+
+        assert!(changed);
+        assert_eq!(paths(&groups), vec![vec!["a"], vec!["a"], vec!["a"]]);
+        assert_eq!(
+            ranges(&groups),
+            vec![
+                vec![Some((0, 10))],
+                vec![Some((10, 20))],
+                vec![Some((20, 25))],
+            ]
+        );
+    }
+
+    #[test]
+    fn equal_sized_ranges_keep_original_file_order() {
+        let files = FileGroup::new(vec![
+            PartitionedFile::new("small", 25),
+            PartitionedFile::new("large", 30),
+        ]);
+
+        let groups = pack_file_groups(files, 1, options(10, 0), true)
+            .unwrap()
+            .0;
+
+        assert_eq!(
+            paths(&groups),
+            vec![
+                vec!["small"],
+                vec!["small"],
+                vec!["large"],
+                vec!["large"],
+                vec!["large"],
+                vec!["small"],
+            ]
+        );
+    }
+
+    #[test]
+    fn does_not_split_unsplittable_files() {
+        let files = FileGroup::new(vec![PartitionedFile::new("a", 25)]);
+
+        let (groups, changed) = pack_file_groups(files, 1, options(10, 0), false).unwrap();
+
+        assert!(!changed);
+        assert_eq!(paths(&groups), vec![vec!["a"]]);
+        assert_eq!(ranges(&groups), vec![vec![None]]);
+    }
+
+    #[test]
+    fn max_partition_rescale_charges_open_cost_per_split_range() {
+        let files = FileGroup::new(vec![PartitionedFile::new("a", 25)]);
+        let options = FileScanPartitioningOptions {
+            max_partition_bytes: 10,
+            open_cost_bytes: 4,
+            max_partitions: Some(2),
+            ..Default::default()
+        };
+
+        let (groups, changed) = pack_file_groups(files, 1, options, true).unwrap();
+
+        assert!(changed);
+        assert_eq!(
+            ranges(&groups),
+            vec![vec![Some((0, 10))], vec![Some((10, 20)), Some((20, 25))],]
+        );
+    }
+
+    #[test]
+    fn max_partition_rescale_rounds_away_from_zero() {
+        let files = FileGroup::new(vec![
+            PartitionedFile::new("a", 4),
+            PartitionedFile::new("b", 3),
+            PartitionedFile::new("c", 2),
+        ]);
+        let options = FileScanPartitioningOptions {
+            max_partition_bytes: 4,
+            open_cost_bytes: 0,
+            max_partitions: Some(2),
+            ..Default::default()
+        };
+
+        let groups = pack_file_groups(files, 1, options, false).unwrap().0;
+
+        assert_eq!(paths(&groups), vec![vec!["a"], vec!["b", "c"]]);
+        assert_eq!(divide_rounding_away_from_zero(9, 2), 5);
+        assert_eq!(divide_rounding_away_from_zero(-9, 2), -5);
+    }
+
+    #[test]
+    fn preserves_spark_signed_split_size_behavior() {
+        let files = FileGroup::new(vec![PartitionedFile::new("a", 25)]);
+
+        let (groups, changed) = pack_file_groups(files, 1, options(-1, 0), true).unwrap();
+
+        assert!(changed);
+        assert!(groups.is_empty());
+    }
+
+    #[test]
+    fn rejects_zero_split_size_for_splittable_files() {
+        let files = FileGroup::new(vec![PartitionedFile::new("a", 25)]);
+
+        let error = pack_file_groups(files, 1, options(0, 0), true).unwrap_err();
+
+        assert!(error.to_string().contains("split size must be non-zero"));
     }
 }

--- a/crates/sail-data-source/src/listing/planner.rs
+++ b/crates/sail-data-source/src/listing/planner.rs
@@ -408,13 +408,21 @@ async fn list_files_for_scan<'a>(
         } else {
             let all_files: Vec<_> = grouped.into_iter().flat_map(|g| g.into_inner()).collect();
             (
-                FileGroup::new(all_files).split_files(source.config().target_partitions),
+                pack_file_groups(
+                    FileGroup::new(all_files),
+                    source.config().target_partitions,
+                    source.config().file_scan_partitioning,
+                ),
                 false,
             )
         }
     } else {
         (
-            file_group.split_files(source.config().target_partitions),
+            pack_file_groups(
+                file_group,
+                source.config().target_partitions,
+                source.config().file_scan_partitioning,
+            ),
             false,
         )
     };
@@ -431,6 +439,71 @@ async fn list_files_for_scan<'a>(
         statistics: stats,
         grouped_by_partition,
     })
+}
+
+/// Packs files using Spark's next-fit-decreasing file partition algorithm.
+fn pack_file_groups(
+    file_group: FileGroup,
+    target_partitions: usize,
+    options: sail_common_datafusion::datasource::FileScanPartitioningOptions,
+) -> Vec<FileGroup> {
+    let files = file_group.into_inner();
+    if files.is_empty() {
+        return vec![];
+    }
+
+    let total_bytes = total_scan_bytes(&files, options.open_cost_bytes);
+    let min_partitions = options.min_partitions.unwrap_or(target_partitions).max(1);
+    let bytes_per_partition = total_bytes / min_partitions as u64;
+    let max_split_bytes = options
+        .max_partition_bytes
+        .min(options.open_cost_bytes.max(bytes_per_partition));
+    let groups = pack_files(files, max_split_bytes, options.open_cost_bytes);
+
+    let Some(max_partitions) = options
+        .max_partitions
+        .filter(|max_partitions| *max_partitions > 0 && groups.len() > *max_partitions)
+    else {
+        return groups;
+    };
+    let files = groups.into_iter().flat_map(FileGroup::into_inner).collect();
+    let desired_split_bytes = total_bytes.div_ceil(max_partitions as u64);
+    pack_files(files, desired_split_bytes, options.open_cost_bytes)
+}
+
+fn total_scan_bytes(files: &[datafusion_datasource::PartitionedFile], open_cost_bytes: u64) -> u64 {
+    files.iter().fold(0_u64, |total, file| {
+        total
+            .saturating_add(file.effective_size())
+            .saturating_add(open_cost_bytes)
+    })
+}
+
+fn pack_files(
+    mut files: Vec<datafusion_datasource::PartitionedFile>,
+    max_split_bytes: u64,
+    open_cost_bytes: u64,
+) -> Vec<FileGroup> {
+    files.sort_by_key(|file| std::cmp::Reverse(file.effective_size()));
+
+    let mut groups = vec![];
+    let mut current_files = vec![];
+    let mut current_size = 0_u64;
+    for file in files {
+        let file_size = file.effective_size();
+        if !current_files.is_empty() && current_size.saturating_add(file_size) > max_split_bytes {
+            groups.push(FileGroup::new(std::mem::take(&mut current_files)));
+            current_size = 0;
+        }
+        current_size = current_size
+            .saturating_add(file_size)
+            .saturating_add(open_cost_bytes);
+        current_files.push(file);
+    }
+    if !current_files.is_empty() {
+        groups.push(FileGroup::new(current_files));
+    }
+    groups
 }
 
 async fn do_collect_statistics_and_ordering(
@@ -553,4 +626,126 @@ async fn get_files_with_limit(
 
     let inexact_stats = all_files.next().await.is_some();
     Ok((file_group, inexact_stats))
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion_datasource::PartitionedFile;
+    use sail_common_datafusion::datasource::FileScanPartitioningOptions;
+
+    use super::*;
+
+    fn paths(groups: &[FileGroup]) -> Vec<Vec<&str>> {
+        groups
+            .iter()
+            .map(|group| group.iter().map(|file| file.path().as_ref()).collect())
+            .collect()
+    }
+
+    fn options(max_partition_bytes: u64, open_cost_bytes: u64) -> FileScanPartitioningOptions {
+        FileScanPartitioningOptions {
+            max_partition_bytes,
+            open_cost_bytes,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn packs_files_by_size_with_next_fit_decreasing() {
+        let files = FileGroup::new(vec![
+            PartitionedFile::new("d", 1),
+            PartitionedFile::new("b", 8),
+            PartitionedFile::new("c", 1),
+            PartitionedFile::new("a", 8),
+        ]);
+
+        let groups = pack_file_groups(files, 2, options(10, 0));
+
+        assert_eq!(paths(&groups), vec![vec!["b"], vec!["a", "d"], vec!["c"]]);
+    }
+
+    #[test]
+    fn includes_object_open_cost_when_packing_small_files() {
+        let files = FileGroup::new(vec![
+            PartitionedFile::new("a", 4),
+            PartitionedFile::new("b", 4),
+            PartitionedFile::new("c", 4),
+        ]);
+
+        let without_open_cost = pack_file_groups(files.clone(), 1, options(12, 0));
+        let with_open_cost = pack_file_groups(files, 1, options(12, 5));
+
+        assert_eq!(paths(&without_open_cost), vec![vec!["a", "b", "c"]]);
+        assert_eq!(
+            paths(&with_open_cost),
+            vec![vec!["a"], vec!["b"], vec!["c"]]
+        );
+    }
+
+    #[test]
+    fn honors_session_file_partition_size_overrides() {
+        let files = FileGroup::new(vec![
+            PartitionedFile::new("a", 8),
+            PartitionedFile::new("b", 8),
+        ]);
+
+        assert_eq!(
+            paths(&pack_file_groups(files.clone(), 1, options(10, 0))),
+            vec![vec!["a"], vec!["b"]]
+        );
+        assert_eq!(
+            paths(&pack_file_groups(files, 1, options(20, 0))),
+            vec![vec!["a", "b"]]
+        );
+    }
+
+    #[test]
+    fn packing_threshold_excludes_next_file_open_cost() {
+        let files = FileGroup::new(vec![
+            PartitionedFile::new("a", 5),
+            PartitionedFile::new("b", 2),
+        ]);
+
+        let groups = pack_file_groups(files, 1, options(10, 3));
+
+        assert_eq!(paths(&groups), vec![vec!["a", "b"]]);
+    }
+
+    #[test]
+    fn honors_minimum_partition_count_when_sizing_splits() {
+        let files = FileGroup::new(vec![
+            PartitionedFile::new("a", 5),
+            PartitionedFile::new("b", 5),
+        ]);
+        let options = FileScanPartitioningOptions {
+            max_partition_bytes: 20,
+            open_cost_bytes: 0,
+            min_partitions: Some(2),
+            max_partitions: None,
+        };
+
+        let groups = pack_file_groups(files, 1, options);
+
+        assert_eq!(paths(&groups), vec![vec!["a"], vec!["b"]]);
+    }
+
+    #[test]
+    fn rescales_when_initial_partition_count_exceeds_maximum() {
+        let files = FileGroup::new(vec![
+            PartitionedFile::new("a", 5),
+            PartitionedFile::new("b", 5),
+            PartitionedFile::new("c", 5),
+            PartitionedFile::new("d", 5),
+        ]);
+        let options = FileScanPartitioningOptions {
+            max_partition_bytes: 6,
+            open_cost_bytes: 1,
+            max_partitions: Some(2),
+            ..Default::default()
+        };
+
+        let groups = pack_file_groups(files, 4, options);
+
+        assert_eq!(paths(&groups), vec![vec!["a", "b"], vec!["c", "d"]]);
+    }
 }

--- a/crates/sail-data-source/src/listing/source.rs
+++ b/crates/sail-data-source/src/listing/source.rs
@@ -84,6 +84,14 @@ pub trait ReadFormat: Debug + Send + Sync + 'static {
     /// Build a scan configuration for listing reads.
     async fn scan(&self, ctx: &dyn Session, input: ListingScanInput) -> Result<FileScanConfig>;
 
+    /// Whether this read mode supports splitting files into byte ranges.
+    ///
+    /// Compression is checked separately because DataFusion cannot safely
+    /// range-scan externally compressed files.
+    fn is_splittable(&self) -> bool {
+        false
+    }
+
     /// Whether validating an explicit schema requires the physical file schema.
     fn requires_explicit_schema_validation(&self) -> bool {
         false

--- a/crates/sail-data-source/src/listing/source.rs
+++ b/crates/sail-data-source/src/listing/source.rs
@@ -169,6 +169,7 @@ impl<T: FormatFactory> TableFormat for ListingTableFormat<T> {
             partition_by,
             bucket_by: _,
             sort_order,
+            file_scan_partitioning,
             options,
             read_case_sensitive,
         } = info;
@@ -266,6 +267,7 @@ impl<T: FormatFactory> TableFormat for ListingTableFormat<T> {
             file_sort_order: vec![sort_order],
             collect_stat: ctx.config().collect_statistics(),
             target_partitions: ctx.config().target_partitions(),
+            file_scan_partitioning,
             read_format: Arc::new(read_format),
             path_glob_filter,
             compression,

--- a/crates/sail-data-source/src/listing/table.rs
+++ b/crates/sail-data-source/src/listing/table.rs
@@ -9,6 +9,7 @@ use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableSource, T
 use datafusion_common::parsers::CompressionTypeVariant;
 use datafusion_common::{Constraints, Result};
 use datafusion_datasource::{ListingTableUrl, TableSchema};
+use sail_common_datafusion::datasource::FileScanPartitioningOptions;
 
 use crate::listing::source::ReadFormat;
 use crate::listing::utils::can_be_evaluated_for_partition_pruning;
@@ -22,6 +23,7 @@ pub struct ListingTableSourceConfig {
     pub file_sort_order: Vec<Vec<Sort>>,
     pub collect_stat: bool,
     pub target_partitions: usize,
+    pub file_scan_partitioning: FileScanPartitioningOptions,
     pub read_format: Arc<dyn ReadFormat>,
     pub path_glob_filter: Option<PathGlobFilter>,
     pub compression: CompressionTypeVariant,

--- a/crates/sail-delta-lake/src/table_format.rs
+++ b/crates/sail-delta-lake/src/table_format.rs
@@ -96,6 +96,7 @@ impl TableFormat for DeltaTableFormat {
             partition_by: _,
             bucket_by: _,
             sort_order: _,
+            file_scan_partitioning: _,
             options,
             read_case_sensitive: _,
         } = info;
@@ -113,6 +114,7 @@ impl TableFormat for DeltaTableFormat {
             partition_by: _,
             bucket_by: _,
             sort_order: _,
+            file_scan_partitioning: _,
             options,
             read_case_sensitive: _,
         } = info;
@@ -134,6 +136,7 @@ impl TableFormat for DeltaTableFormat {
             partition_by: _,
             bucket_by: _,
             sort_order: _,
+            file_scan_partitioning: _,
             options,
             read_case_sensitive: _,
         } = info;

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -5319,6 +5319,24 @@ mod tests {
     }
 
     #[test]
+    fn test_remote_encoding_strips_file_scan_partitioning_fence() -> Result<()> {
+        use datafusion::physical_plan::empty::EmptyExec;
+        use sail_physical_plan::file_scan_partitioning::FileScanPartitioningFenceExec;
+
+        let schema = Arc::new(Schema::empty());
+        let input = Arc::new(EmptyExec::new(schema)) as Arc<dyn ExecutionPlan>;
+        let plan = Arc::new(FileScanPartitioningFenceExec::new(input));
+        let codec = RemoteExecutionCodec;
+
+        let bytes = crate::proto::encode_remote_physical_plan(&codec, plan)?;
+        let decoded =
+            crate::proto::decode_remote_physical_plan(&TaskContext::default(), &codec, &bytes)?;
+
+        assert!(decoded.is::<EmptyExec>());
+        Ok(())
+    }
+
+    #[test]
     fn test_round_trip_schema_evolution_cast_preserves_timezone_mode() -> Result<()> {
         let input_field = Arc::new(Field::new(
             "event_time",

--- a/crates/sail-execution/src/proto/encode.rs
+++ b/crates/sail-execution/src/proto/encode.rs
@@ -19,6 +19,7 @@ use sail_function::scalar::array::spark_array_transform::SparkArrayTransform;
 use sail_function::scalar::array::spark_sequence::SparkSequenceLazy;
 use sail_function::scalar::datetime::convert_tz::ConvertTzLazy;
 use sail_physical_plan::data_source::RemoteDataSourceExec;
+use sail_physical_plan::file_scan_partitioning::FileScanPartitioningFenceExec;
 
 use crate::plan::r#gen;
 use crate::plan::r#gen::higher_order_udf::HigherOrderUdfKind;
@@ -28,6 +29,18 @@ pub fn encode_remote_physical_plan(
     codec: &dyn PhysicalExtensionCodec,
     plan: Arc<dyn ExecutionPlan>,
 ) -> Result<Vec<u8>> {
+    // This fence is normally removed by the physical optimizer. Strip it here
+    // as a codec safeguard so an unoptimized plan cannot leak an optimizer-only
+    // node into the remote protocol.
+    let plan = plan
+        .transform(|node| {
+            if let Some(fence) = node.downcast_ref::<FileScanPartitioningFenceExec>() {
+                Ok(Transformed::yes(fence.input().clone()))
+            } else {
+                Ok(Transformed::no(node))
+            }
+        })
+        .data()?;
     let plan = plan
         .transform(|node| {
             if let Some(data_source) = node.downcast_ref::<DataSourceExec>() {

--- a/crates/sail-iceberg/src/table_format.rs
+++ b/crates/sail-iceberg/src/table_format.rs
@@ -169,6 +169,7 @@ impl TableFormat for IcebergTableFormat {
             partition_by: vec![],
             bucket_by: None,
             sort_order: vec![],
+            file_scan_partitioning: Default::default(),
             options: options.clone(),
             // TODO: Thread resolver session case-sensitivity into TableFormat::create_deleter.
             read_case_sensitive: true,
@@ -731,6 +732,7 @@ async fn build_iceberg_provider(
         partition_by: _,
         bucket_by: _,
         sort_order: _,
+        file_scan_partitioning: _,
         options,
         read_case_sensitive: _,
     } = info;

--- a/crates/sail-physical-optimizer/src/file_scan_partitioning.rs
+++ b/crates/sail-physical-optimizer/src/file_scan_partitioning.rs
@@ -1,0 +1,109 @@
+use std::sync::Arc;
+
+use datafusion::common::tree_node::{Transformed, TreeNode};
+use datafusion::config::ConfigOptions;
+use datafusion::error::Result;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::ExecutionPlan;
+use sail_physical_plan::file_scan_partitioning::FileScanPartitioningFenceExec;
+
+/// Removes the optimizer-only file scan partitioning fence after distribution enforcement.
+#[derive(Debug, Default)]
+pub struct RemoveFileScanPartitioningFence;
+
+impl RemoveFileScanPartitioningFence {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl PhysicalOptimizerRule for RemoveFileScanPartitioningFence {
+    fn optimize(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        _config: &ConfigOptions,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(plan
+            .transform_up(|node| {
+                if let Some(fence) = node.downcast_ref::<FileScanPartitioningFenceExec>() {
+                    Ok(Transformed::yes(fence.input().clone()))
+                } else {
+                    Ok(Transformed::no(node))
+                }
+            })?
+            .data)
+    }
+
+    fn name(&self) -> &str {
+        "RemoveFileScanPartitioningFence"
+    }
+
+    fn schema_check(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+mod tests {
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::datasource::listing::PartitionedFile;
+    use datafusion::datasource::physical_plan::{
+        FileGroup, FileScanConfig, FileScanConfigBuilder, ParquetSource,
+    };
+    use datafusion::datasource::source::DataSourceExec;
+    use datafusion::execution::object_store::ObjectStoreUrl;
+    use datafusion::physical_optimizer::enforce_distribution::EnforceDistribution;
+
+    use super::*;
+
+    fn file_group_count(plan: &Arc<dyn ExecutionPlan>) -> usize {
+        let scan = plan.downcast_ref::<DataSourceExec>().unwrap();
+        let config = scan.data_source().downcast_ref::<FileScanConfig>().unwrap();
+        config.file_groups.len()
+    }
+
+    #[test]
+    fn fence_blocks_file_scan_repartitioning_until_removed() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "value",
+            DataType::Int64,
+            false,
+        )]));
+        let config = FileScanConfigBuilder::new(
+            ObjectStoreUrl::local_filesystem(),
+            Arc::new(ParquetSource::new(schema)),
+        )
+        .with_file_group(FileGroup::new(vec![PartitionedFile::new(
+            "file.parquet",
+            100,
+        )]))
+        .build();
+        let scan: Arc<dyn ExecutionPlan> = DataSourceExec::from_data_source(config);
+
+        let mut optimizer_config = ConfigOptions::default();
+        optimizer_config.execution.target_partitions = 4;
+        optimizer_config.optimizer.repartition_file_scans = true;
+        optimizer_config.optimizer.repartition_file_min_size = 0;
+
+        let Some(repartitioned) = scan.repartitioned(4, &optimizer_config)? else {
+            return datafusion::common::internal_err!(
+                "the unprotected Parquet scan should be repartitionable"
+            );
+        };
+        assert_eq!(file_group_count(&repartitioned), 4);
+
+        let fenced: Arc<dyn ExecutionPlan> = Arc::new(FileScanPartitioningFenceExec::new(scan));
+
+        let optimized = EnforceDistribution::new().optimize(fenced, &optimizer_config)?;
+        let fence = optimized
+            .downcast_ref::<FileScanPartitioningFenceExec>()
+            .unwrap();
+        assert_eq!(file_group_count(fence.input()), 1);
+
+        let optimized =
+            RemoveFileScanPartitioningFence::new().optimize(optimized, &optimizer_config)?;
+        assert_eq!(file_group_count(&optimized), 1);
+        Ok(())
+    }
+}

--- a/crates/sail-physical-optimizer/src/lib.rs
+++ b/crates/sail-physical-optimizer/src/lib.rs
@@ -23,6 +23,7 @@ use datafusion::physical_optimizer::window_topn::WindowTopN;
 use crate::barrier::EnforceBarrierPartitioning;
 use crate::collect_left::RewriteCollectLeftHashJoin;
 use crate::explicit_repartition::RewriteExplicitRepartition;
+use crate::file_scan_partitioning::RemoveFileScanPartitioningFence;
 use crate::join_reorder::JoinReorder;
 pub use crate::join_reorder::JoinReorderOptions;
 use crate::projection_pushdown::LambdaSafeProjectionPushdown;
@@ -30,6 +31,7 @@ use crate::projection_pushdown::LambdaSafeProjectionPushdown;
 mod barrier;
 mod collect_left;
 mod explicit_repartition;
+mod file_scan_partitioning;
 mod join_reorder;
 mod projection_pushdown;
 
@@ -53,6 +55,7 @@ pub fn get_physical_optimizers(
     rules.push(Arc::new(LimitedDistinctAggregation::new()));
     rules.push(Arc::new(FilterPushdown::new()));
     rules.push(Arc::new(EnforceDistribution::new()));
+    rules.push(Arc::new(RemoveFileScanPartitioningFence::new()));
     rules.push(Arc::new(CombinePartialFinalAggregate::new()));
     rules.push(Arc::new(EnforceSorting::new()));
     rules.push(Arc::new(OptimizeAggregateOrder::new()));
@@ -101,6 +104,10 @@ mod tests {
             datafusion_optimizer_names, actual_datafusion_optimizer_names,
             "the custom physical optimizer rules should include all the default DataFusion optimizer rules in the same order"
         );
+        assert!(optimizers.windows(2).any(|rules| {
+            rules[0].name() == "EnforceDistribution"
+                && rules[1].name() == "RemoveFileScanPartitioningFence"
+        }));
 
         Ok(())
     }

--- a/crates/sail-physical-plan/src/file_scan_partitioning.rs
+++ b/crates/sail-physical-plan/src/file_scan_partitioning.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
+use datafusion_common::{Result, Statistics, internal_err};
+
+/// An optimizer-only fence that keeps Spark-planned file groups opaque to
+/// DataFusion's file scan repartitioning.
+///
+/// Sail's physical optimizer removes this node immediately after
+/// `EnforceDistribution`, before job graph planning and remote plan encoding.
+#[derive(Debug, Clone)]
+pub struct FileScanPartitioningFenceExec {
+    input: Arc<dyn ExecutionPlan>,
+    properties: Arc<PlanProperties>,
+}
+
+impl FileScanPartitioningFenceExec {
+    pub fn new(input: Arc<dyn ExecutionPlan>) -> Self {
+        let properties = Arc::new(input.properties().as_ref().clone());
+        Self { input, properties }
+    }
+
+    pub fn input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.input
+    }
+}
+
+impl DisplayAs for FileScanPartitioningFenceExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "FileScanPartitioningFenceExec")
+    }
+}
+
+impl ExecutionPlan for FileScanPartitioningFenceExec {
+    fn name(&self) -> &'static str {
+        Self::static_name()
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    // The input is intentionally hidden until EnforceDistribution has run.
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if !children.is_empty() {
+            return internal_err!("{} does not expose optimizer children", self.name());
+        }
+        Ok(self)
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> Result<SendableRecordBatchStream> {
+        self.input.execute(partition, context)
+    }
+
+    fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
+        self.input.partition_statistics(partition)
+    }
+}

--- a/crates/sail-physical-plan/src/lib.rs
+++ b/crates/sail-physical-plan/src/lib.rs
@@ -2,6 +2,7 @@ pub mod barrier;
 pub mod catalog_command;
 pub mod coalesce;
 pub mod data_source;
+pub mod file_scan_partitioning;
 pub mod map_partitions;
 pub mod merge_cardinality_check;
 pub mod monotonic_id;

--- a/crates/sail-plan/src/config.rs
+++ b/crates/sail-plan/src/config.rs
@@ -2,6 +2,7 @@ use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;
 
+use sail_common_datafusion::datasource::FileScanPartitioningOptions;
 use sail_python_udf::config::PySparkUdfConfig;
 
 use crate::error::PlanResult;
@@ -60,6 +61,8 @@ pub struct PlanConfig {
     /// (`spark.sql.tvf.allowMultipleTableArguments.enabled`, default false). Multiple table
     /// arguments produce the cartesian product of their rows.
     pub tvf_allow_multiple_table_arguments: bool,
+    /// Spark-compatible file scan partition sizing and packing controls.
+    pub file_scan_partitioning: FileScanPartitioningOptions,
 }
 
 impl PlanConfig {
@@ -89,6 +92,7 @@ impl Default for PlanConfig {
             case_sensitive: false,
             pivot_max_values: 10000,
             tvf_allow_multiple_table_arguments: false,
+            file_scan_partitioning: FileScanPartitioningOptions::default(),
         }
     }
 }

--- a/crates/sail-plan/src/resolver/command/delete.rs
+++ b/crates/sail-plan/src/resolver/command/delete.rs
@@ -130,6 +130,7 @@ impl PlanResolver<'_> {
                 partition_by: vec![],
                 bucket_by: None,
                 sort_order: vec![],
+                file_scan_partitioning: self.config.file_scan_partitioning,
                 options: vec![],
                 read_case_sensitive: self.config.case_sensitive,
             };

--- a/crates/sail-plan/src/resolver/command/delta.rs
+++ b/crates/sail-plan/src/resolver/command/delta.rs
@@ -127,6 +127,7 @@ impl PlanResolver<'_> {
             partition_by: vec![],
             bucket_by: None,
             sort_order: vec![],
+            file_scan_partitioning: self.config.file_scan_partitioning,
             options: vec![],
             read_case_sensitive: self.config.case_sensitive,
         };
@@ -540,6 +541,7 @@ impl PlanResolver<'_> {
             partition_by: vec![],
             bucket_by: None,
             sort_order: vec![],
+            file_scan_partitioning: self.config.file_scan_partitioning,
             options: vec![OptionLayer::TablePropertyList {
                 items: info.properties.clone(),
             }],

--- a/crates/sail-plan/src/resolver/command/merge.rs
+++ b/crates/sail-plan/src/resolver/command/merge.rs
@@ -917,6 +917,7 @@ impl PlanResolver<'_> {
                             partition_by: vec![],
                             bucket_by: None,
                             sort_order: vec![],
+                            file_scan_partitioning: self.config.file_scan_partitioning,
                             options: vec![],
                             read_case_sensitive: self.config.case_sensitive,
                         },

--- a/crates/sail-plan/src/resolver/command/write.rs
+++ b/crates/sail-plan/src/resolver/command/write.rs
@@ -648,6 +648,7 @@ impl PlanResolver<'_> {
                         partition_by: vec![],
                         bucket_by: None,
                         sort_order: vec![],
+                        file_scan_partitioning: self.config.file_scan_partitioning,
                         options: vec![OptionLayer::TablePropertyList {
                             items: properties.to_vec(),
                         }],
@@ -686,6 +687,7 @@ impl PlanResolver<'_> {
                         partition_by: vec![],
                         bucket_by: None,
                         sort_order: vec![],
+                        file_scan_partitioning: self.config.file_scan_partitioning,
                         options: vec![OptionLayer::TablePropertyList {
                             items: properties.to_vec(),
                         }],

--- a/crates/sail-plan/src/resolver/query/read.rs
+++ b/crates/sail-plan/src/resolver/query/read.rs
@@ -121,6 +121,7 @@ impl PlanResolver<'_> {
                     partition_by: partition_by.into_iter().map(|field| field.column).collect(),
                     bucket_by: bucket_by.map(|x| x.into()),
                     sort_order: sort_by.into_iter().map(|x| x.into()).collect(),
+                    file_scan_partitioning: self.config.file_scan_partitioning,
                     // TODO: detect duplicated keys in each set of options
                     options: vec![
                         OptionLayer::TablePropertyList { items: properties },
@@ -473,6 +474,7 @@ impl PlanResolver<'_> {
             partition_by: vec![],
             bucket_by: None,
             sort_order: vec![],
+            file_scan_partitioning: self.config.file_scan_partitioning,
             // TODO: detect duplicated keys in the set of options
             options: vec![OptionLayer::OptionList {
                 items: options.into_iter().collect(),

--- a/crates/sail-spark-connect/src/config.rs
+++ b/crates/sail-spark-connect/src/config.rs
@@ -325,9 +325,67 @@ impl TryFrom<&SparkRuntimeConfig> for PlanConfig {
             output.tvf_allow_multiple_table_arguments = value;
         }
 
+        if let Some(value) = config.get_option(SparkConfigKey::SPARK_SQL_FILES_MAX_PARTITION_BYTES)
+        {
+            output.file_scan_partitioning.max_partition_bytes =
+                parse_spark_bytes(SparkConfigKey::SPARK_SQL_FILES_MAX_PARTITION_BYTES, value)?;
+        }
+        if let Some(value) = config.get_option(SparkConfigKey::SPARK_SQL_FILES_OPEN_COST_IN_BYTES) {
+            output.file_scan_partitioning.open_cost_bytes =
+                parse_spark_bytes(SparkConfigKey::SPARK_SQL_FILES_OPEN_COST_IN_BYTES, value)?;
+        }
+        output.file_scan_partitioning.min_partitions = config
+            .get_option(SparkConfigKey::SPARK_SQL_FILES_MIN_PARTITION_NUM)
+            .map(|value| {
+                parse_positive_usize(SparkConfigKey::SPARK_SQL_FILES_MIN_PARTITION_NUM, value)
+            })
+            .transpose()?;
+        output.file_scan_partitioning.max_partitions = config
+            .get_option(SparkConfigKey::SPARK_SQL_FILES_MAX_PARTITION_NUM)
+            .map(|value| {
+                parse_positive_usize(SparkConfigKey::SPARK_SQL_FILES_MAX_PARTITION_NUM, value)
+            })
+            .transpose()?;
+
         output.pyspark_udf_config = Arc::new(PySparkUdfConfig::try_from(config)?);
 
         Ok(output)
+    }
+}
+
+fn parse_spark_bytes(key: &str, value: &str) -> SparkResult<u64> {
+    let value = value.trim().to_ascii_lowercase();
+    let number_end = value
+        .find(|character: char| !character.is_ascii_digit())
+        .unwrap_or(value.len());
+    let (number, suffix) = value.split_at(number_end);
+    let multiplier = match suffix {
+        "" | "b" => 1,
+        "k" | "kb" => 1_u64 << 10,
+        "m" | "mb" => 1_u64 << 20,
+        "g" | "gb" => 1_u64 << 30,
+        "t" | "tb" => 1_u64 << 40,
+        "p" | "pb" => 1_u64 << 50,
+        _ => {
+            return Err(SparkError::invalid(format!(
+                "invalid byte size for {key}: {value}"
+            )));
+        }
+    };
+    number
+        .parse::<i64>()
+        .ok()
+        .and_then(|number| (number as u64).checked_mul(multiplier))
+        .filter(|number| *number <= i64::MAX as u64)
+        .ok_or_else(|| SparkError::invalid(format!("invalid byte size for {key}: {value}")))
+}
+
+fn parse_positive_usize(key: &str, value: &str) -> SparkResult<usize> {
+    match value.trim().parse::<usize>() {
+        Ok(value) if value > 0 => Ok(value),
+        _ => Err(SparkError::invalid(format!(
+            "invalid positive integer for {key}: {value}"
+        ))),
     }
 }
 
@@ -427,5 +485,71 @@ impl TryFrom<&SparkRuntimeConfig> for PySparkUdfConfig {
         }
 
         Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn runtime_config() -> SparkRuntimeConfig {
+        pyo3::Python::initialize();
+        SparkRuntimeConfig::try_new().unwrap()
+    }
+
+    #[test]
+    fn spark_file_partition_defaults_match_sql_conf() {
+        let runtime = runtime_config();
+
+        let config = PlanConfig::try_from(&runtime).unwrap();
+
+        assert_eq!(config.file_scan_partitioning.max_partition_bytes, 128 << 20);
+        assert_eq!(config.file_scan_partitioning.open_cost_bytes, 4 << 20);
+        assert_eq!(config.file_scan_partitioning.min_partitions, None);
+        assert_eq!(config.file_scan_partitioning.max_partitions, None);
+    }
+
+    #[test]
+    fn parses_spark_file_partition_overrides() {
+        let mut runtime = runtime_config();
+        runtime
+            .set(
+                SparkConfigKey::SPARK_SQL_FILES_MAX_PARTITION_BYTES.to_string(),
+                "64MB".to_string(),
+            )
+            .unwrap();
+        runtime
+            .set(
+                SparkConfigKey::SPARK_SQL_FILES_OPEN_COST_IN_BYTES.to_string(),
+                "8m".to_string(),
+            )
+            .unwrap();
+        runtime
+            .set(
+                SparkConfigKey::SPARK_SQL_FILES_MIN_PARTITION_NUM.to_string(),
+                "3".to_string(),
+            )
+            .unwrap();
+        runtime
+            .set(
+                SparkConfigKey::SPARK_SQL_FILES_MAX_PARTITION_NUM.to_string(),
+                "7".to_string(),
+            )
+            .unwrap();
+
+        let config = PlanConfig::try_from(&runtime).unwrap();
+
+        assert_eq!(config.file_scan_partitioning.max_partition_bytes, 64 << 20);
+        assert_eq!(config.file_scan_partitioning.open_cost_bytes, 8 << 20);
+        assert_eq!(config.file_scan_partitioning.min_partitions, Some(3));
+        assert_eq!(config.file_scan_partitioning.max_partitions, Some(7));
+    }
+
+    #[test]
+    fn spark_byte_sizes_use_binary_units() {
+        assert_eq!(parse_spark_bytes("test", "1kb").unwrap(), 1 << 10);
+        assert_eq!(parse_spark_bytes("test", "2MB").unwrap(), 2 << 20);
+        assert!(parse_spark_bytes("test", "1.5mb").is_err());
+        assert!(parse_spark_bytes("test", "9223372036854775808b").is_err());
     }
 }

--- a/crates/sail-spark-connect/src/config.rs
+++ b/crates/sail-spark-connect/src/config.rs
@@ -336,9 +336,18 @@ impl TryFrom<&SparkRuntimeConfig> for PlanConfig {
         }
         output.file_scan_partitioning.min_partitions = config
             .get_option(SparkConfigKey::SPARK_SQL_FILES_MIN_PARTITION_NUM)
-            .map(|value| {
-                parse_positive_usize(SparkConfigKey::SPARK_SQL_FILES_MIN_PARTITION_NUM, value)
+            .map(|value| (SparkConfigKey::SPARK_SQL_FILES_MIN_PARTITION_NUM, value))
+            .or_else(|| {
+                config
+                    .get_option(SparkConfigKey::SPARK_SQL_LEAF_NODE_DEFAULT_PARALLELISM)
+                    .map(|value| {
+                        (
+                            SparkConfigKey::SPARK_SQL_LEAF_NODE_DEFAULT_PARALLELISM,
+                            value,
+                        )
+                    })
             })
+            .map(|(key, value)| parse_positive_usize(key, value))
             .transpose()?;
         output.file_scan_partitioning.max_partitions = config
             .get_option(SparkConfigKey::SPARK_SQL_FILES_MAX_PARTITION_NUM)
@@ -353,7 +362,12 @@ impl TryFrom<&SparkRuntimeConfig> for PlanConfig {
     }
 }
 
-fn parse_spark_bytes(key: &str, value: &str) -> SparkResult<u64> {
+fn parse_spark_bytes(key: &str, value: &str) -> SparkResult<i64> {
+    let original = value;
+    let (value, sign) = match value.strip_prefix('-') {
+        Some(value) => (value, -1),
+        None => (value, 1),
+    };
     let value = value.trim().to_ascii_lowercase();
     let number_end = value
         .find(|character: char| !character.is_ascii_digit())
@@ -361,28 +375,28 @@ fn parse_spark_bytes(key: &str, value: &str) -> SparkResult<u64> {
     let (number, suffix) = value.split_at(number_end);
     let multiplier = match suffix {
         "" | "b" => 1,
-        "k" | "kb" => 1_u64 << 10,
-        "m" | "mb" => 1_u64 << 20,
-        "g" | "gb" => 1_u64 << 30,
-        "t" | "tb" => 1_u64 << 40,
-        "p" | "pb" => 1_u64 << 50,
+        "k" | "kb" => 1_i64 << 10,
+        "m" | "mb" => 1_i64 << 20,
+        "g" | "gb" => 1_i64 << 30,
+        "t" | "tb" => 1_i64 << 40,
+        "p" | "pb" => 1_i64 << 50,
         _ => {
             return Err(SparkError::invalid(format!(
-                "invalid byte size for {key}: {value}"
+                "invalid byte size for {key}: {original}"
             )));
         }
     };
     number
         .parse::<i64>()
         .ok()
-        .and_then(|number| (number as u64).checked_mul(multiplier))
-        .filter(|number| *number <= i64::MAX as u64)
-        .ok_or_else(|| SparkError::invalid(format!("invalid byte size for {key}: {value}")))
+        .and_then(|number| number.checked_mul(multiplier))
+        .and_then(|number| number.checked_mul(sign))
+        .ok_or_else(|| SparkError::invalid(format!("invalid byte size for {key}: {original}")))
 }
 
 fn parse_positive_usize(key: &str, value: &str) -> SparkResult<usize> {
-    match value.trim().parse::<usize>() {
-        Ok(value) if value > 0 => Ok(value),
+    match value.trim().parse::<i32>() {
+        Ok(value) if value > 0 => Ok(value as usize),
         _ => Err(SparkError::invalid(format!(
             "invalid positive integer for {key}: {value}"
         ))),
@@ -547,9 +561,45 @@ mod tests {
     }
 
     #[test]
+    fn spark_file_min_partitions_fall_back_to_leaf_node_default() {
+        let mut runtime = runtime_config();
+        runtime
+            .set(
+                SparkConfigKey::SPARK_SQL_LEAF_NODE_DEFAULT_PARALLELISM.to_string(),
+                "5".to_string(),
+            )
+            .unwrap();
+
+        let config = PlanConfig::try_from(&runtime).unwrap();
+        assert_eq!(config.file_scan_partitioning.min_partitions, Some(5));
+
+        runtime
+            .set(
+                SparkConfigKey::SPARK_SQL_FILES_MIN_PARTITION_NUM.to_string(),
+                "3".to_string(),
+            )
+            .unwrap();
+
+        let config = PlanConfig::try_from(&runtime).unwrap();
+        assert_eq!(config.file_scan_partitioning.min_partitions, Some(3));
+    }
+
+    #[test]
+    fn spark_file_partition_counts_use_positive_int_range() {
+        assert_eq!(
+            parse_positive_usize("test", "2147483647").unwrap(),
+            i32::MAX as usize
+        );
+        for value in ["0", "-1", "2147483648"] {
+            assert!(parse_positive_usize("test", value).is_err());
+        }
+    }
+
+    #[test]
     fn spark_byte_sizes_use_binary_units() {
         assert_eq!(parse_spark_bytes("test", "1kb").unwrap(), 1 << 10);
         assert_eq!(parse_spark_bytes("test", "2MB").unwrap(), 2 << 20);
+        assert_eq!(parse_spark_bytes("test", "-3GB").unwrap(), -(3_i64 << 30));
         assert!(parse_spark_bytes("test", "1.5mb").is_err());
         assert!(parse_spark_bytes("test", "9223372036854775808b").is_err());
     }

--- a/crates/sail-spark-connect/src/config.rs
+++ b/crates/sail-spark-connect/src/config.rs
@@ -488,6 +488,7 @@ impl TryFrom<&SparkRuntimeConfig> for PySparkUdfConfig {
     }
 }
 
+#[expect(clippy::unwrap_used)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/python/pysail/tests/spark/datasource/test_text.py
+++ b/python/pysail/tests/spark/datasource/test_text.py
@@ -34,6 +34,44 @@ def test_text_path_glob_filter(spark, tmp_path):
     assert df.collect() == [Row(value="keep")]
 
 
+def test_text_scan_keeps_spark_file_partition_groups(spark, tmp_path):
+    path = tmp_path / "text_file_partition_groups"
+    path.mkdir()
+    (path / "a.txt").write_text("aaaaaaa\n")
+    (path / "b.txt").write_text("bbbbbb\n")
+    (path / "c.txt").write_text("cc\n")
+    (path / "d.txt").write_text("d\n")
+
+    settings = {
+        "spark.sql.files.maxPartitionBytes": "10",
+        "spark.sql.files.openCostInBytes": "0",
+        "spark.sql.files.minPartitionNum": "2",
+        "spark.sql.files.maxPartitionNum": "100",
+    }
+    previous = {key: spark.conf.get(key, None) for key in settings}
+    try:
+        for key, value in settings.items():
+            spark.conf.set(key, value)
+        rows = (
+            spark.read.text(str(path))
+            .selectExpr("value", "spark_partition_id() AS pid")
+            .collect()
+        )
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                spark.conf.unset(key)
+            else:
+                spark.conf.set(key, value)
+
+    assert {row.value: row.pid for row in rows} == {
+        "aaaaaaa": 0,
+        "bbbbbb": 1,
+        "cc": 1,
+        "d": 2,
+    }
+
+
 def test_text_read_write_compressed(spark, sample_df, tmp_path):
     path = str(tmp_path / "text_compressed_gzip")
     sample_df = sample_df.select("col1")


### PR DESCRIPTION
## What changed

- Pack scan files using Spark's next-fit-decreasing algorithm.
- Account for file-open cost when sizing partitions.
- Support:
    - `spark.sql.files.maxPartitionBytes`
    - `spark.sql.files.openCostInBytes`
    - `spark.sql.files.minPartitionNum`
    - `spark.sql.files.maxPartitionNum`
- Parse Spark byte-size settings using binary units.
- Rescale partitions when the initial count exceeds the configured maximum.

## Why

Sail previously delegated file grouping to DataFusion's target-partition splitting, which does not match Spark's file scan planning. This could produce different partition counts and inefficient grouping, particularly for workloads containing many small files.