### PR TITLE
refactor: remove `async_trait` for actor

### DIFF
--- a/crates/sail-celeborn/src/lifecycle/actor/core.rs
+++ b/crates/sail-celeborn/src/lifecycle/actor/core.rs
@@ -5,7 +5,6 @@ use crate::lifecycle::actor::{ApplicationRegistration, LifecycleManagerActor};
 use crate::lifecycle::{LifecycleManagerMessage, LifecycleManagerOptions};
 use crate::master::MasterClient;
 
-#[tonic::async_trait]
 impl Actor for LifecycleManagerActor {
     type Message = LifecycleManagerMessage;
     type Options = LifecycleManagerOptions;

--- a/crates/sail-celeborn/src/shuffle/actor/core.rs
+++ b/crates/sail-celeborn/src/shuffle/actor/core.rs
@@ -3,7 +3,6 @@ use sail_common::actor::{Actor, ActorAction, ActorContext};
 use crate::shuffle::ShuffleClientMessage;
 use crate::shuffle::actor::{ShuffleClientActor, ShuffleClientOptions};
 
-#[tonic::async_trait]
 impl Actor for ShuffleClientActor {
     type Message = ShuffleClientMessage;
     type Options = ShuffleClientOptions;

--- a/crates/sail-common/src/actor.rs
+++ b/crates/sail-common/src/actor.rs
@@ -62,7 +62,6 @@ impl<M: Send + 'static> Mailbox<M> for UnboundedMailbox {
     }
 }
 
-#[tonic::async_trait]
 pub trait Actor<Q = BoundedMailbox>: Sized + Send + 'static
 where
     Q: Mailbox<MessageEnvelope<Self::Message>>,
@@ -73,8 +72,9 @@ where
     fn name() -> &'static str;
     fn new(options: Self::Options) -> Self;
 
-    #[expect(unused_variables)]
-    async fn start(&mut self, ctx: &mut ActorContext<Self, Q>) {}
+    fn start(&mut self, _: &mut ActorContext<Self, Q>) -> impl Future<Output = ()> + Send {
+        std::future::ready(())
+    }
 
     /// Process one message and return the next action.
     ///
@@ -84,14 +84,15 @@ where
     /// blocking operation should be designed carefully to avoid blocking the actor for too long.
     /// If the actor needs to perform async operations that do not need to happen sequentially,
     /// it should spawn tasks via [ActorContext::spawn].
-    async fn receive(
+    fn receive(
         &mut self,
         ctx: &mut ActorContext<Self, Q>,
         message: Self::Message,
-    ) -> ActorAction;
+    ) -> impl Future<Output = ActorAction> + Send;
 
-    #[expect(unused_variables)]
-    async fn stop(self, ctx: &mut ActorContext<Self, Q>) {}
+    fn stop(self, _: &mut ActorContext<Self, Q>) -> impl Future<Output = ()> + Send {
+        std::future::ready(())
+    }
 }
 
 pub enum ActorAction {
@@ -511,7 +512,6 @@ mod tests {
         }
     }
 
-    #[tonic::async_trait]
     impl Actor for TestActor {
         type Message = TestMessage;
         type Options = ();
@@ -539,7 +539,6 @@ mod tests {
         }
     }
 
-    #[tonic::async_trait]
     impl Actor<UnboundedMailbox> for UnboundedTestActor {
         type Message = TestMessage;
         type Options = ();
@@ -567,7 +566,6 @@ mod tests {
         }
     }
 
-    #[tonic::async_trait]
     impl Actor for ParentActor {
         type Message = ParentMessage;
         type Options = oneshot::Sender<ActorHandle<TestActor>>;

--- a/crates/sail-execution/src/driver/actor/core.rs
+++ b/crates/sail-execution/src/driver/actor/core.rs
@@ -22,7 +22,6 @@ use crate::task_runner::{
     TaskRunnerPlacement,
 };
 
-#[tonic::async_trait]
 impl Actor for DriverActor {
     type Message = DriverMessage;
     type Options = (DriverOptions, DriverComponents);

--- a/crates/sail-execution/src/task_runner/actor/core.rs
+++ b/crates/sail-execution/src/task_runner/actor/core.rs
@@ -3,7 +3,6 @@ use sail_common::actor::{Actor, ActorAction, ActorContext};
 use crate::proto::RemoteExecutionCodec;
 use crate::task_runner::{TaskRunnerActor, TaskRunnerComponents, TaskRunnerMessage};
 
-#[tonic::async_trait]
 impl Actor for TaskRunnerActor {
     type Message = TaskRunnerMessage;
     type Options = TaskRunnerComponents;

--- a/crates/sail-execution/src/worker/actor/core.rs
+++ b/crates/sail-execution/src/worker/actor/core.rs
@@ -20,7 +20,6 @@ use crate::task_runner::{
 use crate::worker::peer_tracker::{PeerTracker, PeerTrackerOptions};
 use crate::worker::{WorkerActor, WorkerMessage, WorkerOptions};
 
-#[tonic::async_trait]
 impl Actor for WorkerActor {
     type Message = WorkerMessage;
     type Options = WorkerOptions;

--- a/crates/sail-session/src/session_manager/actor/core.rs
+++ b/crates/sail-session/src/session_manager/actor/core.rs
@@ -31,7 +31,6 @@ impl DriverRegistryAccessor for SessionDriverRegistry {
     }
 }
 
-#[tonic::async_trait]
 impl Actor for SessionManagerActor {
     type Message = SessionManagerMessage;
     type Options = (SessionManagerOptions, SessionManagerComponents);

--- a/crates/sail-telemetry/src/system_event/actor/core.rs
+++ b/crates/sail-telemetry/src/system_event/actor/core.rs
@@ -2,7 +2,6 @@ use sail_common::actor::{Actor, ActorAction, ActorContext};
 
 use super::{SystemEventActor, SystemEventActorMessage};
 
-#[tonic::async_trait]
 impl Actor for SystemEventActor {
     type Message = SystemEventActorMessage;
     type Options = ();


### PR DESCRIPTION
We do not use `dyn Actor` so the actor does not need to be object safe and we can use RPITIT for async methods. This avoids `async_trait` which produces boxed futures. By returning `impl Future` we avoid an extra heap allocation.

<https://github.com/lakehq/sail/pull/2524#discussion_r3886083470>