### PR TITLE
fix: coerce non-string inputs for formatted to_date

### DIFF
--- a/crates/sail-plan/src/function/scalar/datetime.rs
+++ b/crates/sail-plan/src/function/scalar/datetime.rs
@@ -478,9 +478,11 @@ fn to_date(input: ScalarFunctionInput) -> PlanResult<Expr> {
                 input.function_context.schema,
             );
         }
+        // Spark implicitly casts atomic inputs to string before formatted parsing.
+        // Leave nested inputs to the parser's existing type rejection.
         let expr = match expr_type {
-            Ok(_other) => expr,
-            Err(_) => cast(expr, DataType::Utf8), // In case of error, cast to string
+            Ok(data_type) if data_type.is_string() || data_type.is_nested() => expr,
+            _ => cast(expr, DataType::Utf8),
         };
         Ok(ScalarUDF::from(SparkDate::new(null_on_error)).call(vec![expr, format]))
     } else {

--- a/python/pysail/tests/spark/function/features/datetime/to_date.feature
+++ b/python/pysail/tests/spark/function/features/datetime/to_date.feature
@@ -26,6 +26,98 @@ Feature: to_date with an argument coming from a column
         | 2016-12-31 |
         | 2016-12-31 |
 
+  Rule: Formatted numeric date keys are implicitly cast to string
+
+    Scenario Outline: To date parses a formatted <case> literal
+      When query
+        """
+        SELECT to_date(<value>, 'yyyyMMdd') AS result
+        """
+      Then query result
+        | result   |
+        | <result> |
+
+      Examples:
+        | case         | value                            | result     |
+        | integer      | 20260220                         | 2026-02-20 |
+        | bigint       | CAST(20251201 AS BIGINT)          | 2025-12-01 |
+        | decimal      | CAST(20260220 AS DECIMAL(8, 0))   | 2026-02-20 |
+        | typed null   | CAST(NULL AS BIGINT)             | NULL       |
+        | untyped null | NULL                             | NULL       |
+
+    Scenario Outline: To date parses numeric columns with literal and dynamic formats with ANSI <ansi>
+      Given config spark.sql.ansi.enabled = <ansi>
+      When query
+        """
+        SELECT
+          id,
+          to_date(value, 'yyyyMMdd') AS literal_format,
+          to_date(value, format) AS dynamic_format
+        FROM VALUES
+          (1, 20260220, 'yyyyMMdd'),
+          (2, 20261201, 'yyyyddMM'),
+          (3, CAST(NULL AS INT), 'yyyyMMdd'),
+          (4, 20251201, CAST(NULL AS STRING))
+          AS t(id, value, format)
+        ORDER BY id
+        """
+      Then query result ordered
+        | id | literal_format | dynamic_format |
+        | 1  | 2026-02-20     | 2026-02-20     |
+        | 2  | 2026-12-01     | 2026-01-12     |
+        | 3  | NULL           | NULL           |
+        | 4  | 2025-12-01     | NULL           |
+
+      Examples:
+        | ansi  |
+        | true  |
+        | false |
+
+    Scenario: To date parses a numeric literal using a format column
+      When query
+        """
+        SELECT id, to_date(20261201, format) AS result
+        FROM VALUES
+          (1, 'yyyyMMdd'),
+          (2, 'yyyyddMM'),
+          (3, CAST(NULL AS STRING))
+          AS t(id, format)
+        ORDER BY id
+        """
+      Then query result ordered
+        | id | result     |
+        | 1  | 2026-12-01 |
+        | 2  | 2026-01-12 |
+        | 3  | NULL       |
+
+    Scenario: To date returns NULL for invalid numeric date keys with ANSI disabled
+      Given config spark.sql.ansi.enabled = false
+      When query
+        """
+        SELECT
+          to_date(20260229, 'yyyyMMdd') AS literal_value,
+          to_date(value, 'yyyyMMdd') AS column_value
+        FROM VALUES (20260229), (20260015) AS t(value)
+        """
+      Then query result
+        | literal_value | column_value |
+        | NULL          | NULL         |
+        | NULL          | NULL         |
+
+    Scenario Outline: To date rejects an invalid numeric <case> with ANSI enabled
+      Given config spark.sql.ansi.enabled = true
+      When query
+        """
+        SELECT to_date(<value>, 'yyyyMMdd') AS result
+        FROM VALUES (20260229), (20260015) AS t(value)
+        """
+      Then query error (?i)(CANNOT_PARSE_TIMESTAMP|invalid parsed (date|month)|out of range|DateValue)
+
+      Examples:
+        | case    | value    |
+        | literal | 20260229 |
+        | column  | value    |
+
   Rule: Invalid string input follows ANSI mode
 
     Scenario Outline: To date returns NULL for <case> with ANSI disabled

--- a/python/pysail/tests/spark/function/test_to_date.py
+++ b/python/pysail/tests/spark/function/test_to_date.py
@@ -1,0 +1,18 @@
+from datetime import date
+
+import pytest
+from pyspark.sql import functions as F  # noqa: N812
+from pyspark.sql import types as T  # noqa: N812
+
+
+@pytest.mark.parametrize("input_type", ["bigint", "int"])
+def test_to_date_numeric_column_schema_and_collect(spark, input_type):
+    df = spark.createDataFrame([(20260220,), (20251201,)], ["date_int"])
+    if input_type == "int":
+        df = df.withColumn("date_int", F.col("date_int").cast("int"))
+    assert df.dtypes == [("date_int", input_type)]
+
+    result = df.withColumn("date_col", F.to_date(F.col("date_int"), "yyyyMMdd"))
+    assert result.dtypes == [("date_int", input_type), ("date_col", "date")]
+    assert result.schema["date_col"] == T.StructField("date_col", T.DateType(), nullable=True)
+    assert sorted(result.collect()) == [(20251201, date(2025, 12, 1)), (20260220, date(2026, 2, 20))]


### PR DESCRIPTION
Closes https://github.com/lakehq/sail/issues/2549