### PR TITLE
feat: add Iceberg snapshots metadata table

### DIFF
--- a/crates/sail-common-datafusion/src/datasource.rs
+++ b/crates/sail-common-datafusion/src/datasource.rs
@@ -11,7 +11,7 @@ use datafusion::physical_expr::{
     LexOrdering, LexRequirement, PhysicalSortRequirement, create_physical_sort_exprs,
 };
 use datafusion_common::{
-    Constraints, DFSchema, DFSchemaRef, Result, not_impl_datafusion_err, plan_err,
+    Constraints, DFSchema, DFSchemaRef, Result, not_impl_datafusion_err, not_impl_err, plan_err,
 };
 use datafusion_expr::expr::Sort;
 use datafusion_expr::physical_planning_context::PhysicalPlanningContext;
@@ -442,6 +442,23 @@ pub trait DataSource: Send + Sync {
         ctx: &dyn Session,
         info: SourceInfo,
     ) -> Result<Arc<dyn TableSource>>;
+
+    /// Creates a format-owned metadata table source.
+    ///
+    /// The default is fail-closed so metadata-table semantics cannot leak into
+    /// ordinary data sources.
+    async fn create_metadata_source(
+        &self,
+        ctx: &dyn Session,
+        info: SourceInfo,
+        metadata_table: &str,
+    ) -> Result<Arc<dyn TableSource>> {
+        let _ = (ctx, info);
+        not_impl_err!(
+            "metadata table '{metadata_table}' for data source '{}'",
+            self.name()
+        )
+    }
 
     /// Infers the logical schema for planning without requiring callers to construct a read source.
     async fn infer_schema(&self, ctx: &dyn Session, info: SourceInfo) -> Result<SchemaRef> {

--- a/crates/sail-iceberg/src/datasource/metadata_table.rs
+++ b/crates/sail-iceberg/src/datasource/metadata_table.rs
@@ -1,0 +1,166 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use datafusion::arrow::array::{
+    Array, ArrayRef, Int64Array, MapArray, StringArray, TimestampMicrosecondArray,
+};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::common::{DataFusionError, Result};
+use datafusion::datasource::{MemTable, TableProvider};
+
+use crate::spec::{Snapshot, TableMetadata};
+
+/// Builds Spark-compatible rows for Iceberg's `snapshots` metadata table.
+///
+/// This table is intentionally materialized from the current metadata JSON. Snapshot
+/// metadata is small, and doing so keeps metadata inspection independent from manifest
+/// and data-file scan planning.
+pub(crate) fn snapshots_table(metadata: &TableMetadata) -> Result<Arc<dyn TableProvider>> {
+    let batch = snapshots_record_batch(&metadata.snapshots)?;
+    let schema = batch.schema();
+    Ok(Arc::new(MemTable::try_new(schema, vec![vec![batch]])?))
+}
+
+fn snapshots_record_batch(snapshots: &[Snapshot]) -> Result<RecordBatch> {
+    let mut committed_at = Vec::with_capacity(snapshots.len());
+    let mut summary_keys = Vec::new();
+    let mut summary_values = Vec::new();
+    let mut summary_offsets = Vec::with_capacity(snapshots.len() + 1);
+    summary_offsets.push(0_u32);
+
+    for snapshot in snapshots {
+        committed_at.push(snapshot.timestamp_ms().checked_mul(1_000).ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "Iceberg snapshot timestamp is out of range: {}",
+                snapshot.timestamp_ms()
+            ))
+        })?);
+
+        let mut properties = snapshot
+            .summary()
+            .additional_properties
+            .iter()
+            .collect::<Vec<_>>();
+        properties.sort_unstable_by_key(|(key, _)| *key);
+        for (key, value) in properties {
+            summary_keys.push(key.as_str());
+            summary_values.push(value.as_str());
+        }
+        summary_offsets.push(u32::try_from(summary_keys.len()).map_err(|_| {
+            DataFusionError::Plan("Iceberg snapshot summary is too large".to_string())
+        })?);
+    }
+
+    let committed_at = TimestampMicrosecondArray::from(committed_at).with_timezone("UTC");
+    let snapshot_id = Int64Array::from_iter_values(snapshots.iter().map(Snapshot::snapshot_id));
+    let parent_id = Int64Array::from(
+        snapshots
+            .iter()
+            .map(Snapshot::parent_snapshot_id)
+            .collect::<Vec<_>>(),
+    );
+    let operation = StringArray::from(
+        snapshots
+            .iter()
+            .map(|snapshot| Some(snapshot.summary().operation.as_str()))
+            .collect::<Vec<_>>(),
+    );
+    let manifest_list = StringArray::from(
+        snapshots
+            .iter()
+            .map(|snapshot| {
+                (!snapshot.manifest_list().is_empty()).then(|| snapshot.manifest_list())
+            })
+            .collect::<Vec<_>>(),
+    );
+    let summary_values = StringArray::from(summary_values);
+    let summary =
+        MapArray::new_from_strings(summary_keys.into_iter(), &summary_values, &summary_offsets)?;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new(
+            "committed_at",
+            DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+            false,
+        ),
+        Field::new("snapshot_id", DataType::Int64, false),
+        Field::new("parent_id", DataType::Int64, true),
+        Field::new("operation", DataType::Utf8, true),
+        Field::new("manifest_list", DataType::Utf8, true),
+        Field::new("summary", summary.data_type().clone(), true),
+    ]));
+    let columns: Vec<ArrayRef> = vec![
+        Arc::new(committed_at),
+        Arc::new(snapshot_id),
+        Arc::new(parent_id),
+        Arc::new(operation),
+        Arc::new(manifest_list),
+        Arc::new(summary),
+    ];
+    Ok(RecordBatch::try_new(schema, columns)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::array::{Int64Array, TimestampMicrosecondArray};
+    use datafusion::arrow::datatypes::{DataType, TimeUnit};
+
+    use super::snapshots_record_batch;
+    use crate::spec::{Operation, Snapshot, Summary};
+
+    #[test]
+    fn snapshots_use_spark_schema_and_preserve_snapshot_order()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let first = Snapshot::builder()
+            .with_snapshot_id(10)
+            .with_timestamp_ms(1_000)
+            .with_manifest_list("metadata/first.avro")
+            .with_summary(Summary::new(Operation::Append).with_property("added-records", "1"))
+            .build()?;
+        let second = Snapshot::builder()
+            .with_snapshot_id(20)
+            .with_parent_snapshot_id(10)
+            .with_timestamp_ms(2_000)
+            .with_manifest_list("metadata/second.avro")
+            .with_summary(Summary::new(Operation::Overwrite))
+            .build()?;
+
+        let batch = snapshots_record_batch(&[first, second])?;
+        assert_eq!(
+            batch.schema().field(0).data_type(),
+            &DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into()))
+        );
+        assert_eq!(
+            batch
+                .column(0)
+                .as_any()
+                .downcast_ref::<TimestampMicrosecondArray>()
+                .ok_or("committed_at type")?
+                .values(),
+            &[1_000_000, 2_000_000]
+        );
+        assert_eq!(
+            batch
+                .column(1)
+                .as_any()
+                .downcast_ref::<Int64Array>()
+                .ok_or("snapshot_id type")?
+                .values(),
+            &[10, 20]
+        );
+        assert!(batch.schema().field(5).data_type().is_nested());
+        Ok(())
+    }
+}

