### PR TITLE
fix: validate CSV headers when schema enforcement is disabled

### DIFF
--- a/crates/sail-data-source/data/options/csv.yaml
+++ b/crates/sail-data-source/data/options/csv.yaml
@@ -550,7 +550,7 @@
   default:
     value: "true"
     parser: crate::options::parsers::parse_bool
-  supported: false
+  supported: true
   rust_type: bool
   scopes:
     - read

--- a/crates/sail-data-source/src/formats/csv/header.rs
+++ b/crates/sail-data-source/src/formats/csv/header.rs
@@ -1,0 +1,264 @@
+use std::io::Read;
+
+use bytes::Bytes;
+use csv_core::{ReadRecordResult, Reader, ReaderBuilder, Terminator};
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion_common::config::CsvOptions;
+use datafusion_common::{DataFusionError, Result};
+use futures::{StreamExt, TryStreamExt};
+
+struct CsvHeaderValidator {
+    reader: Reader,
+    output: Vec<u8>,
+    output_len: usize,
+    ends: Vec<usize>,
+    ends_len: usize,
+    expected: Vec<String>,
+    path: String,
+    complete: bool,
+}
+
+impl CsvHeaderValidator {
+    /// Creates a header validator configured with the same dialect as the CSV reader.
+    fn new(schema: &SchemaRef, options: &CsvOptions, path: &str) -> Self {
+        let mut builder = ReaderBuilder::new();
+        builder.escape(options.escape);
+        builder.comment(options.comment);
+        builder.delimiter(options.delimiter);
+        builder.quote(options.quote);
+        if let Some(terminator) = options.terminator {
+            builder.terminator(Terminator::Any(terminator));
+        }
+
+        Self {
+            reader: builder.build(),
+            output: vec![0; 1024],
+            output_len: 0,
+            ends: vec![0; schema.fields().len() + 1],
+            ends_len: 0,
+            expected: schema
+                .fields()
+                .iter()
+                .map(|field| field.name().clone())
+                .collect(),
+            path: path.to_string(),
+            complete: false,
+        }
+    }
+
+    /// Feeds CSV bytes until the first non-comment record is available for validation.
+    fn feed(&mut self, input: &[u8]) -> Result<bool> {
+        if self.complete {
+            return Ok(true);
+        }
+
+        let mut consumed = 0;
+        loop {
+            let (result, read, written, ends) = self.reader.read_record(
+                &input[consumed..],
+                &mut self.output[self.output_len..],
+                &mut self.ends[self.ends_len..],
+            );
+            consumed += read;
+            self.output_len += written;
+            self.ends_len += ends;
+
+            match result {
+                ReadRecordResult::InputEmpty => return Ok(false),
+                ReadRecordResult::OutputFull => {
+                    self.output.resize(self.output.len() * 2, 0);
+                }
+                ReadRecordResult::OutputEndsFull => {
+                    self.ends.resize(self.ends.len() * 2, 0);
+                }
+                ReadRecordResult::Record => {
+                    self.validate()?;
+                    self.complete = true;
+                    return Ok(true);
+                }
+                ReadRecordResult::End => return Ok(false),
+            }
+        }
+    }
+
+    /// Finishes parsing and validates a final header without a record terminator.
+    fn finish(&mut self) -> Result<()> {
+        while !self.complete {
+            if !self.feed(&[])? {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    /// Compares parsed header names with schema fields by position.
+    fn validate(&self) -> Result<()> {
+        let mut start = 0;
+        let actual = self.ends[..self.ends_len]
+            .iter()
+            .map(|end| {
+                let field = String::from_utf8_lossy(&self.output[start..*end]).into_owned();
+                start = *end;
+                field
+            })
+            .collect::<Vec<_>>();
+
+        if actual == self.expected {
+            return Ok(());
+        }
+
+        Err(DataFusionError::Execution(format!(
+            "CSV header does not conform to the schema.\nHeader: [{}]\nSchema: [{}]\nExpected: {} but found: {}\nCSV file: {}",
+            actual.join(", "),
+            self.expected.join(", "),
+            self.expected
+                .iter()
+                .zip(actual.iter())
+                .find_map(|(expected, actual)| (expected != actual).then_some(expected.as_str()))
+                .unwrap_or_else(|| self
+                    .expected
+                    .get(actual.len())
+                    .map_or("<missing>", String::as_str)),
+            self.expected
+                .iter()
+                .zip(actual.iter())
+                .find_map(|(expected, actual)| (expected != actual).then_some(actual.as_str()))
+                .unwrap_or_else(|| actual
+                    .get(self.expected.len())
+                    .map_or("<missing>", String::as_str)),
+            self.path,
+        )))
+    }
+}
+
+/// Validates a reader's CSV header and returns every byte consumed while doing so.
+pub(super) fn validate_reader_header<R: Read>(
+    reader: &mut R,
+    schema: &SchemaRef,
+    options: &CsvOptions,
+    path: &str,
+) -> Result<Vec<u8>> {
+    let mut validator = CsvHeaderValidator::new(schema, options, path);
+    let mut prefix = Vec::new();
+    let mut buffer = [0; 8 * 1024];
+
+    while !validator.complete {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            validator.finish()?;
+            break;
+        }
+        prefix.extend_from_slice(&buffer[..read]);
+        validator.feed(&buffer[..read])?;
+    }
+    Ok(prefix)
+}
+
+/// Validates a stream's CSV header and replays the inspected byte chunks.
+pub(super) async fn validate_stream_header(
+    mut input: futures::stream::BoxStream<'static, Result<Bytes>>,
+    schema: &SchemaRef,
+    options: &CsvOptions,
+    path: &str,
+) -> Result<futures::stream::BoxStream<'static, Result<Bytes>>> {
+    let mut validator = CsvHeaderValidator::new(schema, options, path);
+    let mut prefix = Vec::new();
+
+    while !validator.complete {
+        match input.try_next().await? {
+            Some(bytes) => {
+                validator.feed(&bytes)?;
+                prefix.push(bytes);
+            }
+            None => {
+                validator.finish()?;
+                break;
+            }
+        }
+    }
+
+    Ok(futures::stream::iter(prefix.into_iter().map(Ok))
+        .chain(input)
+        .boxed())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+    use std::sync::Arc;
+
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+
+    use super::*;
+
+    /// Creates a CSV schema and options for header validation tests.
+    fn validation_config(names: &[&str]) -> (SchemaRef, CsvOptions) {
+        let schema = Arc::new(Schema::new(
+            names
+                .iter()
+                .map(|name| Field::new(*name, DataType::Utf8, true))
+                .collect::<Vec<_>>(),
+        ));
+        let options = CsvOptions {
+            has_header: Some(true),
+            ..Default::default()
+        };
+        (schema, options)
+    }
+
+    /// Verifies that bytes inspected through a reader can be replayed unchanged.
+    #[test]
+    fn matching_reader_header_is_replayed() -> Result<()> {
+        let (schema, options) = validation_config(&["f1", "f2"]);
+        let expected = b"f1,f2\n1,2\n";
+        let mut input = Cursor::new(expected.to_vec());
+        let prefix = validate_reader_header(&mut input, &schema, &options, "matching.csv")?;
+        let mut replayed = Vec::new();
+        Cursor::new(prefix)
+            .chain(input)
+            .read_to_end(&mut replayed)?;
+
+        assert_eq!(replayed, expected);
+        Ok(())
+    }
+
+    /// Verifies that header fields are checked against schema fields by position.
+    #[test]
+    fn mismatched_reader_header_returns_error() -> Result<()> {
+        let (schema, options) = validation_config(&["f2", "f1"]);
+        let mut input = Cursor::new(b"f1,f2\n1,2\n".to_vec());
+        let error = validate_reader_header(&mut input, &schema, &options, "mismatched.csv")
+            .err()
+            .ok_or_else(|| {
+                DataFusionError::Execution("reversed header was accepted".to_string())
+            })?;
+
+        assert!(
+            error
+                .to_string()
+                .contains("CSV header does not conform to the schema")
+        );
+        assert!(error.to_string().contains("Expected: f2 but found: f1"));
+        assert!(error.to_string().contains("mismatched.csv"));
+        Ok(())
+    }
+
+    /// Verifies that streaming validation handles quoted fields split across chunks.
+    #[tokio::test]
+    async fn matching_stream_header_is_replayed() -> Result<()> {
+        let (schema, options) = validation_config(&["first,name", "f2"]);
+        let chunks = vec![
+            Ok(Bytes::from_static(b"\"first")),
+            Ok(Bytes::from_static(b",name\",f2\n1")),
+            Ok(Bytes::from_static(b",2\n")),
+        ];
+        let input = futures::stream::iter(chunks).boxed();
+        let output = validate_stream_header(input, &schema, &options, "stream.csv")
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        assert_eq!(output.concat(), b"\"first,name\",f2\n1,2\n".as_slice());
+        Ok(())
+    }
+}

--- a/crates/sail-data-source/src/formats/csv/mod.rs
+++ b/crates/sail-data-source/src/formats/csv/mod.rs
@@ -12,6 +12,7 @@ use crate::options::r#gen::{CsvReadOptions, CsvWriteOptions};
 // [CREDIT]: https://github.com/apache/datafusion/blob/54.1.0/datafusion/datasource-csv/src/source.rs
 
 mod decoder;
+mod header;
 mod options;
 mod projected;
 mod read;

--- a/crates/sail-data-source/src/formats/csv/options.rs
+++ b/crates/sail-data-source/src/formats/csv/options.rs
@@ -29,6 +29,7 @@ impl BuildPartialOptions<CsvReadPartialOptions> for CsvOptions {
             compression: Some(self.compression.to_string()),
             allow_truncated_rows: self.truncated_rows,
             path_glob_filter: None,
+            enforce_schema: None,
         })
     }
 }
