### PR TITLE
fix: derive VALUES column nullability

### DIFF
--- a/crates/sail-plan/src/resolver/query/values.rs
+++ b/crates/sail-plan/src/resolver/query/values.rs
@@ -28,7 +28,7 @@ impl PlanResolver<'_> {
             Ok::<_, PlanError>(results)
         }
         .await?;
-        let plan = LogicalPlanBuilder::values(values)?.build()?;
+        let plan = update_values_nullability(LogicalPlanBuilder::values(values)?.build()?)?;
         let expr = plan
             .schema()
             .columns()
@@ -148,6 +148,32 @@ impl PlanResolver<'_> {
 
         Ok(map_positions)
     }
+}
+
+/// Updates a VALUES schema using the nullability of its resolved expressions.
+fn update_values_nullability(plan: LogicalPlan) -> PlanResult<LogicalPlan> {
+    let LogicalPlan::Values(mut values) = plan else {
+        return Err(PlanError::internal("expected VALUES plan"));
+    };
+    let schema = DFSchema::empty();
+    let fields = values
+        .schema
+        .fields()
+        .iter()
+        .enumerate()
+        .map(|(index, field)| {
+            let nullable = values.values.iter().try_fold(false, |nullable, row| {
+                Ok::<_, PlanError>(nullable || row[index].nullable(&schema)?)
+            })?;
+            Ok(Arc::new(field.as_ref().clone().with_nullable(nullable)))
+        })
+        .collect::<PlanResult<Vec<_>>>()?
+        .into();
+    values.schema = Arc::new(DFSchema::from_unqualified_fields(
+        fields,
+        values.schema.metadata().clone(),
+    )?);
+    Ok(LogicalPlan::Values(values))
 }
 
 fn merge_map_value_nullability(left: DataType, right: DataType) -> DataType {

--- a/python/pysail/tests/spark/analyzer/__snapshots__/features/explain.yaml
+++ b/python/pysail/tests/spark/analyzer/__snapshots__/features/explain.yaml
@@ -16,13 +16,13 @@ name: "test_explain_analyze_executes_and_returns_physical_plan"
 data:
   |-
     == Physical Plan ==
-    ProjectionExec: expr=[#4@0 as k, #5@1 as SUM(v)], metrics=[output_rows=<metric>, elapsed_compute=<metric>, output_bytes=<metric>, output_batches=<metric>, expr_<metric>_eval_time=<metric>, expr_<metric>_eval_time=<metric>], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[k:Int32;N, SUM(v):Int64;N]
-      ProjectionExec: expr=[#2@0 as #4, sum(t.#3)@1 as #5], metrics=[output_rows=<metric>, elapsed_compute=<metric>, output_bytes=<metric>, output_batches=<metric>, expr_<metric>_eval_time=<metric>, expr_<metric>_eval_time=<metric>], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[#4:Int32;N, #5:Int64;N]
-        AggregateExec: mode=FinalPartitioned, gby=[#2@0 as #2], aggr=[sum(t.#3)], metrics=[output_rows=<metric>, elapsed_compute=<metric>, output_bytes=<metric>, output_batches=<metric>, spill_count=<metric>, spilled_bytes=<metric>, spilled_rows=<metric>, peak_mem_used=<metric>, aggregate_arguments_time=<metric>, aggregation_time=<metric>, emitting_time=<metric>, time_calculating_group_ids=<metric>], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[#2:Int32;N, sum(t.#3):Int64;N]
-          RepartitionExec: partitioning=Hash([#2@0], 4), input_partitions=1, metrics=[output_rows=<metric>, elapsed_compute=<metric>, output_bytes=<metric>, output_batches=<metric>, spill_count=<metric>, spilled_bytes=<metric>, spilled_rows=<metric>, fetch_time=<metric>, repartition_time=<metric>, send_time=<metric>], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[#2:Int32;N, sum(t.#3)[sum]:Int64;N]
-            AggregateExec: mode=Partial, gby=[#2@0 as #2], aggr=[sum(t.#3)], metrics=[output_rows=<metric>, elapsed_compute=<metric>, output_bytes=<metric>, output_batches=<metric>, spill_count=<metric>, spilled_bytes=<metric>, spilled_rows=<metric>, skipped_aggregation_rows=<metric>, peak_mem_used=<metric>, aggregate_arguments_time=<metric>, aggregation_time=<metric>, emitting_time=<metric>, time_calculating_group_ids=<metric>, reduction_factor=<metric>], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[#2:Int32;N, sum(t.#3)[sum]:Int64;N]
-              ProjectionExec: expr=[column1@0 as #2, column2@1 as #3], metrics=[output_rows=<metric>, elapsed_compute=<metric>, output_bytes=<metric>, output_batches=<metric>, expr_<metric>_eval_time=<metric>, expr_<metric>_eval_time=<metric>], statistics=[Rows=Exact(2), Bytes=Exact(<bytes>), [(Col[0]: Null=Exact(0)),(Col[1]: Null=Exact(0))]], schema=[#2:Int32;N, #3:Int32;N]
-                DataSourceExec: partitions=1, partition_sizes=[1], metrics=[], statistics=[Rows=Exact(2), Bytes=Exact(<bytes>), [(Col[0]: Null=Exact(0)),(Col[1]: Null=Exact(0))]], schema=[column1:Int32;N, column2:Int32;N]
+    ProjectionExec: expr=[#4@0 as k, #5@1 as SUM(v)], metrics=[output_rows=<metric>, elapsed_compute=<metric>, output_bytes=<metric>, output_batches=<metric>, expr_<metric>_eval_time=<metric>, expr_<metric>_eval_time=<metric>], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[k:Int32, SUM(v):Int64;N]
+      ProjectionExec: expr=[#2@0 as #4, sum(t.#3)@1 as #5], metrics=[output_rows=<metric>, elapsed_compute=<metric>, output_bytes=<metric>, output_batches=<metric>, expr_<metric>_eval_time=<metric>, expr_<metric>_eval_time=<metric>], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[#4:Int32, #5:Int64;N]
+        AggregateExec: mode=FinalPartitioned, gby=[#2@0 as #2], aggr=[sum(t.#3)], metrics=[output_rows=<metric>, elapsed_compute=<metric>, output_bytes=<metric>, output_batches=<metric>, spill_count=<metric>, spilled_bytes=<metric>, spilled_rows=<metric>, peak_mem_used=<metric>, aggregate_arguments_time=<metric>, aggregation_time=<metric>, emitting_time=<metric>, time_calculating_group_ids=<metric>], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[#2:Int32, sum(t.#3):Int64;N]
+          RepartitionExec: partitioning=Hash([#2@0], 4), input_partitions=1, metrics=[output_rows=<metric>, elapsed_compute=<metric>, output_bytes=<metric>, output_batches=<metric>, spill_count=<metric>, spilled_bytes=<metric>, spilled_rows=<metric>, fetch_time=<metric>, repartition_time=<metric>, send_time=<metric>], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[#2:Int32, sum(t.#3)[sum]:Int64;N]
+            AggregateExec: mode=Partial, gby=[#2@0 as #2], aggr=[sum(t.#3)], metrics=[output_rows=<metric>, elapsed_compute=<metric>, output_bytes=<metric>, output_batches=<metric>, spill_count=<metric>, spilled_bytes=<metric>, spilled_rows=<metric>, skipped_aggregation_rows=<metric>, peak_mem_used=<metric>, aggregate_arguments_time=<metric>, aggregation_time=<metric>, emitting_time=<metric>, time_calculating_group_ids=<metric>, reduction_factor=<metric>], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[#2:Int32, sum(t.#3)[sum]:Int64;N]
+              ProjectionExec: expr=[column1@0 as #2, column2@1 as #3], metrics=[output_rows=<metric>, elapsed_compute=<metric>, output_bytes=<metric>, output_batches=<metric>, expr_<metric>_eval_time=<metric>, expr_<metric>_eval_time=<metric>], statistics=[Rows=Exact(2), Bytes=Exact(<bytes>), [(Col[0]: Null=Exact(0)),(Col[1]: Null=Exact(0))]], schema=[#2:Int32, #3:Int32]
+                DataSourceExec: partitions=1, partition_sizes=[1], metrics=[], statistics=[Rows=Exact(2), Bytes=Exact(<bytes>), [(Col[0]: Null=Exact(0)),(Col[1]: Null=Exact(0))]], schema=[column1:Int32, column2:Int32]
 ---
 name: "test_explain_codegen_shows_codegen_notice_and_physical_plan"
 data:
@@ -240,11 +240,11 @@ data:
   
   
     initial_physical_plan_with_schema:
-    ProjectionExec: expr=[#2@0 as #4, sum(t.#3)@1 as #5], schema=[#4:Int32;N, #5:Int64;N]
-      AggregateExec: mode=FinalPartitioned, gby=[#2@0 as #2], aggr=[sum(t.#3)], schema=[#2:Int32;N, sum(t.#3):Int64;N]
-        AggregateExec: mode=Partial, gby=[#2@0 as #2], aggr=[sum(t.#3)], schema=[#2:Int32;N, sum(t.#3)[sum]:Int64;N]
-          ProjectionExec: expr=[column1@0 as #2, column2@1 as #3], schema=[#2:Int32;N, #3:Int32;N]
-            DataSourceExec: partitions=1, partition_sizes=[1], schema=[column1:Int32;N, column2:Int32;N]
+    ProjectionExec: expr=[#2@0 as #4, sum(t.#3)@1 as #5], schema=[#4:Int32, #5:Int64;N]
+      AggregateExec: mode=FinalPartitioned, gby=[#2@0 as #2], aggr=[sum(t.#3)], schema=[#2:Int32, sum(t.#3):Int64;N]
+        AggregateExec: mode=Partial, gby=[#2@0 as #2], aggr=[sum(t.#3)], schema=[#2:Int32, sum(t.#3)[sum]:Int64;N]
+          ProjectionExec: expr=[column1@0 as #2, column2@1 as #3], schema=[#2:Int32, #3:Int32]
+            DataSourceExec: partitions=1, partition_sizes=[1], schema=[column1:Int32, column2:Int32]
   
   
     physical_plan after OutputRequirements:
@@ -442,13 +442,13 @@ name: "test_explain_formatted_includes_statistics_and_schema"
 data:
   |-
     == Physical Plan ==
-    ProjectionExec: expr=[#4@0 as k, #5@1 as SUM(v)], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[k:Int32;N, SUM(v):Int64;N]
-      ProjectionExec: expr=[#2@0 as #4, sum(t.#3)@1 as #5], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[#4:Int32;N, #5:Int64;N]
-        AggregateExec: mode=FinalPartitioned, gby=[#2@0 as #2], aggr=[sum(t.#3)], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[#2:Int32;N, sum(t.#3):Int64;N]
-          RepartitionExec: partitioning=Hash([#2@0], 4), input_partitions=1, statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[#2:Int32;N, sum(t.#3)[sum]:Int64;N]
-            AggregateExec: mode=Partial, gby=[#2@0 as #2], aggr=[sum(t.#3)], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[#2:Int32;N, sum(t.#3)[sum]:Int64;N]
-              ProjectionExec: expr=[column1@0 as #2, column2@1 as #3], statistics=[Rows=Exact(2), Bytes=Exact(<bytes>), [(Col[0]: Null=Exact(0)),(Col[1]: Null=Exact(0))]], schema=[#2:Int32;N, #3:Int32;N]
-                DataSourceExec: partitions=1, partition_sizes=[1], statistics=[Rows=Exact(2), Bytes=Exact(<bytes>), [(Col[0]: Null=Exact(0)),(Col[1]: Null=Exact(0))]], schema=[column1:Int32;N, column2:Int32;N]
+    ProjectionExec: expr=[#4@0 as k, #5@1 as SUM(v)], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[k:Int32, SUM(v):Int64;N]
+      ProjectionExec: expr=[#2@0 as #4, sum(t.#3)@1 as #5], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[#4:Int32, #5:Int64;N]
+        AggregateExec: mode=FinalPartitioned, gby=[#2@0 as #2], aggr=[sum(t.#3)], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[#2:Int32, sum(t.#3):Int64;N]
+          RepartitionExec: partitioning=Hash([#2@0], 4), input_partitions=1, statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[#2:Int32, sum(t.#3)[sum]:Int64;N]
+            AggregateExec: mode=Partial, gby=[#2@0 as #2], aggr=[sum(t.#3)], statistics=[Rows=Inexact(2), Bytes=Inexact(<bytes>), [(Col[0]:),(Col[1]:)]], schema=[#2:Int32, sum(t.#3)[sum]:Int64;N]
+              ProjectionExec: expr=[column1@0 as #2, column2@1 as #3], statistics=[Rows=Exact(2), Bytes=Exact(<bytes>), [(Col[0]: Null=Exact(0)),(Col[1]: Null=Exact(0))]], schema=[#2:Int32, #3:Int32]
+                DataSourceExec: partitions=1, partition_sizes=[1], statistics=[Rows=Exact(2), Bytes=Exact(<bytes>), [(Col[0]: Null=Exact(0)),(Col[1]: Null=Exact(0))]], schema=[column1:Int32, column2:Int32]
 ---
 name: "test_explain_verbose_returns_detailed_physical_plan"
 data:
@@ -474,10 +474,10 @@ data:
   
   
     == Physical Plan (with schema) ==
-    ProjectionExec: expr=[#4@0 as k, #5@1 as SUM(v)], schema=[k:Int32;N, SUM(v):Int64;N]
-      ProjectionExec: expr=[#2@0 as #4, sum(t.#3)@1 as #5], schema=[#4:Int32;N, #5:Int64;N]
-        AggregateExec: mode=FinalPartitioned, gby=[#2@0 as #2], aggr=[sum(t.#3)], schema=[#2:Int32;N, sum(t.#3):Int64;N]
-          RepartitionExec: partitioning=Hash([#2@0], 4), input_partitions=1, schema=[#2:Int32;N, sum(t.#3)[sum]:Int64;N]
-            AggregateExec: mode=Partial, gby=[#2@0 as #2], aggr=[sum(t.#3)], schema=[#2:Int32;N, sum(t.#3)[sum]:Int64;N]
-              ProjectionExec: expr=[column1@0 as #2, column2@1 as #3], schema=[#2:Int32;N, #3:Int32;N]
-                DataSourceExec: partitions=1, partition_sizes=[1], schema=[column1:Int32;N, column2:Int32;N]
+    ProjectionExec: expr=[#4@0 as k, #5@1 as SUM(v)], schema=[k:Int32, SUM(v):Int64;N]
+      ProjectionExec: expr=[#2@0 as #4, sum(t.#3)@1 as #5], schema=[#4:Int32, #5:Int64;N]
+        AggregateExec: mode=FinalPartitioned, gby=[#2@0 as #2], aggr=[sum(t.#3)], schema=[#2:Int32, sum(t.#3):Int64;N]
+          RepartitionExec: partitioning=Hash([#2@0], 4), input_partitions=1, schema=[#2:Int32, sum(t.#3)[sum]:Int64;N]
+            AggregateExec: mode=Partial, gby=[#2@0 as #2], aggr=[sum(t.#3)], schema=[#2:Int32, sum(t.#3)[sum]:Int64;N]
+              ProjectionExec: expr=[column1@0 as #2, column2@1 as #3], schema=[#2:Int32, #3:Int32]
+                DataSourceExec: partitions=1, partition_sizes=[1], schema=[column1:Int32, column2:Int32]

--- a/python/pysail/tests/spark/analyzer/features/values.feature
+++ b/python/pysail/tests/spark/analyzer/features/values.feature
@@ -2,7 +2,6 @@ Feature: VALUES relation output schema
 
   Rule: Column nullability
 
-    @sail-bug
     Scenario: non-null VALUES literals produce a non-nullable column
       When query
         """


### PR DESCRIPTION
DataFusion infers every column in a `VALUES` relation as nullable, even when all expressions in a column are non-nullable. This causes Sail schemas to differ from Spark for queries such as integer literals alongside timestamp casts.

Derive each `VALUES` field's nullability from its resolved expressions while retaining DataFusion's existing type inference and plan construction. Remove the known-bug marker from the existing regression scenario and update affected explain snapshots.