### PR TITLE
fix: normalize JDBC query subqueries

### DIFF
--- a/python/pysail/spark/datasource/jdbc.py
+++ b/python/pysail/spark/datasource/jdbc.py
@@ -356,6 +356,7 @@ class JdbcDataSource(DataSource):
         if not dbtable and not query:
             msg = "Either 'dbtable' or 'query' must be specified for the jdbc data source."
             raise ValueError(msg)
+        query = query.strip().rstrip(";") if query is not None else None
 
         # --- auth ---
         user = opts.get("user") or None

--- a/python/pysail/spark/datasource/jdbc.py
+++ b/python/pysail/spark/datasource/jdbc.py
@@ -349,6 +349,7 @@ class JdbcDataSource(DataSource):
             raise ValueError(msg)
         dbtable = dbtable or None
         query = opts.get("query") or None
+        query = query.strip().rstrip(";") if query is not None else None
 
         if dbtable and query:
             msg = "Options 'dbtable' and 'query' are mutually exclusive. Specify only one."
@@ -356,7 +357,6 @@ class JdbcDataSource(DataSource):
         if not dbtable and not query:
             msg = "Either 'dbtable' or 'query' must be specified for the jdbc data source."
             raise ValueError(msg)
-        query = query.strip().rstrip(";") if query is not None else None
 
         # --- auth ---
         user = opts.get("user") or None

--- a/python/pysail/tests/spark/datasource/test_jdbc.py
+++ b/python/pysail/tests/spark/datasource/test_jdbc.py
@@ -108,11 +108,11 @@ def test_jdbc_shorthand(spark, jdbc_url):
 def test_query_option(spark, jdbc_opts):
     df = (
         spark.read.format("jdbc")
-        .option("query", "SELECT id, name FROM users WHERE active = TRUE")
+        .option("query", " SELECT id, name FROM users WHERE active = TRUE; \n")
         .options(**jdbc_opts)
         .load()
     )
-    rows = df.collect()
+    rows = df.filter("id > 0").collect()
     assert len(rows) > 0
     col_names = {f.name for f in df.schema.fields}
     assert col_names == {"id", "name"}

--- a/python/pysail/tests/spark/datasource/test_jdbc_query.py
+++ b/python/pysail/tests/spark/datasource/test_jdbc_query.py
@@ -27,6 +27,15 @@ def test_query_option_matches_spark_normalization(query, expected):
     assert datasource._resolve_options()["query"] == expected  # noqa: SLF001
 
 
+def test_query_option_rejects_empty_normalized_query():
+    from pysail.spark.datasource.jdbc import JdbcDataSource
+
+    datasource = JdbcDataSource(options={"url": "jdbc:postgresql://localhost/test", "query": " ;;; \n"})
+
+    with pytest.raises(ValueError, match="Either 'dbtable' or 'query'"):
+        datasource._resolve_options()  # noqa: SLF001
+
+
 def test_schema_and_execution_use_the_normalized_query(monkeypatch):
     from pyspark.sql.datasource import GreaterThan
 

--- a/python/pysail/tests/spark/datasource/test_jdbc_query.py
+++ b/python/pysail/tests/spark/datasource/test_jdbc_query.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pyarrow as pa
+import pytest
+
+from pysail.testing.spark.utils.common import pyspark_version
+
+if pyspark_version() < (4, 1):
+    pytest.skip("Python data source requires Spark 4.1+", allow_module_level=True)
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("SELECT 1;", "SELECT 1"),
+        (" SELECT 1; \n", "SELECT 1"),
+        ("SELECT 1;;;", "SELECT 1"),
+        ("SELECT 1", "SELECT 1"),
+        ("SELECT ';' AS x;", "SELECT ';' AS x"),
+    ],
+)
+def test_query_option_matches_spark_normalization(query, expected):
+    from pysail.spark.datasource.jdbc import JdbcDataSource
+
+    datasource = JdbcDataSource(options={"url": "jdbc:postgresql://localhost/test", "query": query})
+
+    assert datasource._resolve_options()["query"] == expected  # noqa: SLF001
+
+
+def test_schema_and_execution_use_the_normalized_query(monkeypatch):
+    from pyspark.sql.datasource import GreaterThan
+
+    from pysail.spark.datasource import jdbc
+
+    schema_queries = []
+
+    def read_sql(_conn_str, query, *, return_type):
+        assert return_type == "arrow"
+        schema_queries.append(query)
+        return pa.table({"n": pa.array([], type=pa.int64())})
+
+    monkeypatch.setattr(jdbc.cx, "read_sql", read_sql)
+    datasource = jdbc.JdbcDataSource(options={"url": "jdbc:postgresql://localhost/test", "query": " SELECT 1 AS n; \n"})
+
+    schema = datasource.schema()
+    reader = datasource.reader(schema)
+    assert list(reader.pushFilters([GreaterThan(("n",), 0)])) == []
+    partition = reader.partitions()[0]
+
+    assert schema_queries == ["SELECT * FROM (SELECT 1 AS n) AS _cx_schema_q LIMIT 0"]
+    assert ";) AS _cx_schema_q" not in schema_queries[0]
+    assert partition.query == 'SELECT * FROM (SELECT 1 AS n) AS _cx_subq WHERE "n" > 0'


### PR DESCRIPTION
## Summary

- normalize the JDBC `query` option once during option resolution
- trim surrounding whitespace and remove all terminal semicolons while preserving internal SQL
- reuse the normalized query for schema inference, reads, and filter pushdown without changing `dbtable`

Matches [Apache Spark's JDBC query normalization](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JDBCOptions.scala#L94-L99).

## Testing

- focused normalization and generated-SQL tests: 6 passed
- PostgreSQL JDBC integration suite: 35 passed
- `hatch fmt --check`
