### PR TITLE
test: remove flaky object store test

### DIFF
--- a/crates/sail-object-store/Cargo.toml
+++ b/crates/sail-object-store/Cargo.toml
@@ -37,9 +37,6 @@ hf-hub = { workspace = true }
 fastrace = { workspace = true }
 fastrace-futures = { workspace = true }
 
-[dev-dependencies]
-tokio = { workspace = true, features = ["test-util"] }
-
 [features]
 hdfs = ["dep:hdfs-native-object-store"]
 default = ["hdfs"]

--- a/crates/sail-object-store/src/layers/runtime.rs
+++ b/crates/sail-object-store/src/layers/runtime.rs
@@ -314,8 +314,7 @@ impl<T> Stream for RuntimeAwareStream<T> {
 #[cfg(test)]
 mod tests {
     use std::error::Error;
-    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-    use std::sync::mpsc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     use futures::future::try_join;
@@ -459,97 +458,5 @@ mod tests {
             Ok::<_, Box<dyn Error>>(())
         })?;
         Ok(())
-    }
-
-    #[derive(Debug)]
-    struct BlockingDropMultipartUpload {
-        drop_started: Arc<Notify>,
-        release_drop: Option<mpsc::Receiver<()>>,
-        abort_called: Arc<AtomicBool>,
-        abort_started: Arc<Notify>,
-    }
-
-    struct BlockOnDrop(Arc<Notify>, mpsc::Receiver<()>);
-
-    impl Drop for BlockOnDrop {
-        fn drop(&mut self) {
-            self.0.notify_one();
-            let _ = self.1.recv();
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl MultipartUpload for BlockingDropMultipartUpload {
-        fn put_part(&mut self, _data: PutPayload) -> UploadPart {
-            let Some(release_drop) = self.release_drop.take() else {
-                return Box::pin(async {
-                    Err(object_store::Error::Generic {
-                        store: "BlockingDropMultipartUpload",
-                        source: "only one part can be uploaded".into(),
-                    })
-                });
-            };
-            let guard = BlockOnDrop(self.drop_started.clone(), release_drop);
-            Box::pin(async move {
-                let _guard = guard;
-                std::future::pending::<Result<()>>().await
-            })
-        }
-
-        async fn complete(&mut self) -> Result<PutResult> {
-            Ok(PutResult {
-                e_tag: None,
-                version: None,
-            })
-        }
-
-        async fn abort(&mut self) -> Result<()> {
-            self.abort_called.store(true, Ordering::SeqCst);
-            self.abort_started.notify_one();
-            Ok(())
-        }
-    }
-
-    #[test]
-    fn multipart_abort_bounds_wait_for_cancelled_parts() -> Result<(), Box<dyn Error>> {
-        let primary = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .start_paused(true)
-            .build()?;
-        let io = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(2)
-            .enable_all()
-            .build()?;
-        let drop_started = Arc::new(Notify::new());
-        let abort_called = Arc::new(AtomicBool::new(false));
-        let abort_started = Arc::new(Notify::new());
-        let (release_drop, wait_for_release) = mpsc::channel();
-        let inner = BlockingDropMultipartUpload {
-            drop_started: drop_started.clone(),
-            release_drop: Some(wait_for_release),
-            abort_called: abort_called.clone(),
-            abort_started: abort_started.clone(),
-        };
-        let mut upload = RuntimeAwareMultipartUpload::new(Box::new(inner), io.handle().clone());
-        // Retain the part future while aborting. The upload must cancel its runtime task itself.
-        let part = upload.put_part(vec![1].into());
-
-        primary.block_on(async move {
-            let abort = tokio::spawn(async move { upload.abort().await });
-            drop_started.notified().await;
-
-            tokio::time::advance(Duration::from_secs(14)).await;
-            assert!(!abort_called.load(Ordering::SeqCst));
-            assert!(!abort.is_finished());
-
-            tokio::time::advance(Duration::from_secs(1)).await;
-            abort_started.notified().await;
-            assert!(abort_called.load(Ordering::SeqCst));
-            abort.await??;
-
-            release_drop.send(())?;
-            assert!(part.await.is_err());
-            Ok(())
-        })
     }
 }


### PR DESCRIPTION
Here is the analysis by Codex:

> Root cause: the test assumes `start_paused(true)` keeps time fixed until `advance()`. Tokio does not: a paused current-thread runtime automatically advances to its next timer when it has no runnable work.
> 
> Timeline in `runtime.rs` (crates/sail-object-store/src/layers/runtime.rs:537):
> 
> 1. The test spawns `upload.abort()`.
> 2. `abort()` cancels the part and registers its 15-second `timeout`.
> 3. The primary runtime awaits `drop_started`, which must be sent by the separate I/O runtime when the cancelled part is dropped.
> 4. If the I/O worker is slow to run that drop, the primary runtime is idle. Tokio auto-advances its paused clock to the 15-second timeout.
> 5. `inner.abort()` sets `abort_called = true`.
> 6. The I/O notification arrives; the test resumes and advances “14 seconds,” but virtual time is already at—or beyond—the deadline. The assertion fails.
> 
> So the failure does not show that production abort fires early; it shows the test’s virtual-time control is racy across two runtimes. Tokio also documents that `advance()` does not guarantee timers have been fully processed before the caller continues.
> 
> The test should be removed or reworked to avoid asserting an exact pre-timeout boundary with an externally scheduled I/O notification. A deterministic version would need a controllable grace duration and synchronization that does not let the paused primary runtime become idle before the 14-second assertion.