### PR TITLE
feat: implement vector l2 distance

### DIFF
--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -252,6 +252,7 @@ use sail_function::scalar::variant::spark_variant_explode::SparkVariantExplodeUd
 use sail_function::scalar::variant::spark_variant_get::SparkVariantGet;
 use sail_function::scalar::variant::spark_variant_to_json::SparkVariantToJsonUdf;
 use sail_function::scalar::vector::inner_product::VectorInnerProduct;
+use sail_function::scalar::vector::l2_distance::VectorL2Distance;
 use sail_function::scalar::xml::from_xml::SparkFromXml;
 use sail_function::scalar::xml::to_xml::SparkToXml;
 use sail_function::scalar::xml::xpath::Xpath;
@@ -2842,6 +2843,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                 Ok(Arc::new(ScalarUDF::from(SparkCastStringToInt32::new())))
             }
             "vector_inner_product" => Ok(Arc::new(ScalarUDF::from(VectorInnerProduct::new()))),
+            "vector_l2_distance" => Ok(Arc::new(ScalarUDF::from(VectorL2Distance::new()))),
             "bitmap_count" => Ok(Arc::new(ScalarUDF::from(BitmapCount::new()))),
             "format_string" => Ok(Arc::new(ScalarUDF::from(FormatStringFunc::new()))),
             "greatest" => Ok(Arc::new(ScalarUDF::from(GreatestFunc::new()))),
@@ -3031,6 +3033,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node_inner.is::<SparkArrayCompact>()
             || node_inner.is::<SparkCastStringToInt32>()
             || node_inner.is::<VectorInnerProduct>()
+            || node_inner.is::<VectorL2Distance>()
             || node_inner.is::<BitmapCount>()
             || node_inner.is::<FormatStringFunc>()
             || node_inner.is::<GreatestFunc>()
@@ -5462,6 +5465,16 @@ mod tests {
                 .is_some()
         );
         assert_eq!(decoded.name(), "vector_inner_product");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_round_trip_vector_l2_distance_udf() -> Result<()> {
+        let decoded = round_trip_udf(ScalarUDF::from(VectorL2Distance::new()))?;
+
+        assert!(decoded.inner().downcast_ref::<VectorL2Distance>().is_some());
+        assert_eq!(decoded.name(), "vector_l2_distance");
 
         Ok(())
     }

