### PR TITLE
fix: use TOP for MSSQL schema queries

### DIFF
--- a/python/pysail/spark/datasource/jdbc.py
+++ b/python/pysail/spark/datasource/jdbc.py
@@ -435,10 +435,11 @@ class JdbcDataSource(DataSource):
         dbtable = resolved["dbtable"]
         query = resolved["query"]
 
-        if query is not None:
-            schema_query = f"SELECT * FROM ({query}) AS _cx_schema_q LIMIT 0"  # noqa: S608
+        source = f"({query}) AS _cx_schema_q" if query is not None else dbtable
+        if conn_str.startswith("mssql://"):
+            schema_query = f"SELECT TOP 0 * FROM {source}"  # noqa: S608
         else:
-            schema_query = f"SELECT * FROM {dbtable} LIMIT 0"  # noqa: S608
+            schema_query = f"SELECT * FROM {source} LIMIT 0"  # noqa: S608
 
         try:
             table: pa.Table = cx.read_sql(conn_str, schema_query, return_type="arrow")

--- a/python/pysail/tests/spark/datasource/test_jdbc.py
+++ b/python/pysail/tests/spark/datasource/test_jdbc.py
@@ -527,6 +527,33 @@ def test_custom_schema_case_insensitive(spark, jdbc_opts):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.parametrize(
+    ("source", "expected_query"),
+    [
+        ({"query": "SELECT 1 AS n"}, "SELECT TOP 0 * FROM (SELECT 1 AS n) AS _cx_schema_q"),
+        ({"dbtable": "events"}, "SELECT TOP 0 * FROM events"),
+    ],
+)
+def test_mssql_schema_query_uses_top(monkeypatch, source, expected_query):
+    import pyarrow as pa
+
+    from pysail.spark.datasource import jdbc
+
+    queries = []
+
+    def read_sql(_conn_str, query, *, return_type):
+        assert return_type == "arrow"
+        queries.append(query)
+        return pa.table({})
+
+    monkeypatch.setattr(jdbc.cx, "read_sql", read_sql)
+
+    datasource = jdbc.JdbcDataSource(options={"url": "jdbc:mssql://localhost:1433/test", **source})
+    datasource.schema()
+
+    assert queries == [expected_query]
+
+
 def test_filter_to_sql_unit():
     from pyspark.sql.datasource import (
         EqualTo,


### PR DESCRIPTION
## What

- use `SELECT TOP 0` for SQL Server schema inference
- keep `LIMIT 0` for other JDBC sources
- cover both `query` and `dbtable` options in default unit CI

Fixes #2449 — [Read from SQL Server fails with syntax error](https://github.com/lakehq/sail/issues/2449)

## Testing

- `.venvs/default/bin/pytest -q python/pysail/tests/test_jdbc.py` — 2 passed
- nearby JDBC unit checks — 7 passed
- `hatch fmt --check`

The PostgreSQL testcontainer suite needs Docker and could not run locally.