### PR TITLE
fix: stabilize Iceberg row-level operations with storage shuffle

### DIFF
--- a/crates/sail-execution/src/driver/job_scheduler/topology.rs
+++ b/crates/sail-execution/src/driver/job_scheduler/topology.rs
@@ -172,7 +172,17 @@ impl JobTopology {
         for (r, region) in regions.iter_mut().enumerate() {
             for task in &region.tasks {
                 for input in &graph.stages()[task.stage].inputs {
-                    if matches!(input.mode, InputMode::Forward) {
+                    let input_partitions = graph.stages()[input.stage]
+                        .plan
+                        .output_partitioning()
+                        .partition_count();
+                    let consumer_partitions = graph.stages()[task.stage]
+                        .plan
+                        .output_partitioning()
+                        .partition_count();
+                    if matches!(input.mode, InputMode::Forward)
+                        && input_partitions == consumer_partitions
+                    {
                         if let Some(&d) = task_to_region.get(&TaskTopology {
                             stage: input.stage,
                             partition: task.partition,
@@ -181,11 +191,11 @@ impl JobTopology {
                             region.dependencies.insert(d);
                         }
                     } else {
-                        let partitions = graph.stages()[input.stage]
-                            .plan
-                            .output_partitioning()
-                            .partition_count();
-                        for p in 0..partitions {
+                        // A multi-input plan such as UnionExec maps consumer stage partitions to
+                        // child-local partition numbers. When the stage partition counts differ,
+                        // that mapping is not represented by StageInput, so conservatively wait
+                        // for every producer partition.
+                        for p in 0..input_partitions {
                             if let Some(&d) = task_to_region.get(&TaskTopology {
                                 stage: input.stage,
                                 partition: p,
@@ -200,5 +210,76 @@ impl JobTopology {
         }
 
         Ok(Self { regions, stages })
+    }
+}
+
+#[cfg(test)]
+#[expect(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::physical_expr::Partitioning;
+    use datafusion::physical_plan::empty::EmptyExec;
+    use datafusion::physical_plan::repartition::RepartitionExec;
+    use datafusion::physical_plan::union::UnionExec;
+
+    use super::JobTopology;
+    use crate::job_graph::{JobGraph, JobGraphOptions};
+    use crate::shuffle::{ShuffleBackendKind, ShuffleCompression};
+
+    fn repartitioned_input() -> Arc<dyn datafusion::physical_plan::ExecutionPlan> {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        Arc::new(
+            RepartitionExec::try_new(
+                Arc::new(EmptyExec::new(schema)),
+                Partitioning::RoundRobinBatch(4),
+            )
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn union_stage_waits_for_every_blocking_forward_input() {
+        let graph = JobGraph::try_new(
+            UnionExec::try_new(vec![repartitioned_input(), repartitioned_input()]).unwrap(),
+            JobGraphOptions {
+                shuffle_backend: ShuffleBackendKind::Storage {
+                    path: None,
+                    max_file_size: 1,
+                    compression: ShuffleCompression::None,
+                },
+            },
+        )
+        .unwrap();
+        let topology = JobTopology::try_new(&graph).unwrap();
+        let final_stage = graph.stages().len() - 1;
+        let blocking_input_stages = graph.stages()[final_stage]
+            .inputs
+            .iter()
+            .map(|input| input.stage)
+            .collect::<Vec<_>>();
+        assert_eq!(blocking_input_stages.len(), 2);
+
+        let blocking_input_regions = blocking_input_stages
+            .iter()
+            .map(|stage| {
+                topology
+                    .regions
+                    .iter()
+                    .position(|region| region.tasks.iter().any(|task| task.stage == *stage))
+                    .expect("blocking input region")
+            })
+            .collect::<Vec<_>>();
+
+        for region in topology
+            .regions
+            .iter()
+            .filter(|region| region.tasks.iter().any(|task| task.stage == final_stage))
+        {
+            for input_region in &blocking_input_regions {
+                assert!(region.dependencies.contains(input_region));
+            }
+        }
     }
 }

--- a/crates/sail-iceberg/src/physical/row_level_planner.rs
+++ b/crates/sail-iceberg/src/physical/row_level_planner.rs
@@ -12,6 +12,7 @@ use sail_logical_plan::merge::RowLevelWriteNode;
 
 use crate::operations::SnapshotUpdateKind;
 use crate::options::r#gen::IcebergWriteOptions;
+use crate::physical_plan::equality_delete_writer_exec::validate_equality_delete_schema;
 use crate::physical_plan::merge_row_projection::IcebergMergeRowProjection;
 use crate::physical_plan::{
     IcebergCommitExec, IcebergEqualityDeleteWriterExec, IcebergWriterExec,
@@ -119,6 +120,10 @@ async fn plan_iceberg_delete(
     )
     .await?;
     ensure_current_row_level_mode(&table, RowLevelCommand::Delete)?;
+    let current_schema = table.metadata().current_schema().ok_or_else(|| {
+        DataFusionError::Plan("Iceberg table metadata is missing current schema".to_string())
+    })?;
+    validate_equality_delete_schema(current_schema)?;
 
     let delete_plan = LogicalPlanBuilder::from(node.raw_target().as_ref().clone())
         .filter(condition.expr.clone())?
@@ -129,9 +134,6 @@ async fn plan_iceberg_delete(
 
     let writer_options = resolve_row_level_writer_options(session_state, node)?;
     let partition_columns = IcebergTableFormat::partition_columns_from_metadata(&table)?;
-    let current_schema = table.metadata().current_schema().ok_or_else(|| {
-        DataFusionError::Plan("Iceberg table metadata is missing current schema".to_string())
-    })?;
     let current_arrow_schema =
         crate::datasource::type_converter::iceberg_schema_to_arrow(current_schema)?;
     let write_context = prepare_iceberg_write_context(

--- a/crates/sail-iceberg/src/physical_plan/equality_delete_writer_exec.rs
+++ b/crates/sail-iceberg/src/physical_plan/equality_delete_writer_exec.rs
@@ -328,9 +328,9 @@ fn equality_delete_fields(
     iceberg_schema: &crate::spec::Schema,
     input_schema: &SchemaRef,
 ) -> Result<Vec<EqualityDeleteField>> {
+    validate_equality_delete_schema(iceberg_schema)?;
     let mut fields = Vec::with_capacity(iceberg_schema.fields().len());
     for field in iceberg_schema.fields() {
-        validate_equality_delete_type(&field.name, &field.field_type)?;
         let arrow_field = Arc::new(iceberg_field_to_arrow(field)?);
         let input_field = input_schema.field_with_name(&field.name).map_err(|_| {
             DataFusionError::Plan(format!(
@@ -353,6 +353,13 @@ fn equality_delete_fields(
         });
     }
     Ok(fields)
+}
+
+pub(crate) fn validate_equality_delete_schema(iceberg_schema: &crate::spec::Schema) -> Result<()> {
+    for field in iceberg_schema.fields() {
+        validate_equality_delete_type(&field.name, &field.field_type)?;
+    }
+    Ok(())
 }
 
 fn validate_equality_delete_type(name: &str, ty: &Type) -> Result<()> {


### PR DESCRIPTION
## Summary

- Validate Iceberg equality-delete schemas before planning the upstream DELETE scan.
- Fix storage-shuffle dependencies when a `Forward` input uses child-local partition numbers, such as inputs under `UnionExec`.
- Add a regression test covering blocking shuffle inputs beneath a union.

## Root cause

This change fixes two independent distributed-execution issues:

1. Equality-delete type validation happened inside the writer task. In local-cluster mode, upstream stages could be materialized first, causing an unrelated comparison error to mask the expected rejection of floating-point equality keys.

2. Job topology assumed that a `Forward` input's partition number always matched the consumer stage's global partition number. `UnionExec` maps each child using local partition numbers, so some consumer tasks could be scheduled without waiting for their blocking storage-shuffle inputs. Those tasks could list the storage location before the producer committed its output and incorrectly read an empty result.

## Changes

- Perform equality-delete schema validation on the driver before physicalizing the DELETE input.
- Retain writer-side validation as a defensive check.
- When producer and consumer partition counts differ, conservatively make the consumer wait for every producer region.
- Add a topology regression test for unioned blocking shuffle inputs.