--- a/crates/sail-iceberg/src/datasource/mod.rs
+++ b/crates/sail-iceberg/src/datasource/mod.rs
@@ -11,6 +11,7 @@
 // limitations under the License.
 
 pub mod expressions;
+pub(crate) mod metadata_table;
 pub mod provider;
 pub mod pruning;
 pub mod type_converter;

--- a/crates/sail-iceberg/src/lake_source.rs
+++ b/crates/sail-iceberg/src/lake_source.rs
@@ -19,6 +19,7 @@ use datafusion::catalog::{Session, TableProvider};
 use datafusion::common::{
     DataFusionError, Result, TableReference, ToDFSchema, not_impl_err, plan_err,
 };
+use datafusion::datasource::provider_as_source;
 use datafusion::logical_expr::{LogicalPlan, TableScanBuilder, TableSource};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_expr::expr::Sort;
@@ -45,6 +46,7 @@ use sail_common_datafusion::variant::with_variant_extension_if_marked_storage;
 use sail_data_source::options::ResolveOptions;
 use url::Url;
 
+use crate::datasource::metadata_table::snapshots_table;
 use crate::datasource::provider::IcebergTableProvider;
 use crate::datasource::type_converter::{ICEBERG_ARROW_FIELD_DOC_KEY, arrow_schema_to_iceberg};
 use crate::io::StoreContext;
