### PR TITLE
feat: improve metrics setup

### DIFF
--- a/crates/sail-catalog-system/src/batch.rs
+++ b/crates/sail-catalog-system/src/batch.rs
@@ -23,6 +23,7 @@ pub fn build_metrics(rows: Vec<MetricRow>) -> Result<RecordBatch> {
     #[derive(Serialize, Deserialize)]
     struct MetricMetadataRow {
         timestamp: DateTime<Utc>,
+        start_timestamp: Option<DateTime<Utc>>,
         name: String,
         attributes: BTreeMap<String, String>,
     }
@@ -31,12 +32,13 @@ pub fn build_metrics(rows: Vec<MetricRow>) -> Result<RecordBatch> {
         .iter()
         .map(|row| MetricMetadataRow {
             timestamp: row.timestamp,
+            start_timestamp: row.start_timestamp,
             name: row.name.clone(),
             attributes: row.attributes.clone(),
         })
         .collect::<Vec<_>>();
     let table_schema = SystemTable::Metrics.schema();
-    let metadata_schema = Arc::new(Schema::new(table_schema.fields()[..3].to_vec()));
+    let metadata_schema = Arc::new(Schema::new(table_schema.fields()[..4].to_vec()));
     let metadata_batch =
         ArrowSerializer::build_record_batch_with_schema(&metadata, metadata_schema)?;
     let mut values = VariantArrayBuilder::new(rows.len());

--- a/crates/sail-catalog-system/src/physical_plan.rs
+++ b/crates/sail-catalog-system/src/physical_plan.rs
@@ -11,6 +11,7 @@ use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
     apply_expression_roots,
 };
+use futures::TryStreamExt;
 use sail_common_datafusion::extension::SessionExtensionAccessor;
 use sail_system_store::catalog::SystemTable;
 
@@ -142,7 +143,8 @@ impl ExecutionPlan for SystemTableExec {
                 .extension::<SystemTableService>()?
                 .read(table, projection, filters, fetch)
                 .await
-        });
+        })
+        .try_flatten();
         Ok(Box::pin(RecordBatchStreamAdapter::new(
             self.schema(),
             stream,

--- a/crates/sail-catalog-system/src/service.rs
+++ b/crates/sail-catalog-system/src/service.rs
@@ -1,8 +1,12 @@
 use std::sync::Arc;
 
 use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::common::Result;
+use datafusion::execution::SendableRecordBatchStream;
 use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
+use futures::StreamExt;
 use sail_common_datafusion::extension::SessionExtension;
 use sail_system_store::SystemStoreReader;
 use sail_system_store::catalog::SystemTable;
@@ -13,11 +17,15 @@ use crate::predicate::PredicateExtractor;
 
 pub struct SystemTableService {
     store_reader: SystemStoreReader,
+    batch_size: usize,
 }
 
 impl SystemTableService {
-    pub fn new(store_reader: SystemStoreReader) -> Self {
-        Self { store_reader }
+    pub fn new(store_reader: SystemStoreReader, batch_size: usize) -> Self {
+        Self {
+            store_reader,
+            batch_size,
+        }
     }
 
     pub async fn read(
@@ -26,10 +34,10 @@ impl SystemTableService {
         projection: Option<Vec<usize>>,
         filters: Vec<Arc<dyn PhysicalExpr>>,
         fetch: Option<usize>,
-    ) -> Result<RecordBatch> {
+    ) -> Result<SendableRecordBatchStream> {
         let fetch = fetch.unwrap_or(usize::MAX);
         let mut filters = PredicateExtractor::new(filters);
-        let batch = match table {
+        let stream = match table {
             SystemTable::Jobs => {
                 let session_id = filters
                     .extract("session_id")?
@@ -38,11 +46,13 @@ impl SystemTableService {
                     .extract("job_id")?
                     .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
                 filters.finalize()?;
-                build_rows(
+                build_rows_stream(
                     SystemTable::Jobs,
                     self.store_reader
                         .read_jobs(session_id, job_id, fetch)
                         .await?,
+                    self.batch_size,
+                    projection,
                 )?
             }
             SystemTable::Metrics => {
@@ -54,12 +64,12 @@ impl SystemTableService {
                     .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
                 let attributes = filters.extract_map_values("attributes")?;
                 filters.finalize()?;
-                // TODO: Push the projection into metric batch construction so queries that omit
-                //   `value` do not serialize every metric payload into a Variant array.
-                build_metrics(
+                build_metrics_stream(
                     self.store_reader
                         .read_metrics(timestamp, name, attributes, fetch)
                         .await?,
+                    self.batch_size,
+                    projection,
                 )?
             }
             SystemTable::Stages => {
@@ -73,11 +83,13 @@ impl SystemTableService {
                     .extract("stage")?
                     .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
                 filters.finalize()?;
-                build_rows(
+                build_rows_stream(
                     SystemTable::Stages,
                     self.store_reader
                         .read_stages(session_id, job_id, stage, fetch)
                         .await?,
+                    self.batch_size,
+                    projection,
                 )?
             }
             SystemTable::Tasks => {
@@ -97,11 +109,13 @@ impl SystemTableService {
                     .extract("attempt")?
                     .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
                 filters.finalize()?;
-                build_rows(
+                build_rows_stream(
                     SystemTable::Tasks,
                     self.store_reader
                         .read_tasks(session_id, job_id, stage, partition, attempt, fetch)
                         .await?,
+                    self.batch_size,
+                    projection,
                 )?
             }
             SystemTable::Options => {
@@ -109,9 +123,11 @@ impl SystemTableService {
                     .extract("key")?
                     .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
                 filters.finalize()?;
-                build_rows(
+                build_rows_stream(
                     SystemTable::Options,
                     self.store_reader.read_options(key, fetch).await?,
+                    self.batch_size,
+                    projection,
                 )?
             }
             SystemTable::Sessions => {
@@ -119,9 +135,11 @@ impl SystemTableService {
                     .extract("session_id")?
                     .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
                 filters.finalize()?;
-                build_rows(
+                build_rows_stream(
                     SystemTable::Sessions,
                     self.store_reader.read_sessions(session_id, fetch).await?,
+                    self.batch_size,
+                    projection,
                 )?
             }
             SystemTable::Workers => {
@@ -132,20 +150,64 @@ impl SystemTableService {
                     .extract("worker_id")?
                     .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
                 filters.finalize()?;
-                build_rows(
+                build_rows_stream(
                     SystemTable::Workers,
                     self.store_reader
                         .read_workers(session_id, worker_id, fetch)
                         .await?,
+                    self.batch_size,
+                    projection,
                 )?
             }
         };
-        if let Some(projection) = projection {
-            Ok(batch.project(&projection)?)
-        } else {
-            Ok(batch)
-        }
+        Ok(stream)
     }
+}
+
+fn projected_schema(table: SystemTable, projection: Option<&[usize]>) -> Result<SchemaRef> {
+    match projection {
+        Some(projection) => Ok(std::sync::Arc::new(table.schema().project(projection)?)),
+        None => Ok(table.schema()),
+    }
+}
+
+fn project_batch(batch: RecordBatch, projection: Option<&[usize]>) -> Result<RecordBatch> {
+    match projection {
+        Some(projection) => Ok(batch.project(projection)?),
+        None => Ok(batch),
+    }
+}
+
+fn build_rows_stream<T>(
+    table: SystemTable,
+    rows: Vec<T>,
+    batch_size: usize,
+    projection: Option<Vec<usize>>,
+) -> Result<SendableRecordBatchStream>
+where
+    T: serde::Serialize + for<'de> serde::Deserialize<'de> + Send + 'static,
+{
+    let schema = projected_schema(table, projection.as_deref())?;
+    let stream = futures::stream::iter(rows)
+        .ready_chunks(batch_size)
+        .map(move |rows| {
+            build_rows(table, rows).and_then(|batch| project_batch(batch, projection.as_deref()))
+        });
+    Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+}
+
+fn build_metrics_stream(
+    rows: Vec<sail_system_store::catalog::MetricRow>,
+    batch_size: usize,
+    projection: Option<Vec<usize>>,
+) -> Result<SendableRecordBatchStream> {
+    let schema = projected_schema(SystemTable::Metrics, projection.as_deref())?;
+    let stream = futures::stream::iter(rows)
+        .ready_chunks(batch_size)
+        .map(move |rows| {
+            build_metrics(rows).and_then(|batch| project_batch(batch, projection.as_deref()))
+        });
+    Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
 }
 
 impl SessionExtension for SystemTableService {

--- a/crates/sail-execution/src/driver/actor/core.rs
+++ b/crates/sail-execution/src/driver/actor/core.rs
@@ -112,6 +112,7 @@ impl Actor for DriverActor {
         };
         self.task_runner = Some(ctx.children_mut().spawn::<TaskRunnerActor>(
             TaskRunnerComponents {
+                session_id: self.options.session_id.clone(),
                 extensions: TaskRunnerExtensions {
                     local_streams,
                     storage_streams,

--- a/crates/sail-execution/src/job_runner.rs
+++ b/crates/sail-execution/src/job_runner.rs
@@ -25,13 +25,15 @@ fn explain_job_graph(
 }
 
 pub struct LocalJobRunner {
+    session_id: String,
     next_job_id: AtomicU64,
     stopped: AtomicBool,
 }
 
 impl LocalJobRunner {
-    pub fn new() -> Self {
+    pub fn new(session_id: String) -> Self {
         Self {
+            session_id,
             next_job_id: AtomicU64::new(1),
             stopped: AtomicBool::new(false),
         }
@@ -40,7 +42,7 @@ impl LocalJobRunner {
 
 impl Default for LocalJobRunner {
     fn default() -> Self {
-        Self::new()
+        Self::new(String::new())
     }
 }
 
@@ -61,6 +63,7 @@ impl JobRunner for LocalJobRunner {
         let job_id = self.next_job_id.fetch_add(1, Ordering::Relaxed);
         let options = TracingExecOptions {
             metrics: global_metrics(),
+            session_id: Some(self.session_id.clone()),
             job_id: Some(job_id),
             stage: None,
             attempt: None,

--- a/crates/sail-execution/src/task_runner/actor/core.rs
+++ b/crates/sail-execution/src/task_runner/actor/core.rs
@@ -13,10 +13,12 @@ impl Actor for TaskRunnerActor {
 
     fn new(options: Self::Options) -> Self {
         let TaskRunnerComponents {
+            session_id,
             extensions,
             placement,
         } = options;
         Self {
+            session_id,
             signals: Default::default(),
             codec: Box::new(RemoteExecutionCodec),
             extensions,

--- a/crates/sail-execution/src/task_runner/actor/handler.rs
+++ b/crates/sail-execution/src/task_runner/actor/handler.rs
@@ -396,6 +396,7 @@ impl TaskRunnerActor {
             plan,
             TracingExecOptions {
                 metrics: global_metrics(),
+                session_id: Some(self.session_id.clone()),
                 job_id: Some(key.job_id.into()),
                 stage: Some(key.stage),
                 attempt: Some(key.attempt),

--- a/crates/sail-execution/src/task_runner/actor/mod.rs
+++ b/crates/sail-execution/src/task_runner/actor/mod.rs
@@ -13,6 +13,7 @@ use tokio::sync::oneshot;
 use crate::id::TaskKey;
 
 pub struct TaskRunnerActor {
+    session_id: String,
     signals: HashMap<TaskKey, oneshot::Sender<()>>,
     codec: Box<dyn PhysicalExtensionCodec>,
     extensions: TaskRunnerExtensions,

--- a/crates/sail-execution/src/task_runner/actor/options.rs
+++ b/crates/sail-execution/src/task_runner/actor/options.rs
@@ -42,6 +42,7 @@ pub enum TaskRunnerPlacement {
 }
 
 pub struct TaskRunnerComponents {
+    pub session_id: String,
     pub extensions: TaskRunnerExtensions,
     pub placement: TaskRunnerPlacement,
 }

--- a/crates/sail-execution/src/worker/actor/core.rs
+++ b/crates/sail-execution/src/worker/actor/core.rs
@@ -92,6 +92,7 @@ impl Actor for WorkerActor {
         let task_runner = ctx
             .children_mut()
             .spawn::<TaskRunnerActor>(TaskRunnerComponents {
+                session_id: self.options.session_id.clone(),
                 extensions: TaskRunnerExtensions {
                     local_streams,
                     storage_streams,

--- a/crates/sail-execution/src/worker/entrypoint.rs
+++ b/crates/sail-execution/src/worker/entrypoint.rs
@@ -23,12 +23,14 @@ pub async fn run_worker(
                     "traceparent: {x}"
                 ))));
             };
-            Span::root("worker", span_context).with_property(|| {
-                (
-                    SpanAttribute::CLUSTER_WORKER_ID,
-                    options.worker_id.to_string(),
-                )
-            })
+            Span::root("worker", span_context)
+                .with_property(|| {
+                    (
+                        SpanAttribute::CLUSTER_WORKER_ID,
+                        options.worker_id.to_string(),
+                    )
+                })
+                .with_property(|| (SpanAttribute::SESSION_ID, options.session_id.clone()))
         }
         Err(std::env::VarError::NotPresent) => Span::noop(),
         Err(e) => {

--- a/crates/sail-flight/src/metrics.rs
+++ b/crates/sail-flight/src/metrics.rs
@@ -44,6 +44,7 @@ impl StatementStatus {
 }
 
 pub struct MetricsRecordingContext {
+    pub session_id: String,
     pub statement_type: StatementType,
 }
 
@@ -62,6 +63,10 @@ impl MetricsRecordingStream {
         metrics: Arc<MetricRegistry>,
         context: MetricsRecordingContext,
     ) -> Self {
+        let session_attr = (
+            MetricAttribute::SESSION_ID,
+            Cow::Owned(context.session_id.clone()),
+        );
         let type_attr = (
             MetricAttribute::FLIGHT_STATEMENT_TYPE,
             Cow::Borrowed(context.statement_type.name()),
@@ -69,11 +74,13 @@ impl MetricsRecordingStream {
         metrics
             .flight_statement_active_count
             .adder(1i64)
+            .with_attribute(session_attr.clone())
             .with_attribute(type_attr.clone())
             .emit();
         metrics
             .flight_statement_total_count
             .adder(1u64)
+            .with_attribute(session_attr)
             .with_attribute(type_attr)
             .emit();
         Self {
@@ -89,6 +96,10 @@ impl MetricsRecordingStream {
 
 impl Drop for MetricsRecordingStream {
     fn drop(&mut self) {
+        let session_attr = (
+            MetricAttribute::SESSION_ID,
+            Cow::Owned(self.context.session_id.clone()),
+        );
         let type_attr = (
             MetricAttribute::FLIGHT_STATEMENT_TYPE,
             Cow::Borrowed(self.context.statement_type.name()),
@@ -101,17 +112,20 @@ impl Drop for MetricsRecordingStream {
         self.metrics
             .flight_statement_active_count
             .adder(-1i64)
+            .with_attribute(session_attr.clone())
             .with_attribute(type_attr.clone())
             .emit();
         self.metrics
             .flight_statement_duration
             .recorder(duration)
+            .with_attribute(session_attr.clone())
             .with_attribute(type_attr.clone())
             .with_attribute(status_attr.clone())
             .emit();
         self.metrics
             .flight_statement_row_count
             .recorder(self.rows)
+            .with_attribute(session_attr)
             .with_attribute(type_attr)
             .with_attribute(status_attr)
             .emit();

--- a/crates/sail-flight/src/service.rs
+++ b/crates/sail-flight/src/service.rs
@@ -121,7 +121,10 @@ impl FlightSqlService for SailFlightSqlService {
             Box::pin(MetricsRecordingStream::new(
                 stream,
                 m.clone(),
-                MetricsRecordingContext { statement_type },
+                MetricsRecordingContext {
+                    session_id: Self::DEFAULT_SESSION_ID.to_string(),
+                    statement_type,
+                },
             ))
         } else {
             stream

--- a/crates/sail-session/src/session_factory/job_runner.rs
+++ b/crates/sail-session/src/session_factory/job_runner.rs
@@ -99,7 +99,9 @@ impl SessionJobRunnerFactory for ServerSessionJobRunnerFactory {
         info: SessionJobRunnerInfo,
     ) -> Result<SessionJobRunner> {
         match self.config.mode {
-            ExecutionMode::Local => Ok(SessionJobRunner::local(LocalJobRunner::new())),
+            ExecutionMode::Local => Ok(SessionJobRunner::local(LocalJobRunner::new(
+                info.session_id,
+            ))),
             ExecutionMode::LocalCluster => {
                 let worker_session =
                     WorkerSessionFactory::new(self.config.clone(), self.runtime.clone())

--- a/crates/sail-session/src/session_factory/server.rs
+++ b/crates/sail-session/src/session_factory/server.rs
@@ -161,7 +161,10 @@ impl ServerSessionFactory {
                 "telemetry is not initialized for system store".to_string(),
             )
         })?;
-        Ok(SystemTableService::new(reader))
+        Ok(SystemTableService::new(
+            reader,
+            self.config.execution.batch_size,
+        ))
     }
 
     fn apply_execution_config(&mut self, config: &mut SessionConfig) -> Result<()> {

--- a/crates/sail-session/src/session_manager/actor/handler.rs
+++ b/crates/sail-session/src/session_manager/actor/handler.rs
@@ -5,6 +5,7 @@ use fastrace::collector::SpanContext;
 use log::{info, warn};
 use sail_cache::remote_checkpoint::RemoteCheckpointRegistry;
 use sail_common::actor::{ActorAction, ActorContext};
+use sail_common::telemetry::SpanAttribute;
 use sail_common_datafusion::extension::SessionExtensionAccessor;
 use sail_common_datafusion::session::activity::ActivityTracker;
 use sail_common_datafusion::session::job::JobService;
@@ -56,7 +57,8 @@ impl SessionManagerActor {
             let span = Span::root(
                 "SessionManagerActor::create_session_context",
                 SpanContext::random(),
-            );
+            )
+            .with_property(|| (SpanAttribute::SESSION_ID, session_id.clone()));
             let _guard = span.set_local_parent();
             let driver_id = match self.driver_id_generator.generate() {
                 Ok(driver_id) => driver_id,

--- a/crates/sail-system-store/data/databases.yaml
+++ b/crates/sail-system-store/data/databases.yaml
@@ -294,6 +294,12 @@
           sql_type: TIMESTAMP_LTZ(6)
           arrow_type: crate::types::timestamp()
           nullable: false
+        - name: start_timestamp
+          description: The start timestamp of the metric aggregation interval.
+          rust_type: Option<chrono::DateTime<chrono::Utc>>
+          sql_type: TIMESTAMP_LTZ(6)
+          arrow_type: crate::types::timestamp()
+          nullable: true
         - name: name
           description: The metric name.
           rust_type: String
@@ -301,7 +307,7 @@
           arrow_type: crate::types::string()
           nullable: false
         - name: attributes
-          description: The resource and data point attributes identifying the metric series.
+          description: The data point attributes identifying the metric series.
           rust_type: std::collections::BTreeMap<String, String>
           sql_type: "MAP<STRING, STRING>"
           arrow_type: crate::types::string_map()

--- a/crates/sail-system-store/src/backend/fjall.rs
+++ b/crates/sail-system-store/src/backend/fjall.rs
@@ -20,11 +20,11 @@ use crate::backend::codec::{
 use crate::catalog::{JobRow, OptionRow, SessionRow, StageRow, TaskRow, WorkerRow};
 use crate::model::{
     JobPrimaryKey, JobTable, MetricAttributeIndex, MetricAttributeKey, MetricFloatPointSeries,
-    MetricHistogramPointSeries, MetricIntegerPointSeries, MetricNameIndex, MetricPointValues,
-    MetricSeriesId, MetricSeriesIdentityTable, MetricSeriesKey, MetricSeriesMetadata,
-    MetricSeriesTable, NextMetricSeriesIdTable, OptionPrimaryKey, OptionTable, SessionPrimaryKey,
-    SessionTable, StagePrimaryKey, StageTable, StoreIndex, StoreSeries, StoreTable, TaskPrimaryKey,
-    TaskTable, WorkerPrimaryKey, WorkerTable,
+    MetricHistogramPointSeries, MetricIntegerPointSeries, MetricNameIndex, MetricPointValue,
+    MetricPointValues, MetricSeriesId, MetricSeriesIdentityTable, MetricSeriesKey,
+    MetricSeriesMetadata, MetricSeriesTable, NextMetricSeriesIdTable, OptionPrimaryKey,
+    OptionTable, SessionPrimaryKey, SessionTable, StagePrimaryKey, StageTable, StoreIndex,
+    StoreSeries, StoreTable, TaskPrimaryKey, TaskTable, WorkerPrimaryKey, WorkerTable,
 };
 
 impl From<CodecError> for fjall::Error {
@@ -493,11 +493,19 @@ macro_rules! series {
     };
 }
 
-series!(MetricIntegerPointSeries, i64, metric_integer_points);
-series!(MetricFloatPointSeries, f64, metric_float_points);
+series!(
+    MetricIntegerPointSeries,
+    MetricPointValue<i64>,
+    metric_integer_points
+);
+series!(
+    MetricFloatPointSeries,
+    MetricPointValue<f64>,
+    metric_float_points
+);
 series!(
     MetricHistogramPointSeries,
-    crate::types::MetricHistogram,
+    MetricPointValue<crate::types::MetricHistogram>,
     metric_histogram_points
 );
 
@@ -553,7 +561,7 @@ mod tests {
     use crate::engine::{MetricSample, write_event, write_metrics};
     use crate::model::{
         MetricAttributeIndex, MetricAttributeKey, MetricIntegerPointSeries, MetricNameIndex,
-        OptionPrimaryKey, OptionTable,
+        MetricPointValue, OptionPrimaryKey, OptionTable,
     };
     use crate::predicate::TimestampMicros;
     use crate::types::{MetricNumber, MetricValue};
@@ -578,12 +586,14 @@ mod tests {
                     name: "sail.metric".to_string(),
                     attributes: BTreeMap::from([("host".to_string(), "one".to_string())]),
                     timestamp: TimestampMicros(1),
+                    start_timestamp: None,
                     value: MetricValue::Gauge(MetricNumber::Integer(1)),
                 },
                 MetricSample {
                     name: "sail.metric".to_string(),
                     attributes: BTreeMap::from([("host".to_string(), "one".to_string())]),
                     timestamp: TimestampMicros(1),
+                    start_timestamp: None,
                     value: MetricValue::Gauge(MetricNumber::Integer(2)),
                 },
             ],
@@ -614,7 +624,22 @@ mod tests {
         )?;
         assert_eq!(
             points,
-            vec![(TimestampMicros(1), 1), (TimestampMicros(1), 2)]
+            vec![
+                (
+                    TimestampMicros(1),
+                    MetricPointValue {
+                        start_timestamp: None,
+                        value: 1,
+                    },
+                ),
+                (
+                    TimestampMicros(1),
+                    MetricPointValue {
+                        start_timestamp: None,
+                        value: 2,
+                    },
+                ),
+            ]
         );
         let mut name_ids = Vec::new();
         snapshot.index::<MetricNameIndex>().scan(

--- a/crates/sail-system-store/src/backend/memory.rs
+++ b/crates/sail-system-store/src/backend/memory.rs
@@ -13,10 +13,10 @@ use crate::catalog::{JobRow, OptionRow, SessionRow, StageRow, TaskRow, WorkerRow
 use crate::model::{
     JobPrimaryKey, JobTable, MetricAttributeIndex, MetricAttributeKey, MetricFloatPointSeries,
     MetricHistogramPointSeries, MetricIntegerPointSeries, MetricNameIndex, MetricPoint,
-    MetricPointValues, MetricSeriesId, MetricSeriesIdentityTable, MetricSeriesKey,
-    MetricSeriesMetadata, MetricSeriesTable, NextMetricSeriesIdTable, OptionPrimaryKey,
-    OptionTable, SessionPrimaryKey, SessionTable, StagePrimaryKey, StageTable, TaskPrimaryKey,
-    TaskTable, WorkerPrimaryKey, WorkerTable,
+    MetricPointValue, MetricPointValues, MetricSeriesId, MetricSeriesIdentityTable,
+    MetricSeriesKey, MetricSeriesMetadata, MetricSeriesTable, NextMetricSeriesIdTable,
+    OptionPrimaryKey, OptionTable, SessionPrimaryKey, SessionTable, StagePrimaryKey, StageTable,
+    TaskPrimaryKey, TaskTable, WorkerPrimaryKey, WorkerTable,
 };
 
 /// All in-memory backend state.
@@ -33,11 +33,13 @@ pub(crate) struct MemoryBackendState {
     metric_series_identities: BTreeMap<MetricSeriesKey, MetricSeriesId>,
     metric_names: BTreeMap<String, BTreeSet<MetricSeriesId>>,
     metric_attributes: BTreeMap<MetricAttributeKey, BTreeSet<MetricSeriesId>>,
-    metric_integer_points: BTreeMap<MetricSeriesId, Vec<MetricPoint<MetricPointValues<i64>>>>,
-    metric_float_points: BTreeMap<MetricSeriesId, Vec<MetricPoint<MetricPointValues<f64>>>>,
+    metric_integer_points:
+        BTreeMap<MetricSeriesId, Vec<MetricPoint<MetricPointValues<MetricPointValue<i64>>>>>,
+    metric_float_points:
+        BTreeMap<MetricSeriesId, Vec<MetricPoint<MetricPointValues<MetricPointValue<f64>>>>>,
     metric_histogram_points: BTreeMap<
         MetricSeriesId,
-        Vec<MetricPoint<MetricPointValues<crate::types::MetricHistogram>>>,
+        Vec<MetricPoint<MetricPointValues<MetricPointValue<crate::types::MetricHistogram>>>>,
     >,
 }
 
@@ -245,11 +247,19 @@ macro_rules! series {
     };
 }
 
-series!(MetricIntegerPointSeries, i64, metric_integer_points);
-series!(MetricFloatPointSeries, f64, metric_float_points);
+series!(
+    MetricIntegerPointSeries,
+    MetricPointValue<i64>,
+    metric_integer_points
+);
+series!(
+    MetricFloatPointSeries,
+    MetricPointValue<f64>,
+    metric_float_points
+);
 series!(
     MetricHistogramPointSeries,
-    crate::types::MetricHistogram,
+    MetricPointValue<crate::types::MetricHistogram>,
     metric_histogram_points
 );
 

--- a/crates/sail-system-store/src/engine/mutation.rs
+++ b/crates/sail-system-store/src/engine/mutation.rs
@@ -12,10 +12,10 @@ use crate::event::{
 use crate::model::{
     JobPrimaryKey, JobTable, MetricAttributeIndex, MetricAttributeKey, MetricAttributes,
     MetricFloatPointSeries, MetricHistogramPointSeries, MetricIntegerPointSeries, MetricNameIndex,
-    MetricSeriesIdentityTable, MetricSeriesKey, MetricSeriesKind, MetricSeriesMetadata,
-    MetricSeriesTable, NextMetricSeriesIdTable, OptionPrimaryKey, OptionTable, SessionPrimaryKey,
-    SessionTable, StagePrimaryKey, StageTable, TaskPrimaryKey, TaskTable, WorkerPrimaryKey,
-    WorkerTable,
+    MetricPointValue, MetricSeriesIdentityTable, MetricSeriesKey, MetricSeriesKind,
+    MetricSeriesMetadata, MetricSeriesTable, NextMetricSeriesIdTable, OptionPrimaryKey,
+    OptionTable, SessionPrimaryKey, SessionTable, StagePrimaryKey, StageTable, TaskPrimaryKey,
+    TaskTable, WorkerPrimaryKey, WorkerTable,
 };
 use crate::predicate::TimestampMicros;
 use crate::types::{MetricNumber, MetricValue, StageInput};
@@ -28,6 +28,7 @@ pub struct MetricSample {
     pub name: String,
     pub attributes: MetricAttributes,
     pub timestamp: TimestampMicros,
+    pub start_timestamp: Option<TimestampMicros>,
     pub value: MetricValue,
 }
 
@@ -496,16 +497,37 @@ where
         };
         match sample.value {
             MetricValue::Count(MetricNumber::Integer(value))
-            | MetricValue::Gauge(MetricNumber::Integer(value)) => writer
-                .series_mut::<MetricIntegerPointSeries>()
-                .put(id, sample.timestamp, value)?,
+            | MetricValue::Gauge(MetricNumber::Integer(value)) => {
+                writer.series_mut::<MetricIntegerPointSeries>().put(
+                    id,
+                    sample.timestamp,
+                    MetricPointValue {
+                        start_timestamp: sample.start_timestamp,
+                        value,
+                    },
+                )?
+            }
             MetricValue::Count(MetricNumber::Float(value))
-            | MetricValue::Gauge(MetricNumber::Float(value)) => writer
-                .series_mut::<MetricFloatPointSeries>()
-                .put(id, sample.timestamp, value)?,
-            MetricValue::Histogram(value) => writer
-                .series_mut::<MetricHistogramPointSeries>()
-                .put(id, sample.timestamp, value)?,
+            | MetricValue::Gauge(MetricNumber::Float(value)) => {
+                writer.series_mut::<MetricFloatPointSeries>().put(
+                    id,
+                    sample.timestamp,
+                    MetricPointValue {
+                        start_timestamp: sample.start_timestamp,
+                        value,
+                    },
+                )?
+            }
+            MetricValue::Histogram(value) => {
+                writer.series_mut::<MetricHistogramPointSeries>().put(
+                    id,
+                    sample.timestamp,
+                    MetricPointValue {
+                        start_timestamp: sample.start_timestamp,
+                        value,
+                    },
+                )?
+            }
         }
     }
     Ok(())

--- a/crates/sail-system-store/src/engine/query.rs
+++ b/crates/sail-system-store/src/engine/query.rs
@@ -11,10 +11,10 @@ use crate::access::StoreReader;
 use crate::catalog::{JobRow, MetricRow, OptionRow, SessionRow, StageRow, TaskRow, WorkerRow};
 use crate::model::{
     JobPrimaryKey, JobTable, MetricAttributeIndex, MetricAttributeKey, MetricFloatPointSeries,
-    MetricHistogramPointSeries, MetricIntegerPointSeries, MetricNameIndex, MetricSeriesId,
-    MetricSeriesKind, MetricSeriesMetadata, MetricSeriesTable, OptionPrimaryKey, OptionTable,
-    SessionPrimaryKey, SessionTable, StagePrimaryKey, StageTable, StoreSeries, TaskPrimaryKey,
-    TaskTable, WorkerPrimaryKey, WorkerTable,
+    MetricHistogramPointSeries, MetricIntegerPointSeries, MetricNameIndex, MetricPointValue,
+    MetricSeriesId, MetricSeriesKind, MetricSeriesMetadata, MetricSeriesTable, OptionPrimaryKey,
+    OptionTable, SessionPrimaryKey, SessionTable, StagePrimaryKey, StageTable, StoreSeries,
+    TaskPrimaryKey, TaskTable, WorkerPrimaryKey, WorkerTable,
 };
 use crate::predicate::{MapValueFilter, TimestampMicros, ValueFilter};
 use crate::{SystemStoreError, SystemStoreResult};
@@ -535,23 +535,30 @@ fn scan_metric_points<R, S, T>(
 ) -> SystemStoreResult<bool>
 where
     R: StoreReader + crate::access::SeriesReader<S, R::Error>,
-    S: StoreSeries<SeriesKey = MetricSeriesId, PointKey = TimestampMicros, PointValue = T>,
+    S: StoreSeries<
+            SeriesKey = MetricSeriesId,
+            PointKey = TimestampMicros,
+            PointValue = MetricPointValue<T>,
+        >,
 {
     let mut predicate_error = None;
     reader
         .series::<S>()
-        .scan(
-            &series.id,
-            lower,
-            upper,
-            &mut |point_timestamp, value| match (timestamp.predicate)(&point_timestamp) {
+        .scan(&series.id, lower, upper, &mut |point_timestamp,
+                                              point: MetricPointValue<
+            T,
+        >| {
+            match (timestamp.predicate)(&point_timestamp) {
                 Ok(true) => {
                     if let Some(timestamp) = DateTime::from_timestamp_micros(point_timestamp.0) {
                         out.push(MetricRow {
                             timestamp,
+                            start_timestamp: point
+                                .start_timestamp
+                                .and_then(|timestamp| DateTime::from_timestamp_micros(timestamp.0)),
                             name: series.name.clone(),
                             attributes: series.attributes.clone(),
-                            value: to_metric_value(value),
+                            value: to_metric_value(point.value),
                         });
                         if out.len() == fetch {
                             return false;
@@ -564,8 +571,8 @@ where
                     predicate_error = Some(SystemStoreError::from(error));
                     false
                 }
-            },
-        )
+            }
+        })
         .map_err(|error| -> SystemStoreError { error.into() })?;
     if let Some(error) = predicate_error {
         return Err(error);
@@ -740,18 +747,21 @@ mod tests {
                         name: "target".to_string(),
                         attributes: [("host".to_string(), "one".to_string())].into(),
                         timestamp: TimestampMicros(1),
+                        start_timestamp: None,
                         value: MetricValue::Gauge(MetricNumber::Integer(1)),
                     },
                     MetricSample {
                         name: "target".to_string(),
                         attributes: [("host".to_string(), "two".to_string())].into(),
                         timestamp: TimestampMicros(2),
+                        start_timestamp: Some(TimestampMicros(1)),
                         value: MetricValue::Gauge(MetricNumber::Integer(2)),
                     },
                     MetricSample {
                         name: "other".to_string(),
                         attributes: [("host".to_string(), "one".to_string())].into(),
                         timestamp: TimestampMicros(3),
+                        start_timestamp: None,
                         value: MetricValue::Gauge(MetricNumber::Integer(3)),
                     },
                 ],
@@ -776,6 +786,10 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].name, "target");
         assert_eq!(rows[0].attributes["host"], "two");
+        assert_eq!(
+            rows[0].start_timestamp,
+            chrono::DateTime::from_timestamp_micros(1)
+        );
         Ok(())
     }
 }

--- a/crates/sail-system-store/src/model.rs
+++ b/crates/sail-system-store/src/model.rs
@@ -76,6 +76,13 @@ pub struct MetricPoint<T> {
     pub value: T,
 }
 
+/// One observation in a metric point, including its optional aggregation start timestamp.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MetricPointValue<T> {
+    pub start_timestamp: Option<TimestampMicros>,
+    pub value: T,
+}
+
 /// A metric sample value as a list of observations at the same timestamp, in insertion order.
 pub type MetricPointValues<T> = SmallVec<[T; 1]>;
 
@@ -181,19 +188,19 @@ series!(
     "metric_integer_points",
     MetricSeriesId,
     TimestampMicros,
-    i64
+    MetricPointValue<i64>
 );
 series!(
     MetricFloatPointSeries,
     "metric_float_points",
     MetricSeriesId,
     TimestampMicros,
-    f64
+    MetricPointValue<f64>
 );
 series!(
     MetricHistogramPointSeries,
     "metric_histogram_points",
     MetricSeriesId,
     TimestampMicros,
-    MetricHistogram
+    MetricPointValue<MetricHistogram>
 );

--- a/crates/sail-telemetry/data/metrics/attributes.yaml
+++ b/crates/sail-telemetry/data/metrics/attributes.yaml
@@ -1,3 +1,6 @@
+- name: session.id
+  description: The unique identifier for the session.
+
 - name: execution.job.id
   description: The unique identifier for the job.
 

--- a/crates/sail-telemetry/data/metrics/registry.yaml
+++ b/crates/sail-telemetry/data/metrics/registry.yaml
@@ -4,6 +4,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -16,6 +17,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -28,6 +30,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -41,6 +44,7 @@
   type: Gauge
   value_type: f64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -53,6 +57,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -66,6 +71,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -78,6 +84,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -91,6 +98,143 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
+    - execution.job.id
+    - execution.stage
+    - execution.partition
+    - execution.attempt
+    - execution.operator.id
+    - execution.operator.name
+
+- name: execution.aggregate.peak_memory_used
+  description: The peak amount of memory used by an aggregate operation.
+  unit: byte
+  type: Gauge
+  value_type: u64
+  attributes:
+    - session.id
+    - execution.job.id
+    - execution.stage
+    - execution.partition
+    - execution.attempt
+    - execution.operator.id
+    - execution.operator.name
+
+- name: execution.aggregate.group_id_calculation_time
+  description: The time taken to calculate group IDs in an aggregate operation.
+  unit: s
+  type: Gauge
+  value_type: f64
+  attributes:
+    - session.id
+    - execution.job.id
+    - execution.stage
+    - execution.partition
+    - execution.attempt
+    - execution.operator.id
+    - execution.operator.name
+
+- name: execution.aggregate.argument_evaluation_time
+  description: The time taken to evaluate aggregate arguments.
+  unit: s
+  type: Gauge
+  value_type: f64
+  attributes:
+    - session.id
+    - execution.job.id
+    - execution.stage
+    - execution.partition
+    - execution.attempt
+    - execution.operator.id
+    - execution.operator.name
+
+- name: execution.aggregate.aggregation_time
+  description: The time taken to update aggregate values.
+  unit: s
+  type: Gauge
+  value_type: f64
+  attributes:
+    - session.id
+    - execution.job.id
+    - execution.stage
+    - execution.partition
+    - execution.attempt
+    - execution.operator.id
+    - execution.operator.name
+
+- name: execution.aggregate.output_emission_time
+  description: The time taken to emit aggregate results.
+  unit: s
+  type: Gauge
+  value_type: f64
+  attributes:
+    - session.id
+    - execution.job.id
+    - execution.stage
+    - execution.partition
+    - execution.attempt
+    - execution.operator.id
+    - execution.operator.name
+
+- name: execution.aggregate.input_row_count
+  description: The number of rows processed by an aggregate operation.
+  type: Gauge
+  value_type: u64
+  attributes:
+    - session.id
+    - execution.job.id
+    - execution.stage
+    - execution.partition
+    - execution.attempt
+    - execution.operator.id
+    - execution.operator.name
+
+- name: execution.aggregate.output_row_count
+  description: The number of rows produced by an aggregate operation.
+  type: Gauge
+  value_type: u64
+  attributes:
+    - session.id
+    - execution.job.id
+    - execution.stage
+    - execution.partition
+    - execution.attempt
+    - execution.operator.id
+    - execution.operator.name
+
+- name: execution.aggregate.skipped_row_count
+  description: The number of rows skipped by partial aggregation.
+  type: Gauge
+  value_type: u64
+  attributes:
+    - session.id
+    - execution.job.id
+    - execution.stage
+    - execution.partition
+    - execution.attempt
+    - execution.operator.id
+    - execution.operator.name
+
+- name: execution.buffer.peak_memory_used
+  description: The peak amount of memory used by a buffer operation.
+  unit: byte
+  type: Gauge
+  value_type: u64
+  attributes:
+    - session.id
+    - execution.job.id
+    - execution.stage
+    - execution.partition
+    - execution.attempt
+    - execution.operator.id
+    - execution.operator.name
+
+- name: execution.buffer.peak_queued_batch_count
+  description: The peak number of record batches queued by a buffer operation.
+  type: Gauge
+  value_type: u64
+  attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -104,6 +248,7 @@
   type: Gauge
   value_type: f64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -120,6 +265,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -134,6 +280,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -147,6 +294,7 @@
   type: Gauge
   value_type: f64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -159,6 +307,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -171,6 +320,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -185,6 +335,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -192,12 +343,13 @@
     - execution.operator.id
     - execution.operator.name
 
-- name: execution.join.build_side_memory_used
-  description: The amount of memory used by the build side of a build-probe join.
+- name: execution.join.build_side_peak_memory_used
+  description: The peak amount of memory used by the build side of a build-probe join.
   unit: byte
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -210,6 +362,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -222,6 +375,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -238,6 +392,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -251,6 +406,7 @@
   type: Gauge
   value_type: f64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -265,6 +421,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -280,6 +437,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -294,6 +452,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -308,6 +467,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -320,6 +480,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -332,6 +493,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -344,6 +506,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -356,6 +519,7 @@
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -365,12 +529,26 @@
 
 - name: execution.join.memory_used
   description: |
-    The amount of memory used by the join operation.
-    This applies to stream joins and sort merge joins.
+    The current amount of memory used by a stream join operation.
   unit: byte
   type: Gauge
   value_type: u64
   attributes:
+    - session.id
+    - execution.job.id
+    - execution.stage
+    - execution.partition
+    - execution.attempt
+    - execution.operator.id
+    - execution.operator.name
+
+- name: execution.join.peak_memory_used
+  description: The peak amount of memory used by a sort-merge join operation.
+  unit: byte
+  type: Gauge
+  value_type: u64
+  attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -383,6 +561,7 @@
   type: Counter
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -396,6 +575,7 @@
   type: Counter
   value_type: u64
   attributes:
+    - session.id
     - execution.job.id
     - execution.stage
     - execution.partition
@@ -409,6 +589,7 @@
   type: Counter
   value_type: u64
   attributes:
+    - session.id
     - flight.statement.type
 
 - name: flight.statement.active_count
@@ -416,6 +597,7 @@
   type: UpDownCounter
   value_type: i64
   attributes:
+    - session.id
     - flight.statement.type
 
 - name: flight.statement.duration
@@ -424,6 +606,7 @@
   type: Histogram
   value_type: f64
   attributes:
+    - session.id
     - flight.statement.type
     - flight.statement.status
 
@@ -432,5 +615,6 @@
   type: Histogram
   value_type: u64
   attributes:
+    - session.id
     - flight.statement.type
     - flight.statement.status

--- a/crates/sail-telemetry/src/execution/metrics/aggregate.rs
+++ b/crates/sail-telemetry/src/execution/metrics/aggregate.rs
@@ -1,0 +1,197 @@
+use datafusion::physical_plan::Metric;
+use datafusion::physical_plan::metrics::MetricValue;
+use sail_common::telemetry::KeyValue;
+
+use crate::execution::metrics::{MetricEmitter, MetricHandled};
+use crate::metrics::{MetricAttribute, MetricRegistry};
+
+/// A metric emitter for aggregate operator metrics.
+pub struct AggregateMetricEmitter;
+
+impl MetricEmitter for AggregateMetricEmitter {
+    fn try_emit(
+        &self,
+        metric: &Metric,
+        attributes: &[KeyValue],
+        registry: &MetricRegistry,
+    ) -> MetricHandled {
+        match metric.value() {
+            MetricValue::PeakMemoryUsage { name, gauge } if name == "peak_mem_used" => {
+                registry
+                    .execution_aggregate_peak_memory_used
+                    .recorder(gauge)
+                    .with_attributes(attributes)
+                    .with_optional_attribute(
+                        MetricAttribute::EXECUTION_PARTITION,
+                        metric.partition(),
+                    )
+                    .emit();
+                MetricHandled::Yes
+            }
+            MetricValue::Time { name, time } if name == "time_calculating_group_ids" => {
+                registry
+                    .execution_aggregate_group_id_calculation_time
+                    .recorder(time)
+                    .with_attributes(attributes)
+                    .with_optional_attribute(
+                        MetricAttribute::EXECUTION_PARTITION,
+                        metric.partition(),
+                    )
+                    .emit();
+                MetricHandled::Yes
+            }
+            MetricValue::Time { name, time } if name == "aggregate_arguments_time" => {
+                registry
+                    .execution_aggregate_argument_evaluation_time
+                    .recorder(time)
+                    .with_attributes(attributes)
+                    .with_optional_attribute(
+                        MetricAttribute::EXECUTION_PARTITION,
+                        metric.partition(),
+                    )
+                    .emit();
+                MetricHandled::Yes
+            }
+            MetricValue::Time { name, time } if name == "aggregation_time" => {
+                registry
+                    .execution_aggregate_aggregation_time
+                    .recorder(time)
+                    .with_attributes(attributes)
+                    .with_optional_attribute(
+                        MetricAttribute::EXECUTION_PARTITION,
+                        metric.partition(),
+                    )
+                    .emit();
+                MetricHandled::Yes
+            }
+            MetricValue::Time { name, time } if name == "emitting_time" => {
+                registry
+                    .execution_aggregate_output_emission_time
+                    .recorder(time)
+                    .with_attributes(attributes)
+                    .with_optional_attribute(
+                        MetricAttribute::EXECUTION_PARTITION,
+                        metric.partition(),
+                    )
+                    .emit();
+                MetricHandled::Yes
+            }
+            MetricValue::Count { name, count } if name == "skipped_aggregation_rows" => {
+                registry
+                    .execution_aggregate_skipped_row_count
+                    .recorder(count)
+                    .with_attributes(attributes)
+                    .with_optional_attribute(
+                        MetricAttribute::EXECUTION_PARTITION,
+                        metric.partition(),
+                    )
+                    .emit();
+                MetricHandled::Yes
+            }
+            MetricValue::Ratio {
+                name,
+                ratio_metrics,
+            } if name == "reduction_factor" => {
+                registry
+                    .execution_aggregate_input_row_count
+                    .recorder(ratio_metrics.total())
+                    .with_attributes(attributes)
+                    .with_optional_attribute(
+                        MetricAttribute::EXECUTION_PARTITION,
+                        metric.partition(),
+                    )
+                    .emit();
+                registry
+                    .execution_aggregate_output_row_count
+                    .recorder(ratio_metrics.part())
+                    .with_attributes(attributes)
+                    .with_optional_attribute(
+                        MetricAttribute::EXECUTION_PARTITION,
+                        metric.partition(),
+                    )
+                    .emit();
+                MetricHandled::Yes
+            }
+            _ => MetricHandled::No,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::arrow::array::Int32Array;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::common::{DataFusionError, Result};
+    use datafusion::execution::TaskContext;
+    use datafusion::functions_aggregate::expr_fn::count;
+    use datafusion::physical_plan::ExecutionPlan;
+    use datafusion::physical_plan::aggregates::AggregateExec;
+    use datafusion::prelude::{SessionConfig, SessionContext, col};
+
+    use crate::execution::metrics::testing::MetricEmitterTester;
+
+    fn find_aggregate_plan(plan: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionPlan>> {
+        for child in plan.children() {
+            if let Ok(plan) = find_aggregate_plan(Arc::clone(child)) {
+                return Ok(plan);
+            }
+        }
+        if plan.is::<AggregateExec>() {
+            Ok(plan)
+        } else {
+            Err(DataFusionError::Plan(
+                "aggregate plan not found".to_string(),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_aggregate_metrics() -> Result<()> {
+        let mut session_config = SessionConfig::new();
+        session_config
+            .options_mut()
+            .execution
+            .enable_migration_aggregate = false;
+        let context = SessionContext::new_with_config(session_config.clone());
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1, 1, 2]))],
+        )?;
+        let plan = context
+            .read_batch(batch)?
+            .aggregate(vec![col("a")], vec![count(col("a"))])?
+            .create_physical_plan()
+            .await?;
+
+        MetricEmitterTester::new()
+            .with_plan(find_aggregate_plan(plan)?)
+            // `peak_mem_used` is emitted by DataFusion's grouped-hash aggregate fallback.
+            .with_task_context(Arc::new(
+                TaskContext::default().with_session_config(session_config),
+            ))
+            .with_baseline_metrics()
+            .with_expected_metrics(|registry| {
+                vec![
+                    registry.execution_aggregate_peak_memory_used.name(),
+                    registry
+                        .execution_aggregate_group_id_calculation_time
+                        .name(),
+                    registry.execution_aggregate_argument_evaluation_time.name(),
+                    registry.execution_aggregate_aggregation_time.name(),
+                    registry.execution_aggregate_output_emission_time.name(),
+                    registry.execution_aggregate_input_row_count.name(),
+                    registry.execution_aggregate_output_row_count.name(),
+                    registry.execution_aggregate_skipped_row_count.name(),
+                    registry.execution_spill_count.name(),
+                    registry.execution_spill_size.name(),
+                    registry.execution_spill_row_count.name(),
+                ]
+            })
+            .run()
+            .await
+    }
+}

--- a/crates/sail-telemetry/src/execution/metrics/buffer.rs
+++ b/crates/sail-telemetry/src/execution/metrics/buffer.rs
@@ -5,10 +5,10 @@ use sail_common::telemetry::KeyValue;
 use crate::execution::metrics::{MetricEmitter, MetricHandled};
 use crate::metrics::{MetricAttribute, MetricRegistry};
 
-/// A metric emitter for filter operator metrics.
-pub struct FilterMetricEmitter;
+/// A metric emitter for buffer operator metrics.
+pub struct BufferMetricEmitter;
 
-impl MetricEmitter for FilterMetricEmitter {
+impl MetricEmitter for BufferMetricEmitter {
     fn try_emit(
         &self,
         metric: &Metric,
@@ -16,22 +16,22 @@ impl MetricEmitter for FilterMetricEmitter {
         registry: &MetricRegistry,
     ) -> MetricHandled {
         match metric.value() {
-            MetricValue::Ratio {
-                name,
-                ratio_metrics,
-            } if name == "selectivity" => {
+            MetricValue::PeakMemoryUsage { name, gauge } if name == "max_mem_used" => {
                 registry
-                    .execution_filter_input_row_count
-                    .recorder(ratio_metrics.total())
+                    .execution_buffer_peak_memory_used
+                    .recorder(gauge)
                     .with_attributes(attributes)
                     .with_optional_attribute(
                         MetricAttribute::EXECUTION_PARTITION,
                         metric.partition(),
                     )
                     .emit();
+                MetricHandled::Yes
+            }
+            MetricValue::Gauge { name, gauge } if name == "max_queued" => {
                 registry
-                    .execution_filter_output_row_count
-                    .recorder(ratio_metrics.part())
+                    .execution_buffer_peak_queued_batch_count
+                    .recorder(gauge)
                     .with_attributes(attributes)
                     .with_optional_attribute(
                         MetricAttribute::EXECUTION_PARTITION,
@@ -51,25 +51,22 @@ mod tests {
 
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use datafusion::common::Result;
-    use datafusion::physical_expr::expressions::Column;
+    use datafusion::physical_plan::buffer::BufferExec;
     use datafusion::physical_plan::empty::EmptyExec;
-    use datafusion::physical_plan::filter::FilterExec;
 
     use crate::execution::metrics::testing::MetricEmitterTester;
 
     #[tokio::test]
-    async fn test_filter_metrics() -> Result<()> {
-        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Boolean, true)]));
-        let plan = Arc::new(EmptyExec::new(schema));
-        let plan = Arc::new(FilterExec::try_new(Arc::new(Column::new("a", 0)), plan)?);
+    async fn test_buffer_metrics() -> Result<()> {
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)]));
+        let plan = Arc::new(BufferExec::new(Arc::new(EmptyExec::new(schema)), 1));
 
         MetricEmitterTester::new()
             .with_plan(plan)
-            .with_baseline_metrics()
             .with_expected_metrics(|registry| {
                 vec![
-                    registry.execution_filter_input_row_count.name(),
-                    registry.execution_filter_output_row_count.name(),
+                    registry.execution_buffer_peak_memory_used.name(),
+                    registry.execution_buffer_peak_queued_batch_count.name(),
                 ]
             })
             .run()

--- a/crates/sail-telemetry/src/execution/metrics/default.rs
+++ b/crates/sail-telemetry/src/execution/metrics/default.rs
@@ -84,7 +84,7 @@ impl MetricEmitter for DefaultMetricEmitter {
                     )
                     .emit();
             }
-            MetricValue::CurrentMemoryUsage(gauge) | MetricValue::PeakMemoryUsage { gauge, .. } => {
+            MetricValue::CurrentMemoryUsage(gauge) => {
                 registry
                     .execution_memory_used
                     .recorder(gauge)
@@ -106,7 +106,10 @@ impl MetricEmitter for DefaultMetricEmitter {
                     )
                     .emit();
             }
-            MetricValue::Count { .. }
+            // Peak-memory metrics are handled only by emitters that recognize both the physical
+            // operator and the DataFusion metric name.
+            MetricValue::PeakMemoryUsage { .. }
+            | MetricValue::Count { .. }
             | MetricValue::Gauge { .. }
             | MetricValue::Time { .. }
             | MetricValue::Ratio { .. }

--- a/crates/sail-telemetry/src/execution/metrics/join.rs
+++ b/crates/sail-telemetry/src/execution/metrics/join.rs
@@ -64,11 +64,9 @@ impl MetricEmitter for BuildProbeJoinMetricEmitter {
                     .emit();
                 MetricHandled::Yes
             }
-            MetricValue::Gauge { name, gauge } | MetricValue::PeakMemoryUsage { name, gauge }
-                if name == "build_mem_used" =>
-            {
+            MetricValue::PeakMemoryUsage { name, gauge } if name == "build_mem_used" => {
                 registry
-                    .execution_join_build_side_memory_used
+                    .execution_join_build_side_peak_memory_used
                     .recorder(gauge)
                     .with_attributes(attributes)
                     .with_optional_attribute(
@@ -309,11 +307,9 @@ impl MetricEmitter for SortMergeJoinMetricEmitter {
                     .emit();
                 MetricHandled::Yes
             }
-            MetricValue::Gauge { name, gauge } | MetricValue::PeakMemoryUsage { name, gauge }
-                if name == "peak_mem_used" =>
-            {
+            MetricValue::PeakMemoryUsage { name, gauge } if name == "peak_mem_used" => {
                 registry
-                    .execution_join_memory_used
+                    .execution_join_peak_memory_used
                     .recorder(gauge)
                     .with_attributes(attributes)
                     .with_optional_attribute(
@@ -354,7 +350,7 @@ mod tests {
             registry.execution_join_build_side_batch_count.name(),
             registry.execution_join_build_side_row_count.name(),
             registry.execution_join_build_side_match_count.name(),
-            registry.execution_join_build_side_memory_used.name(),
+            registry.execution_join_build_side_peak_memory_used.name(),
             registry.execution_join_probe_side_batch_count.name(),
             registry.execution_join_probe_side_row_count.name(),
             registry.execution_join_probe_side_matched_row_count.name(),
@@ -386,7 +382,7 @@ mod tests {
             registry.execution_join_operation_time.name(),
             registry.execution_join_input_batch_count.name(),
             registry.execution_join_input_row_count.name(),
-            registry.execution_join_memory_used.name(),
+            registry.execution_join_peak_memory_used.name(),
             registry.execution_spill_count.name(),
             registry.execution_spill_size.name(),
             registry.execution_spill_row_count.name(),
@@ -413,6 +409,7 @@ mod tests {
 
         MetricEmitterTester::new()
             .with_plan(plan)
+            .with_baseline_metrics()
             .with_expected_metrics(expected_build_probe_join_metrics)
             .run()
             .await
@@ -435,6 +432,7 @@ mod tests {
 
         MetricEmitterTester::new()
             .with_plan(plan)
+            .with_baseline_metrics()
             .with_expected_metrics(expected_build_probe_join_metrics)
             .run()
             .await
@@ -450,6 +448,7 @@ mod tests {
 
         MetricEmitterTester::new()
             .with_plan(plan)
+            .with_baseline_metrics()
             .with_expected_metrics(expected_build_probe_join_metrics)
             .run()
             .await
@@ -471,6 +470,7 @@ mod tests {
 
         MetricEmitterTester::new()
             .with_plan(plan)
+            .with_baseline_metrics()
             .with_expected_metrics(expected_build_probe_join_metrics)
             .with_expected_metrics(expected_nested_loop_join_metrics)
             .run()
@@ -497,6 +497,7 @@ mod tests {
 
         MetricEmitterTester::new()
             .with_plan(plan)
+            .with_baseline_metrics()
             .with_expected_metrics(expected_stream_join_metrics)
             .run()
             .await
@@ -523,6 +524,7 @@ mod tests {
 
         MetricEmitterTester::new()
             .with_plan(plan)
+            .with_baseline_metrics()
             .with_expected_metrics(expected_sort_merge_join_metrics)
             .run()
             .await

--- a/crates/sail-telemetry/src/execution/metrics/mod.rs
+++ b/crates/sail-telemetry/src/execution/metrics/mod.rs
@@ -1,5 +1,7 @@
 //! This module bridges DataFusion query execution metrics with OpenTelemetry.
 
+mod aggregate;
+mod buffer;
 mod default;
 mod filter;
 mod join;
@@ -7,6 +9,8 @@ mod projection;
 #[cfg(test)]
 pub(super) mod testing;
 
+use datafusion::physical_plan::aggregates::AggregateExec;
+use datafusion::physical_plan::buffer::BufferExec;
 use datafusion::physical_plan::filter::FilterExec;
 use datafusion::physical_plan::joins::{
     CrossJoinExec, HashJoinExec, NestedLoopJoinExec, PiecewiseMergeJoinExec, SortMergeJoinExec,
@@ -71,7 +75,14 @@ impl_chained_metric_emitter!(T1 T2 T3 T4 T5 T6 T7 T8 : T9);
 
 /// Build a metric emitter based on the type of the execution plan.
 pub fn build_metric_emitter(plan: &dyn ExecutionPlan) -> Box<dyn MetricEmitter> {
-    if plan.is::<ProjectionExec>() {
+    if plan.is::<AggregateExec>() {
+        Box::new((
+            aggregate::AggregateMetricEmitter,
+            default::DefaultMetricEmitter,
+        ))
+    } else if plan.is::<BufferExec>() {
+        Box::new((buffer::BufferMetricEmitter, default::DefaultMetricEmitter))
+    } else if plan.is::<ProjectionExec>() {
         Box::new((
             projection::ProjectionMetricEmitter,
             default::DefaultMetricEmitter,

--- a/crates/sail-telemetry/src/execution/metrics/projection.rs
+++ b/crates/sail-telemetry/src/execution/metrics/projection.rs
@@ -83,6 +83,7 @@ mod tests {
 
         MetricEmitterTester::new()
             .with_plan(plan)
+            .with_baseline_metrics()
             .with_expected_metrics(|registry| {
                 vec![registry.execution_expression_evaluation_time.name()]
             })

--- a/crates/sail-telemetry/src/execution/metrics/testing.rs
+++ b/crates/sail-telemetry/src/execution/metrics/testing.rs
@@ -32,6 +32,7 @@ pub struct MetricEmitterTester {
     provider: SdkMeterProvider,
     registry: Arc<MetricRegistry>,
     plan: Option<Arc<dyn ExecutionPlan>>,
+    task_context: Option<Arc<TaskContext>>,
     expected_metrics: Vec<Cow<'static, str>>,
 }
 
@@ -43,20 +44,13 @@ impl MetricEmitterTester {
             .build();
         let meter = provider.meter("test");
         let registry = Arc::new(MetricRegistry::new(&meter));
-        let expected_metrics = vec![
-            // Each DataFusion execution plan is expected to at least emit
-            // the metrics defined in `BaselineMetrics`.
-            registry.execution_output_size.name(),
-            registry.execution_output_batch_count.name(),
-            registry.execution_output_row_count.name(),
-            registry.execution_elapsed_compute_time.name(),
-        ];
         Self {
             exporter,
             provider,
             registry,
             plan: None,
-            expected_metrics,
+            task_context: None,
+            expected_metrics: vec![],
         }
     }
 
@@ -66,6 +60,23 @@ impl MetricEmitterTester {
     /// No metrics will be emitted for the child plans.
     pub fn with_plan(mut self, plan: Arc<dyn ExecutionPlan>) -> Self {
         self.plan = Some(plan);
+        self
+    }
+
+    /// Set the task context used to execute the plan.
+    pub fn with_task_context(mut self, task_context: Arc<TaskContext>) -> Self {
+        self.task_context = Some(task_context);
+        self
+    }
+
+    /// Expect the metrics provided by DataFusion's `BaselineMetrics`.
+    pub fn with_baseline_metrics(mut self) -> Self {
+        self.expected_metrics.extend([
+            self.registry.execution_output_size.name(),
+            self.registry.execution_output_batch_count.name(),
+            self.registry.execution_output_row_count.name(),
+            self.registry.execution_elapsed_compute_time.name(),
+        ]);
         self
     }
 
@@ -86,7 +97,9 @@ impl MetricEmitterTester {
             collection_interval: Duration::ZERO,
         });
         let plan = Arc::new(TracingExec::new(plan, options));
-        let context = Arc::new(TaskContext::default());
+        let context = self
+            .task_context
+            .unwrap_or_else(|| Arc::new(TaskContext::default()));
         let _ = plan.execute(0, context)?.try_collect::<Vec<_>>().await?;
         self.provider
             .force_flush()

--- a/crates/sail-telemetry/src/execution/physical_plan.rs
+++ b/crates/sail-telemetry/src/execution/physical_plan.rs
@@ -42,6 +42,7 @@ use crate::metrics::{MetricAttribute, MetricManager, MetricRegistry};
 #[derive(Debug, Clone, Default)]
 pub struct TracingExecOptions {
     pub metrics: Option<MetricManager>,
+    pub session_id: Option<String>,
     pub job_id: Option<u64>,
     pub stage: Option<usize>,
     pub attempt: Option<usize>,
@@ -209,6 +210,11 @@ impl ExecutionPlan for TracingExec {
     ) -> Result<SendableRecordBatchStream> {
         let span = Span::enter_with_local_parent(self.inner.name().to_string())
             .with_property(|| (SpanAttribute::EXECUTION_PARTITION, partition.to_string()));
+        let span = if let Some(session_id) = self.options.session_id.clone() {
+            span.with_property(|| (SpanAttribute::SESSION_ID, session_id))
+        } else {
+            span
+        };
         let stream = {
             let _guard = span.set_local_parent();
             self.inner.execute(partition, context)?
@@ -340,6 +346,9 @@ impl TracingExec {
 
     fn build_metric_attributes(&self) -> Vec<KeyValue> {
         let mut attributes = vec![];
+        if let Some(session_id) = &self.options.session_id {
+            attributes.push((MetricAttribute::SESSION_ID, session_id.clone().into()));
+        }
         if let Some(job_id) = self.options.job_id {
             attributes.push((MetricAttribute::EXECUTION_JOB_ID, job_id.to_string().into()));
         }

--- a/crates/sail-telemetry/src/lib.rs
+++ b/crates/sail-telemetry/src/lib.rs
@@ -15,11 +15,11 @@ pub enum ResourceKind {
 }
 
 impl ResourceKind {
-    pub const fn as_str(self) -> &'static str {
+    pub const fn service_name(self) -> &'static str {
         match self {
-            Self::Server => "server",
-            Self::FlightServer => "flight-server",
-            Self::Worker => "worker",
+            Self::Server => "sail-server",
+            Self::FlightServer => "sail-flight-server",
+            Self::Worker => "sail-worker",
         }
     }
 }

--- a/crates/sail-telemetry/src/metrics/reporter.rs
+++ b/crates/sail-telemetry/src/metrics/reporter.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue, any_value};
 use opentelemetry_proto::tonic::metrics::v1::{
     HistogramDataPoint, NumberDataPoint, ResourceMetrics, metric, number_data_point,
@@ -10,8 +8,6 @@ use sail_system_store::{MetricSample, SystemStoreHandle};
 
 use crate::SCOPE_NAME;
 use crate::error::{TelemetryError, TelemetryResult};
-
-type MetricAttributes = BTreeMap<String, String>;
 
 #[derive(Clone, Copy)]
 enum NumericMetricKind {
@@ -55,10 +51,6 @@ impl SystemMetricReporter {
 fn decode_metric_samples(resource_metrics: Vec<ResourceMetrics>) -> Vec<MetricSample> {
     let mut samples = vec![];
     for resource_metrics in resource_metrics {
-        let resource_attributes = resource_metrics
-            .resource
-            .map(|resource| canonical_attributes(resource.attributes))
-            .unwrap_or_default();
         for scope in resource_metrics.scope_metrics {
             for metric in scope.metrics {
                 let name = metric.name;
@@ -68,7 +60,6 @@ fn decode_metric_samples(resource_metrics: Vec<ResourceMetrics>) -> Vec<MetricSa
                             append_number_sample(
                                 &mut samples,
                                 &name,
-                                &resource_attributes,
                                 point,
                                 NumericMetricKind::Gauge,
                             );
@@ -79,7 +70,6 @@ fn decode_metric_samples(resource_metrics: Vec<ResourceMetrics>) -> Vec<MetricSa
                             append_number_sample(
                                 &mut samples,
                                 &name,
-                                &resource_attributes,
                                 point,
                                 NumericMetricKind::Count,
                             );
@@ -87,12 +77,7 @@ fn decode_metric_samples(resource_metrics: Vec<ResourceMetrics>) -> Vec<MetricSa
                     }
                     Some(metric::Data::Histogram(histogram)) => {
                         for point in histogram.data_points {
-                            append_histogram_sample(
-                                &mut samples,
-                                &name,
-                                &resource_attributes,
-                                point,
-                            );
+                            append_histogram_sample(&mut samples, &name, point);
                         }
                     }
                     // The public system table contract supports only count, gauge, and explicit
@@ -108,7 +93,6 @@ fn decode_metric_samples(resource_metrics: Vec<ResourceMetrics>) -> Vec<MetricSa
 fn append_number_sample(
     samples: &mut Vec<MetricSample>,
     name: &str,
-    resource_attributes: &MetricAttributes,
     point: NumberDataPoint,
     kind: NumericMetricKind,
 ) {
@@ -127,25 +111,22 @@ fn append_number_sample(
     };
     samples.push(MetricSample {
         name: name.to_string(),
-        attributes: merge_attributes(resource_attributes, point.attributes),
+        attributes: canonical_attributes(point.attributes),
         timestamp,
+        start_timestamp: start_timestamp_micros(point.start_time_unix_nano),
         value,
     });
 }
 
-fn append_histogram_sample(
-    samples: &mut Vec<MetricSample>,
-    name: &str,
-    resource_attributes: &MetricAttributes,
-    point: HistogramDataPoint,
-) {
+fn append_histogram_sample(samples: &mut Vec<MetricSample>, name: &str, point: HistogramDataPoint) {
     let Some(timestamp) = timestamp_micros(point.time_unix_nano) else {
         return;
     };
     samples.push(MetricSample {
         name: name.to_string(),
-        attributes: merge_attributes(resource_attributes, point.attributes),
+        attributes: canonical_attributes(point.attributes),
         timestamp,
+        start_timestamp: start_timestamp_micros(point.start_time_unix_nano),
         value: MetricValue::Histogram(MetricHistogram {
             count: point.count,
             sum: point.sum,
@@ -163,13 +144,13 @@ fn timestamp_micros(timestamp_nanos: u64) -> Option<TimestampMicros> {
         .map(TimestampMicros)
 }
 
-fn merge_attributes(resource: &MetricAttributes, point: Vec<KeyValue>) -> MetricAttributes {
-    let mut attributes = resource.clone();
-    attributes.extend(canonical_attributes(point));
-    attributes
+fn start_timestamp_micros(timestamp_nanos: u64) -> Option<TimestampMicros> {
+    (timestamp_nanos != 0)
+        .then_some(timestamp_nanos)
+        .and_then(timestamp_micros)
 }
 
-fn canonical_attributes(attributes: Vec<KeyValue>) -> MetricAttributes {
+fn canonical_attributes(attributes: Vec<KeyValue>) -> BTreeMap<String, String> {
     attributes
         .into_iter()
         .filter_map(|attribute| {
@@ -236,3 +217,4 @@ fn attribute_json_value(value: AnyValue) -> serde_json::Value {
         None => serde_json::Value::Null,
     }
 }
+use std::collections::BTreeMap;

--- a/crates/sail-telemetry/src/telemetry.rs
+++ b/crates/sail-telemetry/src/telemetry.rs
@@ -8,9 +8,9 @@ use datafusion::common::runtime::set_join_set_tracer;
 use fastrace::collector::{Config, Reporter, SpanRecord};
 use fastrace_opentelemetry::OpenTelemetryReporter;
 use log::{Log, debug};
+use opentelemetry::InstrumentationScope;
 use opentelemetry::logs::LoggerProvider;
-use opentelemetry::metrics::Meter;
-use opentelemetry::{InstrumentationScope, global};
+use opentelemetry::metrics::{Meter, MeterProvider};
 use opentelemetry_appender_log::OpenTelemetryLogBridge;
 use opentelemetry_otlp::{LogExporter, Protocol, WithExportConfig};
 use opentelemetry_sdk::Resource;
@@ -47,9 +47,6 @@ struct TelemetryState {
     runtime: Option<tokio::runtime::Handle>,
     actor_system: Option<ActorSystem>,
     system_store: Option<SystemStoreHandle>,
-    system_store_reader: Option<SystemStoreReader>,
-    system_event_reporter: Option<SystemEventReporter>,
-    system_metric_reporter: Option<SystemMetricReporter>,
 }
 
 static TELEMETRY_STATUS: Mutex<TelemetryStatus> = Mutex::new(TelemetryStatus::Uninitialized);
@@ -100,6 +97,9 @@ fn init_system_store(
     state: &mut TelemetryState,
     resource: &ResourceOptions,
 ) -> TelemetryResult<()> {
+    state.runtime = Some(tokio::runtime::Handle::try_current().map_err(|error| {
+        TelemetryError::internal(format!("failed to get runtime handle: {error}"))
+    })?);
     // The system catalog is owned by server processes. Workers report telemetry to the driver
     // and must not open the configured store path themselves.
     if resource.kind == ResourceKind::Worker {
@@ -113,7 +113,6 @@ fn init_system_store(
     .map_err(|error| {
         TelemetryError::internal(format!("failed to initialize system store: {error}"))
     })?;
-    state.system_store_reader = Some(handle.reader());
     state.system_store = Some(handle);
     state.actor_system = Some(actor_system);
     Ok(())
@@ -161,9 +160,11 @@ fn init_metrics(
             let target = if resource.kind == ResourceKind::Worker {
                 SystemMetricExporterTarget::Remote
             } else {
-                SystemMetricExporterTarget::Local(state.system_metric_reporter.clone().ok_or_else(
-                    || TelemetryError::internal("system store telemetry is not initialized"),
-                )?)
+                SystemMetricExporterTarget::Local(SystemMetricReporter::new(
+                    state.system_store.clone().ok_or_else(|| {
+                        TelemetryError::internal("system store telemetry is not initialized")
+                    })?,
+                ))
             };
             let system_reader = PeriodicReader::builder(SystemMetricExporter::new(target))
                 .with_interval(Duration::from_secs(config.metrics_export_interval_secs))
@@ -186,8 +187,7 @@ fn init_metrics(
             provider = provider.with_reader(reader);
         }
         let provider = provider.build();
-        global::set_meter_provider(provider.clone());
-        let meter = global::meter_with_scope(get_instrumentation_scope());
+        let meter = provider.meter_with_scope(get_instrumentation_scope());
         state.meter_provider = Some(provider);
         state.metrics = Some(MetricManager {
             registry: Arc::new(MetricRegistry::new(&meter)),
@@ -218,11 +218,7 @@ fn init_logs(
     let max_level = primary.filter();
 
     let mut secondary: Vec<Box<dyn Log>> = vec![];
-    let runtime = tokio::runtime::Handle::try_current().map_err(|error| {
-        TelemetryError::internal(format!("failed to get runtime handle: {error}"))
-    })?;
     let system_store = state.system_store.clone();
-    let system_metric_reporter = system_store.clone().map(SystemMetricReporter::new);
     let mut provider = SdkLoggerProvider::builder().with_resource(get_resource(resource));
     if let Some(store) = system_store {
         provider = provider.with_log_processor(SystemEventLogProcessor::new(store));
@@ -257,11 +253,6 @@ fn init_logs(
     if config.export_logs && config.exporter.otlp.endpoint.is_some() {
         secondary.push(Box::new(OpenTelemetryLogBridge::new(&provider)));
     }
-    state.system_event_reporter = Some(SystemEventReporter::new(
-        provider.logger_with_scope(get_instrumentation_scope()),
-    ));
-    state.system_metric_reporter = system_metric_reporter;
-    state.runtime = Some(runtime);
     state.logger_provider = Some(provider);
     if config.export_traces && config.exporter.otlp.endpoint.is_some() {
         secondary.push(Box::new(SpanEventLogger));
@@ -326,7 +317,9 @@ pub fn global_system_store_reader() -> Option<SystemStoreReader> {
         .lock()
         .ok()
         .and_then(|status| match &*status {
-            TelemetryStatus::Initialized(state) => state.system_store_reader.clone(),
+            TelemetryStatus::Initialized(state) => {
+                state.system_store.as_ref().map(SystemStoreHandle::reader)
+            }
             _ => None,
         })
 }
@@ -336,7 +329,9 @@ pub fn global_system_event_reporter() -> Option<SystemEventReporter> {
         .lock()
         .ok()
         .and_then(|status| match &*status {
-            TelemetryStatus::Initialized(state) => state.system_event_reporter.clone(),
+            TelemetryStatus::Initialized(state) => state.logger_provider.as_ref().map(|provider| {
+                SystemEventReporter::new(provider.logger_with_scope(get_instrumentation_scope()))
+            }),
             _ => None,
         })
 }
@@ -346,7 +341,9 @@ pub fn global_system_metric_reporter() -> Option<SystemMetricReporter> {
         .lock()
         .ok()
         .and_then(|status| match &*status {
-            TelemetryStatus::Initialized(state) => state.system_metric_reporter.clone(),
+            TelemetryStatus::Initialized(state) => {
+                state.system_store.clone().map(SystemMetricReporter::new)
+            }
             _ => None,
         })
 }
@@ -368,7 +365,7 @@ fn get_otlp_protocol(protocol: &OtlpProtocol) -> Protocol {
 
 fn get_resource(resource: &ResourceOptions) -> Resource {
     Resource::builder()
-        .with_service_name(format!("sail-{}", resource.kind.as_str()))
+        .with_service_name(resource.kind.service_name())
         .build()
 }
 


### PR DESCRIPTION
1. Add `start_timestamp` for the metrics system table.
2. Add `session.id` attribute for metrics and traces.
3. Avoid merging resource attributes into metrics attributes.
4. Respect `execution.batch_size` for system tables and return stream for queries.
5. Handle peak memory usage metric properly and define metrics for aggregate and buffer operators.
6. Clean up telemetry setup.