--- a/crates/sail-function/src/scalar/vector/l2_distance.rs
+++ b/crates/sail-function/src/scalar/vector/l2_distance.rs
@@ -1,0 +1,227 @@
+use std::sync::Arc;
+
+use datafusion::arrow::array::{
+    Array, ArrayRef, AsArray, Float32Array, GenericListArray, OffsetSizeTrait, as_large_list_array,
+    as_list_array,
+};
+use datafusion::arrow::datatypes::{DataType, Float32Type};
+use datafusion_common::{Result, exec_err, plan_err};
+use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+
+use crate::functions_nested_utils::make_scalar_function;
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct VectorL2Distance {
+    signature: Signature,
+}
+
+impl Default for VectorL2Distance {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VectorL2Distance {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::any(2, Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for VectorL2Distance {
+    fn name(&self) -> &str {
+        "vector_l2_distance"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        if arg_types.len() != 2 || !arg_types.iter().all(is_float_vector) {
+            return plan_err!(
+                "vector_l2_distance expects two ARRAY<FLOAT> arguments, got {arg_types:?}"
+            );
+        }
+        Ok(DataType::Float32)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(vector_l2_distance_inner)(&args.args)
+    }
+}
+
+fn is_float_vector(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::List(field) | DataType::LargeList(field)
+            if field.data_type() == &DataType::Float32
+    )
+}
+
+fn vector_l2_distance_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    if args.len() != 2 {
+        return exec_err!("vector_l2_distance needs exactly two arguments");
+    }
+    match (args[0].data_type(), args[1].data_type()) {
+        (DataType::List(_), DataType::List(_)) => {
+            compute_l2_distance(as_list_array(&args[0]), as_list_array(&args[1]))
+        }
+        (DataType::LargeList(_), DataType::LargeList(_)) => {
+            compute_l2_distance(as_large_list_array(&args[0]), as_large_list_array(&args[1]))
+        }
+        (left, right) => {
+            exec_err!("vector_l2_distance expects matching array types, got {left:?} and {right:?}")
+        }
+    }
+}
+
+/// Spark 4.x `vectorL2Distance` accumulates the squared differences eight at a
+/// time in double precision (`sumSq += d0*d0 + ... + d7*d7`) then a scalar tail,
+/// and returns `(float) sqrt(sumSq)`. The accumulator is widened to `f64` so a
+/// sum of squares that is quadratic in the inputs does not overflow to infinity
+/// for distances that are representable as an `f32`.
+fn squared_distance_spark(left: &[f32], right: &[f32]) -> f64 {
+    debug_assert_eq!(left.len(), right.len());
+    let mut sum = 0.0f64;
+    let mut i = 0;
+    let simd_limit = (left.len() / 8) * 8;
+    while i < simd_limit {
+        let d0 = left[i] as f64 - right[i] as f64;
+        let d1 = left[i + 1] as f64 - right[i + 1] as f64;
+        let d2 = left[i + 2] as f64 - right[i + 2] as f64;
+        let d3 = left[i + 3] as f64 - right[i + 3] as f64;
+        let d4 = left[i + 4] as f64 - right[i + 4] as f64;
+        let d5 = left[i + 5] as f64 - right[i + 5] as f64;
+        let d6 = left[i + 6] as f64 - right[i + 6] as f64;
+        let d7 = left[i + 7] as f64 - right[i + 7] as f64;
+        sum += d0 * d0 + d1 * d1 + d2 * d2 + d3 * d3 + d4 * d4 + d5 * d5 + d6 * d6 + d7 * d7;
+        i += 8;
+    }
+    while i < left.len() {
+        let diff = left[i] as f64 - right[i] as f64;
+        sum += diff * diff;
+        i += 1;
+    }
+    sum
+}
+
+fn compute_l2_distance<O: OffsetSizeTrait>(
+    left: &GenericListArray<O>,
+    right: &GenericListArray<O>,
+) -> Result<ArrayRef> {
+    let values = (0..left.len()).map(|row| {
+        if left.is_null(row) || right.is_null(row) {
+            return Ok(None);
+        }
+        let left = left.value(row);
+        let right = right.value(row);
+        if left.len() != right.len() {
+            return exec_err!(
+                "vector_l2_distance requires vectors with matching dimensions, got {} and {}",
+                left.len(),
+                right.len()
+            );
+        }
+        let left = left.as_primitive::<Float32Type>();
+        let right = right.as_primitive::<Float32Type>();
+        if left.null_count() > 0 || right.null_count() > 0 {
+            return Ok(None);
+        }
+        // Match Spark 4.x: accumulate the squared differences in groups of eight,
+        // in double precision, so the Euclidean distance stays Spark-compatible.
+        Ok(Some(
+            squared_distance_spark(left.values(), right.values()).sqrt() as f32,
+        ))
+    });
+    let values = values.collect::<Result<Vec<Option<f32>>>>()?;
+    Ok(Arc::new(Float32Array::from(values)))
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::array::ListArray;
+
+    use super::*;
+
+    #[test]
+    fn computes_spark_compatible_results() -> Result<()> {
+        let left = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![
+            // sqrt((1-4)^2 + (2-5)^2 + (3-6)^2) = sqrt(27) = 5.196152
+            Some(vec![Some(1.0), Some(2.0), Some(3.0)]),
+            // empty vectors -> distance 0.0
+            Some(vec![]),
+            // identical vectors -> distance 0.0
+            Some(vec![Some(3.0), Some(4.0)]),
+            // null element -> NULL
+            Some(vec![Some(1.0), None, Some(3.0)]),
+            // null vector -> NULL
+            None,
+        ]);
+        let right = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![
+            Some(vec![Some(4.0), Some(5.0), Some(6.0)]),
+            Some(vec![]),
+            Some(vec![Some(3.0), Some(4.0)]),
+            Some(vec![Some(1.0), Some(2.0), Some(3.0)]),
+            Some(vec![Some(1.0)]),
+        ]);
+
+        let actual = compute_l2_distance(&left, &right)?;
+        let actual = actual.as_primitive::<Float32Type>();
+        let expected = Float32Array::from(vec![Some(5.196152), Some(0.0), Some(0.0), None, None]);
+        assert_eq!(actual, &expected);
+        Ok(())
+    }
+
+    #[test]
+    fn distance_of_3_4_right_triangle_is_5() -> Result<()> {
+        // sqrt((3-0)^2 + (4-0)^2) = 5.0
+        let left = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(vec![
+            Some(3.0),
+            Some(4.0),
+        ])]);
+        let right = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(vec![
+            Some(0.0),
+            Some(0.0),
+        ])]);
+
+        let actual = compute_l2_distance(&left, &right)?;
+        let actual = actual.as_primitive::<Float32Type>();
+        assert_eq!(actual.value(0), 5.0);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_dimension_mismatch() {
+        let left = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(vec![Some(1.0)])]);
+        let right = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(vec![
+            Some(1.0),
+            Some(2.0),
+        ])]);
+
+        assert!(matches!(
+            compute_l2_distance(&left, &right),
+            Err(error) if error.to_string().contains("matching dimensions")
+        ));
+    }
+
+    #[test]
+    fn double_accumulation_avoids_f32_overflow() -> Result<()> {
+        // The distance 2e20 is representable as an f32 (< f32::MAX ~3.4e38), but
+        // its square 4e40 overflows f32 to +inf. Accumulating the sum of squares
+        // in f64 (as Spark does) keeps the distance recoverable.
+        let left =
+            ListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(vec![Some(2.0e20)])]);
+        let right =
+            ListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(vec![Some(0.0)])]);
+
+        let actual = compute_l2_distance(&left, &right)?;
+        let actual = actual.as_primitive::<Float32Type>();
+        // sqrt((2e20)^2) = 2e20, exactly recovered; an f32 sum-of-squares would
+        // overflow to +inf and produce inf here.
+        assert_eq!(actual.value(0), 2.0e20);
+        assert!(actual.value(0).is_finite());
+        Ok(())
+    }
+}

