### PR TITLE
feat: implement vector cosine similarity

### DIFF
--- a/crates/sail-execution/src/proto/codec.rs
+++ b/crates/sail-execution/src/proto/codec.rs
@@ -256,6 +256,7 @@ use sail_function::scalar::variant::spark_to_variant_object::SparkToVariantObjec
 use sail_function::scalar::variant::spark_variant_explode::SparkVariantExplodeUdf;
 use sail_function::scalar::variant::spark_variant_get::SparkVariantGet;
 use sail_function::scalar::variant::spark_variant_to_json::SparkVariantToJsonUdf;
+use sail_function::scalar::vector::cosine_similarity::VectorCosineSimilarity;
 use sail_function::scalar::vector::inner_product::VectorInnerProduct;
 use sail_function::scalar::xml::from_xml::SparkFromXml;
 use sail_function::scalar::xml::to_xml::SparkToXml;
@@ -3195,6 +3196,9 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             "spark_cast_string_to_int32" => {
                 Ok(Arc::new(ScalarUDF::from(SparkCastStringToInt32::new())))
             }
+            "vector_cosine_similarity" => {
+                Ok(Arc::new(ScalarUDF::from(VectorCosineSimilarity::new())))
+            }
             "vector_inner_product" => Ok(Arc::new(ScalarUDF::from(VectorInnerProduct::new()))),
             "bitmap_count" => Ok(Arc::new(ScalarUDF::from(BitmapCount::new()))),
             "format_string" => Ok(Arc::new(ScalarUDF::from(FormatStringFunc::new()))),