@@ -94,6 +96,16 @@ impl DataSource for IcebergLakeSource {
     ) -> Result<Arc<dyn TableSource>> {
         let provider = build_iceberg_provider(ctx, info).await?;
         Ok(Arc::new(IcebergTableSource::new(provider)))
+    }
+
+    async fn create_metadata_source(
+        &self,
+        ctx: &dyn Session,
+        info: SourceInfo,
+        metadata_table: &str,
+    ) -> Result<Arc<dyn TableSource>> {
+        let provider = build_iceberg_metadata_table_provider(ctx, info, metadata_table).await?;
+        Ok(provider_as_source(provider))
     }
 
     async fn infer_schema(
@@ -795,6 +807,36 @@ async fn build_iceberg_provider(
         catalog_managed_table,
     )
     .await
+}
+
+async fn build_iceberg_metadata_table_provider(
+    ctx: &dyn Session,
+    info: SourceInfo,
+    metadata_table: &str,
+) -> Result<Arc<dyn TableProvider>> {
+    let SourceInfo {
+        paths,
+        lakehouse_table,
+        schema: _,
+        constraints: _,
+        partition_by: _,
+        bucket_by: _,
+        sort_order: _,
+        options,
+        read_case_sensitive: _,
+    } = info;
+
+    validate_iceberg_read_lakehouse_context(lakehouse_table.as_ref())?;
+    let table_url = IcebergLakeSource::parse_table_url(paths).await?;
+    let metadata_location = metadata_location_from_options(&options);
+    let catalog_managed_table = catalog_managed_iceberg_from_options(&options);
+    let metadata_location = catalog_managed_table.then_some(metadata_location).flatten();
+    let table = Table::load_with_metadata_location(ctx, table_url, metadata_location).await?;
+
+    match metadata_table {
+        "snapshots" => snapshots_table(table.metadata()),
+        name => not_impl_err!("unsupported Iceberg metadata table: {name}"),
+    }
 }
 
 fn validate_iceberg_read_lakehouse_context(

--- a/crates/sail-plan/src/resolver/query/read.rs
+++ b/crates/sail-plan/src/resolver/query/read.rs
@@ -27,6 +27,28 @@ use crate::resolver::PlanResolver;
 use crate::resolver::function::PythonUdtf;
 use crate::resolver::state::PlanResolverState;
 
+fn split_iceberg_metadata_table_reference(
+    name: &spec::ObjectName,
+) -> Option<(spec::ObjectName, String)> {
+    let (metadata, table) = name.parts().split_last()?;
+    if table.len() < 3 {
+        return None;
+    }
+    let metadata = metadata.as_ref().to_ascii_lowercase();
+    if !matches!(metadata.as_str(), "snapshots" | "history") {
+        return None;
+    }
+    Some((
+        spec::ObjectName::from(
+            table
+                .iter()
+                .map(|part| part.as_ref().to_string())
+                .collect::<Vec<_>>(),
+        ),
+        metadata,
+    ))
+}
+
 impl PlanResolver<'_> {
     /// Resolves a named table or view reference into a logical plan node.
     /// Looks up the name in the catalog and produces the appropriate plan
@@ -68,7 +90,18 @@ impl PlanResolver<'_> {
             }
         }
 
