### PR TITLE
fix: leak one SQL grammar per thread instead of one per parse

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,9 @@ datasketches = { version = "0.3.0", features = ["hll", "theta"] }
 sha1 = "0.10.6"
 half = { version = "2.7.1", features = ["serde", "num-traits", "zerocopy"] }
 iana-time-zone = "0.1.65"
-chumsky = { version = "0.12.0", default-features = false, features = ["pratt"] }
+# `chumsky::cache` needs `unstable`, which `pratt` happens to enable today.
+# Outside chumsky's semver guarantees; the only user is `sail-sql-analyzer`.
+chumsky = { version = "0.12.0", default-features = false, features = ["pratt", "unstable"] }
 num = "0.4.3"
 hf-hub = { version = "0.5.0", default-features = false, features = ["tokio"] }
 reqwest = { version = "0.12.28", default-features = false, features = ["rustls-tls", "json", "multipart", "stream"] }

--- a/crates/sail-sql-analyzer/src/parser.rs
+++ b/crates/sail-sql-analyzer/src/parser.rs
@@ -1,6 +1,13 @@
-use chumsky::Parser;
-use chumsky::input::Input;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::thread::LocalKey;
+
+use chumsky::cache::{Cache, Cached};
+use chumsky::error::Rich;
+use chumsky::input::{Input, MappedInput};
 use chumsky::span::SimpleSpan;
+use chumsky::{Boxed, Parser, extra};
 use sail_sql_parser::ast::data_type::DataType;
 use sail_sql_parser::ast::expression::{Expr, IntervalLiteral};
 use sail_sql_parser::ast::identifier::{ObjectName, QualifiedWildcard};
@@ -22,40 +29,174 @@ use crate::literal::datetime::{
 };
 use crate::literal::interval::{IntervalValue, parse_unqualified_interval_string};
 
-fn map_parser_input<'a, C>(
-    (t, s): &'a (Token<'a>, SimpleSpan<usize, C>),
-) -> (&'a Token<'a>, &'a SimpleSpan<usize, C>) {
+fn map_parser_input<'a>(
+    (t, s): &'a (Token<'a>, SimpleSpan<usize>),
+) -> (&'a Token<'a>, &'a SimpleSpan<usize>) {
     (t, s)
 }
 