@@ -3387,6 +3391,7 @@ impl PhysicalExtensionCodec for RemoteExecutionCodec {
             || node_inner.is::<SparkArrayPosition>()
             || node_inner.is::<SparkArrayCompact>()
             || node_inner.is::<SparkCastStringToInt32>()
+            || node_inner.is::<VectorCosineSimilarity>()
             || node_inner.is::<VectorInnerProduct>()
             || node_inner.is::<BitmapCount>()
             || node_inner.is::<FormatStringFunc>()
@@ -6177,6 +6182,21 @@ mod tests {
                 .is_some()
         );
         assert_eq!(decoded.name(), "vector_inner_product");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_round_trip_vector_cosine_similarity_udf() -> Result<()> {
+        let decoded = round_trip_udf(ScalarUDF::from(VectorCosineSimilarity::new()))?;
+
+        assert!(
+            decoded
+                .inner()
+                .downcast_ref::<VectorCosineSimilarity>()
+                .is_some()
+        );
+        assert_eq!(decoded.name(), "vector_cosine_similarity");
 
         Ok(())
     }

--- a/crates/sail-function/src/scalar/vector/cosine_similarity.rs
+++ b/crates/sail-function/src/scalar/vector/cosine_similarity.rs
@@ -1,0 +1,260 @@
+use std::sync::Arc;
+
+use datafusion::arrow::array::{
+    Array, ArrayRef, AsArray, Float32Array, GenericListArray, OffsetSizeTrait, as_large_list_array,
+    as_list_array,
+};
+use datafusion::arrow::datatypes::{DataType, Float32Type};
+use datafusion_common::{Result, exec_err, plan_err};
+use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+
+use super::is_float_vector;
+use crate::functions_nested_utils::make_scalar_function;
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct VectorCosineSimilarity {
+    signature: Signature,
+}
+
+impl Default for VectorCosineSimilarity {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VectorCosineSimilarity {
+    pub fn new() -> Self {
+        Self {
+            signature: Signature::any(2, Volatility::Immutable),
+        }
+    }
+}
+
+impl ScalarUDFImpl for VectorCosineSimilarity {
+    fn name(&self) -> &str {
+        "vector_cosine_similarity"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, arg_types: &[DataType]) -> Result<DataType> {
+        if arg_types.len() != 2 || !arg_types.iter().all(is_float_vector) {
+            return plan_err!(
+                "vector_cosine_similarity expects two ARRAY<FLOAT> arguments, got {arg_types:?}"
+            );
+        }
+        Ok(DataType::Float32)
+    }
+
+    fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
+        make_scalar_function(vector_cosine_similarity_inner)(&args.args)
+    }
+}
+
+fn vector_cosine_similarity_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
+    if args.len() != 2 {
+        return exec_err!("vector_cosine_similarity needs exactly two arguments");
+    }
+    match (args[0].data_type(), args[1].data_type()) {
+        (DataType::List(_), DataType::List(_)) => {
+            compute_cosine_similarity(as_list_array(&args[0]), as_list_array(&args[1]))
+        }
+        (DataType::LargeList(_), DataType::LargeList(_)) => {
+            compute_cosine_similarity(as_large_list_array(&args[0]), as_large_list_array(&args[1]))
+        }
+        (left, right) => exec_err!(
+            "vector_cosine_similarity expects matching array types, got {left:?} and {right:?}"
+        ),
+    }
+}
+
+fn cosine_similarity_spark(left: &[f32], right: &[f32]) -> Option<f32> {
+    debug_assert_eq!(left.len(), right.len());
+    if left.is_empty() {
+        return None;
+    }
+
+    let mut dot_product = 0.0f32;
+    let mut left_norm_squared = 0.0f32;
+    let mut right_norm_squared = 0.0f32;
+    let mut index = 0;
+    let simd_limit = (left.len() / 8) * 8;
+
+    while index < simd_limit {
+        let a0 = left[index];
+        let a1 = left[index + 1];
+        let a2 = left[index + 2];
+        let a3 = left[index + 3];
+        let a4 = left[index + 4];
+        let a5 = left[index + 5];
+        let a6 = left[index + 6];
+        let a7 = left[index + 7];
+        let b0 = right[index];
+        let b1 = right[index + 1];
+        let b2 = right[index + 2];
+        let b3 = right[index + 3];
+        let b4 = right[index + 4];
+        let b5 = right[index + 5];
+        let b6 = right[index + 6];
+        let b7 = right[index + 7];
+
+        dot_product +=
+            a0 * b0 + a1 * b1 + a2 * b2 + a3 * b3 + a4 * b4 + a5 * b5 + a6 * b6 + a7 * b7;
+        left_norm_squared +=
+            a0 * a0 + a1 * a1 + a2 * a2 + a3 * a3 + a4 * a4 + a5 * a5 + a6 * a6 + a7 * a7;
+        right_norm_squared +=
+            b0 * b0 + b1 * b1 + b2 * b2 + b3 * b3 + b4 * b4 + b5 * b5 + b6 * b6 + b7 * b7;
+        index += 8;
+    }
+
+    while index < left.len() {
+        let left = left[index];
+        let right = right[index];
+        dot_product += left * right;
+        left_norm_squared += left * left;
+        right_norm_squared += right * right;
+        index += 1;
+    }
+
+    let norm_product = (left_norm_squared * right_norm_squared).sqrt();
+    if norm_product < f32::MIN_POSITIVE {
+        None
+    } else {
+        Some(dot_product / norm_product)
+    }
+}
+
+fn compute_cosine_similarity<O: OffsetSizeTrait>(
+    left: &GenericListArray<O>,
+    right: &GenericListArray<O>,
+) -> Result<ArrayRef> {
+    let values = (0..left.len()).map(|row| {
+        if left.is_null(row) || right.is_null(row) {
+            return Ok(None);
+        }
+        let left = left.value(row);
+        let right = right.value(row);
+        if left.len() != right.len() {
+            return exec_err!(
+                "vector_cosine_similarity requires vectors with matching dimensions, got {} and {}",
+                left.len(),
+                right.len()
+            );
+        }
+        let left = left.as_primitive::<Float32Type>();
+        let right = right.as_primitive::<Float32Type>();
+        if left.null_count() > 0 || right.null_count() > 0 {
+            return Ok(None);
+        }
+        Ok(cosine_similarity_spark(left.values(), right.values()))
+    });
+    let values = values.collect::<Result<Vec<Option<f32>>>>()?;
+    Ok(Arc::new(Float32Array::from(values)))
+}
+
+#[cfg(test)]
+mod tests {
+    use datafusion::arrow::array::{LargeListArray, ListArray};
+
+    use super::*;
+
+    #[test]
+    fn computes_spark_compatible_results() -> Result<()> {
+        let left = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![
+            Some(vec![Some(1.0), Some(2.0), Some(3.0)]),
+            Some(vec![Some(1.0), Some(0.0)]),
+            Some(vec![Some(1.0), Some(0.0)]),
+            Some(vec![Some(0.0), Some(0.0)]),
+            Some(vec![]),
+            Some(vec![Some(1.0), None]),
+            None,
+        ]);
+        let right = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![
+            Some(vec![Some(4.0), Some(5.0), Some(6.0)]),
+            Some(vec![Some(0.0), Some(1.0)]),
+            Some(vec![Some(-1.0), Some(0.0)]),
+            Some(vec![Some(1.0), Some(2.0)]),
+            Some(vec![]),
+            Some(vec![Some(1.0), Some(2.0)]),
+            Some(vec![Some(1.0)]),
+        ]);
+
+        let actual = compute_cosine_similarity(&left, &right)?;
+        let actual = actual.as_primitive::<Float32Type>();
+        let expected = Float32Array::from(vec![
+            Some(0.9746319),
+            Some(0.0),
+            Some(-1.0),
+            None,
+            None,
+            None,
+            None,
+        ]);
+        assert_eq!(actual, &expected);
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_dimension_mismatch() {
+        let left = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(vec![Some(1.0)])]);
+        let right = ListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(vec![
+            Some(1.0),
+            Some(2.0),
+        ])]);
+
+        assert!(matches!(
+            compute_cosine_similarity(&left, &right),
+            Err(error) if error.to_string().contains("matching dimensions")
+        ));
+    }
+
+    #[test]
+    fn matches_spark_float_overflow_and_underflow() {
+        assert!(
+            cosine_similarity_spark(&[3.0e19, 4.0e19], &[3.0e19, 4.0e19]).is_some_and(f32::is_nan)
+        );
+        assert_eq!(
+            cosine_similarity_spark(&[1.0e-23, 0.0], &[1.0e-23, 0.0]),
+            None
+        );
+    }
+
+    #[test]
+    fn uses_the_unrolled_accumulation_path() {
+        let left = [
+            1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0,
+        ];
+        let right = [
+            16.0, 15.0, 14.0, 13.0, 12.0, 11.0, 10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0,
+        ];
+
+        assert_eq!(cosine_similarity_spark(&left, &right), Some(0.54545456));
+    }
+
+    #[test]
+    fn supports_large_list_arrays() -> Result<()> {
+        let left = LargeListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(vec![
+            Some(1.0),
+            Some(2.0),
+        ])]);
+        let right = LargeListArray::from_iter_primitive::<Float32Type, _, _>(vec![Some(vec![
+            Some(1.0),
+            Some(2.0),
+        ])]);
+
+        let actual = vector_cosine_similarity_inner(&[Arc::new(left), Arc::new(right)])?;
+        assert_eq!(
+            actual.as_primitive::<Float32Type>(),
+            &Float32Array::from(vec![Some(1.0)])
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn propagates_infinite_values_as_nan() {
+        let actual = cosine_similarity_spark(&[f32::INFINITY, 1.0], &[1.0, 1.0]);
+        assert!(actual.is_some_and(f32::is_nan));
+    }
+}