--- a/crates/sail-function/src/scalar/vector/mod.rs
+++ b/crates/sail-function/src/scalar/vector/mod.rs
@@ -1,1 +1,2 @@
 pub mod inner_product;
+pub mod l2_distance;

--- a/crates/sail-plan/src/function/scalar/vector.rs
+++ b/crates/sail-plan/src/function/scalar/vector.rs
@@ -1,4 +1,5 @@
 use sail_function::scalar::vector::inner_product::VectorInnerProduct;
+use sail_function::scalar::vector::l2_distance::VectorL2Distance;
 
 use crate::function::common::ScalarFunction;
 
@@ -11,7 +12,7 @@ pub(super) fn list_built_in_vector_functions() -> Vec<(&'static str, ScalarFunct
             F::unknown("vector_cosine_similarity"),
         ),
         ("vector_inner_product", F::udf(VectorInnerProduct::new())),
-        ("vector_l2_distance", F::unknown("vector_l2_distance")),
+        ("vector_l2_distance", F::udf(VectorL2Distance::new())),
         ("vector_norm", F::unknown("vector_norm")),
         ("vector_normalize", F::unknown("vector_normalize")),
     ]

--- a/crates/sail-spark-connect/tests/gold_data/function/vector.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/vector.json
@@ -89,7 +89,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: vector_l2_distance"
+        "success": "ok"
       }
     },
     {

--- a/python/pysail/tests/spark/function/features/vector/vector_l2_distance.feature
+++ b/python/pysail/tests/spark/function/features/vector/vector_l2_distance.feature
@@ -1,0 +1,85 @@
+@spark-4.2
+Feature: vector_l2_distance
+
+  Rule: Basic results
+
+    Scenario: basic, right-triangle, and self distance
+      When query
+        """
+        SELECT
+          vector_l2_distance(array(1.0F, 2.0F, 3.0F), array(4.0F, 5.0F, 6.0F)) AS basic,
+          vector_l2_distance(array(3.0F, 4.0F), array(0.0F, 0.0F)) AS right_triangle,
+          vector_l2_distance(array(3.0F, 4.0F), array(3.0F, 4.0F)) AS self_distance
+        """
+      Then query result
+        | basic    | right_triangle | self_distance |
+        | 5.196152 | 5.0            | 0.0           |
+
+    Scenario: vector columns from VALUES execute the UDF
+      When query
+        """
+        SELECT vector_l2_distance(left_vector, right_vector) AS result
+        FROM VALUES
+          (array(1.0F, 2.0F, 3.0F), array(4.0F, 5.0F, 6.0F)),
+          (array(3.0F, 4.0F), array(0.0F, 0.0F)),
+          (array(3.0F, 4.0F), array(3.0F, 4.0F))
+        AS t(left_vector, right_vector)
+        """
+      Then query result
+        | result   |
+        | 5.196152 |
+        | 5.0      |
+        | 0.0      |
+
+    Scenario: orthogonal unit vectors are sqrt(2) apart
+      When query
+        """
+        SELECT vector_l2_distance(array(1.0F, 0.0F), array(0.0F, 1.0F)) AS result
+        """
+      Then query result
+        | result    |
+        | 1.4142135 |
+
+    Scenario: empty ARRAY<FLOAT> inputs return 0.0
+      When query
+        """
+        SELECT vector_l2_distance(
+          CAST(array() AS ARRAY<FLOAT>),
+          CAST(array() AS ARRAY<FLOAT>)
+        ) AS result
+        """
+      Then query result
+        | result |
+        | 0.0    |
+
+    Scenario: distance across a 16-element vector matches sqrt of the summed squares
+      When query
+        """
+        SELECT vector_l2_distance(
+          array(1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F, 13.0F, 14.0F, 15.0F, 16.0F),
+          array(2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F, 13.0F, 14.0F, 15.0F, 16.0F, 17.0F)
+        ) AS result
+        """
+      Then query result
+        | result |
+        | 4.0    |
+
+  Rule: Null handling
+
+    Scenario: typed null vector returns NULL
+      When query
+        """
+        SELECT vector_l2_distance(CAST(NULL AS ARRAY<FLOAT>), array(1.0F, 2.0F)) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: array containing a null element returns NULL
+      When query
+        """
+        SELECT vector_l2_distance(array(1.0F, CAST(NULL AS FLOAT), 3.0F), array(4.0F, 5.0F, 6.0F)) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |


### PR DESCRIPTION
## Summary

- implement Spark 4.x's `vector_l2_distance` for `ARRAY<FLOAT>` inputs
- preserve Spark-compatible null, empty-vector, and dimension-mismatch behavior
- register the UDF in scalar planning and remote execution serialization
- accumulate squared differences in groups of eight, in double precision, to
  match Spark's floating-point reduction and avoid f32 sum-of-squares overflow

Part of #2358.

## Evidence

Spark documents this as the Euclidean (L2) distance between two float vectors:
https://spark.apache.org/docs/latest/api/sql/#vector_l2_distance

Upstream implementation (equal dimensions, null element → NULL, empty → 0.0,
8-wide squared-difference accumulation widened to double precision):
https://github.com/apache/spark/blob/master/sql/catalyst/src/main/java/org/apache/spark/sql/catalyst/expressions/VectorFunctionImplUtils.java

## Validation

- `cargo test -p sail-function l2_distance` — **4 passed**, 0 failed
  - basic `sqrt(27) = 5.196152` / empty `0.0` / identical `0.0` / null-element `NULL`
  - 3-4-5 right triangle → `5.0`
  - dimension mismatch rejected
  - double-precision accumulation avoids f32 sum-of-squares overflow
- `cargo test -p sail-execution --lib vector_l2_distance` — **1 passed** (remote codec round-trip)
- gold data: `crates/sail-spark-connect/tests/gold_data/function/vector.json`
  `vector_l2_distance(array(1.0F, 2.0F, 3.0F), array(4.0F, 5.0F, 6.0F))` → `5.196152`
- BDD: `python/pysail/tests/spark/function/features/vector/vector_l2_distance.feature` (`@spark-4.2`)
  basic / VALUES columns / orthogonal `sqrt(2)` / empty `0.0` / 16-element `4.0` / typed-null / null-element
- CI re-runs the Spark/BDD and Cargo suites for this PR after push
