### PR TITLE
feat: improve system table reader

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7545,13 +7545,12 @@ dependencies = [
  "datafusion",
  "educe",
  "futures",
+ "parquet-variant",
  "parquet-variant-compute",
- "parquet-variant-json",
  "sail-catalog",
  "sail-common-datafusion",
  "sail-system-store",
  "serde",
- "serde_json",
  "tokio",
 ]
 

--- a/crates/sail-catalog-system/Cargo.toml
+++ b/crates/sail-catalog-system/Cargo.toml
@@ -12,7 +12,6 @@ sail-catalog = { path = "../sail-catalog" }
 sail-system-store = { path = "../sail-system-store" }
 
 serde = { workspace = true }
-serde_json = { workspace = true }
 chrono = { workspace = true }
 datafusion = { workspace = true }
 async-trait = { workspace = true }
@@ -20,4 +19,4 @@ educe = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true }
 parquet-variant-compute = { workspace = true }
-parquet-variant-json = { workspace = true }
+parquet-variant = { workspace = true }

--- a/crates/sail-catalog-system/src/batch.rs
+++ b/crates/sail-catalog-system/src/batch.rs
@@ -2,24 +2,53 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use datafusion::arrow::array::{Array, ArrayRef, RecordBatch, StructArray};
-use datafusion::arrow::datatypes::{Field, Schema};
+use datafusion::arrow::array::{ArrayRef, RecordBatch, StructArray};
+use datafusion::arrow::datatypes::Schema;
 use datafusion::common::{Result, internal_datafusion_err};
+use parquet_variant::{Variant, VariantBuilderExt};
 use parquet_variant_compute::VariantArrayBuilder;
-use parquet_variant_json::JsonToVariant;
-use sail_common_datafusion::array::record_batch::cast_record_batch_relaxed_tz;
+use sail_common_datafusion::array::record_batch::cast_array_recursively;
 use sail_common_datafusion::array::serde::ArrowSerializer;
-use sail_system_store::catalog::{MetricRow, SystemTable};
+use sail_system_store::catalog::{
+    JobRow, MetricRow, OptionRow, SessionRow, StageRow, SystemTable, TaskRow, WorkerRow,
+};
+use sail_system_store::types::{MetricNumber, MetricValue};
 use serde::{Deserialize, Serialize};
 
