### PR TITLE
fix: correct legacy collection sizes and table column regex selection

### DIFF
--- a/crates/sail-plan/src/config.rs
+++ b/crates/sail-plan/src/config.rs
@@ -44,6 +44,8 @@ pub struct PlanConfig {
     pub default_warehouse_directory: String,
     pub session_user_id: String,
     pub ansi_mode: bool,
+    /// Whether size/cardinality return -1 for null input when ANSI mode is disabled.
+    pub legacy_size_of_null: bool,
     /// Type coercion policy for values written into table columns.
     pub store_assignment_policy: StoreAssignmentPolicy,
     /// Policy for duplicate keys created by map functions.
@@ -86,6 +88,7 @@ impl Default for PlanConfig {
             default_warehouse_directory: "spark-warehouse".to_string(),
             session_user_id: "".to_string(),
             ansi_mode: true,
+            legacy_size_of_null: true,
             store_assignment_policy: StoreAssignmentPolicy::Ansi,
             map_key_dedup_policy: MapKeyDedupPolicy::Exception,
             cross_join_enabled: true,

--- a/crates/sail-plan/src/function/scalar/collection.rs
+++ b/crates/sail-plan/src/function/scalar/collection.rs
@@ -1,6 +1,7 @@
 use datafusion::arrow::datatypes::DataType;
 use datafusion_common::ScalarValue;
 use datafusion_expr::{ExprSchemable, ScalarUDF, cast, expr, lit, when};
+use datafusion_functions::core::expr_fn::coalesce;
 use datafusion_functions::math::expr_fn::abs;
 use datafusion_functions_nested::expr_fn;
 use sail_common_datafusion::utils::items::ItemTaker;
@@ -14,7 +15,7 @@ use crate::function::common::{ScalarFunction, ScalarFunctionInput};
 fn size(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
     let value = input.arguments.one()?;
 
-    match value.get_type(input.function_context.schema)? {
+    let result = match value.get_type(input.function_context.schema)? {
         DataType::List(_)
         | DataType::ListView(_)
         | DataType::FixedSizeList(..)
@@ -24,6 +25,14 @@ fn size(input: ScalarFunctionInput) -> PlanResult<expr::Expr> {
         wrong_type => Err(PlanError::InvalidArgument(format!(
             "size expects List or Map as argument, got {wrong_type:?}"
         ))),
+    }?;
+
+    let config = input.function_context.plan_config;
+    if config.legacy_size_of_null && !config.ansi_mode {
+        Ok(coalesce(vec![result, lit(-1_i32)]))
+    } else {
+        // TODO: Preserve input nullability in nonlegacy mode; see the size/cardinality schema tests.
+        Ok(result)
     }
 }
 
@@ -66,9 +75,6 @@ pub(super) fn list_built_in_collection_functions() -> Vec<(&'static str, ScalarF
     use crate::function::common::ScalarFunctionBuilder as F;
 
     vec![
-        // TODO: coalesce(result, -1)
-        // if spark.sql.ansi.enabled is false and spark.sql.legacy.sizeOfNull is true
-        // https://spark.apache.org/docs/latest/api/sql/index.html#cardinality
         ("cardinality", F::custom(size)),
         ("deep_size", F::unary(expr_fn::cardinality)),
         ("element_at", F::custom(|input| element_at(input, false))),

--- a/crates/sail-plan/src/resolver/expression/misc.rs
+++ b/crates/sail-plan/src/resolver/expression/misc.rs
@@ -207,11 +207,6 @@ impl PlanResolver<'_> {
         let mut matching_names = Vec::new();
 
         for (qualifier, field) in schema.iter() {
-            // Skip qualified columns if no qualifier is expected
-            if qualifier.is_some() {
-                continue;
-            }
-
             // Get field info
             let Ok(info) = state.get_field_info(field.name()) else {
                 continue;
@@ -225,7 +220,10 @@ impl PlanResolver<'_> {
             // Check if the field name matches the pattern and plan_id
             let field_name = info.name();
             if pattern.is_match(field_name) && info.matches(field_name, plan_id) {
-                matching_columns.push(expr::Expr::Column(Column::new_unqualified(field.name())));
+                matching_columns.push(expr::Expr::Column(Column::new(
+                    qualifier.cloned(),
+                    field.name(),
+                )));
                 matching_names.push(field_name.to_string());
             }
         }

--- a/crates/sail-spark-connect/src/config.rs
+++ b/crates/sail-spark-connect/src/config.rs
@@ -268,14 +268,6 @@ impl TryFrom<&SparkRuntimeConfig> for PlanConfig {
             output.ansi_mode = value;
         }
 
-        if let Some(value) = config
-            .get_option(SparkConfigKey::SPARK_SQL_LEGACY_SIZE_OF_NULL)
-            .map(|x| x.trim_matches(|c| c <= ' ').to_lowercase().parse::<bool>())
-            .transpose()?
-        {
-            output.legacy_size_of_null = value;
-        }
-
         if let Some(value) = config.get_option(SparkConfigKey::SPARK_SQL_STORE_ASSIGNMENT_POLICY) {
             output.store_assignment_policy = match value.trim().to_ascii_uppercase().as_str() {
                 "ANSI" => StoreAssignmentPolicy::Ansi,
@@ -339,6 +331,14 @@ impl TryFrom<&SparkRuntimeConfig> for PlanConfig {
             .transpose()?
         {
             output.legacy_allow_parameterless_count = value;
+        }
+
+        if let Some(value) = config
+            .get_option(SparkConfigKey::SPARK_SQL_LEGACY_SIZE_OF_NULL)
+            .map(|x| x.trim().to_lowercase().parse::<bool>())
+            .transpose()?
+        {
+            output.legacy_size_of_null = value;
         }
 
         output.pyspark_udf_config = Arc::new(PySparkUdfConfig::try_from(config)?);

--- a/crates/sail-spark-connect/src/config.rs
+++ b/crates/sail-spark-connect/src/config.rs
@@ -230,7 +230,7 @@ impl TryFrom<&SparkRuntimeConfig> for PlanConfig {
 
         if let Some(value) = config
             .get_option(SparkConfigKey::SPARK_SQL_EXECUTION_ARROW_USE_LARGE_VAR_TYPES)
-            .map(|x| x.to_lowercase().parse::<bool>())
+            .map(|x| x.trim().to_lowercase().parse::<bool>())
             .transpose()?
         {
             output.arrow_use_large_var_types = value;
@@ -262,7 +262,7 @@ impl TryFrom<&SparkRuntimeConfig> for PlanConfig {
 
         if let Some(value) = config
             .get_option(SparkConfigKey::SPARK_SQL_ANSI_ENABLED)
-            .map(|x| x.to_lowercase().parse::<bool>())
+            .map(|x| x.trim().to_lowercase().parse::<bool>())
             .transpose()?
         {
             output.ansi_mode = value;
@@ -295,7 +295,7 @@ impl TryFrom<&SparkRuntimeConfig> for PlanConfig {
 
         if let Some(value) = config
             .get_option(SparkConfigKey::SPARK_SQL_CROSS_JOIN_ENABLED)
-            .map(|x| x.to_lowercase().parse::<bool>())
+            .map(|x| x.trim().to_lowercase().parse::<bool>())
             .transpose()?
         {
             output.cross_join_enabled = value;
@@ -303,7 +303,7 @@ impl TryFrom<&SparkRuntimeConfig> for PlanConfig {
 
         if let Some(value) = config
             .get_option(SparkConfigKey::SPARK_SQL_CASE_SENSITIVE)
-            .map(|x| x.to_lowercase().parse::<bool>())
+            .map(|x| x.trim().to_lowercase().parse::<bool>())
             .transpose()?
         {
             output.case_sensitive = value;
@@ -319,7 +319,7 @@ impl TryFrom<&SparkRuntimeConfig> for PlanConfig {
 
         if let Some(value) = config
             .get_option(SparkConfigKey::SPARK_SQL_TVF_ALLOW_MULTIPLE_TABLE_ARGUMENTS_ENABLED)
-            .map(|x| x.to_lowercase().parse::<bool>())
+            .map(|x| x.trim().to_lowercase().parse::<bool>())
             .transpose()?
         {
             output.tvf_allow_multiple_table_arguments = value;
@@ -327,7 +327,7 @@ impl TryFrom<&SparkRuntimeConfig> for PlanConfig {
 
         if let Some(value) = config
             .get_option(SparkConfigKey::SPARK_SQL_LEGACY_ALLOW_PARAMETERLESS_COUNT)
-            .map(|x| x.to_lowercase().parse::<bool>())
+            .map(|x| x.trim().to_lowercase().parse::<bool>())
             .transpose()?
         {
             output.legacy_allow_parameterless_count = value;
@@ -362,7 +362,7 @@ impl TryFrom<&SparkRuntimeConfig> for PySparkUdfConfig {
 
         if let Some(value) = config
             .get_option(SparkConfigKey::SPARK_SQL_LEGACY_EXECUTION_PANDAS_GROUPED_MAP_ASSIGN_COLUMNS_BY_NAME)
-            .map(|x| x.to_lowercase().parse::<bool>())
+            .map(|x| x.trim().to_lowercase().parse::<bool>())
             .transpose()?
         {
             output.pandas_grouped_map_assign_columns_by_name = value;
@@ -370,7 +370,7 @@ impl TryFrom<&SparkRuntimeConfig> for PySparkUdfConfig {
 
         if let Some(value) = config
             .get_option(SparkConfigKey::SPARK_SQL_EXECUTION_PANDAS_CONVERT_TO_ARROW_ARRAY_SAFELY)
-            .map(|x| x.to_lowercase().parse::<bool>())
+            .map(|x| x.trim().to_lowercase().parse::<bool>())
             .transpose()?
         {
             output.pandas_convert_to_arrow_array_safely = value;
@@ -378,7 +378,7 @@ impl TryFrom<&SparkRuntimeConfig> for PySparkUdfConfig {
 
         if let Some(value) = config
             .get_option(SparkConfigKey::SPARK_SQL_EXECUTION_ARROW_MAX_RECORDS_PER_BATCH)
-            .map(|x| x.parse::<i128>())
+            .map(|x| x.trim().parse::<i128>())
             .transpose()?
         {
             output.arrow_max_records_per_batch = if value <= 0 || value > usize::MAX as i128 {
@@ -390,7 +390,7 @@ impl TryFrom<&SparkRuntimeConfig> for PySparkUdfConfig {
 
         if let Some(value) = config
             .get_option(SparkConfigKey::SPARK_SQL_EXECUTION_ARROW_USE_LARGE_VAR_TYPES)
-            .map(|x| x.to_lowercase().parse::<bool>())
+            .map(|x| x.trim().to_lowercase().parse::<bool>())
             .transpose()?
         {
             output.arrow_use_large_var_types = value;
@@ -400,7 +400,7 @@ impl TryFrom<&SparkRuntimeConfig> for PySparkUdfConfig {
             .get_option(
                 SparkConfigKey::SPARK_SQL_LEGACY_EXECUTION_PYTHON_UDF_PANDAS_CONVERSION_ENABLED,
             )
-            .map(|x| x.to_lowercase().parse::<bool>())
+            .map(|x| x.trim().to_lowercase().parse::<bool>())
             .transpose()?
         {
             output.python_udf_pandas_conversion_enabled = value;
@@ -410,7 +410,7 @@ impl TryFrom<&SparkRuntimeConfig> for PySparkUdfConfig {
             .get_option(
                 SparkConfigKey::SPARK_SQL_LEGACY_EXECUTION_PYTHON_UDTF_PANDAS_CONVERSION_ENABLED,
             )
-            .map(|x| x.to_lowercase().parse::<bool>())
+            .map(|x| x.trim().to_lowercase().parse::<bool>())
             .transpose()?
         {
             output.python_udtf_pandas_conversion_enabled = value;
@@ -418,7 +418,7 @@ impl TryFrom<&SparkRuntimeConfig> for PySparkUdfConfig {
 
         if let Some(value) = config
             .get_option(SparkConfigKey::SPARK_SQL_EXECUTION_PYTHON_UDF_PANDAS_INT_TO_DECIMAL_COERCION_ENABLED)
-            .map(|x| x.to_lowercase().parse::<bool>())
+            .map(|x| x.trim().to_lowercase().parse::<bool>())
             .transpose()?
         {
             output.python_udf_pandas_int_to_decimal_coercion_enabled = value;
@@ -428,7 +428,7 @@ impl TryFrom<&SparkRuntimeConfig> for PySparkUdfConfig {
             .get_option(
                 SparkConfigKey::SPARK_SQL_EXECUTION_PYTHON_UDF_PANDAS_PREFER_INT_EXTENSION_DTYPE,
             )
-            .map(|x| x.to_lowercase().parse::<bool>())
+            .map(|x| x.trim().to_lowercase().parse::<bool>())
             .transpose()?
         {
             output.python_udf_pandas_prefer_int_extension_dtype = value;
@@ -436,7 +436,7 @@ impl TryFrom<&SparkRuntimeConfig> for PySparkUdfConfig {
 
         if let Some(value) = config
             .get_option(SparkConfigKey::SPARK_SQL_EXECUTION_PYSPARK_BINARY_AS_BYTES)
-            .map(|x| x.to_lowercase().parse::<bool>())
+            .map(|x| x.trim().to_lowercase().parse::<bool>())
             .transpose()?
         {
             output.binary_as_bytes = value;

--- a/crates/sail-spark-connect/src/config.rs
+++ b/crates/sail-spark-connect/src/config.rs
@@ -268,6 +268,14 @@ impl TryFrom<&SparkRuntimeConfig> for PlanConfig {
             output.ansi_mode = value;
         }
 
+        if let Some(value) = config
+            .get_option(SparkConfigKey::SPARK_SQL_LEGACY_SIZE_OF_NULL)
+            .map(|x| x.trim_matches(|c| c <= ' ').to_lowercase().parse::<bool>())
+            .transpose()?
+        {
+            output.legacy_size_of_null = value;
+        }
+
         if let Some(value) = config.get_option(SparkConfigKey::SPARK_SQL_STORE_ASSIGNMENT_POLICY) {
             output.store_assignment_policy = match value.trim().to_ascii_uppercase().as_str() {
                 "ANSI" => StoreAssignmentPolicy::Ansi,

--- a/python/pysail/tests/spark/dataframe/test_col_regex.py
+++ b/python/pysail/tests/spark/dataframe/test_col_regex.py
@@ -1,5 +1,28 @@
 """Tests for colRegex column selection functionality."""
 
+import pytest
+
+
+@pytest.mark.parametrize("alias", [None, "source"])
+def test_select_columns_from_table(spark, tmp_path, alias):
+    df = spark.createDataFrame([(1, 2, 3)], ["test\n_column", "col1", "col2"])
+    table_name = "col_regex_table"
+    df.write.format("parquet").option("path", str(tmp_path / "data")).saveAsTable(table_name)
+    try:
+        table = spark.read.table(table_name)
+        if alias is not None:
+            table = table.alias(alias)
+        for pattern, columns, rows in [
+            ("`tes.*\n.*mn`", ["test\n_column"], [(1,)]),
+            ("`col[12]`", ["col1", "col2"], [(2, 3)]),
+            ("`missing.*`", [], [()]),
+        ]:
+            result = table.select(table.colRegex(pattern))
+            assert result.columns == columns
+            assert result.collect() == rows
+    finally:
+        spark.sql(f"DROP TABLE {table_name}")
+
 
 def test_select_columns_not_starting_with_col1(spark):
     """Select columns using regex pattern that excludes Col1."""

--- a/python/pysail/tests/spark/function/features/collection/size_null.feature
+++ b/python/pysail/tests/spark/function/features/collection/size_null.feature
@@ -1,0 +1,60 @@
+Feature: size and cardinality null handling
+
+  Scenario Outline: Nullable collections with ANSI <ansi> and legacy size of null <legacy>
+    Given config spark.sql.ansi.enabled = <ansi>
+    And config spark.sql.legacy.sizeOfNull = <legacy>
+    When query
+      """
+      SELECT size(a) AS array_size, cardinality(a) AS array_cardinality,
+             size(m) AS map_size, cardinality(m) AS map_cardinality
+      FROM VALUES
+        (0, CAST(NULL AS ARRAY<INT>), CAST(NULL AS MAP<INT, INT>)),
+        (1, array(), map()),
+        (2, array(1, NULL, 3), map(1, NULL, 3, 4))
+      AS t(id, a, m)
+      ORDER BY id
+      """
+    Then query result ordered
+      | array_size | array_cardinality | map_size | map_cardinality |
+      | <null>     | <null>            | <null>   | <null>          |
+      | 0          | 0                 | 0        | 0               |
+      | 3          | 3                 | 2        | 2               |
+    And query schema
+      """
+      root
+       |-- array_size: integer (nullable = <nullable>)
+       |-- array_cardinality: integer (nullable = <nullable>)
+       |-- map_size: integer (nullable = <nullable>)
+       |-- map_cardinality: integer (nullable = <nullable>)
+      """
+
+    Examples:
+      | ansi  | legacy           | null | nullable |
+      | false | true             | -1   | false    |
+      | false | false            | NULL | true     |
+      | true  | true             | NULL | true     |
+      | true  | false            | NULL | true     |
+      | false | {{ ' TrUe ' }}  | -1   | false    |
+      | false | {{ ' FaLsE ' }} | NULL | true     |
+
+  Scenario: Legacy size and cardinality of null collection literals are non-null integers
+    Given config spark.sql.ansi.enabled = false
+    And config spark.sql.legacy.sizeOfNull = true
+    When query
+      """
+      SELECT size(CAST(NULL AS ARRAY<INT>)) AS array_size,
+             cardinality(CAST(NULL AS ARRAY<INT>)) AS array_cardinality,
+             size(CAST(NULL AS MAP<INT, INT>)) AS map_size,
+             cardinality(CAST(NULL AS MAP<INT, INT>)) AS map_cardinality
+      """
+    Then query result
+      | array_size | array_cardinality | map_size | map_cardinality |
+      | -1         | -1                | -1       | -1              |
+    And query schema
+      """
+      root
+       |-- array_size: integer (nullable = false)
+       |-- array_cardinality: integer (nullable = false)
+       |-- map_size: integer (nullable = false)
+       |-- map_cardinality: integer (nullable = false)
+      """


### PR DESCRIPTION
- Honor `spark.sql.legacy.sizeOfNull` when ANSI mode is disabled. Include table-qualified columns in `colRegex` expansion and preserve their qualifiers.

- Also add trim to configs like Spark does.