@@ -64,6 +65,7 @@ impl CsvReadOptions {
             compression,
             allow_truncated_rows,
             path_glob_filter: _,
+            enforce_schema: _,
         } = self;
         let null_regex = match (null_value.as_str(), null_regex.as_str()) {
             (nv, nr) if !nv.is_empty() && !nr.is_empty() => {

--- a/crates/sail-data-source/src/formats/csv/read.rs
+++ b/crates/sail-data-source/src/formats/csv/read.rs
@@ -125,7 +125,9 @@ impl ReadFormat for CsvReadFormat {
         options.has_header = Some(has_header);
         options.newlines_in_values = Some(newlines_in_values);
 
-        let source = CsvSource::new(input.schema).with_csv_options(options.clone());
+        let source = CsvSource::new(input.schema)
+            .with_csv_options(options.clone())
+            .with_enforce_schema(self.options.enforce_schema);
 
         let config = FileScanConfigBuilder::new(input.object_store_url, Arc::new(source))
             .with_file_groups(input.file_groups)

--- a/crates/sail-data-source/src/formats/csv/source.rs
+++ b/crates/sail-data-source/src/formats/csv/source.rs
@@ -3,8 +3,6 @@ use std::io::{BufReader, Cursor, Read, Seek, SeekFrom};
 use std::sync::Arc;
 use std::task::Poll;
 
-use bytes::Bytes;
-use csv_core::{ReadRecordResult, Reader, ReaderBuilder, Terminator};
 use datafusion::arrow::array::RecordBatch;
 use datafusion::arrow::csv;
 use datafusion::arrow::datatypes::DataType;
@@ -28,184 +26,10 @@ use futures::{StreamExt, TryStreamExt};
 use object_store::{GetOptions, GetResultPayload, ObjectStore};
 
 use super::decoder::{LossyUtf8Reader, decode_utf8_lossy_stream};
+use super::header::{validate_reader_header, validate_stream_header};
 use super::projected::{DecoderBatchReader, ProjectedCsvDecoder, ProjectedCsvOptions};
 
 type CsvBatchReader = Box<dyn Iterator<Item = std::result::Result<RecordBatch, ArrowError>> + Send>;
-
-struct CsvHeaderValidator {
-    reader: Reader,
-    output: Vec<u8>,
-    output_len: usize,
-    ends: Vec<usize>,
-    ends_len: usize,
-    expected: Vec<String>,
-    path: String,
-    complete: bool,
-}
-
-impl CsvHeaderValidator {
-    /// Creates a header validator configured with the same dialect as the CSV reader.
-    fn new(config: &CsvSource, path: &str) -> Self {
-        let mut builder = ReaderBuilder::new();
-        builder.escape(config.escape());
-        builder.comment(config.comment());
-        builder.delimiter(config.delimiter());
-        builder.quote(config.quote());
-        if let Some(terminator) = config.terminator() {
-            builder.terminator(Terminator::Any(terminator));
-        }
-
-        Self {
-            reader: builder.build(),
-            output: vec![0; 1024],
-            output_len: 0,
-            ends: vec![0; config.table_schema.file_schema().fields().len() + 1],
-            ends_len: 0,
-            expected: config
-                .table_schema
-                .file_schema()
-                .fields()
-                .iter()
-                .map(|field| field.name().clone())
-                .collect(),
-            path: path.to_string(),
-            complete: false,
-        }
-    }
-
-    /// Feeds CSV bytes until the first non-comment record is available for validation.
-    fn feed(&mut self, input: &[u8]) -> Result<bool> {
-        if self.complete {
-            return Ok(true);
-        }
-
-        let mut consumed = 0;
-        loop {
-            let (result, read, written, ends) = self.reader.read_record(
-                &input[consumed..],
-                &mut self.output[self.output_len..],
-                &mut self.ends[self.ends_len..],
-            );
-            consumed += read;
-            self.output_len += written;
-            self.ends_len += ends;
-
-            match result {
-                ReadRecordResult::InputEmpty => return Ok(false),
-                ReadRecordResult::OutputFull => {
-                    self.output.resize(self.output.len() * 2, 0);
-                }
-                ReadRecordResult::OutputEndsFull => {
-                    self.ends.resize(self.ends.len() * 2, 0);
-                }
-                ReadRecordResult::Record => {
-                    self.validate()?;
-                    self.complete = true;
-                    return Ok(true);
-                }
-                ReadRecordResult::End => return Ok(false),
-            }
-        }
-    }
-
-    /// Finishes parsing and validates a final header without a record terminator.
-    fn finish(&mut self) -> Result<()> {
-        while !self.complete {
-            if !self.feed(&[])? {
-                break;
-            }
-        }
-        Ok(())
-    }
-
-    /// Compares parsed header names with schema fields by position.
-    fn validate(&self) -> Result<()> {
-        let mut start = 0;
-        let actual = self.ends[..self.ends_len]
-            .iter()
-            .map(|end| {
-                let field = String::from_utf8_lossy(&self.output[start..*end]).into_owned();
-                start = *end;
-                field
-            })
-            .collect::<Vec<_>>();
-
-        if actual == self.expected {
-            return Ok(());
-        }
-
-        Err(DataFusionError::Execution(format!(
-            "CSV header does not conform to the schema.\nHeader: [{}]\nSchema: [{}]\nExpected: {} but found: {}\nCSV file: {}",
-            actual.join(", "),
-            self.expected.join(", "),
-            self.expected
-                .iter()
-                .zip(actual.iter())
-                .find_map(|(expected, actual)| (expected != actual).then_some(expected.as_str()))
-                .unwrap_or_else(|| self
-                    .expected
-                    .get(actual.len())
-                    .map_or("<missing>", String::as_str)),
-            self.expected
-                .iter()
-                .zip(actual.iter())
-                .find_map(|(expected, actual)| (expected != actual).then_some(actual.as_str()))
-                .unwrap_or_else(|| actual
-                    .get(self.expected.len())
-                    .map_or("<missing>", String::as_str)),
-            self.path,
-        )))
-    }
-}
-
-/// Validates a reader's CSV header and returns every byte consumed while doing so.
-fn validate_reader_header<R: Read>(
-    reader: &mut R,
-    config: &CsvSource,
-    path: &str,
-) -> Result<Vec<u8>> {
-    let mut validator = CsvHeaderValidator::new(config, path);
-    let mut prefix = Vec::new();
-    let mut buffer = [0; 8 * 1024];
-
-    while !validator.complete {
-        let read = reader.read(&mut buffer)?;
-        if read == 0 {
-            validator.finish()?;
-            break;
-        }
-        prefix.extend_from_slice(&buffer[..read]);
-        validator.feed(&buffer[..read])?;
-    }
-    Ok(prefix)
-}
-
-/// Validates a stream's CSV header and replays the inspected byte chunks.
-async fn validate_stream_header(
-    mut input: futures::stream::BoxStream<'static, Result<Bytes>>,
-    config: &CsvSource,
-    path: &str,
-) -> Result<futures::stream::BoxStream<'static, Result<Bytes>>> {
-    let mut validator = CsvHeaderValidator::new(config, path);
-    let mut prefix = Vec::new();
-
-    while !validator.complete {
-        match input.try_next().await? {
-            Some(bytes) => {
-                validator.feed(&bytes)?;
-                prefix.push(bytes);
-            }
-            None => {
-                validator.finish()?;
-                break;
-            }
-        }
-    }
-
-    Ok(futures::stream::iter(prefix.into_iter().map(Ok))
-        .chain(input)
-        .boxed())
-}
 
 #[derive(Debug, Clone)]
 pub struct CsvSource {
@@ -486,7 +310,12 @@ impl FileOpener for CsvOpener {
                     };
                     let mut decoded = LossyUtf8Reader::new(decompressed);
                     let prefix = if config.should_validate_header() {
-                        validate_reader_header(&mut decoded, &config, &path)?
+                        validate_reader_header(
+                            &mut decoded,
+                            config.table_schema.file_schema(),
+                            config.options(),
+                            &path,
+                        )?
                     } else {
                         Vec::new()
                     };
@@ -507,7 +336,13 @@ impl FileOpener for CsvOpener {
                     let input = file_compression_type.convert_stream(input)?;
                     let input = decode_utf8_lossy_stream(input);
                     let input = if config.should_validate_header() {
-                        validate_stream_header(input, &config, &path).await?
+                        validate_stream_header(
+                            input,
+                            config.table_schema.file_schema(),
+                            config.options(),
+                            &path,
+                        )
+                        .await?
                     } else {
                         input
                     };
@@ -529,87 +364,5 @@ impl FileOpener for CsvOpener {
                 }
             }
         }))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use datafusion::arrow::datatypes::{Field, Schema};