--- a/crates/sail-function/src/scalar/vector/cosine_similarity.rs
+++ b/crates/sail-function/src/scalar/vector/cosine_similarity.rs
@@ -61,6 +61,12 @@ fn vector_cosine_similarity_inner(args: &[ArrayRef]) -> Result<ArrayRef> {
         (DataType::List(_), DataType::List(_)) => {
             compute_cosine_similarity(as_list_array(&args[0]), as_list_array(&args[1]))
         }
+        (DataType::List(_), DataType::LargeList(_)) => {
+            compute_cosine_similarity(as_list_array(&args[0]), as_large_list_array(&args[1]))
+        }
+        (DataType::LargeList(_), DataType::List(_)) => {
+            compute_cosine_similarity(as_large_list_array(&args[0]), as_list_array(&args[1]))
+        }
         (DataType::LargeList(_), DataType::LargeList(_)) => {
             compute_cosine_similarity(as_large_list_array(&args[0]), as_large_list_array(&args[1]))
         }
@@ -126,9 +132,9 @@ fn cosine_similarity_spark(left: &[f32], right: &[f32]) -> Option<f32> {
     }
 }
 
-fn compute_cosine_similarity<O: OffsetSizeTrait>(
-    left: &GenericListArray<O>,
-    right: &GenericListArray<O>,
+fn compute_cosine_similarity<L: OffsetSizeTrait, R: OffsetSizeTrait>(
+    left: &GenericListArray<L>,
+    right: &GenericListArray<R>,
 ) -> Result<ArrayRef> {
     let values = (0..left.len()).map(|row| {
         if left.is_null(row) || right.is_null(row) {
@@ -249,6 +255,27 @@ mod tests {
             actual.as_primitive::<Float32Type>(),
             &Float32Array::from(vec![Some(1.0)])
         );
+        Ok(())
+    }
+
+    #[test]
+    fn supports_mixed_list_array_widths() -> Result<()> {
+        let list: ArrayRef = Arc::new(ListArray::from_iter_primitive::<Float32Type, _, _>(vec![
+            Some(vec![Some(1.0), Some(2.0)]),
+        ]));
+        let large_list: ArrayRef =
+            Arc::new(LargeListArray::from_iter_primitive::<Float32Type, _, _>(
+                vec![Some(vec![Some(1.0), Some(2.0)])],
+            ));
+        let expected = Float32Array::from(vec![Some(1.0)]);
+
+        let list_large =
+            vector_cosine_similarity_inner(&[Arc::clone(&list), Arc::clone(&large_list)])?;
+        assert_eq!(list_large.as_primitive::<Float32Type>(), &expected);
+
+        let large_list =
+            vector_cosine_similarity_inner(&[Arc::clone(&large_list), Arc::clone(&list)])?;
+        assert_eq!(large_list.as_primitive::<Float32Type>(), &expected);
         Ok(())
     }
 

--- a/crates/sail-function/src/scalar/vector/inner_product.rs
+++ b/crates/sail-function/src/scalar/vector/inner_product.rs
@@ -8,6 +8,7 @@ use datafusion::arrow::datatypes::{DataType, Float32Type};
 use datafusion_common::{Result, exec_err, plan_err};
 use datafusion_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
 
+use super::is_float_vector;
 use crate::functions_nested_utils::make_scalar_function;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -50,14 +51,6 @@ impl ScalarUDFImpl for VectorInnerProduct {
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> Result<ColumnarValue> {
         make_scalar_function(vector_inner_product_inner)(&args.args)
     }
-}
-
-fn is_float_vector(data_type: &DataType) -> bool {
-    matches!(
-        data_type,
-        DataType::List(field) | DataType::LargeList(field)
-            if field.data_type() == &DataType::Float32
-    )
 }
 
 fn vector_inner_product_inner(args: &[ArrayRef]) -> Result<ArrayRef> {

--- a/crates/sail-function/src/scalar/vector/mod.rs
+++ b/crates/sail-function/src/scalar/vector/mod.rs
@@ -1,1 +1,12 @@
+use datafusion::arrow::datatypes::DataType;
+
+pub mod cosine_similarity;
 pub mod inner_product;
+
+fn is_float_vector(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::List(field) | DataType::LargeList(field)
+            if field.data_type() == &DataType::Float32
+    )
+}

--- a/crates/sail-plan/src/function/scalar/vector.rs
+++ b/crates/sail-plan/src/function/scalar/vector.rs
@@ -1,3 +1,4 @@
+use sail_function::scalar::vector::cosine_similarity::VectorCosineSimilarity;
 use sail_function::scalar::vector::inner_product::VectorInnerProduct;
 
 use crate::function::common::ScalarFunction;
@@ -8,7 +9,7 @@ pub(super) fn list_built_in_vector_functions() -> Vec<(&'static str, ScalarFunct
     vec![
         (
             "vector_cosine_similarity",
-            F::unknown("vector_cosine_similarity"),
+            F::udf(VectorCosineSimilarity::new()),
         ),
         ("vector_inner_product", F::udf(VectorInnerProduct::new())),
         ("vector_l2_distance", F::unknown("vector_l2_distance")),

--- a/crates/sail-spark-connect/tests/gold_data/function/vector.json
+++ b/crates/sail-spark-connect/tests/gold_data/function/vector.json
@@ -45,7 +45,7 @@
         }
       },
       "output": {
-        "failure": "not implemented: function: vector_cosine_similarity"
+        "success": "ok"
       }
     },
     {

--- a/python/pysail/tests/spark/function/features/vector/vector_cosine_similarity.feature
+++ b/python/pysail/tests/spark/function/features/vector/vector_cosine_similarity.feature
@@ -1,0 +1,151 @@
+@spark-4.2
+Feature: vector_cosine_similarity
+
+  Rule: Basic results
+
+    Scenario: basic, identical, orthogonal, and opposite vectors
+      When query
+        """
+        SELECT
+          vector_cosine_similarity(array(1.0F, 2.0F, 3.0F), array(4.0F, 5.0F, 6.0F)) AS basic,
+          vector_cosine_similarity(array(1.0F, 0.0F), array(1.0F, 0.0F)) AS identical,
+          vector_cosine_similarity(array(1.0F, 0.0F), array(0.0F, 1.0F)) AS orthogonal,
+          vector_cosine_similarity(array(1.0F, 0.0F), array(-1.0F, 0.0F)) AS opposite
+        """
+      Then query result
+        | basic     | identical | orthogonal | opposite |
+        | 0.9746319 | 1.0       | 0.0        | -1.0     |
+
+    Scenario: vector columns from VALUES execute the UDF
+      When query
+        """
+        SELECT vector_cosine_similarity(left_vector, right_vector) AS result
+        FROM VALUES
+          (array(1.0F, 2.0F, 3.0F), array(4.0F, 5.0F, 6.0F)),
+          (array(1.0F, 0.0F), array(0.0F, 1.0F)),
+          (array(1.0F, 0.0F), array(-1.0F, 0.0F))
+        AS t(left_vector, right_vector)
+        """
+      Then query result
+        | result    |
+        | 0.9746319 |
+        | 0.0       |
+        | -1.0      |
+
+    Scenario: a 16-element vector exercises the unrolled accumulation path
+      When query
+        """
+        SELECT vector_cosine_similarity(
+          array(1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F, 13.0F, 14.0F, 15.0F, 16.0F),
+          array(1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F, 13.0F, 14.0F, 15.0F, 16.0F)
+        ) AS result
+        """
+      Then query result
+        | result |
+        | 1.0    |
+
+  Rule: Null handling
+
+    Scenario: empty and zero-magnitude vectors return NULL
+      When query
+        """
+        SELECT
+          vector_cosine_similarity(
+            CAST(array() AS ARRAY<FLOAT>),
+            CAST(array() AS ARRAY<FLOAT>)
+          ) AS empty,
+          vector_cosine_similarity(array(0.0F, 0.0F), array(1.0F, 2.0F)) AS zero_magnitude
+        """
+      Then query result
+        | empty | zero_magnitude |
+        | NULL  | NULL           |
+
+    Scenario: null vectors return NULL
+      When query
+        """
+        SELECT vector_cosine_similarity(
+          CAST(NULL AS ARRAY<FLOAT>),
+          array(1.0F, 2.0F)
+        ) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+    Scenario: an array containing a null element returns NULL
+      When query
+        """
+        SELECT vector_cosine_similarity(
+          array(1.0F, CAST(NULL AS FLOAT), 3.0F),
+          array(1.0F, 2.0F, 3.0F)
+        ) AS result
+        """
+      Then query result
+        | result |
+        | NULL   |
+
+  Rule: Output schema
+
+    @function(nullability)
+    Scenario: declared FLOAT output schema and nullability
+      When query
+        """
+        SELECT vector_cosine_similarity(
+          array(1.0F, 2.0F),
+          array(3.0F, 4.0F)
+        ) AS result
+        """
+      Then query schema
+        """
+        root
+         |-- result: float (nullable = true)
+        """
+
+  Rule: Error cases
+
+    Scenario: untyped NULL is rejected
+      When query
+        """
+        SELECT vector_cosine_similarity(
+          NULL,
+          array(1.0F, 2.0F)
+        ) AS result
+        """
+      Then query error (?i)(DATATYPE_MISMATCH|UNEXPECTED_INPUT_TYPE|ARRAY|FLOAT|vector_cosine_similarity)
+
+    Scenario: unequal dimensions produce a dimension mismatch error
+      When query
+        """
+        SELECT vector_cosine_similarity(
+          array(1.0F),
+          array(1.0F, 2.0F)
+        ) AS result
+        """
+      Then query error (?i)(VECTOR_DIMENSION_MISMATCH|matching dimensions|dimension)
+
+    Scenario: ARRAY<DOUBLE> inputs are rejected
+      When query
+        """
+        SELECT vector_cosine_similarity(
+          array(1.0D, 2.0D),
+          array(3.0D, 4.0D)
+        ) AS result
+        """
+      Then query error (?i)(DATATYPE_MISMATCH|UNEXPECTED_INPUT_TYPE|ARRAY|FLOAT|vector_cosine_similarity)
+
+    Scenario: ARRAY<INT> inputs are rejected
+      When query
+        """
+        SELECT vector_cosine_similarity(
+          array(1, 2),
+          array(3, 4)
+        ) AS result
+        """
+      Then query error (?i)(DATATYPE_MISMATCH|UNEXPECTED_INPUT_TYPE|ARRAY|FLOAT|vector_cosine_similarity)
+
+    Scenario: non-array values are rejected
+      When query
+        """
+        SELECT vector_cosine_similarity(1.0F, 2.0F) AS result
+        """
+      Then query error (?i)(DATATYPE_MISMATCH|UNEXPECTED_INPUT_TYPE|ARRAY|FLOAT|vector_cosine_similarity)

--- a/python/pysail/tests/spark/function/test_vector_cosine_similarity.py
+++ b/python/pysail/tests/spark/function/test_vector_cosine_similarity.py
@@ -16,8 +16,14 @@ def test_vector_cosine_similarity(spark):
 
 
 def test_vector_cosine_similarity_null_cases(spark):
-    assert spark.sql("SELECT vector_cosine_similarity(NULL, array(1.0F, 2.0F))").first()[0] is None
-    assert spark.sql("SELECT vector_cosine_similarity(array(1.0F, 2.0F), NULL)").first()[0] is None
+    assert (
+        spark.sql("SELECT vector_cosine_similarity(CAST(NULL AS ARRAY<FLOAT>), array(1.0F, 2.0F))").first()[0]
+        is None
+    )
+    assert (
+        spark.sql("SELECT vector_cosine_similarity(array(1.0F, 2.0F), CAST(NULL AS ARRAY<FLOAT>))").first()[0]
+        is None
+    )
     assert (
         spark.sql(
             "SELECT vector_cosine_similarity(CAST(array() AS ARRAY<FLOAT>), CAST(array() AS ARRAY<FLOAT>))"
@@ -32,12 +38,17 @@ def test_vector_cosine_similarity_null_cases(spark):
 
 
 def test_vector_cosine_similarity_extreme_values(spark):
-    assert spark.sql("SELECT vector_cosine_similarity(array(3.0e19F, 4.0e19F), array(3.0e19F, 4.0e19F))").first()[
-        0
-    ] == pytest.approx(1.0)
-    assert spark.sql("SELECT vector_cosine_similarity(array(1.0e-23F, 0.0F), array(1.0e-23F, 0.0F))").first()[
-        0
-    ] == pytest.approx(1.0)
+    assert math.isnan(
+        spark.sql(
+            "SELECT vector_cosine_similarity(array(3.0e19F, 4.0e19F), array(3.0e19F, 4.0e19F))"
+        ).first()[0]
+    )
+    assert (
+        spark.sql(
+            "SELECT vector_cosine_similarity(array(1.0e-23F, 0.0F), array(1.0e-23F, 0.0F))"
+        ).first()[0]
+        is None
+    )
     assert math.isnan(
         spark.sql("SELECT vector_cosine_similarity(array(float('inf'), 1.0F), array(1.0F, 1.0F))").first()[0]
     )

--- a/python/pysail/tests/spark/function/test_vector_cosine_similarity.py
+++ b/python/pysail/tests/spark/function/test_vector_cosine_similarity.py
@@ -17,12 +17,10 @@ def test_vector_cosine_similarity(spark):
 
 def test_vector_cosine_similarity_null_cases(spark):
     assert (
-        spark.sql("SELECT vector_cosine_similarity(CAST(NULL AS ARRAY<FLOAT>), array(1.0F, 2.0F))").first()[0]
-        is None
+        spark.sql("SELECT vector_cosine_similarity(CAST(NULL AS ARRAY<FLOAT>), array(1.0F, 2.0F))").first()[0] is None
     )
     assert (
-        spark.sql("SELECT vector_cosine_similarity(array(1.0F, 2.0F), CAST(NULL AS ARRAY<FLOAT>))").first()[0]
-        is None
+        spark.sql("SELECT vector_cosine_similarity(array(1.0F, 2.0F), CAST(NULL AS ARRAY<FLOAT>))").first()[0] is None
     )
     assert (
         spark.sql(
@@ -39,16 +37,9 @@ def test_vector_cosine_similarity_null_cases(spark):
 
 def test_vector_cosine_similarity_extreme_values(spark):
     assert math.isnan(
-        spark.sql(
-            "SELECT vector_cosine_similarity(array(3.0e19F, 4.0e19F), array(3.0e19F, 4.0e19F))"
-        ).first()[0]
+        spark.sql("SELECT vector_cosine_similarity(array(3.0e19F, 4.0e19F), array(3.0e19F, 4.0e19F))").first()[0]
     )
-    assert (
-        spark.sql(
-            "SELECT vector_cosine_similarity(array(1.0e-23F, 0.0F), array(1.0e-23F, 0.0F))"
-        ).first()[0]
-        is None
-    )
+    assert spark.sql("SELECT vector_cosine_similarity(array(1.0e-23F, 0.0F), array(1.0e-23F, 0.0F))").first()[0] is None
     assert math.isnan(
         spark.sql("SELECT vector_cosine_similarity(array(float('inf'), 1.0F), array(1.0F, 1.0F))").first()[0]
     )

--- a/python/pysail/tests/spark/function/test_vector_cosine_similarity.py
+++ b/python/pysail/tests/spark/function/test_vector_cosine_similarity.py
@@ -1,0 +1,53 @@
+import math
+
+import pytest
+
+
+def test_vector_cosine_similarity(spark):
+    assert spark.sql("SELECT vector_cosine_similarity(array(1.0F, 2.0F, 3.0F), array(4.0F, 5.0F, 6.0F))").first()[
+        0
+    ] == pytest.approx(0.97463185)
+    assert spark.sql("SELECT vector_cosine_similarity(array(1.0F, 0.0F), array(0.0F, 1.0F))").first()[
+        0
+    ] == pytest.approx(0.0)
+    assert spark.sql("SELECT vector_cosine_similarity(array(1.0F, 0.0F), array(-1.0F, 0.0F))").first()[
+        0
+    ] == pytest.approx(-1.0)
+
+
+def test_vector_cosine_similarity_null_cases(spark):
+    assert spark.sql("SELECT vector_cosine_similarity(NULL, array(1.0F, 2.0F))").first()[0] is None
+    assert spark.sql("SELECT vector_cosine_similarity(array(1.0F, 2.0F), NULL)").first()[0] is None
+    assert (
+        spark.sql(
+            "SELECT vector_cosine_similarity(CAST(array() AS ARRAY<FLOAT>), CAST(array() AS ARRAY<FLOAT>))"
+        ).first()[0]
+        is None
+    )
+    assert spark.sql("SELECT vector_cosine_similarity(array(0.0F, 0.0F), array(1.0F, 2.0F))").first()[0] is None
+    assert (
+        spark.sql("SELECT vector_cosine_similarity(array(1.0F, CAST(NULL AS FLOAT)), array(1.0F, 2.0F))").first()[0]
+        is None
+    )
+
+
+def test_vector_cosine_similarity_extreme_values(spark):
+    assert spark.sql("SELECT vector_cosine_similarity(array(3.0e19F, 4.0e19F), array(3.0e19F, 4.0e19F))").first()[
+        0
+    ] == pytest.approx(1.0)
+    assert spark.sql("SELECT vector_cosine_similarity(array(1.0e-23F, 0.0F), array(1.0e-23F, 0.0F))").first()[
+        0
+    ] == pytest.approx(1.0)
+    assert math.isnan(
+        spark.sql("SELECT vector_cosine_similarity(array(float('inf'), 1.0F), array(1.0F, 1.0F))").first()[0]
+    )
+
+
+def test_vector_cosine_similarity_rejects_dimension_mismatch(spark):
+    with pytest.raises(Exception, match="matching dimensions"):
+        spark.sql("SELECT vector_cosine_similarity(array(1.0F, 2.0F), array(1.0F))").collect()
+
+
+def test_vector_cosine_similarity_rejects_non_float_vectors(spark):
+    with pytest.raises(Exception, match=r"ARRAY<FLOAT>"):
+        spark.sql("SELECT vector_cosine_similarity(array(1.0D), array(1.0D))").collect()

--- a/python/pysail/tests/spark/function/test_vector_cosine_similarity.py
+++ b/python/pysail/tests/spark/function/test_vector_cosine_similarity.py
@@ -1,5 +1,7 @@
 import math
 
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
 
@@ -13,6 +15,22 @@ def test_vector_cosine_similarity(spark):
     assert spark.sql("SELECT vector_cosine_similarity(array(1.0F, 0.0F), array(-1.0F, 0.0F))").first()[
         0
     ] == pytest.approx(-1.0)
+
+
+def test_vector_cosine_similarity_with_parquet_large_list(spark, tmp_path):
+    path = tmp_path / "large_list_vector.parquet"
+    pq.write_table(
+        pa.table({"v": pa.array([[1.0, 2.0]], type=pa.large_list(pa.float32()))}),
+        path,
+    )
+
+    actual = (
+        spark.read.parquet(str(path))
+        .selectExpr("vector_cosine_similarity(v, array(1.0F, 2.0F)) AS similarity")
+        .collect()
+    )
+
+    assert actual[0].similarity == pytest.approx(1.0)
 
 
 def test_vector_cosine_similarity_null_cases(spark):


### PR DESCRIPTION
Adds native support for the Spark 4.2 `vector_cosine_similarity` function.

- implemented cosine similarity for `ARRAY<FLOAT>` and large-list vectors
- handle nulls, empty vectors, zero magnitudes, and dimension mismatches
- register the function with scalar planning and distributed execution codecs
- share vector type validation with the inner-product implementation