-        let table_reference = self.resolve_table_reference(&name)?;
+        // Iceberg catalogs interpret a recognized final component after
+        // `<catalog>.<namespace>.<table>` as a metadata-table reference. Preserve
+        // every namespace component while leaving shorter and unknown multipart
+        // identifiers unchanged.
+        let (resolved_name, metadata_table) =
+            if let Some((table, metadata)) = split_iceberg_metadata_table_reference(&name) {
+                (table, Some(metadata))
+            } else {
+                (name.clone(), None)
+            };
+
+        let table_reference = self.resolve_table_reference(&resolved_name)?;
         if let Some(cte) = state.get_cte(&table_reference) {
             if temporal.is_some() {
                 return Err(PlanError::unsupported(
@@ -83,7 +116,7 @@ impl PlanResolver<'_> {
             };
         }
 
-        let reference: Vec<String> = name.clone().into();
+        let reference: Vec<String> = resolved_name.into();
         let status = self
             .ctx
             .extension::<CatalogManager>()?
@@ -102,6 +135,19 @@ impl PlanResolver<'_> {
                 properties,
                 is_external: _,
             } => {
+                if let Some(metadata_table) = metadata_table.as_deref() {
+                    if !format.eq_ignore_ascii_case("iceberg") {
+                        return Err(PlanError::unsupported(format!(
+                            "Iceberg metadata table '{metadata_table}' cannot be read from non-Iceberg table: {}",
+                            reference.join(".")
+                        )));
+                    }
+                    if metadata_table != "snapshots" {
+                        return Err(PlanError::unsupported(format!(
+                            "unsupported Iceberg metadata table: {metadata_table}"
+                        )));
+                    }
+                }
                 let schema = Schema::new(columns.iter().map(|x| x.field()).collect::<Vec<_>>());
                 let constraints = self.resolve_catalog_table_constraints(constraints, &schema)?;
                 let temporal_options = self
@@ -134,10 +180,14 @@ impl PlanResolver<'_> {
                     read_case_sensitive: self.config.case_sensitive,
                 };
                 let registry = self.ctx.extension::<DataSourceRegistry>()?;
-                let table_source = registry
-                    .get_data_source(&format)?
-                    .create_source(&self.ctx.state(), info)
-                    .await?;
+                let data_source = registry.get_data_source(&format)?;
+                let table_source = if let Some(metadata_table) = metadata_table.as_deref() {
+                    data_source
+                        .create_metadata_source(&self.ctx.state(), info, metadata_table)
+                        .await?
+                } else {
+                    data_source.create_source(&self.ctx.state(), info).await?
+                };
                 self.resolve_table_source_with_rename(
                     table_source,
                     table_reference,
@@ -153,6 +203,12 @@ impl PlanResolver<'_> {
                 comment: _,
                 properties: _,
             } => {
+                if let Some(metadata_table) = metadata_table.as_deref() {
+                    return Err(PlanError::unsupported(format!(
+                        "Iceberg metadata table '{metadata_table}' cannot be read from non-Iceberg view: {}",
+                        reference.join(".")
+                    )));
+                }
                 if temporal.is_some() {
                     return Err(PlanError::unsupported(
                         "SQL time travel is not supported for views",
@@ -162,6 +218,12 @@ impl PlanResolver<'_> {
                     .await?
             }
             TableKind::TemporaryView { plan, .. } | TableKind::GlobalTemporaryView { plan, .. } => {
+                if let Some(metadata_table) = metadata_table.as_deref() {
+                    return Err(PlanError::unsupported(format!(
+                        "Iceberg metadata table '{metadata_table}' cannot be read from non-Iceberg view: {}",
+                        reference.join(".")
+                    )));
+                }
                 if temporal.is_some() {
                     return Err(PlanError::unsupported(
                         "SQL time travel is not supported for temporary views",
@@ -560,5 +622,79 @@ impl PlanResolver<'_> {
         } else {
             Ok(table_scan)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sail_common::spec;
+
+    use super::split_iceberg_metadata_table_reference;
+
+    fn object_name(parts: &[&str]) -> spec::ObjectName {
+        spec::ObjectName::from(
+            parts
+                .iter()
+                .map(|part| (*part).to_string())
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    #[test]
+    fn splits_four_part_iceberg_metadata_table_references() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let (table, metadata) = split_iceberg_metadata_table_reference(&object_name(&[
+            "lake",
+            "sales",
+            "bronze_sales",
+            "SNAPSHOTS",
+        ]))
+        .ok_or("snapshots metadata table")?;
+        assert_eq!(
+            Vec::<String>::from(table),
+            ["lake", "sales", "bronze_sales"]
+        );
+        assert_eq!(metadata, "snapshots");
+        Ok(())
+    }
+
+    #[test]
+    fn splits_metadata_table_references_with_nested_namespaces()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let (table, metadata) = split_iceberg_metadata_table_reference(&object_name(&[
+            "lake",
+            "region",
+            "sales",
+            "bronze_sales",
+            "snapshots",
+        ]))
+        .ok_or("nested snapshots metadata table")?;
+        assert_eq!(
+            Vec::<String>::from(table),
+            ["lake", "region", "sales", "bronze_sales"]
+        );
+        assert_eq!(metadata, "snapshots");
+        Ok(())
+    }
+
+    #[test]
+    fn preserves_ordinary_and_unknown_table_references() {
+        assert!(
+            split_iceberg_metadata_table_reference(&object_name(&[
+                "lake",
+                "sales",
+                "bronze_sales",
+            ]))
+            .is_none()
+        );
+        assert!(
+            split_iceberg_metadata_table_reference(&object_name(&[
+                "lake",
+                "sales",
+                "bronze_sales",
+                "not_metadata",
+            ]))
+            .is_none()
+        );
     }
 }

--- a/python/pysail/tests/spark/iceberg/test_iceberg_metadata_tables.py
+++ b/python/pysail/tests/spark/iceberg/test_iceberg_metadata_tables.py
@@ -1,0 +1,85 @@
+import pytest
+
+from pysail.testing.spark.utils.sql import escape_sql_string_literal
+
+EXPECTED_SNAPSHOT_COUNT = 2
+
+
+def test_iceberg_snapshots_metadata_table(spark, tmp_path):
+    table = "sail.default.iceberg_metadata_snapshots"
+    location = escape_sql_string_literal((tmp_path / "iceberg_metadata_snapshots").as_uri())
+    spark.sql(f"CREATE TABLE {table} (id BIGINT) USING iceberg LOCATION '{location}'")
+    try:
+        spark.sql(f"INSERT INTO {table} VALUES (1)")  # noqa: S608
+        spark.sql(f"INSERT INTO {table} VALUES (2)")  # noqa: S608
+
+        rows_sql = f"SELECT id FROM {table} ORDER BY id"  # noqa: S608
+        assert [row.id for row in spark.sql(rows_sql).collect()] == [1, 2]
+
+        snapshots_sql = f"SELECT * FROM {table}.snapshots ORDER BY committed_at"  # noqa: S608
+        snapshots = spark.sql(snapshots_sql)
+        assert snapshots.schema.simpleString() == (
+            "struct<committed_at:timestamp,snapshot_id:bigint,parent_id:bigint,operation:string,"
+            "manifest_list:string,summary:map<string,string>>"
+        )
+        assert [(field.name, field.nullable) for field in snapshots.schema.fields] == [
+            ("committed_at", False),
+            ("snapshot_id", False),
+            ("parent_id", True),
+            ("operation", True),
+            ("manifest_list", True),
+            ("summary", True),
+        ]
+        assert snapshots.schema["summary"].dataType.valueContainsNull is False
+        rows = snapshots.collect()
+        assert len(rows) == EXPECTED_SNAPSHOT_COUNT
+        assert rows[0].committed_at <= rows[1].committed_at
+        assert rows[0].parent_id is None
+        assert rows[1].parent_id == rows[0].snapshot_id
+        assert [row.operation for row in rows] == ["append", "append"]
+
+        latest_sql = f"SELECT snapshot_id FROM {table}.snapshots ORDER BY committed_at DESC LIMIT 1"  # noqa: S608
+        latest = spark.sql(latest_sql).collect()
+        assert len(latest) == 1
+        assert latest[0].snapshot_id == rows[-1].snapshot_id
+
+        # Iceberg's snapshots metadata table is a static list of every known
+        # snapshot, so scan time travel deliberately does not filter its rows.
+        historical_sql = (
+            f"SELECT snapshot_id FROM {table}.snapshots VERSION AS OF {rows[0].snapshot_id} ORDER BY committed_at"  # noqa: S608
+        )
+        historical = spark.sql(historical_sql).collect()
+        assert [row.snapshot_id for row in historical] == [row.snapshot_id for row in rows]
+    finally:
+        spark.sql(f"DROP TABLE IF EXISTS {table}")
+
+
+def test_iceberg_unsupported_metadata_table(spark, tmp_path):
+    table = "sail.default.iceberg_metadata_unsupported"
+    location = escape_sql_string_literal((tmp_path / "iceberg_metadata_unsupported").as_uri())
+    spark.sql(f"CREATE TABLE {table} (id BIGINT) USING iceberg LOCATION '{location}'")
+    try:
+        with pytest.raises(Exception, match="unsupported Iceberg metadata table: history"):
+            spark.sql(f"SELECT * FROM {table}.history").collect()  # noqa: S608
+    finally:
+        spark.sql(f"DROP TABLE IF EXISTS {table}")
+
+
+def test_snapshots_metadata_table_rejects_non_iceberg_table(spark):
+    table = "sail.default.non_iceberg_metadata_snapshots"
+    spark.sql(f"CREATE TABLE {table} (id BIGINT) USING parquet")
+    try:
+        with pytest.raises(Exception, match=r"Iceberg metadata table 'snapshots'.*non-Iceberg table"):
+            spark.sql(f"SELECT * FROM {table}.snapshots").collect()  # noqa: S608
+    finally:
+        spark.sql(f"DROP TABLE IF EXISTS {table}")
+
+
+def test_snapshots_metadata_table_rejects_persistent_view(spark):
+    view = "sail.default.non_iceberg_metadata_view"
+    spark.sql(f"CREATE VIEW {view} AS SELECT 1 AS id")
+    try:
+        with pytest.raises(Exception, match=r"Iceberg metadata table 'snapshots'.*non-Iceberg view"):
+            spark.sql(f"SELECT * FROM {view}.snapshots").collect()  # noqa: S608
+    finally:
+        spark.sql(f"DROP VIEW IF EXISTS {view}")


### PR DESCRIPTION
## Summary

- add Spark-compatible `snapshots` metadata-table reads for catalog Iceberg tables
- preserve nested namespace components in identifiers such as `catalog.region.sales.table.snapshots`
- reject metadata suffixes on non-Iceberg tables and views, and report unsupported metadata tables explicitly
- materialize the six-field Iceberg snapshots schema from the current table metadata

## Behavior

The first supported metadata table is `snapshots`. It exposes `committed_at`, `snapshot_id`, `parent_id`, `operation`, `manifest_list` and `summary` with Iceberg-compatible types and nullability.

The snapshots table follows Apache Iceberg's static-table behavior: it lists every currently known snapshot. A scan-level `VERSION AS OF` selection does not filter that list. Other metadata tables remain unsupported and fail closed.

## Verification

Exact head: `c41b0fc6978a33a8950b858ead6077f6afe1efdb`

- `cargo fmt --all -- --check`
- `hatch fmt --check`
- 42 `sail-common-datafusion` tests passed
- 130 `sail-iceberg` tests passed
- 14 `sail-plan` tests passed
- Clippy passed with warnings denied for all three crates and all targets
- Maturin native build passed
- 4 focused Spark tests passed with `SPARK_REMOTE` explicitly unset