-
-    use super::*;
-
-    /// Creates a validating CSV source with the requested string columns.
-    fn source_with_fields(names: &[&str]) -> CsvSource {
-        let schema = Arc::new(Schema::new(
-            names
-                .iter()
-                .map(|name| Field::new(*name, DataType::Utf8, true))
-                .collect::<Vec<_>>(),
-        ));
-        let options = CsvOptions {
-            has_header: Some(true),
-            ..Default::default()
-        };
-
-        let mut source = CsvSource::new(schema)
-            .with_csv_options(options)
-            .with_enforce_schema(false);
-        source.batch_size = Some(1024);
-        source
-    }
-
-    /// Verifies that validated bytes are replayed to the ordinary CSV decoder.
-    #[test]
-    fn matching_reader_header_is_replayed() -> Result<()> {
-        let source = source_with_fields(&["f1", "f2"]);
-        let mut input = Cursor::new(b"f1,f2\n1,2\n".to_vec());
-        let prefix = validate_reader_header(&mut input, &source, "matching.csv")?;
-        let reader = Cursor::new(prefix).chain(input);
-        let batches = source
-            .open(reader)?
-            .collect::<std::result::Result<Vec<_>, _>>()?;
-
-        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
-        Ok(())
-    }
-
-    /// Verifies that header fields are checked against schema fields by position.
-    #[test]
-    fn mismatched_reader_header_returns_error() -> Result<()> {
-        let source = source_with_fields(&["f2", "f1"]);
-        let mut input = Cursor::new(b"f1,f2\n1,2\n".to_vec());
-        let error = validate_reader_header(&mut input, &source, "mismatched.csv")
-            .err()
-            .ok_or_else(|| {
-                DataFusionError::Execution("reversed header was accepted".to_string())
-            })?;
-
-        assert!(
-            error
-                .to_string()
-                .contains("CSV header does not conform to the schema")
-        );
-        assert!(error.to_string().contains("Expected: f2 but found: f1"));
-        assert!(error.to_string().contains("mismatched.csv"));
-        Ok(())
-    }
-
-    /// Verifies that streaming validation handles quoted fields split across chunks.
-    #[tokio::test]
-    async fn matching_stream_header_is_replayed() -> Result<()> {
-        let source = source_with_fields(&["first,name", "f2"]);
-        let chunks = vec![
-            Ok(Bytes::from_static(b"\"first")),
-            Ok(Bytes::from_static(b",name\",f2\n1")),
-            Ok(Bytes::from_static(b",2\n")),
-        ];
-        let input = futures::stream::iter(chunks).boxed();
-        let output = validate_stream_header(input, &source, "stream.csv")
-            .await?
-            .try_collect::<Vec<_>>()
-            .await?;
-
-        assert_eq!(output.concat(), b"\"first,name\",f2\n1,2\n".as_slice());
-        Ok(())
     }
 }