+type MapFn<'a> = fn(&'a (Token<'a>, SimpleSpan<usize>)) -> (&'a Token<'a>, &'a SimpleSpan<usize>);
+type TokenInput<'a> =
+    MappedInput<'a, Token<'a>, SimpleSpan<usize>, &'a [(Token<'a>, SimpleSpan<usize>)], MapFn<'a>>;
+type TokenExtra<'a> = extra::Err<Rich<'a, Token<'a>, SimpleSpan<usize>>>;
+type CharExtra<'a> = extra::Err<Rich<'a, char, SimpleSpan<usize>>>;
+type Tokens<'a> = Vec<(Token<'a>, SimpleSpan<usize>)>;
+
+/// Builds a parser once per thread instead of once per call.
+///
+/// The grammars behind `statement()` and `expression()` use
+/// `Recursive::declare()`, whose definition holds a strong `Rc` to itself, so
+/// every construction leaks. A thread keeps what it builds even after it exits,
+/// so parse these only on threads that outlive the process: moving a parse onto
+/// the blocking pool or a spawned thread turns a fixed cost back into a leak.
+macro_rules! cached_parser {
+    ($cache:ident, $output:ty, $factory:ident $(,)?) => {
+        struct $cache(&'static ParserOptions);
+
+        impl Cached for $cache {
+            type Parser<'a> = Boxed<'a, 'a, TokenInput<'a>, $output, TokenExtra<'a>>;
+
+            fn make_parser<'a>(self) -> Self::Parser<'a> {
+                $factory(self.0).boxed()
+            }
+        }
+    };
+}
+
+struct LexerCache(&'static ParserOptions);
+
+impl Cached for LexerCache {
+    type Parser<'a> = Boxed<'a, 'a, &'a str, Tokens<'a>, CharExtra<'a>>;
+
+    fn make_parser<'a>(self) -> Self::Parser<'a> {
+        create_lexer(self.0).boxed()
+    }
+}
+
+cached_parser!(DataTypeCache, DataType, create_data_type_parser);
+cached_parser!(ExpressionCache, Expr, create_expression_parser);
+cached_parser!(StatementCache, Vec<Statement>, create_parser);
+cached_parser!(ObjectNameCache, ObjectName, create_object_name_parser);
+cached_parser!(
+    QualifiedWildcardCache,
+    QualifiedWildcard,
+    create_qualified_wildcard_parser,
+);
+cached_parser!(NamedExprCache, NamedExpr, create_named_expression_parser);
+cached_parser!(
+    IntervalLiteralCache,
+    IntervalLiteral,
+    create_interval_literal_parser,
+);
+
+/// One parser per dialect, per thread: sessions sharing a dialect share a
+/// parser, and the map holds only the dialects actually used.
+type DialectCaches<C> = RefCell<HashMap<ParserOptions, Rc<Cache<C>>>>;
+
+/// Returns the parser for a dialect, building it on first use.
+///
+/// `Cached::make_parser` is quantified over the parser lifetime, so the options
+/// it borrows must be `'static`: every cache map leaks one `ParserOptions` per
+/// thread per dialect — up to one per parser kind, since each kind misses
+/// independently. The map is never borrowed across a build, which would make future
+/// re-entry a panic instead of a compile error, and `try_with` keeps a parse
+/// during thread-local teardown from panicking in a destructor.
+fn cache_for<C: Cached>(
+    caches: &'static LocalKey<DialectCaches<C>>,
+    options: &ParserOptions,
+    make: impl FnOnce(&'static ParserOptions) -> C,
+) -> Rc<Cache<C>> {
+    let cached = caches.try_with(|caches| caches.borrow().get(options).map(Rc::clone));
+    if let Ok(Some(cache)) = cached {
+        return cache;
+    }
+    let cache = Rc::new(Cache::new(make(Box::leak(Box::new(options.clone())))));
+    if cached.is_ok() {
+        let _ = caches.try_with(|caches| {
+            caches
+                .borrow_mut()
+                .insert(options.clone(), Rc::clone(&cache));
+        });
+    }
+    cache
+}
+
+thread_local! {
+    static LEXER: DialectCaches<LexerCache> = RefCell::new(HashMap::new());
+    static DATA_TYPE: DialectCaches<DataTypeCache> = RefCell::new(HashMap::new());
+    static EXPRESSION: DialectCaches<ExpressionCache> = RefCell::new(HashMap::new());
+    static STATEMENT: DialectCaches<StatementCache> = RefCell::new(HashMap::new());
+    static OBJECT_NAME: DialectCaches<ObjectNameCache> = RefCell::new(HashMap::new());
+    static QUALIFIED_WILDCARD: DialectCaches<QualifiedWildcardCache> = RefCell::new(HashMap::new());
+    static NAMED_EXPR: DialectCaches<NamedExprCache> = RefCell::new(HashMap::new());
+    static INTERVAL_LITERAL: DialectCaches<IntervalLiteralCache> = RefCell::new(HashMap::new());
+}
+
+fn tokenize<'a>(input: &'a str, options: &ParserOptions) -> SqlResult<Tokens<'a>> {
+    let cache = cache_for(&LEXER, options, LexerCache);
+    cache
+        .get()
+        .parse(input)
+        .into_result()
+        .map_err(SqlError::parser)
+}
+
 macro_rules! parse {
-    ($input:ident, $parser:ident $(,)?) => {{
+    ($input:ident, $caches:ident, $cache:ident $(,)?) => {{
         let options = ParserOptions::default();
         let length = $input.len();
-        let lexer = create_lexer::<_, chumsky::extra::Err<chumsky::error::Rich<_, _>>>(&options);
-        let tokens = lexer
-            .parse($input)
-            .into_result()
-            .map_err(SqlError::parser)?;
+        let tokens = tokenize($input, &options)?;
         let tokens = tokens
             .as_slice()
-            .map((length..length).into(), map_parser_input);
-        let parser = $parser::<_, chumsky::extra::Err<chumsky::error::Rich<_, _>>>(&options);
-        parser.parse(tokens).into_result().map_err(SqlError::parser)
+            .map((length..length).into(), map_parser_input as MapFn);
+        let cache = cache_for(&$caches, &options, $cache);
+        cache
+            .get()
+            .parse(tokens)
+            .into_result()
+            .map_err(SqlError::parser)
     }};
+}
+
+/// The same, for the dialect-independent parsers. They take no options, so
+/// there is nothing to key on, and none of them is recursive, so none leaked:
+/// they are cached so every entry point here reaches its parser the same way.
+macro_rules! simple_parser {
+    ($cache:ident, $output:ty, $factory:ident $(,)?) => {
+        struct $cache;
+
+        impl Cached for $cache {
+            type Parser<'a> = Boxed<'a, 'a, &'a str, $output, CharExtra<'a>>;
+
+            fn make_parser<'a>(self) -> Self::Parser<'a> {
+                $factory().boxed()
+            }
+        }
+    };
+}
+
+simple_parser!(DateCache, DateValue, create_date_parser);
+simple_parser!(TimeCache, TimeValue, create_time_parser);
+// `'a` is the one `Parser<'a>` introduces: a timestamp borrows its timezone.
+simple_parser!(TimestampCache, TimestampValue<'a>, create_timestamp_parser);
+
+thread_local! {
+    static DATE: Cache<DateCache> = Cache::new(DateCache);
+    static TIME: Cache<TimeCache> = Cache::new(TimeCache);
+    static TIMESTAMP: Cache<TimestampCache> = Cache::new(TimestampCache);
 }
 
 macro_rules! parse_simple {
-    ($input:ident, $parser:ident $(,)?) => {{
-        let parser = $parser::<chumsky::extra::Err<chumsky::error::Rich<_, _>>>();
-        parser.parse($input).into_result().map_err(SqlError::parser)
-    }};
+    ($input:ident, $caches:ident, $cache:ident $(,)?) => {
+        $caches
+            .try_with(|cache| cache.get().parse($input).into_result())
+            .unwrap_or_else(|_| Cache::new($cache).get().parse($input).into_result())
+            .map_err(SqlError::parser)
+    };
 }
 
 pub fn rewrite_positional_parameter_markers(s: &str) -> SqlResult<(String, usize)> {
-    let options = ParserOptions::default();
-    let lexer = create_lexer::<_, chumsky::extra::Err<chumsky::error::Rich<_, _>>>(&options);
-    let tokens = lexer.parse(s).into_result().map_err(SqlError::parser)?;
+    let tokens = tokenize(s, &ParserOptions::default())?;
 
     let mut output = String::with_capacity(s.len());
     let mut last = 0;
@@ -74,15 +215,15 @@ pub fn rewrite_positional_parameter_markers(s: &str) -> SqlResult<(String, usize
 }
 
 pub fn parse_data_type(s: &str) -> SqlResult<DataType> {
-    parse!(s, create_data_type_parser)
+    parse!(s, DATA_TYPE, DataTypeCache)
 }
 
 pub fn parse_expression(s: &str) -> SqlResult<Expr> {
-    parse!(s, create_expression_parser)
+    parse!(s, EXPRESSION, ExpressionCache)
 }
 
 pub fn parse_statements(s: &str) -> SqlResult<Vec<Statement>> {
-    parse!(s, create_parser)
+    parse!(s, STATEMENT, StatementCache)
 }
 
 /// Parses a SQL string containing exactly one statement into an AST.
@@ -95,19 +236,19 @@ pub fn parse_one_statement(s: &str) -> SqlResult<Statement> {
 }
 
 pub fn parse_object_name(s: &str) -> SqlResult<ObjectName> {
-    parse!(s, create_object_name_parser)
+    parse!(s, OBJECT_NAME, ObjectNameCache)
 }
 
 pub fn parse_qualified_wildcard(s: &str) -> SqlResult<QualifiedWildcard> {
-    parse!(s, create_qualified_wildcard_parser)
+    parse!(s, QUALIFIED_WILDCARD, QualifiedWildcardCache)
 }
 
 pub fn parse_named_expression(s: &str) -> SqlResult<NamedExpr> {
-    parse!(s, create_named_expression_parser)
+    parse!(s, NAMED_EXPR, NamedExprCache)
 }
 
 pub(crate) fn parse_interval_literal(s: &str) -> SqlResult<IntervalLiteral> {
-    parse!(s, create_interval_literal_parser)
+    parse!(s, INTERVAL_LITERAL, IntervalLiteralCache)
 }
 
 pub fn parse_interval(s: &str) -> SqlResult<IntervalValue> {
@@ -115,25 +256,56 @@ pub fn parse_interval(s: &str) -> SqlResult<IntervalValue> {
 }
 
 pub fn parse_date(s: &str) -> SqlResult<DateValue> {
-    parse_simple!(s, create_date_parser)
+    parse_simple!(s, DATE, DateCache)
 }
 
 pub fn parse_timestamp(s: &str) -> SqlResult<TimestampValue<'_>> {
-    parse_simple!(s, create_timestamp_parser)
+    parse_simple!(s, TIMESTAMP, TimestampCache)
 }
 
 pub fn parse_time(s: &str) -> SqlResult<TimeValue> {
-    parse_simple!(s, create_time_parser)
+    parse_simple!(s, TIME, TimeCache)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::rc::Rc;
+
     use sail_sql_parser::ast::query::Query;
     use sail_sql_parser::ast::statement::Statement;
+    use sail_sql_parser::options::ParserOptions;
     use sail_sql_parser::tree::TreeText;
 
     use crate::error::SqlResult;
-    use crate::parser::{parse_one_statement, parse_statements};
+    use crate::parser::{
+        STATEMENT, StatementCache, cache_for, parse_one_statement, parse_statements,
+    };
+
+    #[test]
+    fn test_cached_parser_reuse() {
+        let default = ParserOptions::default();
+        let first = cache_for(&STATEMENT, &default, StatementCache);
+        let second = cache_for(&STATEMENT, &default, StatementCache);
+        assert!(
+            Rc::ptr_eq(&first, &second),
+            "equal options must reuse the parser"
+        );
+
+        let dialect = ParserOptions {
+            allow_double_quote_identifier: true,
+            ..Default::default()
+        };
+        let third = cache_for(&STATEMENT, &dialect, StatementCache);
+        assert!(
+            !Rc::ptr_eq(&first, &third),
+            "differing options must build their own parser"
+        );
+        let fourth = cache_for(&STATEMENT, &dialect, StatementCache);
+        assert!(
+            Rc::ptr_eq(&third, &fourth),
+            "the second dialect must be cached too"
+        );
+    }
 
     #[test]
     fn test_parse() -> SqlResult<()> {

--- a/crates/sail-sql-parser/src/options.rs
+++ b/crates/sail-sql-parser/src/options.rs
@@ -1,5 +1,10 @@
 /// Options for the SQL parser.
-#[derive(Debug, Clone, Default)]
+///
+/// `Eq` and `Hash` let a parser be looked up by the dialect it was built for.
+/// Keep the set of possible values small and enumerable: a parser is built and
+/// retained for each distinct value, and a field with an open range of values
+/// would make that unbounded.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
 pub struct ParserOptions {
     /// Whether to allow dual quote escape in strings with single-character quotes.
     /// If true, the quote character can be escaped by repeating it twice.

--- a/crates/sail-sql-parser/src/parser.rs
+++ b/crates/sail-sql-parser/src/parser.rs
@@ -2,6 +2,7 @@ use chumsky::extra::ParserExtra;
 use chumsky::input::{Input, ValueInput};
 use chumsky::label::LabelError;
 use chumsky::prelude::{Recursive, end};
+use chumsky::recursive::recursive;
 use chumsky::{IterParser, Parser};
 
 use crate::ast::data_type::DataType;
@@ -62,9 +63,9 @@ where
     E: ParserExtra<'a, I> + 'a,
     E::Error: LabelError<'a, I, TokenLabel>,
 {
-    let mut data_type = Recursive::declare();
-    data_type.define(DataType::parser(data_type.clone(), options));
-    data_type
+    // `recursive()` builds the back edge weakly, so this grammar is freed on
+    // drop. The mutually recursive ones below cannot use it and still leak.
+    recursive(|data_type| DataType::parser(data_type, options))
 }
 
 fn object_name<'a, I, E>(options: &'a ParserOptions) -> impl Parser<'a, I, ObjectName, E> + Clone


### PR DESCRIPTION
## Summary

- Build each SQL parser once per thread instead of on every parse, keyed by the parser options.
- Move `data_type()` onto `recursive()`, which frees on drop.
- Name the already-enabled chumsky `unstable` feature in the manifest (`chumsky::cache` needs it).

## Problem

Every entry point in `sail-sql-analyzer::parser` rebuilt its grammar and lexer on each call, and grammars from `Recursive::declare()` hold a strong `Rc` to themselves, so each construction leaked its whole graph — about 117 KB per SQL query, never returned. Closing the session releases none of it, and neither does `malloc_trim(0)`.

Measured on an in-process server over 20k queries, with the same loop through the DataFrame API as control (it never reaches the parser): 123.4 KB/query on the SQL path against 7.3 for the control — 116.1 KB attributable.

## Solution

Each thread builds a parser once per options value and reuses it; sessions with the same dialect share one, and a hit takes no lock and allocates nothing. After: 12.1 against 7.8 KB/query — 4.3 KB attributable, 27x less. Query latency is unchanged.

The `Rc` cycle itself is upstream (zesterer/chumsky#486), so a thread keeps its grammars, about 56 KB. The threads that reach the parser are the runtime workers created at startup, so that residue is fixed rather than growing. `data_type()` is self-recursive, so `recursive()` can express it with a weak back edge and it now frees entirely.

May account for part of #1916; 3-4 KB/query from elsewhere remains.
