### PR TITLE
fix: coerce CASE branches to common type

### DIFF
--- a/crates/sail-plan/src/function/scalar/conditional.rs
+++ b/crates/sail-plan/src/function/scalar/conditional.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use arrow::datatypes::{DataType, TimeUnit};
 use datafusion::functions::expr_fn;
 use datafusion_common::ScalarValue;
+use datafusion_expr::binary::try_type_union_resolution;
 use datafusion_expr::{ExprSchemable, ScalarUDF, cast, expr, lit};
 use sail_common_datafusion::utils::items::ItemTaker;
 use sail_function::scalar::datetime::spark_date::SparkDate;
@@ -33,7 +34,7 @@ fn case(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
             }
         }
     }
-    let branch_values = coerce_string_temporal_values(branch_values, &function_context)?;
+    let branch_values = coerce_case_values(branch_values, &function_context)?;
     let when_then_expr = conditions
         .into_iter()
         .zip(branch_values)
@@ -53,7 +54,7 @@ fn if_expr(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     } = input;
     let (when_expr, then_expr, else_expr) = arguments.three()?;
     let (then_expr, else_expr) =
-        coerce_string_temporal_values(vec![then_expr, else_expr], &function_context)?.two()?;
+        coerce_case_values(vec![then_expr, else_expr], &function_context)?.two()?;
     Ok(expr::Expr::Case(expr::Case {
         expr: None,
         when_then_expr: vec![(Box::new(when_expr), Box::new(then_expr))],
@@ -68,6 +69,29 @@ fn coalesce(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     } = input;
     let arguments = coerce_string_temporal_values(arguments, &function_context)?;
     Ok(expr_fn::coalesce(arguments))
+}
+
+fn coerce_case_values(
+    arguments: Vec<expr::Expr>,
+    function_context: &FunctionContextInput<'_>,
+) -> PlanResult<Vec<expr::Expr>> {
+    let arguments = coerce_string_temporal_values(arguments, function_context)?;
+    let data_types = arguments
+        .iter()
+        .map(|arg| arg.get_type(function_context.schema))
+        .collect::<Result<Vec<_>, _>>()?;
+    if !data_types
+        .iter()
+        .all(|data_type| data_type.is_numeric() || matches!(data_type, DataType::Null))
+    {
+        return Ok(arguments);
+    }
+    let target_types = try_type_union_resolution(&data_types)?;
+    arguments
+        .into_iter()
+        .zip(target_types)
+        .map(|(arg, target_type)| Ok(arg.cast_to(&target_type, function_context.schema)?))
+        .collect()
 }
 
 fn coerce_string_temporal_values(

--- a/python/pysail/tests/spark/function/features/conditional/if.feature
+++ b/python/pysail/tests/spark/function/features/conditional/if.feature
@@ -68,3 +68,16 @@ Feature: if output schema
         root
          |-- result: string (nullable = false)
         """
+
+  Rule: Numeric branches use a common type
+
+    Scenario: IF widens numeric branches
+      When query
+        """
+        SELECT
+          typeof(if(false, 1, CAST(1 AS BIGINT))) AS result_type,
+          if(false, 1, CAST(3000000000 AS BIGINT)) AS result
+        """
+      Then query result
+        | result_type | result     |
+        | bigint      | 3000000000 |

--- a/python/pysail/tests/spark/function/features/conditional/when.feature
+++ b/python/pysail/tests/spark/function/features/conditional/when.feature
@@ -81,3 +81,49 @@ Feature: when output schema
         root
          |-- result: decimal(11,1) (nullable = false)
         """
+
+  Rule: Numeric branches use a common type
+
+    Scenario: CASE widens branches independently of order
+      When query
+        """
+        SELECT
+          typeof(CASE WHEN false THEN 1 ELSE CAST(1 AS BIGINT) END) AS narrow_first,
+          typeof(CASE WHEN false THEN CAST(1 AS BIGINT) ELSE 1 END) AS wide_first,
+          CASE WHEN false THEN 1 ELSE CAST(3000000000 AS BIGINT) END AS value
+        """
+      Then query result
+        | narrow_first | wide_first | value      |
+        | bigint       | bigint     | 3000000000 |
+
+    Scenario Outline: CASE finds the common numeric type: <case>
+      When query
+        """
+        SELECT typeof(CASE WHEN false THEN <narrow> ELSE <wide> END) AS result_type
+        """
+      Then query result
+        | result_type |
+        | <type>      |
+
+      Examples:
+        | case               | narrow              | wide                     | type          |
+        | INT to DOUBLE      | 1                   | CAST(1 AS DOUBLE)        | double        |
+        | INT to DECIMAL     | 1                   | CAST(1 AS DECIMAL(20,0)) | decimal(20,0) |
+        | SMALLINT to BIGINT | CAST(1 AS SMALLINT) | CAST(1 AS BIGINT)        | bigint        |
+
+    Scenario: CASE common type remains valid for downstream kernels
+      When query
+        """
+        SELECT count(*) AS count
+        FROM (
+          SELECT explode(sequence(0, CASE WHEN c <= 0 THEN 1 ELSE c END - 1))
+          FROM VALUES
+            (CAST(3 AS BIGINT)),
+            (CAST(1 AS BIGINT)),
+            (CAST(5 AS BIGINT))
+          AS t(c)
+        )
+        """
+      Then query result
+        | count |
+        | 9     |


### PR DESCRIPTION
## Summary

- coerce numeric CASE and if result branches to their common DataFusion union type
- preserve existing Sail behavior for non-numeric and string/temporal branches
- cover branch order, BIGINT values, DOUBLE/DECIMAL/SMALLINT widening, and the downstream sequence/explode panic

Fixes #2503

## Testing

- cargo fmt --all --check
- cargo check -p sail-plan
- Sail conditional CASE/IF BDD features: 14 passed, 1 existing xfail
- JVM Spark conditional CASE/IF BDD features: 15 passed
- ClickBench query 39 plan snapshot: passed