--- a/crates/sail-data-source/src/formats/csv/source.rs
+++ b/crates/sail-data-source/src/formats/csv/source.rs
@@ -1,8 +1,10 @@
 use std::fmt;
-use std::io::{BufReader, Read, Seek, SeekFrom};
+use std::io::{BufReader, Cursor, Read, Seek, SeekFrom};
 use std::sync::Arc;
 use std::task::Poll;
 
+use bytes::Bytes;
+use csv_core::{ReadRecordResult, Reader, ReaderBuilder, Terminator};
 use datafusion::arrow::array::RecordBatch;
 use datafusion::arrow::csv;
 use datafusion::arrow::datatypes::DataType;
@@ -30,9 +32,185 @@ use super::projected::{DecoderBatchReader, ProjectedCsvDecoder, ProjectedCsvOpti
 
 type CsvBatchReader = Box<dyn Iterator<Item = std::result::Result<RecordBatch, ArrowError>> + Send>;
 
+struct CsvHeaderValidator {
+    reader: Reader,
+    output: Vec<u8>,
+    output_len: usize,
+    ends: Vec<usize>,
+    ends_len: usize,
+    expected: Vec<String>,
+    path: String,
+    complete: bool,
+}
+
+impl CsvHeaderValidator {
+    /// Creates a header validator configured with the same dialect as the CSV reader.
+    fn new(config: &CsvSource, path: &str) -> Self {
+        let mut builder = ReaderBuilder::new();
+        builder.escape(config.escape());
+        builder.comment(config.comment());
+        builder.delimiter(config.delimiter());
+        builder.quote(config.quote());
+        if let Some(terminator) = config.terminator() {
+            builder.terminator(Terminator::Any(terminator));
+        }
+
+        Self {
+            reader: builder.build(),
+            output: vec![0; 1024],
+            output_len: 0,
+            ends: vec![0; config.table_schema.file_schema().fields().len() + 1],
+            ends_len: 0,
+            expected: config
+                .table_schema
+                .file_schema()
+                .fields()
+                .iter()
+                .map(|field| field.name().clone())
+                .collect(),
+            path: path.to_string(),
+            complete: false,
+        }
+    }
+
+    /// Feeds CSV bytes until the first non-comment record is available for validation.
+    fn feed(&mut self, input: &[u8]) -> Result<bool> {
+        if self.complete {
+            return Ok(true);
+        }
+
+        let mut consumed = 0;
+        loop {
+            let (result, read, written, ends) = self.reader.read_record(
+                &input[consumed..],
+                &mut self.output[self.output_len..],
+                &mut self.ends[self.ends_len..],
+            );
+            consumed += read;
+            self.output_len += written;
+            self.ends_len += ends;
+
+            match result {
+                ReadRecordResult::InputEmpty => return Ok(false),
+                ReadRecordResult::OutputFull => {
+                    self.output.resize(self.output.len() * 2, 0);
+                }
+                ReadRecordResult::OutputEndsFull => {
+                    self.ends.resize(self.ends.len() * 2, 0);
+                }
+                ReadRecordResult::Record => {
+                    self.validate()?;
+                    self.complete = true;
+                    return Ok(true);
+                }
+                ReadRecordResult::End => return Ok(false),
+            }
+        }
+    }
+
+    /// Finishes parsing and validates a final header without a record terminator.
+    fn finish(&mut self) -> Result<()> {
+        while !self.complete {
+            if !self.feed(&[])? {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    /// Compares parsed header names with schema fields by position.
+    fn validate(&self) -> Result<()> {
+        let mut start = 0;
+        let actual = self.ends[..self.ends_len]
+            .iter()
+            .map(|end| {
+                let field = String::from_utf8_lossy(&self.output[start..*end]).into_owned();
+                start = *end;
+                field
+            })
+            .collect::<Vec<_>>();
+
+        if actual == self.expected {
+            return Ok(());
+        }
+
+        Err(DataFusionError::Execution(format!(
+            "CSV header does not conform to the schema.\nHeader: [{}]\nSchema: [{}]\nExpected: {} but found: {}\nCSV file: {}",
+            actual.join(", "),
+            self.expected.join(", "),
+            self.expected
+                .iter()
+                .zip(actual.iter())
+                .find_map(|(expected, actual)| (expected != actual).then_some(expected.as_str()))
+                .unwrap_or_else(|| self
+                    .expected
+                    .get(actual.len())
+                    .map_or("<missing>", String::as_str)),
+            self.expected
+                .iter()
+                .zip(actual.iter())
+                .find_map(|(expected, actual)| (expected != actual).then_some(actual.as_str()))
+                .unwrap_or_else(|| actual
+                    .get(self.expected.len())
+                    .map_or("<missing>", String::as_str)),
+            self.path,
+        )))
+    }
+}
+
+/// Validates a reader's CSV header and returns every byte consumed while doing so.
+fn validate_reader_header<R: Read>(
+    reader: &mut R,
+    config: &CsvSource,
+    path: &str,
+) -> Result<Vec<u8>> {
+    let mut validator = CsvHeaderValidator::new(config, path);
+    let mut prefix = Vec::new();
+    let mut buffer = [0; 8 * 1024];
+
+    while !validator.complete {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            validator.finish()?;
+            break;
+        }
+        prefix.extend_from_slice(&buffer[..read]);
+        validator.feed(&buffer[..read])?;
+    }
+    Ok(prefix)
+}
+
+/// Validates a stream's CSV header and replays the inspected byte chunks.
+async fn validate_stream_header(
+    mut input: futures::stream::BoxStream<'static, Result<Bytes>>,
+    config: &CsvSource,
+    path: &str,
+) -> Result<futures::stream::BoxStream<'static, Result<Bytes>>> {
+    let mut validator = CsvHeaderValidator::new(config, path);
+    let mut prefix = Vec::new();
+
+    while !validator.complete {
+        match input.try_next().await? {
+            Some(bytes) => {
+                validator.feed(&bytes)?;
+                prefix.push(bytes);
+            }
+            None => {
+                validator.finish()?;
+                break;
+            }
+        }
+    }
+
+    Ok(futures::stream::iter(prefix.into_iter().map(Ok))
+        .chain(input)
+        .boxed())
+}
+
 #[derive(Debug, Clone)]
 pub struct CsvSource {
     options: CsvOptions,
+    enforce_schema: bool,
     batch_size: Option<usize>,
     table_schema: TableSchema,
     projection: SplitProjection,
@@ -44,6 +222,7 @@ impl CsvSource {
         let table_schema = table_schema.into();
         Self {
             options: CsvOptions::default(),
+            enforce_schema: true,
             batch_size: None,
             projection: SplitProjection::unprojected(&table_schema),
             table_schema,
@@ -56,12 +235,28 @@ impl CsvSource {
         self
     }
 
+    /// Sets whether the configured schema is applied without validating CSV headers.
+    pub fn with_enforce_schema(mut self, enforce_schema: bool) -> Self {
+        self.enforce_schema = enforce_schema;
+        self
+    }
+
     pub fn options(&self) -> &CsvOptions {
         &self.options
     }
 
+    /// Returns whether the configured schema is applied without validating CSV headers.
+    pub fn enforce_schema(&self) -> bool {
+        self.enforce_schema
+    }
+
     fn has_header(&self) -> bool {
         self.options.has_header.unwrap_or(true)
+    }
+
+    /// Returns whether this source should validate the first CSV record as a header.
+    fn should_validate_header(&self) -> bool {
+        self.has_header() && !self.enforce_schema
     }
 
     fn truncate_rows(&self) -> bool {
@@ -256,6 +451,7 @@ impl FileOpener for CsvOpener {
         let object_store = Arc::clone(&self.object_store);
         let terminator = self.config.terminator();
         let baseline_metrics = BaselineMetrics::new(&self.config.metrics, self.partition);
+        let path = partitioned_file.object_meta.location.to_string();
 
         Ok(Box::pin(async move {
             let calculated_range =
@@ -288,7 +484,13 @@ impl FileOpener for CsvOpener {
                             file.take((result.range.end - result.range.start) as u64),
                         )?
                     };
-                    let mut reader = config.open(LossyUtf8Reader::new(decompressed))?;
+                    let mut decoded = LossyUtf8Reader::new(decompressed);
+                    let prefix = if config.should_validate_header() {
+                        validate_reader_header(&mut decoded, &config, &path)?
+                    } else {
+                        Vec::new()
+                    };
+                    let mut reader = config.open(Cursor::new(prefix).chain(decoded))?;
                     let iterator = std::iter::from_fn(move || {
                         let mut timer = baseline_metrics.elapsed_compute().timer();
                         let result = reader.next();
@@ -303,7 +505,13 @@ impl FileOpener for CsvOpener {
                 GetResultPayload::Stream(stream) => {
                     let input = stream.map_err(DataFusionError::from).boxed();
                     let input = file_compression_type.convert_stream(input)?;
-                    let input = decode_utf8_lossy_stream(input).fuse();
+                    let input = decode_utf8_lossy_stream(input);
+                    let input = if config.should_validate_header() {
+                        validate_stream_header(input, &config, &path).await?
+                    } else {
+                        input
+                    };
+                    let input = input.fuse();
                     let stream = match config.projected_decoder()? {
                         Some(decoder) => {
                             deserialize_stream(input, DecoderDeserializer::new(decoder))
@@ -321,5 +529,87 @@ impl FileOpener for CsvOpener {
                 }
             }
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::datatypes::{Field, Schema};
+
+    use super::*;
+
+    /// Creates a validating CSV source with the requested string columns.
+    fn source_with_fields(names: &[&str]) -> CsvSource {
+        let schema = Arc::new(Schema::new(
+            names
+                .iter()
+                .map(|name| Field::new(*name, DataType::Utf8, true))
+                .collect::<Vec<_>>(),
+        ));
+        let options = CsvOptions {
+            has_header: Some(true),
+            ..Default::default()
+        };
+
+        let mut source = CsvSource::new(schema)
+            .with_csv_options(options)
+            .with_enforce_schema(false);
+        source.batch_size = Some(1024);
+        source
+    }
+
+    /// Verifies that validated bytes are replayed to the ordinary CSV decoder.
+    #[test]
+    fn matching_reader_header_is_replayed() -> Result<()> {
+        let source = source_with_fields(&["f1", "f2"]);
+        let mut input = Cursor::new(b"f1,f2\n1,2\n".to_vec());
+        let prefix = validate_reader_header(&mut input, &source, "matching.csv")?;
+        let reader = Cursor::new(prefix).chain(input);
+        let batches = source
+            .open(reader)?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+
+        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 1);
+        Ok(())
+    }
+
+    /// Verifies that header fields are checked against schema fields by position.
+    #[test]
+    fn mismatched_reader_header_returns_error() -> Result<()> {
+        let source = source_with_fields(&["f2", "f1"]);
+        let mut input = Cursor::new(b"f1,f2\n1,2\n".to_vec());
+        let error = validate_reader_header(&mut input, &source, "mismatched.csv")
+            .err()
+            .ok_or_else(|| {
+                DataFusionError::Execution("reversed header was accepted".to_string())
+            })?;
+
+        assert!(
+            error
+                .to_string()
+                .contains("CSV header does not conform to the schema")
+        );
+        assert!(error.to_string().contains("Expected: f2 but found: f1"));
+        assert!(error.to_string().contains("mismatched.csv"));
+        Ok(())
+    }
+
+    /// Verifies that streaming validation handles quoted fields split across chunks.
+    #[tokio::test]
+    async fn matching_stream_header_is_replayed() -> Result<()> {
+        let source = source_with_fields(&["first,name", "f2"]);
+        let chunks = vec![
+            Ok(Bytes::from_static(b"\"first")),
+            Ok(Bytes::from_static(b",name\",f2\n1")),
+            Ok(Bytes::from_static(b",2\n")),
+        ];
+        let input = futures::stream::iter(chunks).boxed();
+        let output = validate_stream_header(input, &source, "stream.csv")
+            .await?
+            .try_collect::<Vec<_>>()
+            .await?;
+
+        assert_eq!(output.concat(), b"\"first,name\",f2\n1,2\n".as_slice());
+        Ok(())
     }
 }

--- a/crates/sail-execution/proto/sail/plan/physical.proto
+++ b/crates/sail-execution/proto/sail/plan/physical.proto
@@ -680,6 +680,7 @@ message NdJsonExecNode {
 message CsvExecNode {
   bytes base_config = 1;
   bytes options = 2;
+  optional bool enforce_schema = 3;
 }
 
 message ParquetExecNode {

--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -561,13 +561,16 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             NodeKind::Csv(r#gen::CsvExecNode {
                 base_config,
                 options,
+                enforce_schema,
             }) => {
                 let base_config = try_decode_message(&base_config)?;
                 let table_schema = parse_table_schema_from_proto(&base_config)?;
                 let options = try_decode_message::<gen_datafusion_common::CsvOptions>(&options)?;
                 let csv_options: CsvOptions = (&options).try_into()?;
                 let file_compression_type: FileCompressionType = csv_options.compression.into();
-                let source = CsvSource::new(table_schema).with_csv_options(csv_options);
+                let source = CsvSource::new(table_schema)
+                    .with_csv_options(csv_options)
+                    .with_enforce_schema(enforce_schema.unwrap_or(true));
                 let source = parse_protobuf_file_scan_config(
                     &base_config,
                     &PhysicalPlanDecodeContext::new(ctx, self),
@@ -1923,6 +1926,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
                     NodeKind::Csv(r#gen::CsvExecNode {
                         base_config,
                         options,
+                        enforce_schema: Some(csv_source.enforce_schema()),
                     })
                 } else if let Some(parquet_source) = file_source.downcast_ref::<ParquetSource>() {
                     let base_config = try_encode_message(serialize_file_scan_config(
@@ -5293,7 +5297,11 @@ mod tests {
         };
         let mut expected_options = csv_options.clone();
         expected_options.compression = CompressionTypeVariant::GZIP;
-        let source = Arc::new(CsvSource::new(table_schema).with_csv_options(csv_options));
+        let source = Arc::new(
+            CsvSource::new(table_schema)
+                .with_csv_options(csv_options)
+                .with_enforce_schema(false),
+        );
         let file_scan = FileScanConfigBuilder::new(
             datafusion::execution::object_store::ObjectStoreUrl::local_filesystem(),
             source,
@@ -5315,6 +5323,7 @@ mod tests {
 
         assert_eq!(file_scan.file_compression_type, FileCompressionType::GZIP);
         assert_eq!(csv_source.options(), &expected_options);
+        assert!(!csv_source.enforce_schema());
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

- support the Spark CSV `enforceSchema` read option
- validate each CSV header against the requested schema during file execution
- preserve the option when physical plans are serialized to workers