-pub fn build_rows<T>(table: SystemTable, rows: Vec<T>) -> Result<RecordBatch>
-where
-    T: Serialize + for<'de> Deserialize<'de>,
-{
-    ArrowSerializer::build_record_batch_with_schema(&rows, table.schema())
+pub(crate) trait SystemTableRow {
+    fn build_record_batch(table: SystemTable, rows: Vec<Self>) -> Result<RecordBatch>
+    where
+        Self: Sized;
 }
 
-pub fn build_metrics(rows: Vec<MetricRow>) -> Result<RecordBatch> {
+pub(crate) fn build_rows<T>(table: SystemTable, rows: Vec<T>) -> Result<RecordBatch>
+where
+    T: SystemTableRow,
+{
+    T::build_record_batch(table, rows)
+}
+
+macro_rules! impl_serialized_system_table_row {
+    ($($row:ty),+ $(,)?) => {
+        $(
+            impl SystemTableRow for $row {
+                fn build_record_batch(table: SystemTable, rows: Vec<Self>) -> Result<RecordBatch> {
+                    ArrowSerializer::build_record_batch_with_schema(&rows, table.schema())
+                }
+            }
+        )+
+    };
+}
+
+impl_serialized_system_table_row!(JobRow, OptionRow, SessionRow, StageRow, TaskRow, WorkerRow);
+
+impl SystemTableRow for MetricRow {
+    fn build_record_batch(_table: SystemTable, rows: Vec<Self>) -> Result<RecordBatch> {
+        build_metrics(rows)
+    }
+}
+
+fn build_metrics(rows: Vec<MetricRow>) -> Result<RecordBatch> {
     #[derive(Serialize, Deserialize)]
     struct MetricMetadataRow {
         timestamp: DateTime<Utc>,
@@ -38,29 +67,64 @@ pub fn build_metrics(rows: Vec<MetricRow>) -> Result<RecordBatch> {
         })
         .collect::<Vec<_>>();
     let table_schema = SystemTable::Metrics.schema();
-    let metadata_schema = Arc::new(Schema::new(table_schema.fields()[..4].to_vec()));
+    let value_field = table_schema.field_with_name("value")?;
+    let metadata_schema = Arc::new(Schema::new(
+        table_schema
+            .fields()
+            .iter()
+            .filter(|field| field.name() != value_field.name())
+            .cloned()
+            .collect::<Vec<_>>(),
+    ));
     let metadata_batch =
         ArrowSerializer::build_record_batch_with_schema(&metadata, metadata_schema)?;
     let mut values = VariantArrayBuilder::new(rows.len());
     for row in rows {
-        let value = serde_json::to_string(&row.value)
-            .map_err(|error| internal_datafusion_err!("failed to serialize metric: {error}"))?;
-        values.append_json(&value)?;
+        append_metric_value(&mut values, row.value);
     }
     let values: StructArray = values.build().into();
-    let mut fields = metadata_batch
-        .schema()
+    let values = cast_array_recursively(&(Arc::new(values) as ArrayRef), value_field.data_type())?;
+    let mut metadata_columns = metadata_batch.columns().iter();
+    let columns = table_schema
         .fields()
         .iter()
-        .cloned()
-        .collect::<Vec<_>>();
-    fields.push(Arc::new(Field::new(
-        "value",
-        values.data_type().clone(),
-        false,
-    )));
-    let mut columns = metadata_batch.columns().to_vec();
-    columns.push(Arc::new(values) as ArrayRef);
-    let batch = RecordBatch::try_new(Arc::new(Schema::new(fields)), columns)?;
-    cast_record_batch_relaxed_tz(&batch, &table_schema)
+        .map(|field| {
+            if field.name() == value_field.name() {
+                Ok(values.clone())
+            } else {
+                metadata_columns.next().cloned().ok_or_else(|| {
+                    internal_datafusion_err!("missing metric metadata column: {}", field.name())
+                })
+            }
+        })
+        .collect::<Result<Vec<_>>>()?;
+    RecordBatch::try_new(table_schema, columns).map_err(Into::into)
+}
+
+fn append_metric_value(values: &mut VariantArrayBuilder, value: MetricValue) {
+    let mut metric = values.new_object();
+    match value {
+        MetricValue::Count(MetricNumber::Integer(value)) => metric.insert("count", value),
+        MetricValue::Count(MetricNumber::Float(value)) => metric.insert("count", value),
+        MetricValue::Gauge(MetricNumber::Integer(value)) => metric.insert("gauge", value),
+        MetricValue::Gauge(MetricNumber::Float(value)) => metric.insert("gauge", value),
+        MetricValue::Histogram(histogram) => {
+            let mut value = metric.new_object("histogram");
+            value.insert("count", histogram.count);
+            value.insert("sum", histogram.sum.map_or(Variant::Null, Variant::from));
+            value.insert("min", histogram.min.map_or(Variant::Null, Variant::from));
+            value.insert("max", histogram.max.map_or(Variant::Null, Variant::from));
+
+            let mut bucket_counts = value.new_list("bucket_counts");
+            bucket_counts.extend(histogram.bucket_counts);
+            bucket_counts.finish();
+
+            let mut explicit_bounds = value.new_list("explicit_bounds");
+            explicit_bounds.extend(histogram.explicit_bounds);
+            explicit_bounds.finish();
+
+            value.finish();
+        }
+    }
+    metric.finish();
 }

--- a/crates/sail-catalog-system/src/predicate.rs
+++ b/crates/sail-catalog-system/src/predicate.rs
@@ -13,7 +13,7 @@ use datafusion::physical_expr::expressions::{BinaryExpr, Column, InListExpr, Lit
 use datafusion::physical_expr::{PhysicalExpr, ScalarFunctionExpr};
 use datafusion::physical_plan::internal_err;
 use sail_system_store::predicate::{
-    MapValueFilter, Predicate, TimestampMicros, ValueDomain, ValueFilter,
+    MapValueFilter, Predicate, Predicates, TimestampMicros, ValueDomain, ValueFilter,
 };
 
 pub struct PredicateExtractor {
@@ -54,6 +54,16 @@ impl PredicateExtractor {
         let evaluator = ArrowPredicateEvaluator::<T>::try_new(conjunction)?;
         let predicate: Predicate<T> = Arc::new(move |value: &T| evaluator.evaluate(value));
         Ok(Some(ValueFilter::new(domain, predicate)))
+    }
+
+    #[expect(private_bounds)]
+    pub fn extract_or_default<T: PredicateInput>(
+        &mut self,
+        column: &str,
+    ) -> Result<ValueFilter<T>> {
+        Ok(self
+            .extract(column)?
+            .unwrap_or_else(|| ValueFilter::all(Predicates::always_true())))
     }
 
     #[expect(private_bounds)]

--- a/crates/sail-catalog-system/src/service.rs
+++ b/crates/sail-catalog-system/src/service.rs
@@ -2,17 +2,17 @@ use std::sync::Arc;
 
 use datafusion::arrow::array::RecordBatch;
 use datafusion::arrow::datatypes::SchemaRef;
-use datafusion::common::Result;
+use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::physical_expr::PhysicalExpr;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-use futures::StreamExt;
+use futures::TryStreamExt;
 use sail_common_datafusion::extension::SessionExtension;
-use sail_system_store::SystemStoreReader;
 use sail_system_store::catalog::SystemTable;
-use sail_system_store::predicate::{Predicates, ValueFilter};
+use sail_system_store::{SystemStoreReader, SystemStoreResult};
+use tokio::sync::mpsc;
 
-use crate::batch::{build_metrics, build_rows};
+use crate::batch::{SystemTableRow, build_rows};
 use crate::predicate::PredicateExtractor;
 
 pub struct SystemTableService {
@@ -39,123 +39,103 @@ impl SystemTableService {
         let mut filters = PredicateExtractor::new(filters);
         let stream = match table {
             SystemTable::Jobs => {
-                let session_id = filters
-                    .extract("session_id")?
-                    .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
-                let job_id = filters
-                    .extract("job_id")?
-                    .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
+                let session_id = filters.extract_or_default("session_id")?;
+                let job_id = filters.extract_or_default("job_id")?;
                 filters.finalize()?;
                 build_rows_stream(
                     SystemTable::Jobs,
                     self.store_reader
-                        .read_jobs(session_id, job_id, fetch)
-                        .await?,
-                    self.batch_size,
+                        .read_jobs(session_id, job_id, fetch, self.batch_size)?,
                     projection,
                 )?
             }
             SystemTable::Metrics => {
-                let timestamp = filters
-                    .extract("timestamp")?
-                    .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
-                let name = filters
-                    .extract("name")?
-                    .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
+                let timestamp = filters.extract_or_default("timestamp")?;
+                let name = filters.extract_or_default("name")?;
                 let attributes = filters.extract_map_values("attributes")?;
                 filters.finalize()?;
-                build_metrics_stream(
-                    self.store_reader
-                        .read_metrics(timestamp, name, attributes, fetch)
-                        .await?,
-                    self.batch_size,
+                build_rows_stream(
+                    SystemTable::Metrics,
+                    self.store_reader.read_metrics(
+                        timestamp,
+                        name,
+                        attributes,
+                        fetch,
+                        self.batch_size,
+                    )?,
                     projection,
                 )?
             }
             SystemTable::Stages => {
-                let session_id = filters
-                    .extract("session_id")?
-                    .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
-                let job_id = filters
-                    .extract("job_id")?
-                    .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
-                let stage = filters
-                    .extract("stage")?
-                    .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
+                let session_id = filters.extract_or_default("session_id")?;
+                let job_id = filters.extract_or_default("job_id")?;
+                let stage = filters.extract_or_default("stage")?;
                 filters.finalize()?;
                 build_rows_stream(
                     SystemTable::Stages,
-                    self.store_reader
-                        .read_stages(session_id, job_id, stage, fetch)
-                        .await?,
-                    self.batch_size,
+                    self.store_reader.read_stages(
+                        session_id,
+                        job_id,
+                        stage,
+                        fetch,
+                        self.batch_size,
+                    )?,
                     projection,
                 )?
             }
             SystemTable::Tasks => {
-                let session_id = filters
-                    .extract("session_id")?
-                    .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
-                let job_id = filters
-                    .extract("job_id")?
-                    .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
-                let stage = filters
-                    .extract("stage")?
-                    .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
-                let partition = filters
-                    .extract("partition")?
-                    .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
-                let attempt = filters
-                    .extract("attempt")?
-                    .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
+                let session_id = filters.extract_or_default("session_id")?;
+                let job_id = filters.extract_or_default("job_id")?;
+                let stage = filters.extract_or_default("stage")?;
+                let partition = filters.extract_or_default("partition")?;
+                let attempt = filters.extract_or_default("attempt")?;
                 filters.finalize()?;
                 build_rows_stream(
                     SystemTable::Tasks,
-                    self.store_reader
-                        .read_tasks(session_id, job_id, stage, partition, attempt, fetch)
-                        .await?,
-                    self.batch_size,
+                    self.store_reader.read_tasks(
+                        session_id,
+                        job_id,
+                        stage,
+                        partition,
+                        attempt,
+                        fetch,
+                        self.batch_size,
+                    )?,
                     projection,
                 )?
             }
             SystemTable::Options => {
-                let key = filters
-                    .extract("key")?
-                    .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
+                let key = filters.extract_or_default("key")?;
                 filters.finalize()?;
                 build_rows_stream(
                     SystemTable::Options,
-                    self.store_reader.read_options(key, fetch).await?,
-                    self.batch_size,
+                    self.store_reader
+                        .read_options(key, fetch, self.batch_size)?,
                     projection,
                 )?
             }
             SystemTable::Sessions => {
-                let session_id = filters
-                    .extract("session_id")?
-                    .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
+                let session_id = filters.extract_or_default("session_id")?;
                 filters.finalize()?;
                 build_rows_stream(
                     SystemTable::Sessions,
-                    self.store_reader.read_sessions(session_id, fetch).await?,
-                    self.batch_size,
+                    self.store_reader
+                        .read_sessions(session_id, fetch, self.batch_size)?,
                     projection,
                 )?
             }
             SystemTable::Workers => {
-                let session_id = filters
-                    .extract("session_id")?
-                    .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
-                let worker_id = filters
-                    .extract("worker_id")?
-                    .unwrap_or_else(|| ValueFilter::all(Predicates::always_true()));
+                let session_id = filters.extract_or_default("session_id")?;
+                let worker_id = filters.extract_or_default("worker_id")?;
                 filters.finalize()?;
                 build_rows_stream(
                     SystemTable::Workers,
-                    self.store_reader
-                        .read_workers(session_id, worker_id, fetch)
-                        .await?,
-                    self.batch_size,
+                    self.store_reader.read_workers(
+                        session_id,
+                        worker_id,
+                        fetch,
+                        self.batch_size,
+                    )?,
                     projection,
                 )?
             }
@@ -166,7 +146,7 @@ impl SystemTableService {
 
 fn projected_schema(table: SystemTable, projection: Option<&[usize]>) -> Result<SchemaRef> {
     match projection {
-        Some(projection) => Ok(std::sync::Arc::new(table.schema().project(projection)?)),
+        Some(projection) => Ok(Arc::new(table.schema().project(projection)?)),
         None => Ok(table.schema()),
     }
 }
@@ -180,33 +160,28 @@ fn project_batch(batch: RecordBatch, projection: Option<&[usize]>) -> Result<Rec
 
 fn build_rows_stream<T>(
     table: SystemTable,
-    rows: Vec<T>,
-    batch_size: usize,
+    rows: mpsc::Receiver<SystemStoreResult<Option<Vec<T>>>>,
     projection: Option<Vec<usize>>,
 ) -> Result<SendableRecordBatchStream>
 where
-    T: serde::Serialize + for<'de> serde::Deserialize<'de> + Send + 'static,
+    T: SystemTableRow + Send + 'static,
 {
     let schema = projected_schema(table, projection.as_deref())?;
-    let stream = futures::stream::iter(rows)
-        .ready_chunks(batch_size)
-        .map(move |rows| {
-            build_rows(table, rows).and_then(|batch| project_batch(batch, projection.as_deref()))
-        });
-    Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
-}
-
-fn build_metrics_stream(
-    rows: Vec<sail_system_store::catalog::MetricRow>,
-    batch_size: usize,
-    projection: Option<Vec<usize>>,
-) -> Result<SendableRecordBatchStream> {
-    let schema = projected_schema(SystemTable::Metrics, projection.as_deref())?;
-    let stream = futures::stream::iter(rows)
-        .ready_chunks(batch_size)
-        .map(move |rows| {
-            build_metrics(rows).and_then(|batch| project_batch(batch, projection.as_deref()))
-        });
+    let stream = futures::stream::try_unfold(rows, |mut rows| async move {
+        match rows.recv().await {
+            Some(Ok(Some(batch))) => Ok(Some((batch, rows))),
+            Some(Ok(None)) => Ok(None),
+            Some(Err(error)) => Err(DataFusionError::External(Box::new(error))),
+            None => Err(DataFusionError::Internal(
+                "system store read ended before reporting completion".to_string(),
+            )),
+        }
+    });
+    let stream = stream.and_then(move |rows| {
+        futures::future::ready(
+            build_rows(table, rows).and_then(|batch| project_batch(batch, projection.as_deref())),
+        )
+    });
     Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
 }
 

--- a/crates/sail-system-store/src/actor/handler.rs
+++ b/crates/sail-system-store/src/actor/handler.rs
@@ -19,7 +19,16 @@ where
                 | SystemStoreMessage::Flush { reply } => {
                     let _ = reply.send(Err(self.failure()));
                 }
-                SystemStoreMessage::Read(query) => query.fail(self.failure()),
+                SystemStoreMessage::Read(query) => {
+                    let failure = self.failure();
+                    ctx.spawn(async move {
+                        if let Err(error) =
+                            tokio::task::spawn_blocking(move || query.fail(failure)).await
+                        {
+                            log::error!("system store read failure task failed: {error}");
+                        }
+                    });
+                }
                 SystemStoreMessage::Shutdown { reply } => {
                     let _ = reply.send(Ok(()));
                     return ActorAction::Stop;
@@ -41,23 +50,17 @@ where
                 }
                 let _ = reply.send(result);
             }
-            SystemStoreMessage::Read(query) => match self.engine.read(query).await {
-                Ok(None) => {}
-                Ok(Some(read)) => {
-                    ctx.spawn(async move {
-                        // Aborting this task cancels the reply. Tokio cannot interrupt a
-                        // blocking scan that has already started, but it will release its snapshot
-                        // when it completes.
-                        if let Err(error) = tokio::task::spawn_blocking(read).await {
-                            log::error!("system store read task failed: {error}");
-                        }
-                    });
-                }
-                Err(error) => {
-                    self.fail(&error);
-                    log::error!("failed to acquire system store read snapshot: {error}");
-                }
-            },
+            SystemStoreMessage::Read(query) => {
+                let read = self.engine.read(query).await;
+                ctx.spawn(async move {
+                    // Aborting this task cancels the reply. Tokio cannot interrupt a
+                    // blocking scan that has already started, but it will release its snapshot
+                    // when it completes.
+                    if let Err(error) = tokio::task::spawn_blocking(read).await {
+                        log::error!("system store read task failed: {error}");
+                    }
+                });
+            }
             SystemStoreMessage::Flush { reply } => {
                 let result = self.engine.flush().await;
                 if let Err(error) = &result {

--- a/crates/sail-system-store/src/engine/mod.rs
+++ b/crates/sail-system-store/src/engine/mod.rs
@@ -8,7 +8,7 @@ mod query;
 
 pub use mutation::MetricSample;
 pub(crate) use mutation::{write_event, write_metrics};
-pub(crate) use query::SystemStoreQuery;
+pub(crate) use query::{Deferred, Eager, SystemStoreQuery};
 
 use crate::access::{Commit, DirectStoreBackend, TransactionalStoreBackend};
 use crate::{SystemEvent, SystemStoreError, SystemStoreResult};
@@ -28,7 +28,7 @@ pub(crate) trait StoreEngine: Send + 'static {
     fn read(
         &mut self,
         query: SystemStoreQuery,
-    ) -> impl Future<Output = SystemStoreResult<Option<Box<dyn FnOnce() + Send>>>> + Send;
+    ) -> impl Future<Output = Box<dyn FnOnce() + Send>> + Send;
 
     fn flush(&mut self) -> impl Future<Output = SystemStoreResult<()>> + Send;
 }
@@ -49,16 +49,11 @@ where
         write_metrics(&mut self.backend.write(), samples).map_err(SystemStoreError::from)
     }
 
-    async fn read(
-        &mut self,
-        query: SystemStoreQuery,
-    ) -> SystemStoreResult<Option<Box<dyn FnOnce() + Send>>> {
-        // The direct storage engine executes the query immediately
-        // and does not return a deferred read closure to be executed later.
-        // This is because the direct storage engine does not support snapshots or transactions,
-        // so the read operation must finish before subsequent writes.
-        query.execute(&self.backend.read());
-        Ok(None)
+    async fn read(&mut self, query: SystemStoreQuery) -> Box<dyn FnOnce() + Send> {
+        // Direct-backend reads must finish while the backend is borrowed, so they materialize rows
+        // first.
+        // The returned closure forwards those rows in batches without blocking later actor writes.
+        query.execute(&self.backend.read(), Eager)
     }
 
     async fn flush(&mut self) -> SystemStoreResult<()> {
@@ -99,10 +94,7 @@ where
         .map_err(|error| SystemStoreError::internal(format!("system store task failed: {error}")))?
     }
 
-    async fn read(
-        &mut self,
-        query: SystemStoreQuery,
-    ) -> SystemStoreResult<Option<Box<dyn FnOnce() + Send>>> {
+    async fn read(&mut self, query: SystemStoreQuery) -> Box<dyn FnOnce() + Send> {
         // The transactional storage engine acquires a snapshot of the store and returns
         // a closure that executes the query against that snapshot.
         // This allows multiple concurrent reads without blocking writes.
@@ -111,10 +103,12 @@ where
             move || store.snapshot().map_err(SystemStoreError::from)
         })
         .await
-        .map_err(|error| {
-            SystemStoreError::internal(format!("system store task failed: {error}"))
-        })??;
-        Ok(Some(Box::new(move || query.execute(&snapshot))))
+        .map_err(|error| SystemStoreError::internal(format!("system store task failed: {error}")))
+        .and_then(|result| result);
+        match snapshot {
+            Ok(snapshot) => Box::new(move || query.execute(&snapshot, Deferred)),
+            Err(error) => Box::new(move || query.fail(error)),
+        }
     }
 
     async fn flush(&mut self) -> SystemStoreResult<()> {

--- a/crates/sail-system-store/src/engine/query.rs
+++ b/crates/sail-system-store/src/engine/query.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeSet;
 use std::ops::Bound;
 
 use chrono::DateTime;
-use tokio::sync::oneshot;
+use tokio::sync::mpsc;
 
 use super::candidate::{CandidateSet, ValueOrd, candidate_key_bound, candidate_set};
 use crate::access::StoreReader;
@@ -17,7 +17,137 @@ use crate::model::{
     TaskPrimaryKey, TaskTable, WorkerPrimaryKey, WorkerTable,
 };
 use crate::predicate::{MapValueFilter, TimestampMicros, ValueFilter};
+use crate::types::{MetricNumber, MetricValue};
 use crate::{SystemStoreError, SystemStoreResult};
+
+/// Receives query rows without coupling the query implementation to its delivery mechanism.
+pub(crate) trait RowCollector<T> {
+    /// Returns `false` when the consumer has gone away and scanning should stop.
+    fn push(&mut self, row: T) -> SystemStoreResult<bool>;
+}
+
+struct VecCollector<T> {
+    rows: Vec<T>,
+}
+
+impl<T> Default for VecCollector<T> {
+    fn default() -> Self {
+        Self { rows: Vec::new() }
+    }
+}
+
+impl<T> VecCollector<T> {
+    fn into_rows(self) -> Vec<T> {
+        self.rows
+    }
+}
+
+impl<T> RowCollector<T> for VecCollector<T> {
+    fn push(&mut self, row: T) -> SystemStoreResult<bool> {
+        self.rows.push(row);
+        Ok(true)
+    }
+}
+
+struct ChannelCollector<T> {
+    sender: mpsc::Sender<SystemStoreResult<Option<Vec<T>>>>,
+    rows: Vec<T>,
+    batch_size: usize,
+}
+
+impl<T> ChannelCollector<T> {
+    fn new(sender: mpsc::Sender<SystemStoreResult<Option<Vec<T>>>>, batch_size: usize) -> Self {
+        let batch_size = batch_size.max(1);
+        Self {
+            sender,
+            rows: Vec::with_capacity(batch_size),
+            batch_size,
+        }
+    }
+
+    fn flush(&mut self) -> bool {
+        if self.rows.is_empty() {
+            return true;
+        }
+        let rows = std::mem::replace(&mut self.rows, Vec::with_capacity(self.batch_size));
+        self.sender.blocking_send(Ok(Some(rows))).is_ok()
+    }
+
+    fn finish(&mut self) {
+        if self.flush() {
+            let _ = self.sender.blocking_send(Ok(None));
+        }
+    }
+
+    fn fail(&self, error: SystemStoreError) {
+        let _ = self.sender.blocking_send(Err(error));
+    }
+}
+
+impl<T> RowCollector<T> for ChannelCollector<T> {
+    fn push(&mut self, row: T) -> SystemStoreResult<bool> {
+        self.rows.push(row);
+        Ok(self.rows.len() < self.batch_size || self.flush())
+    }
+}
+
+/// Materializes the query while borrowing the direct backend, then forwards row batches.
+pub(crate) struct Eager;
+
+/// Sends row batches as they are scanned from a transactional snapshot.
+pub(crate) struct Deferred;
+
+pub(crate) trait QueryDelivery {
+    type Output;
+
+    fn deliver<T>(
+        self,
+        sender: mpsc::Sender<SystemStoreResult<Option<Vec<T>>>>,
+        batch_size: usize,
+        execute: impl FnOnce(&mut dyn RowCollector<T>) -> SystemStoreResult<()>,
+    ) -> Self::Output
+    where
+        T: Send + 'static;
+}
+
+impl QueryDelivery for Eager {
+    type Output = Box<dyn FnOnce() + Send>;
+
+    fn deliver<T>(
+        self,
+        sender: mpsc::Sender<SystemStoreResult<Option<Vec<T>>>>,
+        batch_size: usize,
+        execute: impl FnOnce(&mut dyn RowCollector<T>) -> SystemStoreResult<()>,
+    ) -> Self::Output
+    where
+        T: Send + 'static,
+    {
+        let mut collector = VecCollector::default();
+        let result = execute(&mut collector).map(|()| collector.into_rows());
+        Box::new(move || send_rows(sender, result, batch_size))
+    }
+}
+
+impl QueryDelivery for Deferred {
+    type Output = ();
+
+    fn deliver<T>(
+        self,
+        sender: mpsc::Sender<SystemStoreResult<Option<Vec<T>>>>,
+        batch_size: usize,
+        execute: impl FnOnce(&mut dyn RowCollector<T>) -> SystemStoreResult<()>,
+    ) where
+        T: Send + 'static,
+    {
+        let mut collector = ChannelCollector::new(sender, batch_size);
+        match execute(&mut collector) {
+            Ok(()) => {
+                collector.finish();
+            }
+            Err(error) => collector.fail(error),
+        }
+    }
+}
 
 candidate_key_bound! {
     JobPrimaryKey => JobPrimaryKeyBound {
@@ -68,6 +198,10 @@ fn matches_metric_attributes(
     series: &MetricSeriesMetadata,
 ) -> SystemStoreResult<bool> {
     for filter in filters {
+        // Attribute values are non-null strings, so this only supports predicates over present
+        // map entries. In particular, `attributes['key'] IS NULL` cannot be pushed down here, since
+        // a missing key has no attribute-index entry to evaluate. Such predicates remain residual
+        // filters that are not seen by this function.
         let Some(value) = series.attributes.get(&filter.key) else {
             return Ok(false);
         };
@@ -166,27 +300,34 @@ fn metric_series_ids<R: StoreReader>(
     Ok(ids)
 }
 
-/// A strongly typed system store read request. Each variant owns the reply channel for its row type.
+/// A strongly typed system store read request.
+///
+/// Each variant owns a row-batch channel. `Ok(Some(rows))` delivers rows, `Ok(None)` marks
+/// successful completion, and `Err(error)` fails the query. Closing the channel without one of
+/// those terminal messages means the read was cancelled before it could report its result.
 pub(crate) enum SystemStoreQuery {
     Jobs {
         session_id: ValueFilter<String>,
         job_id: ValueFilter<u64>,
         fetch: usize,
-        reply: oneshot::Sender<SystemStoreResult<Vec<JobRow>>>,
+        batch_size: usize,
+        sender: mpsc::Sender<SystemStoreResult<Option<Vec<JobRow>>>>,
     },
     Metrics {
         timestamp: ValueFilter<TimestampMicros>,
         name: ValueFilter<String>,
         attributes: Vec<MapValueFilter<String, String>>,
         fetch: usize,
-        reply: oneshot::Sender<SystemStoreResult<Vec<MetricRow>>>,
+        batch_size: usize,
+        sender: mpsc::Sender<SystemStoreResult<Option<Vec<MetricRow>>>>,
     },
     Stages {
         session_id: ValueFilter<String>,
         job_id: ValueFilter<u64>,
         stage: ValueFilter<u64>,
         fetch: usize,
-        reply: oneshot::Sender<SystemStoreResult<Vec<StageRow>>>,
+        batch_size: usize,
+        sender: mpsc::Sender<SystemStoreResult<Option<Vec<StageRow>>>>,
     },
     Tasks {
         session_id: ValueFilter<String>,
@@ -195,84 +336,92 @@ pub(crate) enum SystemStoreQuery {
         partition: ValueFilter<u64>,
         attempt: ValueFilter<u64>,
         fetch: usize,
-        reply: oneshot::Sender<SystemStoreResult<Vec<TaskRow>>>,
+        batch_size: usize,
+        sender: mpsc::Sender<SystemStoreResult<Option<Vec<TaskRow>>>>,
     },
     Options {
         key: ValueFilter<String>,
         fetch: usize,
-        reply: oneshot::Sender<SystemStoreResult<Vec<OptionRow>>>,
+        batch_size: usize,
+        sender: mpsc::Sender<SystemStoreResult<Option<Vec<OptionRow>>>>,
     },
     Sessions {
         session_id: ValueFilter<String>,
         fetch: usize,
-        reply: oneshot::Sender<SystemStoreResult<Vec<SessionRow>>>,
+        batch_size: usize,
+        sender: mpsc::Sender<SystemStoreResult<Option<Vec<SessionRow>>>>,
     },
     Workers {
         session_id: ValueFilter<String>,
         worker_id: ValueFilter<u64>,
         fetch: usize,
-        reply: oneshot::Sender<SystemStoreResult<Vec<WorkerRow>>>,
+        batch_size: usize,
+        sender: mpsc::Sender<SystemStoreResult<Option<Vec<WorkerRow>>>>,
     },
 }
 
 impl SystemStoreQuery {
     pub(crate) fn fail(self, error: SystemStoreError) {
         match self {
-            Self::Jobs { reply, .. } => {
-                let _ = reply.send(Err(error));
+            Self::Jobs { sender, .. } => {
+                let _ = sender.blocking_send(Err(error));
             }
-            Self::Metrics { reply, .. } => {
-                let _ = reply.send(Err(error));
+            Self::Metrics { sender, .. } => {
+                let _ = sender.blocking_send(Err(error));
             }
-            Self::Stages { reply, .. } => {
-                let _ = reply.send(Err(error));
+            Self::Stages { sender, .. } => {
+                let _ = sender.blocking_send(Err(error));
             }
-            Self::Tasks { reply, .. } => {
-                let _ = reply.send(Err(error));
+            Self::Tasks { sender, .. } => {
+                let _ = sender.blocking_send(Err(error));
             }
-            Self::Options { reply, .. } => {
-                let _ = reply.send(Err(error));
+            Self::Options { sender, .. } => {
+                let _ = sender.blocking_send(Err(error));
             }
-            Self::Sessions { reply, .. } => {
-                let _ = reply.send(Err(error));
+            Self::Sessions { sender, .. } => {
+                let _ = sender.blocking_send(Err(error));
             }
-            Self::Workers { reply, .. } => {
-                let _ = reply.send(Err(error));
+            Self::Workers { sender, .. } => {
+                let _ = sender.blocking_send(Err(error));
             }
         }
     }
 
-    pub(crate) fn execute<R>(self, reader: &R)
+    pub(crate) fn execute<R, D>(self, reader: &R, delivery: D) -> D::Output
     where
         R: StoreReader,
+        D: QueryDelivery,
     {
         match self {
             Self::Jobs {
                 session_id,
                 job_id,
                 fetch,
-                reply,
-            } => {
-                let _ = reply.send(query_jobs(reader, session_id, job_id, fetch));
-            }
+                batch_size,
+                sender,
+            } => delivery.deliver(sender, batch_size, |collector| {
+                query_jobs(reader, session_id, job_id, fetch, collector)
+            }),
             Self::Metrics {
                 timestamp,
                 name,
                 attributes,
                 fetch,
-                reply,
-            } => {
-                let _ = reply.send(query_metrics(reader, timestamp, name, attributes, fetch));
-            }
+                batch_size,
+                sender,
+            } => delivery.deliver(sender, batch_size, |collector| {
+                query_metrics(reader, timestamp, name, attributes, fetch, collector)
+            }),
             Self::Stages {
                 session_id,
                 job_id,
                 stage,
                 fetch,
-                reply,
-            } => {
-                let _ = reply.send(query_stages(reader, session_id, job_id, stage, fetch));
-            }
+                batch_size,
+                sender,
+            } => delivery.deliver(sender, batch_size, |collector| {
+                query_stages(reader, session_id, job_id, stage, fetch, collector)
+            }),
             Self::Tasks {
                 session_id,
                 job_id,
@@ -280,54 +429,92 @@ impl SystemStoreQuery {
                 partition,
                 attempt,
                 fetch,
-                reply,
-            } => {
-                let _ = reply.send(query_tasks(
-                    reader, session_id, job_id, stage, partition, attempt, fetch,
-                ));
-            }
-            Self::Options { key, fetch, reply } => {
-                let _ = reply.send(query_options(reader, key, fetch));
-            }
+                batch_size,
+                sender,
+            } => delivery.deliver(sender, batch_size, |collector| {
+                query_tasks(
+                    reader, session_id, job_id, stage, partition, attempt, fetch, collector,
+                )
+            }),
+            Self::Options {
+                key,
+                fetch,
+                batch_size,
+                sender,
+            } => delivery.deliver(sender, batch_size, |collector| {
+                query_options(reader, key, fetch, collector)
+            }),
             Self::Sessions {
                 session_id,
                 fetch,
-                reply,
-            } => {
-                let _ = reply.send(query_sessions(reader, session_id, fetch));
-            }
+                batch_size,
+                sender,
+            } => delivery.deliver(sender, batch_size, |collector| {
+                query_sessions(reader, session_id, fetch, collector)
+            }),
             Self::Workers {
                 session_id,
                 worker_id,
                 fetch,
-                reply,
-            } => {
-                let _ = reply.send(query_workers(reader, session_id, worker_id, fetch));
-            }
+                batch_size,
+                sender,
+            } => delivery.deliver(sender, batch_size, |collector| {
+                query_workers(reader, session_id, worker_id, fetch, collector)
+            }),
         }
     }
 }
 
-fn scan_candidates<K, B, V, E>(
+fn send_rows<T>(
+    sender: mpsc::Sender<SystemStoreResult<Option<Vec<T>>>>,
+    result: SystemStoreResult<Vec<T>>,
+    batch_size: usize,
+) where
+    T: Send + 'static,
+{
+    let batch_size = batch_size.max(1);
+    match result {
+        Ok(rows) => {
+            let mut rows = rows.into_iter();
+            loop {
+                let batch = rows.by_ref().take(batch_size).collect::<Vec<_>>();
+                if batch.is_empty() {
+                    let _ = sender.blocking_send(Ok(None));
+                    break;
+                }
+                if sender.blocking_send(Ok(Some(batch))).is_err() {
+                    break;
+                }
+            }
+        }
+        Err(error) => {
+            let _ = sender.blocking_send(Err(error));
+        }
+    }
+}
+
+fn scan_candidates<K, B, V, E, C>(
     candidates: CandidateSet<K, B>,
     fetch: usize,
     mut get: impl FnMut(&K) -> Result<Option<V>, E>,
     mut scan: impl FnMut(Bound<K>, Bound<K>, &mut dyn FnMut(K, V) -> bool) -> Result<(), E>,
     predicate: impl Fn(&V) -> SystemStoreResult<bool>,
-) -> SystemStoreResult<Vec<V>>
+    collector: &mut C,
+) -> SystemStoreResult<()>
 where
     K: Ord,
     B: ValueOrd<K>,
     E: Into<SystemStoreError>,
+    C: RowCollector<V> + ?Sized,
 {
     if fetch == 0 {
-        return Ok(vec![]);
+        return Ok(());
     }
-    let mut rows = Vec::new();
+    let mut count = 0;
     let mut add_if_matching = |row: V| -> SystemStoreResult<bool> {
         if predicate(&row)? {
-            rows.push(row);
-            if rows.len() == fetch {
+            count += 1;
+            if !collector.push(row)? || count == fetch {
                 return Ok(true);
             }
         }
@@ -380,15 +567,20 @@ where
             }
         }
     }
-    Ok(rows)
+    Ok(())
 }
 
-fn query_jobs<R: StoreReader>(
+fn query_jobs<R, C>(
     reader: &R,
     session_id: ValueFilter<String>,
     job_id: ValueFilter<u64>,
     fetch: usize,
-) -> SystemStoreResult<Vec<JobRow>> {
+    collector: &mut C,
+) -> SystemStoreResult<()>
+where
+    R: StoreReader,
+    C: RowCollector<JobRow> + ?Sized,
+{
     let candidates = candidate_set! {
         JobPrimaryKey => JobPrimaryKeyBound {
             session_id: String => &session_id.domain,
@@ -401,16 +593,22 @@ fn query_jobs<R: StoreReader>(
         |key| reader.table::<JobTable>().get(key),
         |lower, upper, visitor| reader.table::<JobTable>().scan(lower, upper, visitor),
         |row| Ok((session_id.predicate)(&row.session_id)? && (job_id.predicate)(&row.job_id)?),
+        collector,
     )
 }
 
-fn query_stages<R: StoreReader>(
+fn query_stages<R, C>(
     reader: &R,
     session_id: ValueFilter<String>,
     job_id: ValueFilter<u64>,
     stage: ValueFilter<u64>,
     fetch: usize,
-) -> SystemStoreResult<Vec<StageRow>> {
+    collector: &mut C,
+) -> SystemStoreResult<()>
+where
+    R: StoreReader,
+    C: RowCollector<StageRow> + ?Sized,
+{
     let candidates = candidate_set! {
         StagePrimaryKey => StagePrimaryKeyBound {
             session_id: String => &session_id.domain,
@@ -428,10 +626,11 @@ fn query_stages<R: StoreReader>(
                 && (job_id.predicate)(&row.job_id)?
                 && (stage.predicate)(&row.stage)?)
         },
+        collector,
     )
 }
 
-fn query_tasks<R: StoreReader>(
+fn query_tasks<R, C>(
     reader: &R,
     session_id: ValueFilter<String>,
     job_id: ValueFilter<u64>,
@@ -439,7 +638,12 @@ fn query_tasks<R: StoreReader>(
     partition: ValueFilter<u64>,
     attempt: ValueFilter<u64>,
     fetch: usize,
-) -> SystemStoreResult<Vec<TaskRow>> {
+    collector: &mut C,
+) -> SystemStoreResult<()>
+where
+    R: StoreReader,
+    C: RowCollector<TaskRow> + ?Sized,
+{
     let candidates = candidate_set! {
         TaskPrimaryKey => TaskPrimaryKeyBound {
             session_id: String => &session_id.domain,
@@ -461,14 +665,20 @@ fn query_tasks<R: StoreReader>(
                 && (partition.predicate)(&row.partition)?
                 && (attempt.predicate)(&row.attempt)?)
         },
+        collector,
     )
 }
 
-fn query_options<R: StoreReader>(
+fn query_options<R, C>(
     reader: &R,
     key: ValueFilter<String>,
     fetch: usize,
-) -> SystemStoreResult<Vec<OptionRow>> {
+    collector: &mut C,
+) -> SystemStoreResult<()>
+where
+    R: StoreReader,
+    C: RowCollector<OptionRow> + ?Sized,
+{
     let candidates = candidate_set! {
         OptionPrimaryKey => OptionPrimaryKeyBound {
             key: String => &key.domain,
@@ -480,14 +690,20 @@ fn query_options<R: StoreReader>(
         |key| reader.table::<OptionTable>().get(key),
         |lower, upper, visitor| reader.table::<OptionTable>().scan(lower, upper, visitor),
         |row| Ok((key.predicate)(&row.key)?),
+        collector,
     )
 }
 
-fn query_sessions<R: StoreReader>(
+fn query_sessions<R, C>(
     reader: &R,
     session_id: ValueFilter<String>,
     fetch: usize,
-) -> SystemStoreResult<Vec<SessionRow>> {
+    collector: &mut C,
+) -> SystemStoreResult<()>
+where
+    R: StoreReader,
+    C: RowCollector<SessionRow> + ?Sized,
+{
     let candidates = candidate_set! {
         SessionPrimaryKey => SessionPrimaryKeyBound {
             session_id: String => &session_id.domain,
@@ -499,15 +715,21 @@ fn query_sessions<R: StoreReader>(
         |key| reader.table::<SessionTable>().get(key),
         |lower, upper, visitor| reader.table::<SessionTable>().scan(lower, upper, visitor),
         |row| Ok((session_id.predicate)(&row.session_id)?),
+        collector,
     )
 }
 
-fn query_workers<R: StoreReader>(
+fn query_workers<R, C>(
     reader: &R,
     session_id: ValueFilter<String>,
     worker_id: ValueFilter<u64>,
     fetch: usize,
-) -> SystemStoreResult<Vec<WorkerRow>> {
+    collector: &mut C,
+) -> SystemStoreResult<()>
+where
+    R: StoreReader,
+    C: RowCollector<WorkerRow> + ?Sized,
+{
     let candidates = candidate_set! {
         WorkerPrimaryKey => WorkerPrimaryKeyBound {
             session_id: String => &session_id.domain,
@@ -520,18 +742,24 @@ fn query_workers<R: StoreReader>(
         |key| reader.table::<WorkerTable>().get(key),
         |lower, upper, visitor| reader.table::<WorkerTable>().scan(lower, upper, visitor),
         |row| Ok((session_id.predicate)(&row.session_id)? && (worker_id.predicate)(&row.worker_id)?),
+        collector,
     )
 }
 
-fn scan_metric_points<R, S, T>(
+struct MetricScanState {
+    fetch: usize,
+    count: usize,
+}
+
+fn scan_metric_points<R, S, T, C>(
     reader: &R,
     series: &MetricSeriesMetadata,
     timestamp: &ValueFilter<TimestampMicros>,
     lower: Bound<TimestampMicros>,
     upper: Bound<TimestampMicros>,
-    fetch: usize,
-    out: &mut Vec<MetricRow>,
-    to_metric_value: impl Fn(T) -> crate::types::MetricValue,
+    scan_state: &mut MetricScanState,
+    collector: &mut C,
+    to_metric_value: impl Fn(T) -> MetricValue,
 ) -> SystemStoreResult<bool>
 where
     R: StoreReader + crate::access::SeriesReader<S, R::Error>,
@@ -540,8 +768,10 @@ where
             PointKey = TimestampMicros,
             PointValue = MetricPointValue<T>,
         >,
+    C: RowCollector<MetricRow> + ?Sized,
 {
     let mut predicate_error = None;
+    let mut stop = false;
     reader
         .series::<S>()
         .scan(&series.id, lower, upper, &mut |point_timestamp,
@@ -551,7 +781,8 @@ where
             match (timestamp.predicate)(&point_timestamp) {
                 Ok(true) => {
                     if let Some(timestamp) = DateTime::from_timestamp_micros(point_timestamp.0) {
-                        out.push(MetricRow {
+                        scan_state.count += 1;
+                        let row = MetricRow {
                             timestamp,
                             start_timestamp: point
                                 .start_timestamp
@@ -559,9 +790,18 @@ where
                             name: series.name.clone(),
                             attributes: series.attributes.clone(),
                             value: to_metric_value(point.value),
-                        });
-                        if out.len() == fetch {
-                            return false;
+                        };
+                        match collector.push(row) {
+                            Ok(continue_scan) => {
+                                if !continue_scan || scan_state.count == scan_state.fetch {
+                                    stop = true;
+                                    return false;
+                                }
+                            }
+                            Err(error) => {
+                                predicate_error = Some(error);
+                                return false;
+                            }
                         }
                     }
                     true
@@ -577,20 +817,25 @@ where
     if let Some(error) = predicate_error {
         return Err(error);
     }
-    Ok(out.len() == fetch)
+    Ok(stop)
 }
 
-fn query_metrics<R: StoreReader>(
+fn query_metrics<R, C>(
     reader: &R,
     timestamp: ValueFilter<TimestampMicros>,
     name: ValueFilter<String>,
     attributes: Vec<MapValueFilter<String, String>>,
     fetch: usize,
-) -> SystemStoreResult<Vec<MetricRow>> {
+    collector: &mut C,
+) -> SystemStoreResult<()>
+where
+    R: StoreReader,
+    C: RowCollector<MetricRow> + ?Sized,
+{
     if fetch == 0 {
-        return Ok(vec![]);
+        return Ok(());
     }
-    let mut out = Vec::new();
+    let mut scan_state = MetricScanState { fetch, count: 0 };
     for id in metric_series_ids(reader, &name, &attributes)? {
         let Some(series) = reader
             .table::<MetricSeriesTable>()
@@ -605,80 +850,72 @@ fn query_metrics<R: StoreReader>(
         for range in timestamp.domain.ranges() {
             let complete = match series.kind {
                 MetricSeriesKind::IntegerCount => {
-                    scan_metric_points::<_, MetricIntegerPointSeries, _>(
+                    scan_metric_points::<_, MetricIntegerPointSeries, _, _>(
                         reader,
                         &series,
                         &timestamp,
                         range.lower,
                         range.upper,
-                        fetch,
-                        &mut out,
-                        |value| {
-                            crate::types::MetricValue::Count(crate::types::MetricNumber::Integer(
-                                value,
-                            ))
-                        },
+                        &mut scan_state,
+                        collector,
+                        |value| MetricValue::Count(MetricNumber::Integer(value)),
                     )?
                 }
-                MetricSeriesKind::FloatCount => scan_metric_points::<_, MetricFloatPointSeries, _>(
-                    reader,
-                    &series,
-                    &timestamp,
-                    range.lower,
-                    range.upper,
-                    fetch,
-                    &mut out,
-                    |value| {
-                        crate::types::MetricValue::Count(crate::types::MetricNumber::Float(value))
-                    },
-                )?,
+                MetricSeriesKind::FloatCount => {
+                    scan_metric_points::<_, MetricFloatPointSeries, _, _>(
+                        reader,
+                        &series,
+                        &timestamp,
+                        range.lower,
+                        range.upper,
+                        &mut scan_state,
+                        collector,
+                        |value| MetricValue::Count(MetricNumber::Float(value)),
+                    )?
+                }
                 MetricSeriesKind::IntegerGauge => {
-                    scan_metric_points::<_, MetricIntegerPointSeries, _>(
+                    scan_metric_points::<_, MetricIntegerPointSeries, _, _>(
                         reader,
                         &series,
                         &timestamp,
                         range.lower,
                         range.upper,
-                        fetch,
-                        &mut out,
-                        |value| {
-                            crate::types::MetricValue::Gauge(crate::types::MetricNumber::Integer(
-                                value,
-                            ))
-                        },
+                        &mut scan_state,
+                        collector,
+                        |value| MetricValue::Gauge(MetricNumber::Integer(value)),
                     )?
                 }
-                MetricSeriesKind::FloatGauge => scan_metric_points::<_, MetricFloatPointSeries, _>(
-                    reader,
-                    &series,
-                    &timestamp,
-                    range.lower,
-                    range.upper,
-                    fetch,
-                    &mut out,
-                    |value| {
-                        crate::types::MetricValue::Gauge(crate::types::MetricNumber::Float(value))
-                    },
-                )?,
-                MetricSeriesKind::Histogram => {
-                    scan_metric_points::<_, MetricHistogramPointSeries, _>(
+                MetricSeriesKind::FloatGauge => {
+                    scan_metric_points::<_, MetricFloatPointSeries, _, _>(
                         reader,
                         &series,
                         &timestamp,
                         range.lower,
                         range.upper,
-                        fetch,
-                        &mut out,
-                        crate::types::MetricValue::Histogram,
+                        &mut scan_state,
+                        collector,
+                        |value| MetricValue::Gauge(MetricNumber::Float(value)),
+                    )?
+                }
+                MetricSeriesKind::Histogram => {
+                    scan_metric_points::<_, MetricHistogramPointSeries, _, _>(
+                        reader,
+                        &series,
+                        &timestamp,
+                        range.lower,
+                        range.upper,
+                        &mut scan_state,
+                        collector,
+                        MetricValue::Histogram,
                     )?
                 }
             };
             if complete {
-                return Ok(out);
+                return Ok(());
             }
         }
     }
-    Ok(out)
+    Ok(())
 }
 
 #[cfg(test)]
@@ -688,7 +925,7 @@ mod tests {
 
     use chrono::Utc;
 
-    use super::{ValueFilter, query_jobs, query_metrics};
+    use super::{ValueFilter, VecCollector, query_jobs, query_metrics};
     use crate::access::DirectStoreBackend;
     use crate::backend::MemoryBackend;
     use crate::engine::{MetricSample, write_event, write_metrics};
@@ -716,7 +953,8 @@ mod tests {
         }
 
         let reader = backend.read();
-        let rows = query_jobs(
+        let mut collector = VecCollector::default();
+        query_jobs(
             &reader,
             ValueFilter::new(
                 ValueDomain::point("target".to_string()),
@@ -727,7 +965,9 @@ mod tests {
                 Arc::new(|job_id| Ok(*job_id > 1 && *job_id <= 2)),
             ),
             usize::MAX,
+            &mut collector,
         )?;
+        let rows = collector.into_rows();
 
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].session_id, "target");
@@ -768,7 +1008,8 @@ mod tests {
             )?;
         }
 
-        let rows = query_metrics(
+        let mut collector = VecCollector::default();
+        query_metrics(
             &backend.read(),
             ValueFilter::all(Predicates::always_true()),
             ValueFilter::new(
@@ -781,7 +1022,9 @@ mod tests {
                 Predicates::always_true(),
             )],
             usize::MAX,
+            &mut collector,
         )?;
+        let rows = collector.into_rows();
 
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].name, "target");

--- a/crates/sail-system-store/src/reader.rs
+++ b/crates/sail-system-store/src/reader.rs
@@ -1,6 +1,6 @@
-//! Public asynchronous reader for system tables.
+//! Public row-batch reader for system tables.
 
-use tokio::sync::oneshot;
+use tokio::sync::mpsc;
 
 use crate::actor::SystemStoreMessage;
 use crate::catalog::{JobRow, MetricRow, OptionRow, SessionRow, StageRow, TaskRow, WorkerRow};
@@ -9,51 +9,50 @@ use crate::handle::SystemStoreHandleInner;
 use crate::predicate::{MapValueFilter, TimestampMicros, ValueFilter};
 use crate::{SystemStoreError, SystemStoreResult};
 
+// Keep at most one batch queued behind the batch currently being converted by the service.
+const ROW_BATCH_CHANNEL_CAPACITY: usize = 1;
+
 #[derive(Clone, Debug)]
 pub struct SystemStoreReader {
     pub(crate) inner: SystemStoreHandleInner,
 }
 
 impl SystemStoreReader {
-    pub async fn read_jobs(
+    pub fn read_jobs(
         &self,
         session_id: ValueFilter<String>,
         job_id: ValueFilter<u64>,
         fetch: usize,
-    ) -> SystemStoreResult<Vec<JobRow>> {
-        let (reply, receiver) = oneshot::channel();
-        self.send(SystemStoreQuery::Jobs {
+        batch_size: usize,
+    ) -> SystemStoreResult<mpsc::Receiver<SystemStoreResult<Option<Vec<JobRow>>>>> {
+        self.start(|sender| SystemStoreQuery::Jobs {
             session_id,
             job_id,
             fetch,
-            reply,
-        })?;
-        receiver.await.map_err(|error| {
-            SystemStoreError::internal(format!("system store jobs read cancelled: {error}"))
-        })?
+            batch_size,
+            sender,
+        })
     }
 
-    pub async fn read_stages(
+    pub fn read_stages(
         &self,
         session_id: ValueFilter<String>,
         job_id: ValueFilter<u64>,
         stage: ValueFilter<u64>,
         fetch: usize,
-    ) -> SystemStoreResult<Vec<StageRow>> {
-        let (reply, receiver) = oneshot::channel();
-        self.send(SystemStoreQuery::Stages {
+        batch_size: usize,
+    ) -> SystemStoreResult<mpsc::Receiver<SystemStoreResult<Option<Vec<StageRow>>>>> {
+        self.start(|sender| SystemStoreQuery::Stages {
             session_id,
             job_id,
             stage,
             fetch,
-            reply,
-        })?;
-        receiver.await.map_err(|error| {
-            SystemStoreError::internal(format!("system store stages read cancelled: {error}"))
-        })?
+            batch_size,
+            sender,
+        })
     }
 
-    pub async fn read_tasks(
+    pub fn read_tasks(
         &self,
         session_id: ValueFilter<String>,
         job_id: ValueFilter<u64>,
@@ -61,93 +60,92 @@ impl SystemStoreReader {
         partition: ValueFilter<u64>,
         attempt: ValueFilter<u64>,
         fetch: usize,
-    ) -> SystemStoreResult<Vec<TaskRow>> {
-        let (reply, receiver) = oneshot::channel();
-        self.send(SystemStoreQuery::Tasks {
+        batch_size: usize,
+    ) -> SystemStoreResult<mpsc::Receiver<SystemStoreResult<Option<Vec<TaskRow>>>>> {
+        self.start(|sender| SystemStoreQuery::Tasks {
             session_id,
             job_id,
             stage,
             partition,
             attempt,
             fetch,
-            reply,
-        })?;
-        receiver.await.map_err(|error| {
-            SystemStoreError::internal(format!("system store tasks read cancelled: {error}"))
-        })?
+            batch_size,
+            sender,
+        })
     }
 
-    pub async fn read_options(
+    pub fn read_options(
         &self,
         key: ValueFilter<String>,
         fetch: usize,
-    ) -> SystemStoreResult<Vec<OptionRow>> {
-        let (reply, receiver) = oneshot::channel();
-        self.send(SystemStoreQuery::Options { key, fetch, reply })?;
-        receiver.await.map_err(|error| {
-            SystemStoreError::internal(format!("system store options read cancelled: {error}"))
-        })?
+        batch_size: usize,
+    ) -> SystemStoreResult<mpsc::Receiver<SystemStoreResult<Option<Vec<OptionRow>>>>> {
+        self.start(|sender| SystemStoreQuery::Options {
+            key,
+            fetch,
+            batch_size,
+            sender,
+        })
     }
 
-    pub async fn read_sessions(
+    pub fn read_sessions(
         &self,
         session_id: ValueFilter<String>,
         fetch: usize,
-    ) -> SystemStoreResult<Vec<SessionRow>> {
-        let (reply, receiver) = oneshot::channel();
-        self.send(SystemStoreQuery::Sessions {
+        batch_size: usize,
+    ) -> SystemStoreResult<mpsc::Receiver<SystemStoreResult<Option<Vec<SessionRow>>>>> {
+        self.start(|sender| SystemStoreQuery::Sessions {
             session_id,
             fetch,
-            reply,
-        })?;
-        receiver.await.map_err(|error| {
-            SystemStoreError::internal(format!("system store sessions read cancelled: {error}"))
-        })?
+            batch_size,
+            sender,
+        })
     }
 
-    pub async fn read_workers(
+    pub fn read_workers(
         &self,
         session_id: ValueFilter<String>,
         worker_id: ValueFilter<u64>,
         fetch: usize,
-    ) -> SystemStoreResult<Vec<WorkerRow>> {
-        let (reply, receiver) = oneshot::channel();
-        self.send(SystemStoreQuery::Workers {
+        batch_size: usize,
+    ) -> SystemStoreResult<mpsc::Receiver<SystemStoreResult<Option<Vec<WorkerRow>>>>> {
+        self.start(|sender| SystemStoreQuery::Workers {
             session_id,
             worker_id,
             fetch,
-            reply,
-        })?;
-        receiver.await.map_err(|error| {
-            SystemStoreError::internal(format!("system store workers read cancelled: {error}"))
-        })?
+            batch_size,
+            sender,
+        })
     }
 
-    pub async fn read_metrics(
+    pub fn read_metrics(
         &self,
         timestamp: ValueFilter<TimestampMicros>,
         name: ValueFilter<String>,
         attributes: Vec<MapValueFilter<String, String>>,
         fetch: usize,
-    ) -> SystemStoreResult<Vec<MetricRow>> {
-        let (reply, receiver) = oneshot::channel();
-        self.send(SystemStoreQuery::Metrics {
+        batch_size: usize,
+    ) -> SystemStoreResult<mpsc::Receiver<SystemStoreResult<Option<Vec<MetricRow>>>>> {
+        self.start(|sender| SystemStoreQuery::Metrics {
             timestamp,
             name,
             attributes,
             fetch,
-            reply,
-        })?;
-        receiver.await.map_err(|error| {
-            SystemStoreError::internal(format!("system store metrics read cancelled: {error}"))
-        })?
+            batch_size,
+            sender,
+        })
     }
 
-    fn send(&self, query: SystemStoreQuery) -> SystemStoreResult<()> {
+    fn start<T>(
+        &self,
+        query: impl FnOnce(mpsc::Sender<SystemStoreResult<Option<Vec<T>>>>) -> SystemStoreQuery,
+    ) -> SystemStoreResult<mpsc::Receiver<SystemStoreResult<Option<Vec<T>>>>> {
+        let (sender, receiver) = mpsc::channel(ROW_BATCH_CHANNEL_CAPACITY);
         self.inner
-            .send(SystemStoreMessage::Read(query))
+            .send(SystemStoreMessage::Read(query(sender)))
             .map_err(|error| {
                 SystemStoreError::internal(format!("failed to send system store read: {error}"))
-            })
+            })?;
+        Ok(receiver)
     }
 }

--- a/crates/sail-telemetry/src/metrics/reporter.rs
+++ b/crates/sail-telemetry/src/metrics/reporter.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue, any_value};
 use opentelemetry_proto::tonic::metrics::v1::{
     HistogramDataPoint, NumberDataPoint, ResourceMetrics, metric, number_data_point,
@@ -217,4 +219,3 @@ fn attribute_json_value(value: AnyValue) -> serde_json::Value {
         None => serde_json::Value::Null,
     }
 }
-use std::collections::BTreeMap;


### PR DESCRIPTION
1. Improve metrics record batch creation by avoiding `serde_json` when building variant values.
2. Avoid materializing all rows in memory when querying the on-disk system store backend.