### PR TITLE
feat: use mimalloc as the Python wheel's global allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8114,6 +8114,7 @@ dependencies = [
  "fastrace",
  "futures",
  "log",
+ "mimalloc",
  "pyo3",
  "sail-catalog",
  "sail-catalog-glue",

--- a/crates/sail-cli/Cargo.toml
+++ b/crates/sail-cli/Cargo.toml
@@ -22,7 +22,10 @@ sail-telemetry = { path = "../sail-telemetry" }
 sail-spark-connect = { path = "../sail-spark-connect" }
 sail-session = { path = "../sail-session" }
 
-mimalloc = { workspace = true, optional = true }
+# TODO: Drop "v2" after:
+#       - libmimalloc-sys vendors the fix for https://github.com/microsoft/mimalloc/issues/1287 and
+#       - exposes MI_TLS_MODEL_LOCAL for macOS coexistence https://github.com/microsoft/mimalloc/issues/1301
+mimalloc = { workspace = true, optional = true, features = ["v2"] }
 clap = { workspace = true }
 tokio = { workspace = true }
 log = { workspace = true }

--- a/crates/sail-python/Cargo.toml
+++ b/crates/sail-python/Cargo.toml
@@ -6,6 +6,9 @@ edition = { workspace = true }
 [lints]
 workspace = true
 
+[features]
+mimalloc = ["dep:mimalloc"]
+
 [dependencies]
 sail-common = { path = "../sail-common" }
 sail-common-datafusion = { path = "../sail-common-datafusion" }
@@ -22,6 +25,10 @@ sail-catalog-unity = { path = "../sail-catalog-unity" }
 
 arrow-schema = { workspace = true }
 bytes = { workspace = true }
+# TODO: Drop "v2" after:
+#       - libmimalloc-sys vendors the fix for https://github.com/microsoft/mimalloc/issues/1287 and
+#       - exposes MI_TLS_MODEL_LOCAL for macOS coexistence https://github.com/microsoft/mimalloc/issues/1301
+mimalloc = { workspace = true, optional = true, features = ["local_dynamic_tls", "v2"] }
 pyo3 = { workspace = true }
 tokio = { workspace = true }
 log = { workspace = true }

--- a/crates/sail-python/src/lib.rs
+++ b/crates/sail-python/src/lib.rs
@@ -11,6 +11,15 @@ mod spark;
 
 use pyo3::prelude::*;
 
+// A `#[global_allocator]` only takes effect in the final linked artifact that compiles it in.
+// The mimalloc static in `sail-cli` lives in its bin target (`main.rs`), so this
+// cdylib does not inherit it (linking `sail-cli` as a lib causes no duplicate-allocator conflict).
+// Without the static below, Rust code in the Python wheel falls back to the system allocator.
+// This swaps the allocator for Rust allocations only; CPython's own allocator is untouched.
+#[cfg(feature = "mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 /// Creates the `_native` Python module.
 /// Registers the version constant, the `main` function,
 /// and various submodules.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -286,6 +286,7 @@ python-source = "python"
 module-name = "pysail._native"
 manifest-path = "crates/sail-python/Cargo.toml"
 features = [
+    "mimalloc",
     "pyo3/extension-module",
     "pyo3/abi3-py38",
     "pyo3/generate-import-lib",


### PR DESCRIPTION
> [!NOTE]
> This PR carves the Python-wheel allocator change out of #2235 (@shehabgamin) so it can land on its own, independently of the perf/ClickBench work still in flight there. The approach here — including the mimalloc `v2` pin — follows that PR.

### The problem

Sail sets a mimalloc `#[global_allocator]` in `sail-cli`, but a `#[global_allocator]` only takes effect in the crate that roots the *final artifact*. That static lives in `sail-cli`'s **binary** target (`main.rs`), which isn't linked into the `sail-python` **cdylib**. So the `pysail` wheel silently falls back to the **system allocator (glibc)**.

glibc keeps freed chunks on per-arena free lists and doesn't return them to the OS without an explicit `malloc_trim`. In a long-lived Spark Connect server, that reads as memory that never comes back between queries — matching the report in #1916 (*"spark.stop() is not releasing memory to os… taking more memory than apache spark"*).

On workloads that run several memory-intensive queries back to back in one long-lived server, that retention can accumulate until the process is **OOM-killed**, even though no single query's peak comes close to the limit. The work around is making explicit `malloc_trim` calls between queries which most users wont be savvy enough for.

### SedonaDB vs Sail

[SedonaDB](https://github.com/apache/sedona-db) is the same shape — a Rust engine shipped as a pyo3 cdylib wheel — and it sets its mimalloc `#[global_allocator]` in **both** roots (its CLI *and* `python/sedonadb/src/lib.rs`). Because Sail set it only in the CLI, two otherwise-similar engines behaved very differently on the same long-running workload: SedonaDB's memory plateaus across queries; Sail's climbs. This PR closes that gap by giving the wheel the allocator the CLI already has.

### The change

- Add the mimalloc `#[global_allocator]` to the `sail-python` cdylib root (+ the `mimalloc` feature, enabled via the maturin build).
- Pin mimalloc to **v2**. The crate currently defaults to v3.3.2, which segfaults under multi-threaded aligned allocation (microsoft/mimalloc#1287) and SIGABRTs on macOS when statically linked into a second shared library (microsoft/mimalloc#1301) — both fatal for a threaded cdylib. `local_dynamic_tls` selects the local-dynamic TLS model so the static loads cleanly from the extension module. Once a `libmimalloc-sys > 0.1.49` vendors the 1287 and 1301 fixes, the `v2` pin can be dropped.
